### PR TITLE
openshift-sdn: EgressNetworkPolicy is namespaced

### DIFF
--- a/bindata/network/openshift-sdn/001-crd.yaml
+++ b/bindata/network/openshift-sdn/001-crd.yaml
@@ -157,7 +157,7 @@ metadata:
 spec:
   group: network.openshift.io
   version: v1
-  scope: Cluster
+  scope: Namespaced
   names:
     kind: EgressNetworkPolicy
     singular: egressnetworkpolicy


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1661983