### PR TITLE
DHCP Daemon

### DIFF
--- a/bindata/network/multus/003-dhcp-daemon.yaml
+++ b/bindata/network/multus/003-dhcp-daemon.yaml
@@ -1,0 +1,62 @@
+{{if .RenderDHCP}}
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: dhcp-daemon
+  namespace: openshift-multus
+  annotations:
+    kubernetes.io/description: |
+      This daemon set launches the containernetworking plugins DHCP daemon on each node.
+    release.openshift.io/version: "{{.ReleaseVersion}}"
+spec:
+  selector:
+    matchLabels:
+      app: dhcp-daemon
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: dhcp-daemon
+        component: network
+        type: infra
+        openshift.io/component: network
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      tolerations:
+      - operator: Exists
+      initContainers:
+      - name: dhcp-daemon-initialization
+        image: {{.CNIPluginsSupportedImage}}
+        command: ["/bin/sh"]
+        args: ["-c", "rm -f /var/run/cni/dhcp.sock"]
+        volumeMounts:
+        - name: socketpath
+          mountPath: /var/run/cni
+      containers:
+      - name: dhcp-daemon
+        # Based on: https://github.com/s1061123/cni-dhcp-daemon/blob/master/Dockerfile
+        image: {{.CNIPluginsSupportedImage}}
+        imagePullPolicy: Always
+        command: ["/usr/src/plugins/bin/dhcp"]
+        args:
+        - "daemon"
+        - "-hostprefix"
+        - "/host"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: socketpath
+          mountPath: /var/run/cni
+        - name: procpath
+          mountPath: /host/proc
+      volumes:
+        - name: socketpath
+          hostPath:
+            path: /var/run/cni
+        - name: procpath
+          hostPath:
+            path: /proc
+{{- end}}

--- a/pkg/network/dhcp_daemon.go
+++ b/pkg/network/dhcp_daemon.go
@@ -1,0 +1,63 @@
+package network
+
+import (
+	"encoding/json"
+	operv1 "github.com/openshift/api/operator/v1"
+	"log"
+)
+
+// UseDHCP determines if the the DHCP CNI plugin running as a daemon should be rendered.
+func UseDHCP(conf *operv1.NetworkSpec) bool {
+	renderdhcp := false
+
+	// This isn't useful without Multinetwork.
+	if *conf.DisableMultiNetwork {
+		return renderdhcp
+	}
+
+	// Look and see if we have an AdditionalNetworks
+	if conf.AdditionalNetworks != nil {
+		for _, addnet := range conf.AdditionalNetworks {
+			// Parse the RawCNIConfig
+			var rawConfig map[string]interface{}
+			var err error
+
+			confBytes := []byte(addnet.RawCNIConfig)
+			err = json.Unmarshal(confBytes, &rawConfig)
+			if err != nil {
+				log.Printf("WARNING: Not rendering DHCP daemonset, failed to Unmarshal RawCNIConfig: %v", confBytes)
+				return renderdhcp
+			}
+
+			// Cycle through the IPAM keys, and determine if the type is dhcp
+			if rawConfig["ipam"] != nil {
+				ipam, okipamcast := rawConfig["ipam"].(map[string]interface{})
+				if !okipamcast {
+					log.Printf("WARNING: IPAM element has data of type %T but wanted map[string]interface{}", rawConfig["ipam"])
+					continue
+				}
+
+				for key, value := range ipam {
+					if key == "type" {
+						typeval, oktypecast := value.(string)
+						if !oktypecast {
+							log.Printf("WARNING: IPAM type element has data of type %T but wanted string", value)
+							break
+						}
+
+						if typeval == "dhcp" {
+							renderdhcp = true
+							break
+						}
+					}
+				}
+			}
+
+			if renderdhcp == true {
+				break
+			}
+		}
+	}
+
+	return renderdhcp
+}

