### PR TITLE
A ovs process gets killed when oom-killer is invoked

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -72,13 +72,8 @@ spec:
           /usr/share/openvswitch/scripts/ovs-ctl start --no-ovsdb-server --system-id=random
 
           tail --follow=name /var/log/openvswitch/ovs-vswitchd.log /var/log/openvswitch/ovsdb-server.log &
-          sleep 20
           while true; do
-            if ! /usr/share/openvswitch/scripts/ovs-ctl status &>/dev/null; then
-              echo "OVS seems to have crashed, exiting"
-              quit
-            fi
-            sleep 15
+            sleep 10000
           done
         securityContext:
           privileged: true
@@ -97,9 +92,16 @@ spec:
           name: host-config-openvswitch
         resources:
           requests:
-            cpu: 100m
-            memory: 300Mi
+            cpu: 200m
+            memory: 400Mi
         terminationMessagePolicy: FallbackToLogsOnError
+        livenessProbe:
+          exec:
+            command:
+            - /usr/share/openvswitch/scripts/ovs-ctl
+            - status
+          initialDelaySeconds: 15
+          periodSeconds: 5
       nodeSelector:
         beta.kubernetes.io/os: linux
       volumes:


### PR DESCRIPTION
Changes from 3.9 to 3.10 now has OVS running in a pod. There must be
sufficient memory or the OOM killer will be invoked. This change adds a
liveness probe that checks the process is running. Also, resource limits
are relaxed a little.

bug 1671822
https://bugzilla.redhat.com/show_bug.cgi?id=1671822
clone of bug 1669311
https://bugzilla.redhat.com/show_bug.cgi?id=1669311

Signed-off-by: Phil Cameron <pcameron@redhat.com>