### PR TITLE
Pass the "real" apiserver info to the multus setup script

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -65,6 +65,11 @@ spec:
           mountPath: /host/etc/cni/net.d
         - name: cnibin
           mountPath: /host/opt/cni/bin
+        env:
+        - name: KUBERNETES_SERVICE_PORT
+          value: "{{.KUBERNETES_SERVICE_PORT}}"
+        - name: KUBERNETES_SERVICE_HOST
+          value: "{{.KUBERNETES_SERVICE_HOST}}"
       volumes:
         - name: cni
           hostPath:

--- a/pkg/network/multus.go
+++ b/pkg/network/multus.go
@@ -19,6 +19,8 @@ func renderMultusConfig(manifestDir string, useDHCP bool) ([]*uns.Unstructured, 
 	data.Data["MultusImage"] = os.Getenv("MULTUS_IMAGE")
 	data.Data["CNIPluginsSupportedImage"] = os.Getenv("CNI_PLUGINS_SUPPORTED_IMAGE")
 	data.Data["CNIPluginsUnsupportedImage"] = os.Getenv("CNI_PLUGINS_UNSUPPORTED_IMAGE")
+	data.Data["KUBERNETES_SERVICE_HOST"] = os.Getenv("KUBERNETES_SERVICE_HOST")
+	data.Data["KUBERNETES_SERVICE_PORT"] = os.Getenv("KUBERNETES_SERVICE_PORT")
 	data.Data["RenderDHCP"] = useDHCP
 
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/multus"), &data)


### PR DESCRIPTION
That way multus will use that to look up pod info during setup/teardown, and not depend on the service IP working.

Fixes for https://bugzilla.redhat.com/show_bug.cgi?id=1695554. (Either https://github.com/openshift/origin/pull/22471 or this should fix the bug. Both are independently worthwhile fixes though.)