### PR TITLE
Initial support for ovn-kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It follows the [Controller pattern](https://godoc.org/github.com/kubernetes-sigs
 
 Most users will be able to use the top-level OpenShift Config API, which has a [Network type](https://github.com/openshift/api/blob/master/config/v1/types_network.go#L26). The operator will automatically translate the `Network.config.openshift.io` object in to a `Network.operator.openshift.io`.
 
-When the controller has reconciled and all its dependent resources have converged, the cluster should have an installed SDN plugin and a working service network. In OpenShift, the Cluster Network Operator runs very early in the install process -- while the boostrap API server is still running.
+When the controller has reconciled and all its dependent resources have converged, the cluster should have an installed network plugin and a working service network. In OpenShift, the Cluster Network Operator runs very early in the install process -- while the boostrap API server is still running.
 
 # Configuring
 The network operator gets its configuration from two objects: the Cluster and the Operator configuration. Most users only need to create the Cluster configuration - the operator will generate its configuration automatically. If you need finer-grained configuration of your network, you will need to create both configurations.
@@ -44,6 +44,8 @@ spec:
   - 172.30.0.0/16
 ```
 
+Alternatively, ovn-kubernetes can be configured by setting `networkType: OVNKubernetes`.
+
 *Corresponding Operator Config*
 This configuration is the auto-generated translation of the above Cluster configuration.
 ```yaml
@@ -62,8 +64,10 @@ spec:
   - 172.30.0.0/16
 ```
 
+(For ovn-kubernetes, `type: OVNKubernetes`.)
+
 ## Configuring IP address pools
-Users must supply at least two address pools - one for pods, and one for services. These are the ClusterNetwork and ServiceNetwork parameter. Some network plugins, such as OpenShiftSDN, support multiple ClusterNetworks. All address blocks must be non-overlapping. You should select address pools large enough to fit your anticipated workload.
+Users must supply at least two address pools - one for pods, and one for services. These are the ClusterNetwork and ServiceNetwork parameter. Some network plugins, such as OpenShiftSDN and OVNKubernetes, support multiple ClusterNetworks. All address blocks must be non-overlapping. You should select address pools large enough to fit your anticipated workload. Each pool must be able to hold 1 or more hostPrefix allocations.
 
 For future expansion, multiple `serviceNetwork` entries are allowed by the configuration but not actually supported by any network plugins. Supplying multiple addresses is invalid.
 
@@ -74,12 +78,12 @@ hostPrefix: 23
 ```
 means nodes would get blocks of size `/23`, or 512 addresses.
 
-IP address pools are always read from the Cluster configuration and propagated "downwards" in to the Operator configuration. Any changes to the Operator configuration will be ignored.
+IP address pools are always read from the Cluster configuration and propagated "downwards" into the Operator configuration. Any changes to the Operator configuration are ignored.
 
 Currently, changing the address pools once set is not supported. In the future, some network providers may support expanding the address pools.
 
 
-Example
+Example:
 ```yaml
 spec:
   serviceNetwork:
@@ -96,7 +100,7 @@ Users must select a default network provider. This cannot be changed. Different 
 
 The network type is always read from the Cluster configuration.
 
-Currently, the only understood value for network Type is `OpenShiftSDN`.
+Currently, the only understood values for network Type are `OpenShiftSDN` and `OVNKubernetes`.
 
 Other values are ignored. If you wish to use use a third-party network provider not managed by the operator, set the network type to something meaningful to you. The operator will not install or upgrade a network provider, but all other Network Operator functionality remains.
 
@@ -122,8 +126,30 @@ spec:
       useExternalOpenvswitch: false
 ```
 
+### Configuring OVNKubernetes
+OVNKubernetes supports the following configuration options, all of which are optional:
+* `MTU`: The MTU to use for the geneve overlay. The default is the MTU of the node that the cluster-network-operator is first run on, minus 100 bytes for geneve overhead. If the nodes in your cluster don't all have the same MTU then you may need to set this explicitly.
+
+These configuration flags are only in the Operator configuration object.
+
+Example:
+```yaml
+spec:
+  defaultNetwork:
+    type: OVNKubernetes
+    ovnKubernetesConfig:
+      mtu: 1400
+```
+
 ## Configuring kube-proxy
-Users may customize the kube-proxy configuration. None of these settings are required:
+Some plugins (like OpenShift SDN) have a built-in kube-proxy, some plugins require a standalone kube-proxy to be deployed, and some (like ovn-kubnernetes) don't use kube-proxy at all.
+
+The deployKubeProxy flag can be used to indicate whether CNO should deploy a standalone kube-proxy, but for supported network types, this will default to the correct value automatically.
+
+The configuration here can be used for third-party plugins with a separate kube-proxy process as well.
+
+For plugins that use kube-proxy (whether built-in or standalone), you can configure the proxy via kubeProxyConfig
+
 
 * `iptablesSyncPeriod`: The interval between periodic iptables refreshes. Default: 30 seconds. Increasing this can reduce the number of iptables invocations.
 * `bindAddress`: The address to "bind" to - the address for which traffic will be redirected.

--- a/bindata/network/ovn-kubernetes/000-ns.yaml
+++ b/bindata/network/ovn-kubernetes/000-ns.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  # NOTE: ovnkube.sh in the OVN image currently hardcodes this namespace name
+  name: openshift-ovn-kubernetes
+  labels:
+    openshift.io/run-level: "0"
+  annotations:
+    openshift.io/node-selector: "beta.kubernetes.io/os=linux"
+    openshift.io/description: "OVN Kubernetes components"

--- a/bindata/network/ovn-kubernetes/002-rbac.yaml
+++ b/bindata/network/ovn-kubernetes/002-rbac.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ovn-kubernetes-node
+  namespace: openshift-ovn-kubernetes
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openshift-ovn-kubernetes-node
+rules:
+- apiGroups: [""]
+  resources:
+  - endpoints
+  - namespaces
+  - nodes
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["extensions", "networking.k8s.io"]
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: [""]
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openshift-ovn-kubernetes-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-ovn-kubernetes-node
+subjects:
+- kind: ServiceAccount
+  name: ovn-kubernetes-node
+  namespace: openshift-ovn-kubernetes

--- a/bindata/network/ovn-kubernetes/003-rbac-controller.yaml
+++ b/bindata/network/ovn-kubernetes/003-rbac-controller.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ovn-kubernetes-controller
+  namespace: openshift-ovn-kubernetes
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openshift-ovn-kubernetes-controller
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - nodes
+  - pods
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups: [""]
+  resources:
+  - services
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["extensions", "networking.k8s.io"]
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: [""]
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openshift-ovn-kubernetes-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-ovn-kubernetes-controller
+subjects:
+- kind: ServiceAccount
+  name: ovn-kubernetes-controller
+  namespace: openshift-ovn-kubernetes

--- a/bindata/network/ovn-kubernetes/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/004-config.yaml
@@ -1,0 +1,11 @@
+---
+# The network cidr and service cidr are set in the ovn-config configmap
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ovn-config
+  namespace: openshift-ovn-kubernetes
+data:
+  net_cidr:   {{.OVN_cidr}}
+  svc_cidr:   {{.OVN_service_cidr}}
+  k8s_apiserver: "{{.K8S_APISERVER}}"

--- a/bindata/network/ovn-kubernetes/005-service.yaml
+++ b/bindata/network/ovn-kubernetes/005-service.yaml
@@ -1,0 +1,25 @@
+---
+# service to expose the ovn-master pod
+# at present ovn-master is limited to a single instance so
+# when the cluster has multiple masters we can get to the
+# ovn-master via this service.
+apiVersion: v1
+kind: Service
+metadata:
+  name: ovnkube-master
+  namespace: openshift-ovn-kubernetes
+spec:
+  ports:
+  - name: north
+    port: 6641
+    protocol: TCP
+    targetPort: 6641
+  - name: south
+    port: 6642
+    protocol: TCP
+    targetPort: 6642
+  sessionAffinity: None
+  clusterIP: None
+  type: ClusterIP
+  selector:
+    name: ovnkube-master

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -1,0 +1,303 @@
+# ovnkube-master
+# daemonset version 3
+# starts master daemons, each in a separate container
+# it is run on the master node(s)
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: ovnkube-master
+  # namespace set up by install
+  namespace: openshift-ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This daemonset launches the ovn-kubernetes controller (master) networking components.
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: ovnkube-master
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: ovnkube-master
+        component: network
+        type: infra
+        openshift.io/component: network
+        beta.kubernetes.io/os: "linux"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      # Requires fairly broad permissions - ability to read all services and network functions as well
+      # as all pods.
+      serviceAccountName: ovn-kubernetes-controller
+      hostNetwork: true
+      hostPID: true
+      containers:
+      # firewall rules for ovn - assumed to be setup
+      # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6641 -j ACCEPT
+      # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6642 -j ACCEPT
+      # ovs flow for ovn (geneve)
+      # /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol
+
+      # run-ovn-northd - v3
+      - name: run-ovn-northd
+        image: {{.OvnImage}}
+
+        command: ["/root/ovnkube.sh", "run-ovn-northd"]
+
+        volumeMounts:
+        # ovn db is stored in the pod in /etc/openvswitch (default ovs tool location)
+        # and on the host in /var/lib/openvswitch/
+        - mountPath: /etc/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /var/lib/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_LOG_NORTHD
+          value: "-vconsole:info"
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        ports:
+        - name: healthz
+          containerPort: 10257
+        # TODO: Temporarily disabled until we determine how to wait for clean default
+        # config
+        # livenessProbe:
+        #   initialDelaySeconds: 10
+        #   httpGet:
+        #     path: /healthz
+        #     port: 10257
+        #     scheme: HTTP
+        lifecycle:
+      # end of container
+
+      # nb-ovsdb - v3
+      - name: nb-ovsdb
+        image: {{.OvnImage}}
+
+        command: ["/root/ovnkube.sh", "nb-ovsdb"]
+
+        volumeMounts:
+        # ovn db is stored in the pod in /etc/openvswitch (default ovs tool location)
+        # and on the host in /var/lib/openvswitch/
+        - mountPath: /etc/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /var/lib/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_LOG_NB
+          value: "-vconsole:info -vfile:info"
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        ports:
+        - name: healthz
+          containerPort: 10256
+        # TODO: Temporarily disabled until we determine how to wait for clean default
+        # config
+        # livenessProbe:
+        #   initialDelaySeconds: 10
+        #   httpGet:
+        #     path: /healthz
+        #     port: 10256
+        #     scheme: HTTP
+        lifecycle:
+      # end of container
+
+      # sb-ovsdb - v3
+      - name: sb-ovsdb
+        image: {{.OvnImage}}
+
+        command: ["/root/ovnkube.sh", "sb-ovsdb"]
+
+        volumeMounts:
+        # ovn db is stored in the pod in /etc/openvswitch (default ovs tool location)
+        # and on the host in /var/lib/openvswitch/
+        - mountPath: /etc/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /var/lib/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/kubernetes/
+          name: host-var-run-kubernetes
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_LOG_SB
+          value: "-vconsole:info -vfile:info"
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        ports:
+        - name: healthz
+          containerPort: 10255
+        # TODO: Temporarily disabled until we determine how to wait for clean default
+        # config
+        # livenessProbe:
+        #   initialDelaySeconds: 10
+        #   httpGet:
+        #     path: /healthz
+        #     port: 10255
+        #     scheme: HTTP
+        lifecycle:
+      # end of container
+
+      - name: ovnkube-master
+        image: {{.OvnImage}}
+
+        command: ["/root/ovnkube.sh", "ovn-master"]
+
+        volumeMounts:
+        # ovn db is stored in the pod in /etc/openvswitch (default ovs tool location)
+        # and on the host in /var/lib/openvswitch/
+        - mountPath: /etc/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /var/lib/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/kubernetes/
+          name: host-var-run-kubernetes
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_MASTER
+          value: "true"
+        - name: OVNKUBE_LOGLEVEL
+          value: "4"
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        ports:
+        - name: healthz
+          containerPort: 10254
+        # TODO: Temporarily disabled until we determine how to wait for clean default
+        # config
+        # livenessProbe:
+        #   initialDelaySeconds: 10
+        #   httpGet:
+        #     path: /healthz
+        #     port: 10254
+        #     scheme: HTTP
+        lifecycle:
+      # end of container
+
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+        beta.kubernetes.io/os: "linux"
+      volumes:
+      - name: host-modules
+        hostPath:
+          path: /lib/modules
+      - name: host-var-lib-ovs
+        hostPath:
+          path: /var/lib/openvswitch
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+      - name: host-var-run-kubernetes
+        hostPath:
+          path: /var/run/kubernetes
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoSchedule"

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -1,0 +1,243 @@
+---
+# ovnkube-node
+# daemonset version 3
+# starts node daemons for ovs and ovn, each in a separate container
+# it is run on all nodes
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: ovnkube-node
+  # namespace set up by install
+  namespace: openshift-ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This daemonset launches the ovn-kubernetes per node networking components.
+spec:
+  selector:
+    matchLabels:
+      app: ovnkube-node
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: ovnkube-node
+        component: network
+        type: infra
+        openshift.io/component: network
+        beta.kubernetes.io/os: "linux"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      # Requires fairly broad permissions - ability to read all services and network functions as well
+      # as all pods.
+      serviceAccountName: ovn-kubernetes-node
+      hostNetwork: true
+      hostPID: true
+      containers:
+
+      # ovsdb-server and ovs-switchd daemons
+      - name: ovs-daemons
+        image: {{.OvnImage}}
+
+        command: ["/root/ovnkube.sh", "ovs-server"]
+
+        securityContext:
+          # Permission could be reduced by selecting an appropriate SELinux policy
+          privileged: true
+
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: host-modules
+          readOnly: true
+        - mountPath: /run/openvswitch
+          name: host-run-ovs
+        - mountPath: /var/run/openvswitch
+          name: host-var-run-ovs
+        - mountPath: /sys
+          name: host-sys
+          readOnly: true
+        - mountPath: /etc/openvswitch
+          name: host-config-openvswitch
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+
+
+      # firewall rules for ovn - assumed to be setup
+      # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6641 -j ACCEPT
+      # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6642 -j ACCEPT
+      # ovs flow for ovn (geneve)
+      # /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol
+      # The network container launches the ovn-k8s-cni-overlay process, the kube-proxy, and the local DNS service.
+      # It relies on an up to date node-config.yaml being present.
+      - name: ovn-controller
+        image: {{.OvnImage}}
+
+        command: ["/root/ovnkube.sh", "ovn-controller"]
+
+        securityContext:
+          # Permission could be reduced by selecting an appropriate SELinux policy
+          privileged: true
+
+        volumeMounts:
+        # Directory which contains the host configuration.
+        - mountPath: /var/lib/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        # CNI related mounts which we take over
+        - mountPath: /host/opt/cni/bin
+          name: host-opt-cni-bin
+        - mountPath: /etc/cni/net.d
+          name: host-etc-cni-netd
+        - mountPath: /var/lib/cni/networks/ovn-k8s-cni-overlay
+          name: host-var-lib-cni-networks-ovn-kubernetes
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVNKUBE_LOGLEVEL
+          value: "4"
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+
+        ports:
+        - name: healthz
+          containerPort: 10258
+        # TODO: Temporarily disabled until we determine how to wait for clean default
+        # config
+        # livenessProbe:
+        #   initialDelaySeconds: 10
+        #   httpGet:
+        #     path: /healthz
+        #     port: 10258
+        #     scheme: HTTP
+        lifecycle:
+
+      - name: ovn-node
+        image: {{.OvnImage}}
+
+        command: ["/root/ovnkube.sh", "ovn-node"]
+
+        securityContext:
+          # Permission could be reduced by selecting an appropriate SELinux policy
+          privileged: true
+
+        volumeMounts:
+        # Directory which contains the host configuration.
+        - mountPath: /var/lib/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        # CNI related mounts which we take over
+        - mountPath: /host/opt/cni/bin
+          name: host-opt-cni-bin
+        - mountPath: /etc/cni/net.d
+          name: host-etc-cni-netd
+        - mountPath: /var/lib/cni/networks/ovn-k8s-cni-overlay
+          name: host-var-lib-cni-networks-ovn-kubernetes
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVNKUBE_LOGLEVEL
+          value: "5"
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+
+        ports:
+        - name: healthz
+          containerPort: 10259
+        # TODO: Temporarily disabled until we determine how to wait for clean default
+        # config
+        # livenessProbe:
+        #   initialDelaySeconds: 10
+        #   httpGet:
+        #     path: /healthz
+        #     port: 10259
+        #     scheme: HTTP
+        lifecycle:
+
+      nodeSelector:
+        beta.kubernetes.io/os: "linux"
+      volumes:
+      # In bootstrap mode, the host config contains information not easily available
+      # from other locations.
+      - name: host-modules
+        hostPath:
+          path: /lib/modules
+
+      - name: host-var-lib-ovs
+        hostPath:
+          path: /var/lib/openvswitch
+      - name: host-run-ovs
+        hostPath:
+          path: /run/openvswitch
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+      - name: host-sys
+        hostPath:
+          path: /sys
+
+      - name: host-opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: host-etc-cni-netd
+        hostPath:
+          path: /etc/kubernetes/cni/net.d
+      - name: host-config-openvswitch
+        hostPath:
+          path: /etc/origin/openvswitch
+      - name: host-var-lib-cni-networks-ovn-kubernetes
+        hostPath:
+          path: /var/lib/cni/networks/ovn-k8s-cni-overlay
+      tolerations:
+      - operator: "Exists"

--- a/manifests/0000_07_cluster-network-operator_03_daemonset.yaml
+++ b/manifests/0000_07_cluster-network-operator_03_daemonset.yaml
@@ -41,6 +41,8 @@ spec:
           value: "quay.io/openshift/origin-sriov-cni:v4.0.0"
         - name: SRIOV_DEVICE_PLUGIN_IMAGE
           value: "quay.io/openshift/origin-sriov-network-device-plugin:v4.0.0"
+        - name: OVN_IMAGE
+          value: "quay.io/openshift/origin-ovn-kubernetes:v4.0.0"
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -34,3 +34,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-sriov-network-device-plugin:v4.0.0
+  - name: ovn-kubernetes
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-ovn-kubernetes:v4.0.0

--- a/pkg/network/cluster_config.go
+++ b/pkg/network/cluster_config.go
@@ -65,7 +65,7 @@ func ValidateClusterConfig(clusterConfig configv1.NetworkSpec) error {
 	return nil
 }
 
-// MergeClusterConfig merges the cluster configuration in to the real
+// MergeClusterConfig merges the cluster configuration into the real
 // CRD configuration.
 func MergeClusterConfig(operConf *operv1.NetworkSpec, clusterConf configv1.NetworkSpec) {
 	operConf.ServiceNetwork = clusterConf.ServiceNetwork
@@ -78,6 +78,7 @@ func MergeClusterConfig(operConf *operv1.NetworkSpec, clusterConf configv1.Netwo
 		})
 	}
 
+	// OpenShiftSDN (default), OVNKubenetes
 	operConf.DefaultNetwork.Type = operv1.NetworkType(clusterConf.NetworkType)
 }
 
