### PR TITLE
fix OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,12 @@
 reviewers:
-  - JacobTanenbaum
-  - pecameron
-
-approvers:
-  - squeed
-  - dcbw
   - danwinship
+  - dcbw
+  - JacobTanenbaum
   - knobunc
+  - pecameron
+  - squeed
+approvers:
+  - danwinship
+  - dcbw
+  - knobunc
+  - squeed


### PR DESCRIPTION
So I had noticed that for some reason, the bot *always* assigns @JacobTanenbaum and @pecameron to review cluster-network-operator PRs, and apparently this is because they're the only people listed as reviewers in the OWNERS file... ("approvers" aren't automatically assumed to be "reviewers" too)

also, alphabetization!