### PR TITLE
Block unsafe changes

### DIFF
--- a/cmd/cluster-network-renderer/main.go
+++ b/cmd/cluster-network-renderer/main.go
@@ -47,7 +47,14 @@ func render() error {
 		return err
 	}
 
-	objs, err := network.Render(conf, manifestPath)
+	err = network.Validate(&conf.Spec)
+	if err != nil {
+		return err
+	}
+
+	network.FillDefaults(&conf.Spec)
+
+	objs, err := network.Render(&conf.Spec, manifestPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/apis/networkoperator/v1/networkconfig_types.go
+++ b/pkg/apis/networkoperator/v1/networkconfig_types.go
@@ -164,10 +164,10 @@ type ProxyConfig struct {
 
 	// The address to "bind" on
 	// Defaults to 0.0.0.0
-	BindAddress string
+	BindAddress string `json:"bindAddress,omitempty"`
 
 	// Any additional arguments to pass to the kubeproxy process
-	ProxyArguments map[string][]string
+	ProxyArguments map[string][]string `json:"proxyArguments,omitempty"`
 }
 
 const (

--- a/pkg/controller/networkconfig/previous.go
+++ b/pkg/controller/networkconfig/previous.go
@@ -1,0 +1,74 @@
+package networkconfig
+
+import (
+	"context"
+	"encoding/json"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	netv1 "github.com/openshift/cluster-network-operator/pkg/apis/networkoperator/v1"
+)
+
+const NAME_PREFIX = "applied-"
+
+// The operator-sdk actually has the notion of an operator's namespace, but
+// since the network configuration is not namespaced, we can't use it.
+// This is hardcoded in 00_namespace.yaml anyways
+const NAMESPACE = "openshift-cluster-network-operator"
+
+// GetAppliedConfiguration retrieves the configuration we applied.
+// Returns nil with no error if no previous configuration was observed.
+func GetAppliedConfiguration(ctx context.Context, client k8sclient.Client, name string) (*netv1.NetworkConfigSpec, error) {
+	cm := &corev1.ConfigMap{}
+	err := client.Get(ctx, types.NamespacedName{Namespace: NAMESPACE, Name: NAME_PREFIX + name}, cm)
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	spec := &netv1.NetworkConfigSpec{}
+	err = json.Unmarshal([]byte(cm.Data["applied"]), spec)
+	if err != nil {
+		return nil, err
+	}
+	return spec, nil
+}
+
+// AppliedConfiguration renders the ConfigMap in which we store the configuration
+// we've applied.
+func AppliedConfiguration(applied *netv1.NetworkConfig) (*uns.Unstructured, error) {
+	app, err := json.Marshal(applied.Spec)
+	if err != nil {
+		return nil, err
+	}
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: NAMESPACE,
+			Name:      NAME_PREFIX + applied.Name,
+		},
+		Data: map[string]string{
+			"applied": string(app),
+		},
+	}
+
+	// transmute to unstructured
+	b, err := json.Marshal(cm)
+	if err != nil {
+		return nil, err
+	}
+	u := &uns.Unstructured{}
+	if err := json.Unmarshal(b, &u); err != nil {
+		return nil, err
+	}
+	return u, nil
+}

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"log"
+	"reflect"
 
 	"github.com/pkg/errors"
 
