### PR TITLE
manifests: switch network operator to deployment

### DIFF
--- a/manifests/0000_07_cluster-network-operator_03_daemonset.yaml
+++ b/manifests/0000_07_cluster-network-operator_03_daemonset.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   name: cluster-network-operator
   namespace: openshift-cluster-network-operator


### PR DESCRIPTION
https://github.com/openshift/cluster-version-operator/pull/38#issuecomment-438465640

@deads2k suggests that a deployment should be able to schedule even when node is not-ready.