### PR TITLE
Allow DefaultNetwork.Type to have arbitrary values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,10 @@ Users must select a default network provider. This cannot be changed. Different 
 
 The network type is always read from the Cluster configuration.
 
-Currently, the only supported value for network Type is `OpenShiftSDN`.
+Currently, the only understood value for network Type is `OpenShiftSDN`.
+
+Other values are ignored. If you wish to use use a third-party network provider not managed by the operator, set the network type to something meaningful to you. The operator will not install or upgrade a network provider, but all other Network Operator functionality remains.
+
 
 ### Configuring OpenShiftSDN
 OpenShiftSDN supports the following configuration options, all of which are optional:

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -140,7 +140,7 @@ func ValidateDefaultNetwork(conf *netv1.NetworkConfigSpec) []error {
 	case netv1.NetworkTypeOpenShiftSDN, netv1.NetworkTypeDeprecatedOpenshiftSDN:
 		return validateOpenShiftSDN(conf)
 	default:
-		return []error{errors.Errorf("unknown or unsupported NetworkType: %s", conf.DefaultNetwork.Type)}
+		return nil
 	}
 }
 
@@ -155,9 +155,10 @@ func RenderDefaultNetwork(conf *netv1.NetworkConfigSpec, manifestDir string) ([]
 	switch dn.Type {
 	case netv1.NetworkTypeOpenShiftSDN, netv1.NetworkTypeDeprecatedOpenshiftSDN:
 		return renderOpenShiftSDN(conf, manifestDir)
+	default:
+		log.Printf("NOTICE: Unknown network type %s, ignoring", dn.Type)
+		return nil, nil
 	}
-
-	return nil, errors.Errorf("unknown or unsupported NetworkType: %s", dn.Type)
 }
 
 // FillDefaultNetworkDefaults
@@ -166,8 +167,6 @@ func FillDefaultNetworkDefaults(conf, previous *netv1.NetworkConfigSpec, hostMTU
 	case netv1.NetworkTypeOpenShiftSDN, netv1.NetworkTypeDeprecatedOpenshiftSDN:
 		fillOpenShiftSDNDefaults(conf, previous, hostMTU)
 	default:
-		// This case has already been excluded by Validate
-		panic("invalid network")
 	}
 }
 
@@ -179,8 +178,8 @@ func IsDefaultNetworkChangeSafe(prev, next *netv1.NetworkConfigSpec) []error {
 	switch prev.DefaultNetwork.Type {
 	case netv1.NetworkTypeOpenShiftSDN, netv1.NetworkTypeDeprecatedOpenshiftSDN:
 		return isOpenShiftSDNChangeSafe(prev, next)
-	default: // should be unreachable
-		return []error{errors.Errorf("unknown network type %s", prev.DefaultNetwork.Type)}
+	default:
+		return nil
 	}
 }
 

--- a/pkg/network/render_test.go
+++ b/pkg/network/render_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+
+	netv1 "github.com/openshift/cluster-network-operator/pkg/apis/networkoperator/v1"
 )
 
 func TestIsChangeSafe(t *testing.T) {
@@ -32,4 +34,49 @@ func TestIsChangeSafe(t *testing.T) {
 	next.DefaultNetwork.Type = "Kuryr"
 	err = IsChangeSafe(prev, next)
 	g.Expect(err).To(MatchError(ContainSubstring("cannot change default network type")))
+}
+
+func TestRenderUnknownNetwork(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	config := netv1.NetworkConfig{
+		Spec: netv1.NetworkConfigSpec{
+			ServiceNetwork: "172.30.0.0/16",
+			ClusterNetworks: []netv1.ClusterNetwork{
+				{
+					CIDR:             "10.128.0.0/15",
+					HostSubnetLength: 9,
+				},
+				{
+					CIDR:             "10.0.0.0/14",
+					HostSubnetLength: 8,
+				},
+			},
+			DefaultNetwork: netv1.DefaultNetworkDefinition{
+				Type: "MyAwesomeThirdPartyPlugin",
+			},
+		},
+	}
+
+	err := Validate(&config.Spec)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	prev := config.Spec.DeepCopy()
+	FillDefaults(prev, nil)
+	next := config.Spec.DeepCopy()
+	FillDefaults(next, nil)
+
+	err = IsChangeSafe(prev, next)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	objs, err := Render(prev, manifestDir)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Validate that openshift-sdn isn't rendered
+	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("DaemonSet", "openshift-sdn", "ovs")))
+
+	// validate that Multus is still rendered
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "multus")))
+
+	// TODO(cdc) validate that kube-proxy is rendered
 }


### PR DESCRIPTION
The intention is for users of third-party network plugins to still be able to set their network type.