@@ -10,7 +11,7 @@ import (
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func Render(conf *netv1.NetworkConfig, manifestDir string) ([]*uns.Unstructured, error) {
+func Render(conf *netv1.NetworkConfigSpec, manifestDir string) ([]*uns.Unstructured, error) {
 	log.Printf("Starting render phase")
 	objs := []*uns.Unstructured{}
 
@@ -32,7 +33,7 @@ func Render(conf *netv1.NetworkConfig, manifestDir string) ([]*uns.Unstructured,
 }
 
 // Validate checks that the supplied configuration is reasonable.
-func Validate(conf *netv1.NetworkConfig) error {
+func Validate(conf *netv1.NetworkConfigSpec) error {
 	errs := []error{}
 
 	errs = append(errs, ValidateDefaultNetwork(conf)...)
@@ -43,21 +44,68 @@ func Validate(conf *netv1.NetworkConfig) error {
 	return nil
 }
 
+// FillDefaults computes any default values and applies them to the configuration
+// This is a mutating operation. It should be called after Validate.
+//
+// This is done as an explicit step so we can check if a change is safe. We
+// explicitly record all generated defaults at apply time, rather than leaving
+// them implicit, so that a change in code later won't accidentally introduce
+// an unsafe change.
+func FillDefaults(conf *netv1.NetworkConfigSpec) {
+	FillDefaultNetworkDefaults(conf)
+}
+
+// IsChangeSafe checks to see if the change between prev and next are allowed
+// FillDefaults and Validate should have been called.
+func IsChangeSafe(prev, next *netv1.NetworkConfigSpec) error {
+	if prev == nil {
+		return nil
+	}
+
+	// Easy way out: nothing changed.
+	if reflect.DeepEqual(prev, next) {
+		return nil
+	}
+
+	errs := []error{}
+
+	// TODO: implement cluster network / service network expansion
+	// We don't support cluster network changes
+	if !reflect.DeepEqual(prev.ClusterNetworks, next.ClusterNetworks) {
+		errs = append(errs, errors.Errorf("cannot change ClusterNetworks"))
+	}
+
+	// Nor can you change service network
+	if prev.ServiceNetwork != next.ServiceNetwork {
+		errs = append(errs, errors.Errorf("cannot change ServiceNetwork"))
+	}
+
+	// Check the default network
+	errs = append(errs, IsDefaultNetworkChangeSafe(prev, next)...)
+
+	// Changing KubeProxyConfig and DeployKubeProxy is allowed, so we don't check that
+
+	if len(errs) > 0 {
+		return errors.Errorf("invalid configuration: %v", errs)
+	}
+	return nil
+}
+
 // ValidateDefaultNetwork validates whichever network is specified
 // as the default network.
-func ValidateDefaultNetwork(conf *netv1.NetworkConfig) []error {
-	switch conf.Spec.DefaultNetwork.Type {
+func ValidateDefaultNetwork(conf *netv1.NetworkConfigSpec) []error {
+	switch conf.DefaultNetwork.Type {
 	case netv1.NetworkTypeOpenshiftSDN:
 		return validateOpenshiftSDN(conf)
 	default:
-		return []error{errors.Errorf("unknown or unsupported NetworkType: %s", conf.Spec.DefaultNetwork.Type)}
+		return []error{errors.Errorf("unknown or unsupported NetworkType: %s", conf.DefaultNetwork.Type)}
 	}
 }
 
 // RenderDefaultNetwork generates the manifests corresponding to the requested
 // default network
-func RenderDefaultNetwork(conf *netv1.NetworkConfig, manifestDir string) ([]*uns.Unstructured, error) {
-	dn := conf.Spec.DefaultNetwork
+func RenderDefaultNetwork(conf *netv1.NetworkConfigSpec, manifestDir string) ([]*uns.Unstructured, error) {
+	dn := conf.DefaultNetwork
 	if errs := ValidateDefaultNetwork(conf); len(errs) > 0 {
 		return nil, errors.Errorf("invalid Default Network configuration: %v", errs)
 	}
@@ -68,4 +116,28 @@ func RenderDefaultNetwork(conf *netv1.NetworkConfig, manifestDir string) ([]*uns
 	}
 
 	return nil, errors.Errorf("unknown or unsupported NetworkType: %s", dn.Type)
+}
+
+// FillDefaultNetworkDefaults
+func FillDefaultNetworkDefaults(conf *netv1.NetworkConfigSpec) {
+	switch conf.DefaultNetwork.Type {
+	case netv1.NetworkTypeOpenshiftSDN:
+		fillOpenshiftSDNDefaults(conf)
+	default:
+		// This case has already been excluded by Validate
+		panic("invalid network")
+	}
+}
+
+func IsDefaultNetworkChangeSafe(prev, next *netv1.NetworkConfigSpec) []error {
+	if prev.DefaultNetwork.Type != next.DefaultNetwork.Type {
+		return []error{errors.Errorf("cannot change default network type")}
+	}
+
+	switch prev.DefaultNetwork.Type {
+	case netv1.NetworkTypeOpenshiftSDN:
+		return isOpenshiftSDNChangeSafe(prev, next)
+	default: // should be unreachable
+		return []error{errors.Errorf("unknown network type %s", prev.DefaultNetwork.Type)}
+	}
 }

--- a/pkg/network/render_test.go
+++ b/pkg/network/render_test.go
@@ -1,0 +1,35 @@
+package network
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestIsChangeSafe(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	prev := OpenshiftSDNConfig.Spec.DeepCopy()
+	FillDefaults(prev)
+	next := OpenshiftSDNConfig.Spec.DeepCopy()
+	FillDefaults(next)
+
+	err := IsChangeSafe(prev, next)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	next.ClusterNetworks[0].HostSubnetLength = 1
+	err = IsChangeSafe(prev, next)
+	g.Expect(err).To(MatchError(ContainSubstring("cannot change ClusterNetworks")))
+
+	next = OpenshiftSDNConfig.Spec.DeepCopy()
+	FillDefaults(next)
+	next.ServiceNetwork = "1.2.3.4/99"
+	err = IsChangeSafe(prev, next)
+	g.Expect(err).To(MatchError(ContainSubstring("cannot change ServiceNetwork")))
+
+	next = OpenshiftSDNConfig.Spec.DeepCopy()
+	FillDefaults(next)
+	next.DefaultNetwork.Type = "Kuryr"
+	err = IsChangeSafe(prev, next)
+	g.Expect(err).To(MatchError(ContainSubstring("cannot change default network type")))
+}


### PR DESCRIPTION
This saves the applied configuration as a config map, then retrieves it and compares against the newly-requested configuration.

It also makes the step of applying defaults explicit, so we can reason more clearly about proposed changes. In other words, changing a field from null to it's default should not be blocked. Likewise, a code bug that changes a default dangerously should also not propagate.