### PR TITLE
Report version number from payload "when we hit level"

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     kubernetes.io/description: |
       This daemon set launches the Multus networking component on each node.
+    release.openshift.io/version: "{{.ReleaseVersion}}"
 spec:
   selector:
     matchLabels:

--- a/bindata/network/openshift-sdn/controller.yaml
+++ b/bindata/network/openshift-sdn/controller.yaml
@@ -17,6 +17,7 @@ metadata:
   annotations:
     kubernetes.io/description: |
       This deployment runs the openshift SDN networking controller.
+    release.openshift.io/version: "{{.ReleaseVersion}}"
   labels:
     app: sdn-controller
 spec:

--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     kubernetes.io/description: |
       This daemon set launches the Open vSwitch daemon.
+    release.openshift.io/version: "{{.ReleaseVersion}}"
 spec:
   selector:
     matchLabels:

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -16,6 +16,7 @@ metadata:
     kubernetes.io/description: |
       This daemon set launches the OpenShift networking components (kube-proxy and openshift-sdn).
       It expects that OVS is running on the node.
+    release.openshift.io/version: "{{.ReleaseVersion}}"
 spec:
   selector:
     matchLabels:

--- a/manifests/0000_07_cluster-network-operator_03_daemonset.yaml
+++ b/manifests/0000_07_cluster-network-operator_03_daemonset.yaml
@@ -25,6 +25,8 @@ spec:
             cpu: 10m
             memory: 50Mi
         env:
+        - name: RELEASE_VERSION
+          value: "0.0.1-snapshot"
         - name: NODE_IMAGE
           value: "docker.io/openshift/origin-node:v4.0.0"
         - name: HYPERSHIFT_IMAGE

--- a/manifests/0000_07_cluster-network-operator_04_clusteroperator.yaml
+++ b/manifests/0000_07_cluster-network-operator_04_clusteroperator.yaml
@@ -2,3 +2,7 @@ apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: network
+status:
+  versions:
+  - name: operator
+    version: "0.0.1-snapshot"

--- a/pkg/controller/statusmanager/status_manager_test.go
+++ b/pkg/controller/statusmanager/status_manager_test.go
@@ -76,7 +76,7 @@ func TestStatusManager_set(t *testing.T) {
 		Reason:  "Reason",
 		Message: "Message",
 	}
-	status.Set(condFail)
+	status.Set(false, condFail)
 
 	co, err = getCO(client, "testing")
 	if err != nil {
@@ -90,7 +90,7 @@ func TestStatusManager_set(t *testing.T) {
 		Type:   configv1.OperatorProgressing,
 		Status: configv1.ConditionTrue,
 	}
-	status.Set(condProgress)
+	status.Set(false, condProgress)
 
 	co, err = getCO(client, "testing")
 	if err != nil {
@@ -104,7 +104,7 @@ func TestStatusManager_set(t *testing.T) {
 		Type:   configv1.OperatorFailing,
 		Status: configv1.ConditionFalse,
 	}
-	status.Set(condNoFail)
+	status.Set(false, condNoFail)
 
 	co, err = getCO(client, "testing")
 	if err != nil {
@@ -122,7 +122,7 @@ func TestStatusManager_set(t *testing.T) {
 		Type:   configv1.OperatorAvailable,
 		Status: configv1.ConditionTrue,
 	}
-	status.Set(condNoProgress, condAvailable)
+	status.Set(false, condNoProgress, condAvailable)
 
 	co, err = getCO(client, "testing")
 	if err != nil {

--- a/pkg/network/multus.go
+++ b/pkg/network/multus.go
@@ -1,11 +1,12 @@
 package network
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/openshift/cluster-network-operator/pkg/render"
 	"github.com/pkg/errors"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"os"
-	"path/filepath"
 )
 
 // renderMultusConfig returns the manifests of Multus
@@ -14,6 +15,7 @@ func renderMultusConfig(manifestDir string) ([]*uns.Unstructured, error) {
 
 	// render the manifests on disk
 	data := render.MakeRenderData()
+	data.Data["ReleaseVersion"] = os.Getenv("RELEASE_VERSION")
 	data.Data["MultusImage"] = os.Getenv("MULTUS_IMAGE")
 	data.Data["CNIPluginsSupportedImage"] = os.Getenv("CNI_PLUGINS_SUPPORTED_IMAGE")
 	data.Data["CNIPluginsUnsupportedImage"] = os.Getenv("CNI_PLUGINS_UNSUPPORTED_IMAGE")

--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -34,6 +34,7 @@ func renderOpenShiftSDN(conf *netv1.NetworkConfigSpec, manifestDir string) ([]*u
 
 	// render the manifests on disk
 	data := render.MakeRenderData()
+	data.Data["ReleaseVersion"] = os.Getenv("RELEASE_VERSION")
 	data.Data["InstallOVS"] = (c.UseExternalOpenvswitch == nil || *c.UseExternalOpenvswitch == false)
 	data.Data["NodeImage"] = os.Getenv("NODE_IMAGE")
 	data.Data["HypershiftImage"] = os.Getenv("HYPERSHIFT_IMAGE")


### PR DESCRIPTION
As part of closing out cluster operators they must report when they
reach "level" - have rolled out the code in the update. For the network
operator that involves ensuring all the daemonsets and deployments
have the latest code deployed, and then reporting the current
controller release version via cluster operator status.

Related to https://github.com/openshift/cluster-image-registry-operator/pull/219

Needs a bump to vendor and updates to the cluster operator conditions
coming from @danwinship