### PR TITLE
specify the same location for the openshift-sdn binary

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -76,7 +76,7 @@ spec:
           cp -Rf /opt/cni/bin/* /host/opt/cni/bin/
 
           # Launch the network process
-          exec /bin/openshift-sdn --config=/config/sdn-config.yaml  --url-only-kubeconfig=/etc/kubernetes/kubeconfig --loglevel=${DEBUG_LOGLEVEL:-2}
+          exec /usr/bin/openshift-sdn --config=/config/sdn-config.yaml  --url-only-kubeconfig=/etc/kubernetes/kubeconfig --loglevel=${DEBUG_LOGLEVEL:-2}
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
RHEL7 unifies /usr/bin and /bin but we should refer to the location of the openshift-sdn binary as the same place even though the two are functionally equivalent