### PR TITLE
Update namespace/pods to current naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ It is safe to edit the following fields in `NetworkConfig.Spec`:
 Administrators may wish to forcefully apply a disruptive change to a cluster that is not serving production traffic. To do this, first they should make the desired configuration change to the CRD. Then, delete the network operator's understanding of the state of the system:
 
 ```
-oc -n openshift-cluster-network-operator delete configmap applied-default
+oc -n openshift-network-operator delete configmap applied-default
 ```
 
 Be warned: this is an unsafe operation! It may cause the entire cluster to lose connectivity or even be permanently broken. For example, changing the ServiceNetwork will cause existing services to be unreachable, as their ServiceIP won't be reassigned.
@@ -219,7 +219,7 @@ Note that, like all operators installed by the Cluster Version Operator, it dete
 
 You can determine the current values of these environment variables by inspecting the valid deployed daemonset. Do this before you delete it...
 ```sh
-oc get -n openshift-cluster-network-operator daemonset cluster-network-operator -ojsonpath='{range .spec.template.spec.containers[0].env[?(@.value)]}{.name}{"="}{.value}{" "}' | tee images
+oc get -n openshift-network-operator daemonset cluster-network-operator -ojsonpath='{range .spec.template.spec.containers[0].env[?(@.value)]}{.name}{"="}{.value}{" "}' | tee images
 ```
 
 After stopping the deployed operator (see below), you can run the operator locally with
@@ -234,7 +234,7 @@ To do this, just scale the CVO down to 0 replicas and delete the network-operato
 
 ```sh
 oc scale --replicas 0 -n openshift-cluster-version deployments/cluster-version-operator
-oc delete -n openshift-cluster-network-operator daemonset cluster-network-operator 
+oc delete -n openshift-network-operator daemonset cluster-network-operator
 ```
 
 ## Building images

--- a/manifests/0000_07_cluster-network-operator_00_namespace.yaml
+++ b/manifests/0000_07_cluster-network-operator_00_namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: openshift-cluster-network-operator
+  name: openshift-network-operator
   labels:
-    name: openshift-cluster-network-operator
+    name: openshift-network-operator
     openshift.io/run-level: "0"

--- a/manifests/0000_07_cluster-network-operator_02_rbac.yaml
+++ b/manifests/0000_07_cluster-network-operator_02_rbac.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: openshift-cluster-network-operator
+  namespace: openshift-network-operator
 roleRef:
   kind: ClusterRole
   name: cluster-admin

--- a/manifests/0000_07_cluster-network-operator_03_daemonset.yaml
+++ b/manifests/0000_07_cluster-network-operator_03_daemonset.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: cluster-network-operator
-  namespace: openshift-cluster-network-operator
+  name: network-operator
+  namespace: openshift-network-operator
   labels:
-    k8s-app: cluster-network-operator
+    name: network-operator
 spec:
   selector:
     matchLabels:
-      k8s-app: cluster-network-operator
+      name: network-operator
   template:
     metadata:
       labels:
-        k8s-app: cluster-network-operator
+        name: network-operator
     spec:
       containers:
-      - name: cluster-network-operator
+      - name: network-operator
         image: docker.io/openshift/origin-cluster-network-operator:v4.0.0
         command:
         - "/usr/bin/cluster-network-operator"

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -17,4 +17,4 @@ const APPLIED_PREFIX = "applied-"
 // APPLIED_NAMESPACE is the namespace where applied configuration
 // configmaps are stored.
 // Should match 00_namespace.yaml
-const APPLIED_NAMESPACE = "openshift-cluster-network-operator"
+const APPLIED_NAMESPACE = "openshift-network-operator"


### PR DESCRIPTION
We currently run pods called `cluster-network-operator-xxxxx` in a namespace called `openshift-cluster-network-operator`, but current naming conventions would prefer `network-operator-xxxxx` and `openshift-network-operator`, respectively.

Not sure if there are other things we need to change too?