--- a/pkg/network/dhcp_daemon_test.go
+++ b/pkg/network/dhcp_daemon_test.go
@@ -1,0 +1,118 @@
+package network
+
+import (
+	. "github.com/onsi/gomega"
+	operv1 "github.com/openshift/api/operator/v1"
+	"testing"
+)
+
+var NoDHCPConfig = operv1.Network{
+	Spec: operv1.NetworkSpec{
+		AdditionalNetworks: []operv1.AdditionalNetworkDefinition{
+			{Type: operv1.NetworkTypeRaw, Name: "net-attach-1", RawCNIConfig: "{}"},
+			{Type: operv1.NetworkTypeRaw, Name: "net-attach-2", RawCNIConfig: "{}"},
+		},
+		ServiceNetwork: []string{"172.30.0.0/16"},
+		ClusterNetwork: []operv1.ClusterNetworkEntry{
+			{
+				CIDR:       "10.128.0.0/15",
+				HostPrefix: 23,
+			},
+		},
+		DefaultNetwork: operv1.DefaultNetworkDefinition{
+			Type: operv1.NetworkTypeOpenShiftSDN,
+			OpenShiftSDNConfig: &operv1.OpenShiftSDNConfig{
+				Mode: operv1.SDNModeNetworkPolicy,
+			},
+		},
+	},
+}
+
+var DHCPConfig = operv1.Network{
+	Spec: operv1.NetworkSpec{
+		AdditionalNetworks: []operv1.AdditionalNetworkDefinition{
+			{
+				Type:         operv1.NetworkTypeRaw,
+				Name:         "net-attach-dhcp",
+				RawCNIConfig: "{\"cniVersion\":\"0.3.0\",\"type\":\"macvlan\",\"master\":\"eth0\",\"mode\":\"bridge\",\"ipam\":{\"type\":\"dhcp\"}}",
+			},
+		},
+		ServiceNetwork: []string{"172.30.0.0/16"},
+		ClusterNetwork: []operv1.ClusterNetworkEntry{
+			{
+				CIDR:       "10.128.0.0/15",
+				HostPrefix: 23,
+			},
+		},
+		DefaultNetwork: operv1.DefaultNetworkDefinition{
+			Type: operv1.NetworkTypeOpenShiftSDN,
+			OpenShiftSDNConfig: &operv1.OpenShiftSDNConfig{
+				Mode: operv1.SDNModeNetworkPolicy,
+			},
+		},
+	},
+}
+
+var InvalidDHCPConfig = operv1.Network{
+	Spec: operv1.NetworkSpec{
+		AdditionalNetworks: []operv1.AdditionalNetworkDefinition{
+			{
+				Type:         operv1.NetworkTypeRaw,
+				Name:         "net-attach-dhcp",
+				RawCNIConfig: "{\"cniVersion\":\"0.3.0\",\"type\":\"macvlan\",\"master\":\"eth0\",\"mode\":\"bridge\",\"ipam\":\"invalid\"}",
+			},
+		},
+		ServiceNetwork: []string{"172.30.0.0/16"},
+		ClusterNetwork: []operv1.ClusterNetworkEntry{
+			{
+				CIDR:       "10.128.0.0/15",
+				HostPrefix: 23,
+			},
+		},
+		DefaultNetwork: operv1.DefaultNetworkDefinition{
+			Type: operv1.NetworkTypeOpenShiftSDN,
+			OpenShiftSDNConfig: &operv1.OpenShiftSDNConfig{
+				Mode: operv1.SDNModeNetworkPolicy,
+			},
+		},
+	},
+}
+
+// TestRenderWithDHCP tests a rendering with the DHCP daemonset.
+func TestRenderWithDHCP(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	crd := DHCPConfig.DeepCopy()
+	config := &crd.Spec
+	FillDefaults(config, nil)
+
+	objs, err := RenderMultus(config, manifestDir)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "dhcp-daemon")))
+}
+
+// TestRenderNoDHCP tests a rendering WITHOUT the DHCP daemonset.
+func TestRenderNoDHCP(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	crd := NoDHCPConfig.DeepCopy()
+	config := &crd.Spec
+	FillDefaults(config, nil)
+
+	objs, err := RenderMultus(config, manifestDir)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "dhcp-daemon")))
+}
+
+// TestRenderInvalidDHCP tests a rendering with the DHCP daemonset.
+func TestRenderInvalidDHCP(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	crd := InvalidDHCPConfig.DeepCopy()
+	config := &crd.Spec
+	FillDefaults(config, nil)
+
+	objs, err := RenderMultus(config, manifestDir)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "dhcp-daemon")))
+}

--- a/pkg/network/multus.go
+++ b/pkg/network/multus.go
@@ -10,7 +10,7 @@ import (
 )
 
 // renderMultusConfig returns the manifests of Multus
-func renderMultusConfig(manifestDir string) ([]*uns.Unstructured, error) {
+func renderMultusConfig(manifestDir string, useDHCP bool) ([]*uns.Unstructured, error) {
 	objs := []*uns.Unstructured{}
 
 	// render the manifests on disk
@@ -19,6 +19,7 @@ func renderMultusConfig(manifestDir string) ([]*uns.Unstructured, error) {
 	data.Data["MultusImage"] = os.Getenv("MULTUS_IMAGE")
 	data.Data["CNIPluginsSupportedImage"] = os.Getenv("CNI_PLUGINS_SUPPORTED_IMAGE")
 	data.Data["CNIPluginsUnsupportedImage"] = os.Getenv("CNI_PLUGINS_UNSUPPORTED_IMAGE")
+	data.Data["RenderDHCP"] = useDHCP
 
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/multus"), &data)
 	if err != nil {

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -311,7 +311,8 @@ func RenderMultus(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Unstruct
 	}
 	out = append(out, objs...)
 
-	objs, err = renderMultusConfig(manifestDir)
+	usedhcp := UseDHCP(conf)
+	objs, err = renderMultusConfig(manifestDir, usedhcp)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adds rendering, bindata & unit tests for the containernetworking/plugins DHCP CNI plugin running as a daemon.

Currently has no dependency on the macvlan functionality, however, it anticipates it with a commented-out `TODO` block.