### PR TITLE
bindata: use system-node-critical priority

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -20,12 +20,11 @@ spec:
         component: network
         type: infra
         openshift.io/component: network
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       serviceAccountName: sdn #needed to run privileged pods; not used for api access
       hostNetwork: true
       hostPID: true
+      priorityClassName: system-node-critical
       containers:
       - name: openvswitch
         image: {{.NodeImage}}

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -29,14 +29,13 @@ spec:
         component: network
         type: infra
         openshift.io/component: network
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       # Requires fairly broad permissions - ability to read all services and network functions as well
       # as all pods.
       serviceAccountName: sdn
       hostNetwork: true
       hostPID: true
+      priorityClassName: system-node-critical
       containers:
       - name: sdn
         image: {{.NodeImage}}


### PR DESCRIPTION
This in combination with https://github.com/openshift/origin/pull/21978 should help avoid OOM of sdn and ovs pods

xref https://github.com/openshift/cluster-network-operator/pull/80

@derekwaynecarr @danwinship @dcbw @squeed