### PR TITLE
openshift-sdn: use the crio CRI socket

### DIFF
--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -195,6 +195,12 @@ func nodeConfig(conf *netv1.NetworkConfig) (string, error) {
 			ClientCA:    "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
 			BindAddress: bindAddress + ":10251", // port is unused
 		},
+
+		// Openshift-sdn calls the CRI endpoint directly; point it to crio
+		KubeletArguments: legacyconfigv1.ExtendedArguments{
+			"container-runtime":          {"remote"},
+			"container-runtime-endpoint": {"/var/run/crio/crio.sock"},
+		},
 	}
 
 	if kpc != nil && kpc.IptablesSyncPeriod != "" {


### PR DESCRIPTION
We query the CRI endpoint directly. The code defaults to the dockershim, but now we're using crio.