### PR TITLE
Adds parameter to set multus log level to verbose in multus.yaml

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -57,6 +57,7 @@ spec:
         - "--multus-conf-file=auto"
         - "--multus-kubeconfig-file-host=/etc/kubernetes/cni/net.d/multus.d/multus.kubeconfig"
         - "--namespace-isolation=true"
+        - "--multus-log-level=verbose"
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
This requires that this pull request is merged first: https://github.com/openshift/multus-cni/pull/7/files

If this gets merged before that pull request -- Multus may fail to come up due to the fact that previous versions did not support unknown parameters (that will be mitigated in the future by changes within the referenced PR)