### PR TITLE
Remove invalid replicas 1 in daemonset in openshift-sdn/controller.yaml

### DIFF
--- a/bindata/network/openshift-sdn/controller.yaml
+++ b/bindata/network/openshift-sdn/controller.yaml
@@ -20,7 +20,6 @@ metadata:
   labels:
     app: sdn-controller
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: sdn-controller


### PR DESCRIPTION
Even though daemonset does allow `replicas`,
`bindata/network/openshift-sdn/controller.yaml` set the value.

This patch removes `replicas: 1` from `openshift-sdn/controller.yaml`.

Fixes https://github.com/openshift/cluster-network-operator/issues/61