### PR TITLE
Call syncFailing on SetNotFailing method

### DIFF
--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -144,8 +144,8 @@ func (status *StatusManager) SetFailing(level StatusLevel, reason, message strin
 func (status *StatusManager) SetNotFailing(level StatusLevel) {
 	if status.failing[level] != nil {
 		status.failing[level] = nil
-		status.syncFailing()
 	}
+	status.syncFailing()
 }
 
 func (status *StatusManager) SetDaemonSets(daemonSets []types.NamespacedName) {


### PR DESCRIPTION
We should also need to call syncFailing in case level is nil.

Signed-off-by: Ricardo Carrillo Cruz <ricardo.carrillo.cruz@gmail.com>