### PR TITLE
Installer + RHCOS fixes

### DIFF
--- a/bindata/network/openshift-sdn/controller.yaml
+++ b/bindata/network/openshift-sdn/controller.yaml
@@ -47,10 +47,12 @@ spec:
           name: config
           readOnly: true
         env:
+        # TODO: bind-mount the kubelet's kubeconfig like the openshift-sdn process
+        # need to get the `oc` binary in to the hypershift image first
         - name: KUBERNETES_SERVICE_PORT # allows the controller to communicate with apiserver directly on same host.
-          value: "6443"
+          value: "{{.KUBERNETES_SERVICE_PORT}}"
         - name: KUBERNETES_SERVICE_HOST # allows the controller to communicate with apiserver directly on same host.
-          value: "127.0.0.1"
+          value: "{{.KUBERNETES_SERVICE_HOST}}"
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -107,7 +107,7 @@ spec:
           path: /sys
       - name: host-config-openvswitch
         hostPath:
-          path: /etc/origin/openvswitch
+          path: /var/lib/openvswitch
       tolerations:
       - operator: "Exists"
 {{- end}}

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -49,6 +49,9 @@ spec:
           #!/bin/bash
           set -euo pipefail
 
+          # enable ip forwarding
+          sysctl -w net.ipv4.ip_forward=1
+
           # if another process is listening on the cni-server socket, wait until it exits
           trap 'kill $(jobs -p); exit 0' TERM
           retries=0
