### PR TITLE
Fix build on non-Linux by not trying to guess the default MTU

### DIFF
--- a/pkg/network/mtu.go
+++ b/pkg/network/mtu.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package network
 
 import (

--- a/pkg/network/mtu_unsupported.go
+++ b/pkg/network/mtu_unsupported.go
@@ -1,0 +1,5 @@
+// +build !linux
+
+package network
+
+func GetDefaultMTU() (int, error) { return 1500, nil }


### PR DESCRIPTION
Split out of #110 (and with the default fixed from 1400 to 1500) since the rest of #110 is going to get absorbed into another PR.

(See also #113, but this fix is still needed to make it easier for non-Linux-users to send us bugfixes.)
