### PR TITLE
fix mount path for sriov device plugin socket

### DIFF
--- a/bindata/network/additional-networks/sriov/sriov-device-plugin.yaml
+++ b/bindata/network/additional-networks/sriov/sriov-device-plugin.yaml
@@ -38,7 +38,7 @@ spec:
           privileged: true
         volumeMounts:
         - name: devicesock
-          mountPath: /var/lib/kubelet/device-plugins/
+          mountPath: /var/lib/kubelet/
           readOnly: false
         - name: net
           mountPath: /sys/class/net
@@ -46,7 +46,7 @@ spec:
       volumes:
         - name: devicesock
           hostPath:
-            path: /var/lib/kubelet/device-plugins/
+            path: /var/lib/kubelet/
         - name: net
           hostPath:
             path: /sys/class/net


### PR DESCRIPTION
Kubernetes 1.13 supports(GA) a new plugin registration
path {kubelet_root_dir}/plugins_registry, but it also
maintains backward compat for old registration path at
{kubelet_root_dir}/device-plugins; This change allows
both pathes be mounted to sriov device plugin daemonset.