### PR TITLE
openshift-sdn: Add stupid loop to wait out crio SELinux relabeling.

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -36,6 +36,24 @@ spec:
           #!/bin/bash
           set -euo pipefail
 
+          # wait out the SELinux relabeling race on crio
+          retries=0
+          while true; do
+            if touch /etc/openvswitch/.test; then
+              break;
+            else
+              echo "Still waiting for SELinux relabeling"
+              (( retries += 1 ))
+              sleep 15
+            fi
+            if [[ "${retries}" -gt 40 ]]; then
+              echo "error: unable to create necessary host files, existing"
+              exit 1
+            fi
+          done
+          rm /etc/openvswitch/.test;
+
+
           # if another process is listening on the cni-server socket, wait until it exits
           trap 'kill $(jobs -p); exit 0' TERM
           retries=0

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -52,6 +52,23 @@ spec:
           # enable ip forwarding
           sysctl -w net.ipv4.ip_forward=1
 
+          # wait out the SELinux relabeling race on crio
+          retries=0
+          while true; do
+            if touch /host/opt/cni/bin/.test; then
+              break;
+            else
+              echo "Still waiting for SELinux relabeling"
+              (( retries += 1 ))
+              sleep 15
+            fi
+            if [[ "${retries}" -gt 40 ]]; then
+              echo "error: unable to create necessary host files, existing"
+              exit 1
+            fi
+          done
+          rm /host/opt/cni/bin/.test
+
           # if another process is listening on the cni-server socket, wait until it exits
           trap 'kill $(jobs -p); exit 0' TERM
           retries=0


### PR DESCRIPTION
As discovered in openshift/installer#600, there is some murky race within crio with regards to SELinux relabeling. Unfortunately, the SDN is one of the first containers to run, so it loses the race.