### PR TITLE
Remove /etc/cni/net.d/ file when plugin is down

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -48,7 +48,7 @@ spec:
           set -euo pipefail
 
           # if another process is listening on the cni-server socket, wait until it exits
-          trap 'kill $(jobs -p); exit 0' TERM
+          trap 'kill $(jobs -p); rm -f /etc/cni/net.d/80-openshift-network.conf ; exit 0' TERM
           retries=0
           while true; do
             if echo 'test' | socat - UNIX-CONNECT:/var/run/openshift-sdn/cni-server.sock >/dev/null; then
@@ -72,8 +72,8 @@ spec:
           fi
 
           # Take over network functions on the node
-          rm -Rf /etc/cni/net.d/80-openshift-network.conf
-          cp -Rf /opt/cni/bin/* /host/opt/cni/bin/
+          rm -f /etc/cni/net.d/80-openshift-network.conf
+          cp -f /opt/cni/bin/* /host/opt/cni/bin/
 
           # Launch the network process
           exec /usr/bin/openshift-sdn --config=/config/sdn-config.yaml  --url-only-kubeconfig=/etc/kubernetes/kubeconfig --loglevel=${DEBUG_LOGLEVEL:-2}
@@ -134,6 +134,10 @@ spec:
         - name: healthz
           containerPort: 10256
         terminationMessagePolicy: FallbackToLogsOnError
+        lifecycle:
+          preStop:
+            exec:
+              command: ["rm","-f","/etc/cni/net.d/80-openshift-network.conf", "/host/opt/cni/bin/openshift-sdn"]
       nodeSelector:
         beta.kubernetes.io/os: linux
       volumes:

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -139,6 +139,9 @@ spec:
         #     port: 10258
         #     scheme: HTTP
         lifecycle:
+          preStop:
+            exec:
+              command: ["rm","-f","/etc/cni/net.d/10-ovn-kubernetes.conf", "/host/opt/cni/bin/ovn-k8s-cni-overlay"]
 
       - name: ovn-node
         image: {{.OvnImage}}


### PR DESCRIPTION
The node is ready when the cni plugin creates its .conf file
in /etc/cni/net.d/ This change deletes thefile when the cni
plugin terminates.

bug: 1654044
https://bugzilla.redhat.com/show_bug.cgi?id=1654044

SDN 352 - 4.0 Keep node NotReady until sdn is up.
https://jira.coreos.com/browse/SDN-352

Signed-off-by: Phil Cameron <pcameron@redhat.com>