@@ -73,17 +76,8 @@ spec:
           rm -Rf /etc/cni/net.d/80-openshift-network.conf
           cp -Rf /opt/cni/bin/* /host/opt/cni/bin/
 
-          # use either the bootstrapped node kubeconfig or the static configuration
-          file=/etc/origin/node/node.kubeconfig
-          if [[ ! -f "${file}" ]]; then
-            # use the static node config if it exists
-            # TODO: remove when static node configuration is no longer supported
-            for f in /etc/origin/node/system*.kubeconfig; do
-              echo "info: Using ${f} for node configuration" 1>&2
-              file="${f}"
-              break
-            done
-          fi
+          file=/etc/kubernetes/kubeconfig
+
           # Use the same config as the node, but with the service account token
           oc config "--config=${file}" view --flatten > /tmp/kubeconfig
           oc config --config=/tmp/kubeconfig set-credentials sa "--token=$( cat /var/run/secrets/kubernetes.io/serviceaccount/token )"
@@ -99,10 +93,12 @@ spec:
         - mountPath: /config
           name: config
           readOnly: true
-        # Directory which contains the host configuration.
-        - mountPath: /etc/origin/node/
-          name: host-config
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: host-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/pki
+          readOnly: true
+          name: host-pki
         # Mount the entire run directory for socket access for Docker or CRI-o
         # TODO: remove
         - mountPath: /var/run
@@ -122,9 +118,9 @@ spec:
           name: host-var-run-openshift-sdn
         # CNI related mounts which we take over
         - mountPath: /host/opt/cni/bin
-          name: host-opt-cni-bin
+          name: host-cni-bin
         - mountPath: /etc/cni/net.d
-          name: host-etc-cni-netd
+          name: host-cni-netd
         - mountPath: /var/lib/cni/networks/openshift-sdn
           name: host-var-lib-cni-networks-openshift-sdn
         resources:
@@ -147,11 +143,12 @@ spec:
       - name: config
         configMap:
           name: sdn-config
-      # In bootstrap mode, the host config contains information not easily available
-      # from other locations.
-      - name: host-config
+      - name: host-kubeconfig
         hostPath:
-          path: /etc/origin/node
+          path: /etc/kubernetes/kubeconfig
+      - name: host-pki
+        hostPath:
+          path: /var/lib/kubelet/pki
       - name: host-modules
         hostPath:
           path: /lib/modules
@@ -171,12 +168,12 @@ spec:
       - name: host-var-run-openshift-sdn
         hostPath:
           path: /var/run/openshift-sdn
-      - name: host-opt-cni-bin
+      - name: host-cni-bin
         hostPath:
-          path: /opt/cni/bin
-      - name: host-etc-cni-netd
+          path: /var/lib/cni/bin
+      - name: host-cni-netd
         hostPath:
-          path: /etc/cni/net.d
+          path: /etc/kubernetes/cni/net.d
       - name: host-var-lib-cni-networks-openshift-sdn
         hostPath:
           path: /var/lib/cni/networks/openshift-sdn

--- a/cmd/cluster-network-operator/main.go
+++ b/cmd/cluster-network-operator/main.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"flag"
 	"log"
+	"net/url"
+	"os"
 	"runtime"
 
 	"github.com/openshift/cluster-network-operator/pkg/apis"
@@ -11,6 +13,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
@@ -24,6 +27,15 @@ func printVersion() {
 
 const LOCK_NAME = "cluster-network-operator"
 
+// urlOnlyKubeconfig is a slight hack; we need to get the apiserver from the
+// kubeconfig but should use the in-cluster service account
+var urlOnlyKubeconfig string
+
+func init() {
+	flag.StringVar(&urlOnlyKubeconfig, "url-only-kubeconfig", "",
+		"Path to a kubeconfig, but only for the apiserver url.")
+}
+
 func main() {
 	printVersion()
 	flag.Parse()
@@ -32,6 +44,30 @@ func main() {
 
 	// TODO: Expose metrics port after SDK uses controller-runtime's dynamic client
 	// sdk.ExposeMetricsPort()
+
+	// Hack: the network operator can't use the apiserver service ip, since theres
+	// no network. We also can't hard-code it to 127.0.0.1, because we run during
+	// bootstrap. Instead, we bind-mount in the kubelets kubeconfig, but just
+	// use it to get the apiserver url.
+	if urlOnlyKubeconfig != "" {
+		kubeconfig, err := clientcmd.LoadFromFile(urlOnlyKubeconfig)
+		if err != nil {
+			log.Fatal(err)
+		}
+		clusterName := kubeconfig.Contexts[kubeconfig.CurrentContext].Cluster
+		apiURL := kubeconfig.Clusters[clusterName].Server
+
+		url, err := url.Parse(apiURL)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// The kubernetes in-cluster functions don't let you override the apiserver
+		// directly; gotta "pass" it via environment vars.
+		log.Printf("overriding kubernetes api to %s", apiURL)
+		os.Setenv("KUBERNETES_SERVICE_HOST", url.Hostname())
+		os.Setenv("KUBERNETES_SERVICE_PORT", url.Port())
+	}
 
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()

--- a/manifests/0000_07_cluster-network-operator_03_daemonset.yaml
+++ b/manifests/0000_07_cluster-network-operator_03_daemonset.yaml
@@ -17,6 +17,9 @@ spec:
       containers:
       - name: cluster-network-operator
         image: docker.io/openshift/origin-cluster-network-operator:v4.0.0
+        command:
+        - "/bin/cluster-network-operator"
+        - "--url-only-kubeconfig=/etc/kubernetes/kubeconfig"
         resources:
           limits:
             cpu: 20m
@@ -33,17 +36,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        envFrom:
-        # this is a configmap that defines KUBERNETES_SERVICE_HOST|PORT
-        # it is created directly by the installer, so we can find the
-        # apiserver during bootstrap.
-        # Other operators can hard-code 127.0.0.1, but we run on the real masters
-        # while the apiserver is still on the bootstrap node.
-        - configMapRef:
-            name: "cluster-config"
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: host-kubeconfig
+          readOnly: true
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      volumes:
+        - name: host-kubeconfig
+          hostPath:
+            path: /etc/kubernetes/kubeconfig
       restartPolicy: Always
       securityContext:
         runAsNonRoot: true

--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -40,6 +40,8 @@ func renderOpenshiftSDN(conf *netv1.NetworkConfig, manifestDir string) ([]*uns.U
 	data.Data["InstallOVS"] = (c.UseExternalOpenvswitch == nil || *c.UseExternalOpenvswitch == false)
 	data.Data["NodeImage"] = os.Getenv("NODE_IMAGE")
 	data.Data["HypershiftImage"] = os.Getenv("HYPERSHIFT_IMAGE")
+	data.Data["KUBERNETES_SERVICE_HOST"] = os.Getenv("KUBERNETES_SERVICE_HOST")
+	data.Data["KUBERNETES_SERVICE_PORT"] = os.Getenv("KUBERNETES_SERVICE_PORT")
 
 	operCfg, err := controllerConfig(conf)
 	if err != nil {
@@ -187,10 +189,10 @@ func nodeConfig(conf *netv1.NetworkConfig) (string, error) {
 		ServingInfo: legacyconfigv1.ServingInfo{
 			// These files are bind-mounted in at a hard-coded location
 			CertInfo: legacyconfigv1.CertInfo{
-				CertFile: "/etc/origin/node/server.crt",
-				KeyFile:  "/etc/origin/node/server.key",
+				CertFile: "/etc/kubernetes/pki/kubelet.crt",
+				KeyFile:  "/etc/kubernetes/pki/kubelet.key",
 			},
-			ClientCA:    "/etc/origin/node/ca.crt",
+			ClientCA:    "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
 			BindAddress: bindAddress + ":10251", // port is unused
 		},
 	}

--- a/sample-config.yaml
+++ b/sample-config.yaml
@@ -3,9 +3,9 @@ kind: "NetworkConfig"
 metadata:
   name: "default"
 spec:
-  serviceNetwork: "172.30.0.0/16"
+  serviceNetwork: "10.3.0.0/16"
   clusterNetworks:
-    - cidr: "10.128.0.0/14"
+    - cidr: "10.2.0.0/16"
       hostSubnetLength: 9
   defaultNetwork:
     type: OpenshiftSDN


### PR DESCRIPTION
Fixes to bring the operator working with the new installer:

- some kubeconfig hackery
- path changes due to SELinux and installer divergence
- need to enable ip forwarding (wat)

ref openshift/installer#600