### PR TITLE
Add priorityClass to sdn-controller

### DIFF
--- a/bindata/network/openshift-sdn/controller.yaml
+++ b/bindata/network/openshift-sdn/controller.yaml
@@ -28,6 +28,7 @@ spec:
       labels:
         app: sdn-controller
     spec:
+      priorityClassName: system-node-critical
       containers:
       - name: sdn-controller
         image: {{.HypershiftImage}}


### PR DESCRIPTION
Add `system-node-critical` priorityClass to ensure that these DS pods won't be evicted by default scheduler.