### PR TITLE
Remove ip_forward sysctl

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -49,9 +49,6 @@ spec:
           #!/bin/bash
           set -euo pipefail
 
-          # enable ip forwarding
-          sysctl -w net.ipv4.ip_forward=1
-
           # if another process is listening on the cni-server socket, wait until it exits
           trap 'kill $(jobs -p); exit 0' TERM
           retries=0

--- a/cmd/cluster-network-operator/main.go
+++ b/cmd/cluster-network-operator/main.go
@@ -45,9 +45,9 @@ func main() {
 	// TODO: Expose metrics port after SDK uses controller-runtime's dynamic client
 	// sdk.ExposeMetricsPort()
 
-	// Hack: the network operator can't use the apiserver service ip, since theres
+	// Hack: the network operator can't use the apiserver service ip, since there's
 	// no network. We also can't hard-code it to 127.0.0.1, because we run during
-	// bootstrap. Instead, we bind-mount in the kubelets kubeconfig, but just
+	// bootstrap. Instead, we bind-mount in the kubelet's kubeconfig, but just
 	// use it to get the apiserver url.
 	if urlOnlyKubeconfig != "" {
 		kubeconfig, err := clientcmd.LoadFromFile(urlOnlyKubeconfig)

--- a/sample-config.yaml
+++ b/sample-config.yaml
@@ -3,9 +3,9 @@ kind: "NetworkConfig"
 metadata:
   name: "default"
 spec:
-  serviceNetwork: "10.3.0.0/16"
+  serviceNetwork: "172.30.0.0/16"
   clusterNetworks:
-    - cidr: "10.2.0.0/16"
+    - cidr: "10.128.0.0/14"
       hostSubnetLength: 9
   defaultNetwork:
     type: OpenshiftSDN


### PR DESCRIPTION
This addresses @danwinship's review comments in #28.

The sysctl was moved to openshift/machine-config-operator#178.

The default network blocks are being changed in openshift/installer#658

some extra apostrophe's we're added.