### PR TITLE
openshift-sdn: join control plane namespaces so multitenant works in 4+

### DIFF
--- a/bindata/network/openshift-sdn/004-multitenant.yaml
+++ b/bindata/network/openshift-sdn/004-multitenant.yaml
@@ -1,0 +1,75 @@
+{{if eq .Mode "Multitenant"}}
+# Namespaces which must be reachable to all pods, or can reach all pods
+# - openshift-dns
+# - openshift-ingress
+# - openshift-monitoring
+# - openshift-kube-apiserver
+# - openshift-operator-lifecycle-manager
+# - openshift-image-registry
+apiVersion: network.openshift.io/v1
+kind: NetNamespace
+metadata:
+  name: openshift-dns
+netid: 0
+netname: openshift-dns
+
+---
+apiVersion: network.openshift.io/v1
+kind: NetNamespace
+metadata:
+  name: openshift-ingress
+netid: 0
+netname: openshift-ingress
+
+---
+apiVersion: network.openshift.io/v1
+kind: NetNamespace
+metadata:
+  name: openshift-monitoring
+netid: 0
+netname: openshift-monitoring
+
+---
+apiVersion: network.openshift.io/v1
+kind: NetNamespace
+metadata:
+  name: openshift-kube-apiserver
+netid: 0
+netname: openshift-kube-apiserver
+
+---
+apiVersion: network.openshift.io/v1
+kind: NetNamespace
+metadata:
+  name: openshift-operator-lifecycle-manager
+netid: 0
+netname: openshift-operator-lifecycle-manager
+
+---
+apiVersion: network.openshift.io/v1
+kind: NetNamespace
+metadata:
+  name: openshift-image-registry
+netid: 0
+netname: openshift-image-registry
+
+---
+# Namespaces which are part of the "control plane" and need to reach each other:
+# - kube-system (etcd)
+# - openshift-apiserver
+apiVersion: network.openshift.io/v1
+kind: NetNamespace
+metadata:
+  name: openshift-apiserver
+netid: 1
+netname: openshift-apiserver
+
+---
+apiVersion: network.openshift.io/v1
+kind: NetNamespace
+metadata:
+  name: kube-system
+netid: 1
+netname: kube-system
+
+{{- end}}

--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -38,6 +38,7 @@ func renderOpenShiftSDN(conf *netv1.NetworkConfigSpec, manifestDir string) ([]*u
 	data.Data["HypershiftImage"] = os.Getenv("HYPERSHIFT_IMAGE")
 	data.Data["KUBERNETES_SERVICE_HOST"] = os.Getenv("KUBERNETES_SERVICE_HOST")
 	data.Data["KUBERNETES_SERVICE_PORT"] = os.Getenv("KUBERNETES_SERVICE_PORT")
+	data.Data["Mode"] = c.Mode
 
 	operCfg, err := controllerConfig(conf)
 	if err != nil {

--- a/pkg/network/openshift_sdn_test.go
+++ b/pkg/network/openshift_sdn_test.go
@@ -72,6 +72,9 @@ func TestRenderOpenShiftSDN(t *testing.T) {
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-sdn", "sdn")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-sdn", "sdn-controller")))
 
+	// No netnamespaces by default
+	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("NetNamespace", "", "openshift-ingress")))
+
 	// make sure all deployments are in the master
 	for _, obj := range objs {
 		if obj.GetKind() != "Deployment" {
@@ -263,4 +266,32 @@ func TestOpenShiftSDNIsSafe(t *testing.T) {
 	errs = isOpenShiftSDNChangeSafe(prev, next)
 	g.Expect(errs).To(HaveLen(1))
 	g.Expect(errs[0]).To(MatchError("cannot change openshift-sdn configuration"))
+}
+
+func TestOpenShiftSDNMultitenant(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	crd := OpenShiftSDNConfig.DeepCopy()
+	config := &crd.Spec
+	FillDefaults(config, nil)
+	config.DefaultNetwork.OpenShiftSDNConfig.Mode = "Multitenant"
+
+	objs, err := renderOpenShiftSDN(config, manifestDir)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// the full list of namespaces with a netns
+	netNS := []string{
+		"openshift-dns",
+		"openshift-ingress",
+		"openshift-monitoring",
+		"openshift-kube-apiserver",
+		"openshift-apiserver",
+		"kube-system",
+		"openshift-operator-lifecycle-manager",
+		"openshift-image-registry",
+	}
+
+	for _, ns := range netNS {
+		g.Expect(objs).To(ContainElement(HaveKubernetesID("NetNamespace", "", ns)))
+	}
 }


### PR DESCRIPTION
This groups control-plane namespaces in to three groups:

- VNID 0 (default, can access and be accessed by all)
  - openshift-kube-apiserver
  - openshift-dns
  - openshift-ingress
  - openshift-monitoring
  - openshift-operator-lifecycle-manager
  - openshift-image-registry

- VNID 1 (control plane)
  - openshift-apiserver
  - kube-system (etcd)

And all others will have their own isolated network.

Fixes SDN-284 / BZ 1659376