### PR TITLE
manifests: ensure system priorities

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -25,6 +25,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/os: linux
+      priorityClassName: "system-node-critical"
       tolerations:
       - operator: Exists
       serviceAccountName: multus

--- a/bindata/network/openshift-sdn/controller.yaml
+++ b/bindata/network/openshift-sdn/controller.yaml
@@ -53,6 +53,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       restartPolicy: Always
       serviceAccountName: sdn-controller
       securityContext:

--- a/manifests/0000_07_cluster-network-operator_03_daemonset.yaml
+++ b/manifests/0000_07_cluster-network-operator_03_daemonset.yaml
@@ -47,6 +47,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       volumes:
         - name: host-kubeconfig
           hostPath:


### PR DESCRIPTION
blocks passing smoke tests for ensuring control plane pods always schedule.

see: openshift/origin#22217