### PR TITLE
hack: add a development way to run the operator as part of the installer

### DIFF
--- a/INSTALLER-HACKING.md
+++ b/INSTALLER-HACKING.md
@@ -1,0 +1,61 @@
+# Running local builds with the installer
+
+If you want to run a local build with the installer, you need to do a bit of hacking. There is a script that will do most of the dirty work for you. It will modify the installer so the network operator doesn't run, and spin up a local copy of the network operator.
+
+This requires `oc` and `kubectl` in your $PATH.
+
+## Steps
+
+You will need to execute all steps for every installation, since the installer deletes the intermediate files we customize.
+
+1. In one window, prepare the cluster:
+
+```
+export CLUSTER_DIR=<your cluster directory>
+openshift-install --dir=$CLUSTER_DIR create manifests
+```
+
+2. In another window, prepare the operator. This will apply some overrides that disable the default cluster-network-operator. It will also extract the release image.
+
+```
+export CLUSTER_DIR=<your cluster directory>
+hack/run-locally.sh prepare
+hack/build-go.sh
+```
+
+3. Optionally, override image references. If you are doing downstream image development, e.g. working on openshift-sdn, you should build, publish, and edit `$CLUSTER_DIR/env.sh` to point to your development image.
+
+4. In the installer window, create the cluster *and move on to the next step*
+
+```
+openshift-install --dir=$CLUSTER_DIR create cluster
+```
+
+5. In the operator window, *while the installer is running*, launch the operator locally
+```
+hack/run-locally.sh start
+```
+
+
+## Tips, Tricks, & Limitations
+
+### Cleaning up
+After destroying your cluster, you should delete your `$CLUSTER_DIR`.
+
+If you're using libvirt, you can use `./scripts/maintenance/virsh-cleanup.sh` in the installer repository to quickly delete the virtual machines instead of waiting for Terraform.
+
+### RBAC
+This runs the operator with the `admin` role, so it will have full permissions. When run by the real installer, this will not be the case. Created objects, e.g. DaemonSets, will still have RBAC, though.
+
+### Saving install-config between runs
+If you're sick of answering all the questions over and over, you can shortcut the installer. Just do
+```
+openshift-install --dir=$CLUSTER_DIR create install-config
+cp $CLUSTER_DIR/install-config.yaml ~/.cache/openshift-install/install-config.yaml
+```
+
+Then, for subsequent installer runs, you can do
+```
+rm -r $CLUSTER_DIR; mkdir -p $CLUSTER_DIR
+cp ~/.cache/openshift-install/install-config.yaml $CLUSTER_DIR/
+```

