### PR TITLE
remove kubelet pki from sdn pod

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -91,9 +91,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: host-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki
-          readOnly: true
-          name: host-pki
         # Mount the entire run directory for socket access for Docker or CRI-o
         # TODO: remove
         - mountPath: /var/run
@@ -141,9 +138,6 @@ spec:
       - name: host-kubeconfig
         hostPath:
           path: /etc/kubernetes/kubeconfig
-      - name: host-pki
-        hostPath:
-          path: /var/lib/kubelet/pki
       - name: host-modules
         hostPath:
           path: /lib/modules

--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -205,11 +205,6 @@ func nodeConfig(conf *netv1.NetworkConfigSpec) (string, error) {
 		},
 		// ServingInfo is used by both the proxy and metrics components
 		ServingInfo: legacyconfigv1.ServingInfo{
-			// These files are bind-mounted in at a hard-coded location
-			CertInfo: legacyconfigv1.CertInfo{
-				CertFile: "/etc/kubernetes/pki/kubelet.crt",
-				KeyFile:  "/etc/kubernetes/pki/kubelet.key",
-			},
 			ClientCA:    "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
 			BindAddress: conf.KubeProxyConfig.BindAddress + ":10251", // port is unused but required
 		},


### PR DESCRIPTION
now that https://github.com/openshift/origin/pull/21551 is merged, remove kubelet certs from the sdn pod

needed for https://github.com/openshift/machine-config-operator/pull/187

@smarterclayton @squeed 