### PR TITLE
operator: Switch to a deployment to be consistent with other operators

### DIFF
--- a/manifests/0000_07_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_07_cluster-network-operator_03_deployment.yaml
@@ -1,11 +1,12 @@
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   name: cluster-network-operator
   namespace: openshift-cluster-network-operator
   labels:
     k8s-app: cluster-network-operator
 spec:
+  replicas: 1
   selector:
     matchLabels:
       k8s-app: cluster-network-operator


### PR DESCRIPTION
The CNO only needs to schedule to masters, it does not need to be running
on all of them.