--- a/README.md
+++ b/README.md
@@ -216,6 +216,9 @@ _output/linux/amd64/cluster-network-renderer --config sample-config.yaml --out o
 ```
 
 ## Running manually against a test cluster
+
+If you want to run the operator as part of an installer run, see INSTALLER-HACKING.md.
+
 If you have a running cluster, you can run the operator locally against that cluster. Just set the `KUBECONFIG` environment variable.
 
 In addition to `KUBECONFIG`, you will also need to set several other variables:

--- a/hack/null-kubeconfig
+++ b/hack/null-kubeconfig
@@ -1,0 +1,4 @@
+# Needed for one run-locally command
+clusters:
+- cluster:
+    server: http://localhost

--- a/hack/overrides-patch.yaml
+++ b/hack/overrides-patch.yaml
@@ -1,0 +1,10 @@
+- op: add
+  path: /spec/overrides
+  value: []
+- op: add
+  path: /spec/overrides/-
+  value:
+    kind: Deployment
+    name: network-operator
+    namespace: openshift-network-operator
+    unmanaged: true

--- a/hack/run-locally.sh
+++ b/hack/run-locally.sh
@@ -1,0 +1,107 @@
+#!/bin/bash 
+
+# run-locally.sh is some scaffolding around running a local instance of the
+# network operator with the installer.
+# See INSTALLER-HACKING.md
+
+set -o errexit
+set -o nounset
+
+# Install our overrides so the cluster doesn't run the network operator.
+function override() {
+    if [[ ! -e ${CLUSTER_DIR}/manifests/cvo-overrides.yaml ]]; then
+        echo "cannot find cvo-overrides.yaml; please run"
+        echo "openshift-install --dir=${CLUSTER_DIR} create manifests"
+        exit 1
+    fi
+
+    # Patch the CVO to not create the network operator
+    echo "Applying overrides to ${CLUSTER_DIR}/manifests/cvo-overrides.yaml"
+
+    kubectl --kubeconfig=hack/null-kubeconfig patch --type=json --local=true -f=${CLUSTER_DIR}/manifests/cvo-overrides.yaml -p "$(cat hack/overrides-patch.yaml)" -o yaml > ${CLUSTER_DIR}/manifests/.cvo-overrides.yaml.new
+
+    mv ${CLUSTER_DIR}/manifests/.cvo-overrides.yaml.new ${CLUSTER_DIR}/manifests/cvo-overrides.yaml
+}
+
+# Extract the image references from the release image.
+function build_env() {
+    echo "Writing image references to ${CLUSTER_DIR}/env.sh"
+    oc --kubeconfig=hack/null-kubeconfig convert --local=true -f manifests/0000_07_cluster-network-operator_03_daemonset.yaml -ojsonpath='{range .spec.template.spec.containers[0].env[?(@.value)]}{.name}{"="}{.value}{"\n"}' > ${CLUSTER_DIR}/env.sh
+}
+
+# start_operator waits for the cluster to come up, then launches
+# the operator locally.
+function start_operator() {
+    export KUBECONFIG=${CLUSTER_DIR}/auth/kubeconfig
+
+    echo "Waiting for $KUBECONFIG"
+    while true; do 
+        if [[ ! -e ${KUBECONFIG} ]]; then
+            sleep 10
+        else
+            break
+        fi
+    done
+
+    # A few environment variables we set in the Daemonset
+    export POD_NAME=LOCAL
+    export KUBERNETES_SERVICE_PORT=6443
+    export KUBERNETES_SERVICE_HOST=$(oc config view -o jsonpath='{.clusters[0].cluster.server}' | awk -F'[/:]' '{print $4}')
+
+    echo "Waiting for the apiserver to come up and for the network configuration to be rceated."
+    echo "You can ignore the error message 'error: the server doesn't have a resource type \"Network\"'"
+
+    while true; do 
+        if oc get Network.config.openshift.io cluster; then
+            echo "Network config exists, continuing"
+            break
+        else
+            echo "No network config or apiserver not up yet, retrying"
+            sleep 15
+            continue
+        fi
+    done
+    echo "Starting operator"
+    env $(cat ${CLUSTER_DIR}/env.sh) _output/linux/amd64/cluster-network-operator
+}
+
+function usage() {
+    >&2 echo "Usage: $0 (prepare|start)
+
+Scaffoding for running a local build of the network operator with the installer.
+For more info, see INSTALLER-HACKING.md
+
+Commands:
+- prepare: adds overrides to prevent the default network operator from starting, extracts image references
+- start: Starts the local network operator
+
+Required environment variables:
+CLUSTER_DIR - The state directory used by the installer.
+"
+}
+
+if [[ -z "${CLUSTER_DIR:-}" ]]; then
+    echo error: CLUSTER_DIR is required
+    echo
+    usage
+    exit 1
+fi
+
+case "${1:-""}" in
+    prepare)
+        override;
+        build_env;
+        ;;
+    start)
+        if [[ ! -e ${CLUSTER_DIR}/env.sh ]]; then
+            echo "env.sh missing, run prepare first"
+            exit 1
+        fi
+
+        start_operator ${CLUSTER_DIR};
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
This is a stupid way to tell the installer not to run the network operator, and let us run it manually as part of the install process.