### PR TITLE
Remove networks.config.openshift.io which is already instantiated by cluster-config-operator

### DIFF
--- a/manifests/0000_07_cluster-network-operator_01_crd.yaml
+++ b/manifests/0000_07_cluster-network-operator_01_crd.yaml
@@ -95,21 +95,3 @@ spec:
         status:
           type: object
 
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: networks.config.openshift.io
-spec:
-  group: config.openshift.io
-  names:
-    kind: Network
-    listKind: NetworkList
-    plural: networks
-    singular: network
-  scope: Cluster
-  versions:
-  - name: v1
-    served: true
-    storage: true


### PR DESCRIPTION
Namely this is the place https://github.com/openshift/cluster-config-operator/blob/master/manifests/0000_05_config-operator_01_network.crd.yaml and that is guaranteed to be instantiated before you run your operator. 