### PR TITLE
Remove hardcoded 'amd64' from Dockerfile to support multi-arch builds.

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,11 +1,14 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-network-operator
 COPY . .
-RUN hack/build-go.sh
+RUN hack/build-go.sh; \
+    mkdir -p /tmp/build; \
+    cp /go/src/github.com/openshift/cluster-network-operator/_output/linux/$(go env GOARCH)/cluster-network-operator /tmp/build/; \
+    cp /go/src/github.com/openshift/cluster-network-operator/_output/linux/$(go env GOARCH)/cluster-network-renderer /tmp/build/
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
-COPY --from=builder /go/src/github.com/openshift/cluster-network-operator/_output/linux/amd64/cluster-network-operator /usr/bin/
-COPY --from=builder /go/src/github.com/openshift/cluster-network-operator/_output/linux/amd64/cluster-network-renderer /usr/bin/
+COPY --from=builder /tmp/build/cluster-network-operator /usr/bin/
+COPY --from=builder /tmp/build/cluster-network-renderer /usr/bin/
 COPY manifests /manifests
 COPY bindata /bindata
 ENV OPERATOR_NAME=cluster-network-operator


### PR DESCRIPTION
Remove hardcoded 'amd64' from Dockerfile to support multi-arch builds.