### PR TITLE
pkg/reconcile: ServiceAccount-specific logic

### DIFF
--- a/pkg/operator/openshift_sdn_test.go
+++ b/pkg/operator/openshift_sdn_test.go
@@ -84,6 +84,21 @@ func TestRenderOpenshiftSDN(t *testing.T) {
 		_, ok := sel["node-role.kubernetes.io/master"]
 		g.Expect(ok).To(BeTrue())
 	}
+
+	// Make sure every obj is reasonable:
+	// - it is supported
+	// - it reconciles to itself (steady state)
+	for _, obj := range objs {
+		g.Expect(IsObjectSupported(obj)).NotTo(HaveOccurred())
+		cur := obj.DeepCopy()
+		upd := obj.DeepCopy()
+
+		err = MergeObjectForUpdate(cur, upd)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		tweakMetaForCompare(cur)
+		g.Expect(cur).To(Equal(upd))
+	}
 }
 
 func TestValidateOpenshiftSDN(t *testing.T) {

--- a/pkg/operator/testutil_test.go
+++ b/pkg/operator/testutil_test.go
@@ -72,3 +72,19 @@ func UnstructuredFromYaml(t *testing.T, obj string) *uns.Unstructured {
 
 	return &u
 }
+
+// tweakMetaForCompare adjust the metadata so that if you compare an object
+// reconciled with itself, it will come out DeepEqual
+// This is just because we always set some metadata, so it diverges in a way
+// that is kubernetes equivalent but not go equal.
+func tweakMetaForCompare(obj *uns.Unstructured) {
+	// Silly thing: we always set annotations and labels in Merge
+	// just a little overwrite to make Equals happy
+	if obj.GetLabels() == nil {
+		obj.SetLabels(map[string]string{})
+	}
+	if obj.GetAnnotations() == nil {
+		obj.SetAnnotations(map[string]string{})
+	}
+	obj.SetResourceVersion("")
+}


### PR DESCRIPTION
ServiceAccounts have a token that is automatically generated, but we were deleting it every time we reconciled. Let the auto-generated one win.

Also, test that all objects from openshift-sdn reconcile to themselves.