### PR TITLE
cluster config controller: fix nil dereference

### DIFF
--- a/pkg/controller/clusterconfig/clusterconfig_controller.go
+++ b/pkg/controller/clusterconfig/clusterconfig_controller.go
@@ -115,8 +115,9 @@ func (r *ReconcileClusterConfig) Reconcile(request reconcile.Request) (reconcile
 			r.status.SetConfigFailing("ApplyClusterConfig", err)
 			return reconcile.Result{}, err
 		}
+
+		log.Printf("successfully updated ClusterNetwork (%s) %s/%s", operatorConfig.GroupVersionKind(), operatorConfig.GetNamespace(), operatorConfig.GetName())
 	}
 
-	log.Printf("successfully updated ClusterNetwork (%s) %s/%s", operatorConfig.GroupVersionKind(), operatorConfig.GetNamespace(), operatorConfig.GetName())
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
The offending line was added in a spree of new logging, oops.