### PR TITLE
controller: allow objects to signify errors should be ignored.

### DIFF
--- a/pkg/controller/networkconfig/networkconfig_controller.go
+++ b/pkg/controller/networkconfig/networkconfig_controller.go
@@ -209,6 +209,15 @@ func (r *ReconcileNetworkConfig) Reconcile(request reconcile.Request) (reconcile
 		if err := apply.ApplyObject(context.TODO(), r.client, obj); err != nil {
 			err = errors.Wrapf(err, "could not apply (%s) %s/%s", obj.GroupVersionKind(), obj.GetNamespace(), obj.GetName())
 			log.Println(err)
+
+			// Ignore errors if we've asked to do so.
+			anno := obj.GetAnnotations()
+			if anno != nil {
+				if _, ok := anno[names.IgnoreObjectErrorAnnotation]; ok {
+					log.Println("Object has ignore-errors annotation set, continuing")
+					continue
+				}
+			}
 			r.status.SetConfigFailing("ApplyOperatorConfig", err)
 			return reconcile.Result{}, err
 		}

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -18,3 +18,8 @@ const APPLIED_PREFIX = "applied-"
 // configmaps are stored.
 // Should match 00_namespace.yaml
 const APPLIED_NAMESPACE = "openshift-network-operator"
+
+// IgnoreObjectErrorAnnotation is an annotation we can set on objects
+// to signal to the reconciler that we don't care if they fail to create
+// or update. Useful when we want to make a CR for which the CRD may not exist yet.
+const IgnoreObjectErrorAnnotation = "networkoperator.openshift.io/ignore-errors"


### PR DESCRIPTION
This is most useful when we want to create an instance of a CRD, but the definition itself may not yet exist. We shouldn't necessarily ignore that in all cases, but it's useful for non-critical objects.