@@ -111,6 +112,8 @@ func StatusFromOperatorConfig(operConf *operv1.NetworkSpec) configv1.NetworkStat
 	switch operConf.DefaultNetwork.Type {
 	case operv1.NetworkTypeOpenShiftSDN:
 		status.ClusterNetworkMTU = int(*operConf.DefaultNetwork.OpenShiftSDNConfig.MTU)
+	case operv1.NetworkTypeOVNKubernetes:
+		status.ClusterNetworkMTU = int(*operConf.DefaultNetwork.OVNKubernetesConfig.MTU)
 	}
 
 	return status

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -1,0 +1,118 @@
+package network
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+
+	"github.com/pkg/errors"
+
+	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	operv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/cluster-network-operator/pkg/render"
+)
+
+// renderOVNKubernetes returns the manifests for the ovn-kubernetes.
+// This creates
+// - the ClusterNetwork object
+// - the ovn-kubernetes namespace
+// - the ovn-kubeernetes setup
+// - the ovnkube-node daemonset
+// - the ovnkube-master deployment
+// and some other small things.
+func renderOVNKubernetes(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Unstructured, error) {
+	c := conf.DefaultNetwork.OVNKubernetesConfig
+
+	objs := []*uns.Unstructured{}
+
+	// render the manifests on disk
+	data := render.MakeRenderData()
+	data.Data["OvnImage"] = os.Getenv("OVN_IMAGE")
+	data.Data["HypershiftImage"] = os.Getenv("HYPERSHIFT_IMAGE")
+	data.Data["K8S_APISERVER"] = fmt.Sprintf("https://%s:%s", os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT"))
+	data.Data["MTU"] = c.MTU
+
+	var ippools string
+	for _, net := range conf.ClusterNetwork {
+		if len(ippools) != 0 {
+			ippools += ","
+		}
+		ippools += fmt.Sprintf("%s/%d", net.CIDR, net.HostPrefix)
+	}
+	data.Data["OVN_cidr"] = ippools
+
+	var svcpools string
+	for _, net := range conf.ServiceNetwork {
+		if len(svcpools) != 0 {
+			svcpools += ","
+		}
+		svcpools += fmt.Sprintf("%s", net)
+	}
+	data.Data["OVN_service_cidr"] = svcpools
+
+	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/ovn-kubernetes"), &data)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to render manifests")
+	}
+
+	objs = append(objs, manifests...)
+	return objs, nil
+}
+
+// validateOVNKubernetes checks that the ovn-kubernetes specific configuration
+// is basically sane.
+func validateOVNKubernetes(conf *operv1.NetworkSpec) []error {
+	out := []error{}
+
+	if len(conf.ClusterNetwork) == 0 {
+		out = append(out, errors.Errorf("ClusterNetworks cannot be empty"))
+	}
+	if len(conf.ServiceNetwork) != 1 {
+		out = append(out, errors.Errorf("ServiceNetwork must have exactly 1 entry"))
+	}
+
+	oc := conf.DefaultNetwork.OVNKubernetesConfig
+	if oc != nil {
+		if oc.MTU != nil && (*oc.MTU < 576 || *oc.MTU > 65536) {
+			out = append(out, errors.Errorf("invalid MTU %d", *oc.MTU))
+		}
+	}
+
+	return out
+}
+
+// isOVNKubernetesChangeSafe currently returns an error if any changes are made.
+// In the future, we may support rolling out MTU or other alterations.
+func isOVNKubernetesChangeSafe(prev, next *operv1.NetworkSpec) []error {
+	pn := prev.DefaultNetwork.OVNKubernetesConfig
+	nn := next.DefaultNetwork.OVNKubernetesConfig
+
+	if reflect.DeepEqual(pn, nn) {
+		return []error{}
+	}
+	return []error{errors.Errorf("cannot change ovn-kubernetes configuration")}
+}
+
+func fillOVNKubernetesDefaults(conf, previous *operv1.NetworkSpec, hostMTU int) {
+	if conf.DefaultNetwork.OVNKubernetesConfig == nil {
+		conf.DefaultNetwork.OVNKubernetesConfig = &operv1.OVNKubernetesConfig{}
+	}
+
+	sc := conf.DefaultNetwork.OVNKubernetesConfig
+	// MTU is currently the only field we pull from previous.
+	// If it's not supplied, we infer it from  the node on which we're running.
+	// However, this can never change, so we always prefer previous.
+	if sc.MTU == nil {
+		var mtu uint32 = uint32(hostMTU) - 100 // 100 byte geneve header
+		if previous != nil && previous.DefaultNetwork.OVNKubernetesConfig != nil {
+			mtu = *previous.DefaultNetwork.OVNKubernetesConfig.MTU
+		}
+		sc.MTU = &mtu
+	}
+}
+
+func networkPluginName() string {
+	return "ovn-kubernetes"
+}

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -1,0 +1,174 @@
+package network
+
+import (
+	"testing"
+
+	operv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/cluster-network-operator/pkg/apply"
+
+	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	. "github.com/onsi/gomega"
+)
+
+var OVNKubernetesConfig = operv1.Network{
+	Spec: operv1.NetworkSpec{
+		ServiceNetwork: []string{"172.30.0.0/16"},
+		ClusterNetwork: []operv1.ClusterNetworkEntry{
+			{
+				CIDR:       "10.128.0.0/15",
+				HostPrefix: 23,
+			},
+			{
+				CIDR:       "10.0.0.0/14",
+				HostPrefix: 24,
+			},
+		},
+		DefaultNetwork: operv1.DefaultNetworkDefinition{
+			Type:                operv1.NetworkTypeOVNKubernetes,
+			OVNKubernetesConfig: &operv1.OVNKubernetesConfig{},
+		},
+	},
+}
+
+var manifestDirOvn = "../../bindata"
+
+// TestRenderOVNKubernetes has some simple rendering tests
+func TestRenderOVNKubernetes(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	crd := OVNKubernetesConfig.DeepCopy()
+	config := &crd.Spec
+
+	errs := validateOVNKubernetes(config)
+	g.Expect(errs).To(HaveLen(0))
+	FillDefaults(config, nil)
+
+	// enable openvswitch
+	objs, err := renderOVNKubernetes(config, manifestDirOvn)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-ovn-kubernetes", "ovnkube-node")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("Deployment", "openshift-ovn-kubernetes", "ovnkube-master")))
+
+	// It's important that the namespace is first
+	g.Expect(objs[0]).To(HaveKubernetesID("Namespace", "", "openshift-ovn-kubernetes"))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "openshift-ovn-kubernetes-node")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "openshift-ovn-kubernetes-controller")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ServiceAccount", "openshift-ovn-kubernetes", "ovn-kubernetes-node")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ServiceAccount", "openshift-ovn-kubernetes", "ovn-kubernetes-controller")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRoleBinding", "", "openshift-ovn-kubernetes-node")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("Deployment", "openshift-ovn-kubernetes", "ovnkube-master")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-ovn-kubernetes", "ovnkube-node")))
+
+	// make sure all deployments are in the master
+	for _, obj := range objs {
+		if obj.GetKind() != "Deployment" {
+			continue
+		}
+
+		sel, found, err := uns.NestedStringMap(obj.Object, "spec", "template", "spec", "nodeSelector")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(found).To(BeTrue())
+
+		_, ok := sel["node-role.kubernetes.io/master"]
+		g.Expect(ok).To(BeTrue())
+	}
+
+	// Make sure every obj is reasonable:
+	// - it is supported
+	// - it reconciles to itself (steady state)
+	for _, obj := range objs {
+		g.Expect(apply.IsObjectSupported(obj)).NotTo(HaveOccurred())
+		cur := obj.DeepCopy()
+		upd := obj.DeepCopy()
+
+		err = apply.MergeObjectForUpdate(cur, upd)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		tweakMetaForCompare(cur)
+		g.Expect(cur).To(Equal(upd))
+	}
+}
+
+func TestFillOVNKubernetesDefaults(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	crd := OVNKubernetesConfig.DeepCopy()
+	conf := &crd.Spec
+	conf.DefaultNetwork.OVNKubernetesConfig = nil
+
+	// vars
+	m := uint32(8900)
+
+	expected := operv1.NetworkSpec{
+		ServiceNetwork: []string{"172.30.0.0/16"},
+		ClusterNetwork: []operv1.ClusterNetworkEntry{
+			{
+				CIDR:       "10.128.0.0/15",
+				HostPrefix: 23,
+			},
+			{
+				CIDR:       "10.0.0.0/14",
+				HostPrefix: 24,
+			},
+		},
+		DefaultNetwork: operv1.DefaultNetworkDefinition{
+			Type: operv1.NetworkTypeOVNKubernetes,
+			OVNKubernetesConfig: &operv1.OVNKubernetesConfig{
+				MTU: &m,
+			},
+		},
+	}
+
+	fillOVNKubernetesDefaults(conf, nil, 9000)
+
+	g.Expect(conf).To(Equal(&expected))
+
+}
+
+func TestValidateOVNKubernetes(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	crd := OVNKubernetesConfig.DeepCopy()
+	config := &crd.Spec
+	ovnConfig := config.DefaultNetwork.OVNKubernetesConfig
+
+	err := validateOVNKubernetes(config)
+	g.Expect(err).To(BeEmpty())
+	FillDefaults(config, nil)
+
+	errExpect := func(substr string) {
+		t.Helper()
+		g.Expect(validateOVNKubernetes(config)).To(
+			ContainElement(MatchError(
+				ContainSubstring(substr))))
+	}
+
+	// set mtu to insanity
+	mtu := uint32(70000)
+	ovnConfig.MTU = &mtu
+	errExpect("invalid MTU 70000")
+
+	config.ClusterNetwork = nil
+	errExpect("ClusterNetworks cannot be empty")
+}
+
+func TestOVNKubernetesIsSafe(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	prev := OVNKubernetesConfig.Spec.DeepCopy()
+	FillDefaults(prev, nil)
+	next := OVNKubernetesConfig.Spec.DeepCopy()
+	FillDefaults(next, nil)
+
+	errs := isOVNKubernetesChangeSafe(prev, next)
+	g.Expect(errs).To(BeEmpty())
+
+	// change the mtu
+	mtu := uint32(70000)
+	next.DefaultNetwork.OVNKubernetesConfig.MTU = &mtu
+	errs = isOVNKubernetesChangeSafe(prev, next)
+	g.Expect(errs).To(HaveLen(1))
+
+	g.Expect(errs[0]).To(MatchError("cannot change ovn-kubernetes configuration"))
+}

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -200,6 +200,8 @@ func ValidateDefaultNetwork(conf *operv1.NetworkSpec) []error {
 	switch conf.DefaultNetwork.Type {
 	case operv1.NetworkTypeOpenShiftSDN:
 		return validateOpenShiftSDN(conf)
+	case operv1.NetworkTypeOVNKubernetes:
+		return validateOVNKubernetes(conf)
 	default:
 		return nil
 	}
@@ -216,6 +218,8 @@ func RenderDefaultNetwork(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.
 	switch dn.Type {
 	case operv1.NetworkTypeOpenShiftSDN:
 		return renderOpenShiftSDN(conf, manifestDir)
+	case operv1.NetworkTypeOVNKubernetes:
+		return renderOVNKubernetes(conf, manifestDir)
 	default:
 		log.Printf("NOTICE: Unknown network type %s, ignoring", dn.Type)
 		return nil, nil
@@ -227,6 +231,8 @@ func FillDefaultNetworkDefaults(conf, previous *operv1.NetworkSpec, hostMTU int)
 	switch conf.DefaultNetwork.Type {
 	case operv1.NetworkTypeOpenShiftSDN:
 		fillOpenShiftSDNDefaults(conf, previous, hostMTU)
+	case operv1.NetworkTypeOVNKubernetes:
+		fillOVNKubernetesDefaults(conf, previous, hostMTU)
 	default:
 	}
 }
@@ -239,6 +245,8 @@ func IsDefaultNetworkChangeSafe(prev, next *operv1.NetworkSpec) []error {
 	switch prev.DefaultNetwork.Type {
 	case operv1.NetworkTypeOpenShiftSDN:
 		return isOpenShiftSDNChangeSafe(prev, next)
+	case operv1.NetworkTypeOVNKubernetes:
+		return isOVNKubernetesChangeSafe(prev, next)
 	default:
 		return nil
 	}


### PR DESCRIPTION
This sets up the structural support for ovn-kubernetes overlay networks.
This is very early, lots more changes in the works.
It supplies pkg/network/{ovn_kubernetes.go,}

And modifies pkg/network/{cluster_config.go,render.go} to reference ovn

It supplies the needed bindata/network/ovn-kubernetes/ files.

The operator comes up and creates the ovn environment
