### PR TITLE
manifests: change to using installer-created apiserver environment.

### DIFF
--- a/manifests/0000_07_cluster-network-operator_03_daemonset.yaml
+++ b/manifests/0000_07_cluster-network-operator_03_daemonset.yaml
@@ -29,14 +29,18 @@ spec:
           value: "docker.io/openshift/origin-node:v4.0.0"
         - name: HYPERSHIFT_IMAGE
           value: "docker.io/openshift/origin-hypershift:v4.0.0"
-        - name: KUBERNETES_SERVICE_PORT # allows CVO to communicate with apiserver directly on same host.
-          value: "6443"
-        - name: KUBERNETES_SERVICE_HOST # allows CVO to communicate with apiserver directly on same host.
-          value: "127.0.0.1"
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        envFrom:
+        # this is a configmap that defines KUBERNETES_SERVICE_HOST|PORT
+        # it is created directly by the installer, so we can find the
+        # apiserver during bootstrap.
+        # Other operators can hard-code 127.0.0.1, but we run on the real masters
+        # while the apiserver is still on the bootstrap node.
+        - configMapRef:
+            name: "cluster-config"
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""


### PR DESCRIPTION
We override `KUBERNETES_SERVICE_HOST|PORT` since we can't use the service IP. We previously used 127.0.0.1, but that doesn't work during bootstrap since the apiserver is still running on the bootstrap node. Switch to a new configmap created by the installer.