### PR TITLE
New namespaces for Service Catalog

### DIFF
--- a/bindata/network/openshift-sdn/004-multitenant.yaml
+++ b/bindata/network/openshift-sdn/004-multitenant.yaml
@@ -57,10 +57,10 @@ netname: openshift-image-registry
 # Namespaces which are part of the "control plane" and need to reach each other:
 # - kube-system (etcd)
 # - openshift-apiserver
-# - kube-service-catalog
+# - openshift-service-catalog-apiserver
+# - openshift-service-catalog-controller-manager
 # - openshift-template-service-broker
 # - openshift-ansible-service-broker
-# - kube-service-catalog-controller-manager
 apiVersion: network.openshift.io/v1
 kind: NetNamespace
 metadata:
@@ -80,9 +80,9 @@ netname: kube-system
 apiVersion: network.openshift.io/v1
 kind: NetNamespace
 metadata:
-  name: kube-service-catalog
+  name: openshift-service-catalog-apiserver
 netid: 1
-netname: kube-service-catalog
+netname: openshift-service-catalog-apiserver
 
 ---
 apiVersion: network.openshift.io/v1
@@ -104,8 +104,8 @@ netname: openshift-ansible-service-broker
 apiVersion: network.openshift.io/v1
 kind: NetNamespace
 metadata:
-  name: kube-service-catalog-controller-manager
+  name: openshift-service-catalog-controller-manager
 netid: 1
-netname: kube-service-catalog-controller-manager
+netname: openshift-service-catalog-controller-manager
 
 {{- end}}


### PR DESCRIPTION
A recent requirement hit Service Catalog to set the priorityClassName to "system-cluster-critical" which in turn required changing the namespaces for Service Catalog.  See associated Service Catalog updates:  

https://github.com/openshift/cluster-svcat-apiserver-operator/pull/37
https://github.com/openshift/cluster-svcat-controller-manager-operator/pull/24

This PR updates the namespaces in the multi tenant netid mappings.
