### PR TITLE
configure endpoints to expose openshift-sdn metrics to Prometheus

### DIFF
--- a/bindata/network/openshift-sdn/000-ns.yaml
+++ b/bindata/network/openshift-sdn/000-ns.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     name: openshift-sdn
     openshift.io/run-level: "0"
+    openshift.io/cluster-monitoring: "true"
   annotations:
     openshift.io/node-selector: "" #override default node selector
     openshift.io/description: "OpenShift SDN components"

--- a/bindata/network/openshift-sdn/monitor.yaml
+++ b/bindata/network/openshift-sdn/monitor.yaml
@@ -1,0 +1,70 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: sdn
+  annotations:
+    networkoperator.openshift.io/ignore-errors: ""
+  name: monitor-sdn
+  namespace: openshift-sdn
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+  jobLabel: app
+  namespaceSelector:
+    matchNames:
+    - openshift-sdn
+  selector:
+    matchLabels:
+      app: sdn
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: sdn
+  name: sdn
+  namespace: openshift-sdn
+spec:
+  selector:
+    app: sdn
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: 9101
+    protocol: TCP
+    targetPort: 9101
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-sdn
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-sdn
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/pkg/controller/networkconfig/networkconfig_controller.go
+++ b/pkg/controller/networkconfig/networkconfig_controller.go
@@ -209,6 +209,15 @@ func (r *ReconcileNetworkConfig) Reconcile(request reconcile.Request) (reconcile
 		if err := apply.ApplyObject(context.TODO(), r.client, obj); err != nil {
 			err = errors.Wrapf(err, "could not apply (%s) %s/%s", obj.GroupVersionKind(), obj.GetNamespace(), obj.GetName())
 			log.Println(err)
+
+			// Ignore errors if we've asked to do so.
+			anno := obj.GetAnnotations()
+			if anno != nil {
+				if _, ok := anno[names.IgnoreObjectErrorAnnotation]; ok {
+					log.Println("Object has ignore-errors annotation set, continuing")
+					continue
+				}
+			}
 			r.status.SetConfigFailing("ApplyOperatorConfig", err)
 			return reconcile.Result{}, err
 		}

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -18,3 +18,8 @@ const APPLIED_PREFIX = "applied-"
 // configmaps are stored.
 // Should match 00_namespace.yaml
 const APPLIED_NAMESPACE = "openshift-network-operator"
+
+// IgnoreObjectErrorAnnotation is an annotation we can set on objects
+// to signal to the reconciler that we don't care if they fail to create
+// or update. Useful when we want to make a CR for which the CRD may not exist yet.
+const IgnoreObjectErrorAnnotation = "networkoperator.openshift.io/ignore-errors"

--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -117,6 +117,14 @@ func fillOpenShiftSDNDefaults(conf, previous *netv1.NetworkConfigSpec, hostMTU i
 		conf.DefaultNetwork.OpenShiftSDNConfig = &netv1.OpenShiftSDNConfig{}
 	}
 
+	if conf.KubeProxyConfig.ProxyArguments == nil {
+		conf.KubeProxyConfig.ProxyArguments = map[string][]string{}
+	}
+
+	if conf.KubeProxyConfig.ProxyArguments["metrics-bind-address"] == nil  {
+		conf.KubeProxyConfig.ProxyArguments["metrics-bind-address"] = []string{"0.0.0.0:9101"}
+	}
+
 	sc := conf.DefaultNetwork.OpenShiftSDNConfig
 	if sc.VXLANPort == nil {
 		var port uint32 = 4789

--- a/pkg/network/openshift_sdn_test.go
+++ b/pkg/network/openshift_sdn_test.go
@@ -137,6 +137,7 @@ func TestFillOpenShiftSDNDefaults(t *testing.T) {
 		DeployKubeProxy: &f,
 		KubeProxyConfig: &netv1.ProxyConfig{
 			BindAddress: "0.0.0.0",
+			ProxyArguments: map[string][]string{"metrics-bind-address": []string{"0.0.0.0:9101"}},
 		},
 	}
 


### PR DESCRIPTION
Add the required service, serviceMonitor, role, and rolebinding to allow Prometheus
to scrape the metrics that the sdn provides