### PR TITLE
Add openAPIV3Schema to operator config type

### DIFF
--- a/manifests/0000_07_cluster-network-operator_01_crd.yaml
+++ b/manifests/0000_07_cluster-network-operator_01_crd.yaml
@@ -14,6 +14,87 @@ spec:
     - name: v1
       served: true
       storage: true
+  validation:
+    # Ensure we will be able to deserialize the object into the golang type
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          required: ["clusterNetworks", "serviceNetwork", "defaultNetwork"]
+          properties:
+            clusterNetworks:
+              type: array
+              items:
+                type: object
+                required: ["cidr", "hostSubnetLength"]
+                properties:
+                  cidr:
+                    type: string
+                  hostSubnetLength:
+                    type: integer
+                    minimum: 0
+            serviceNetwork:
+              type: string
+            defaultNetwork:
+              type: object
+              required: ["type"]
+              properties:
+                type:
+                  type: string
+                openshiftSDNConfig:
+                  type: object
+                  required: ["mode"]
+                  properties:
+                    mode:
+                      type: string
+                    vxlanPort:
+                      type: integer
+                      minimum: 0
+                    mtu:
+                      type: integer
+                      minimum: 0
+                    useExternalOpenvswitch:
+                      type: boolean
+                ovnKubernetesConfig:
+                  type: object
+                  properties:
+                    genevePort:
+                      type: integer
+                      minimum: 0
+                    mtu:
+                      type: integer
+                      minimum: 0
+                otherConfig:
+                  type: object
+            additionalNetworks:
+              type: array
+              items:
+                type: object
+                required: ["type", "name", "rawCNIConfig"]
+                properties:
+                  type:
+                    type: string
+                  name:
+                    type: string
+                  rawCNIConfig:
+                    type: string
+            deployKubeProxy:
+              type: boolean
+            kubeProxyConfig:
+              type: object
+              properties:
+                iptablesSyncPeriod:
+                  type: string
+                bindAddress:
+                  type: string
+                proxyArguments:
+                  type: object
+                  additionalProperties:
+                    type: array
+                    items:
+                      type: string
+        status:
+          type: object
 
 ---
 


### PR DESCRIPTION
The controller-runtime code gets very angry if one of the objects it's watching can't be deserialized into the expected golang type.

For the cluster config, we can fix this using the new CRD validation hack in origin, but for the network config that's not the greatest idea, since then origin would have to vendor cluster-network-operator to get the type, and then we'd have to coordinate changes between the two repos whenever we changed anything.

Instead, we can use OpenAPI validation to ensure that objects will only be accepted by the apiserver if they are at least close-enough-to-valid that we'll be able to deserialize them. (Eg, you don't have a string where an integer is supposed to be.)

This is based on the current definition of the struct but maybe we should remove the unsupported bits (OVN, Kuryr) until the code to deal with them has landed?

Fixes half of #69