### PR TITLE
openshift-sdn, manifests: capture last few log lines as our TerminationMessage

### DIFF
--- a/bindata/network/openshift-sdn/controller.yaml
+++ b/bindata/network/openshift-sdn/controller.yaml
@@ -49,6 +49,7 @@ spec:
           value: "{{.KUBERNETES_SERVICE_PORT}}"
         - name: KUBERNETES_SERVICE_HOST # allows the controller to communicate with apiserver directly on same host.
           value: "{{.KUBERNETES_SERVICE_HOST}}"
+        terminationMessagePolicy: FallbackToLogsOnError
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -99,6 +99,7 @@ spec:
           requests:
             cpu: 100m
             memory: 300Mi
+        terminationMessagePolicy: FallbackToLogsOnError
       nodeSelector:
         beta.kubernetes.io/os: linux
       volumes:

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -131,6 +131,7 @@ spec:
         ports:
         - name: healthz
           containerPort: 10256
+        terminationMessagePolicy: FallbackToLogsOnError
       nodeSelector:
         beta.kubernetes.io/os: linux
       volumes:

--- a/manifests/0000_07_cluster-network-operator_03_daemonset.yaml
+++ b/manifests/0000_07_cluster-network-operator_03_daemonset.yaml
@@ -33,6 +33,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: host-kubeconfig


### PR DESCRIPTION
This can be useful when we have the Pod but not its logs.

Thanks @deads2k for the suggestion.