### PR TITLE
Pipe socat stdout and stderr to dev null

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -51,7 +51,7 @@ spec:
           trap 'kill $(jobs -p); exit 0' TERM
           retries=0
           while true; do
-            if echo 'test' | socat - UNIX-CONNECT:/var/run/openshift-sdn/cni-server.sock >/dev/null; then
+            if echo 'test' | socat - UNIX-CONNECT:/var/run/openshift-sdn/cni-server.sock &>/dev/null; then
               echo "warning: Another process is currently listening on the CNI socket, waiting 15s ..." 2>&1
               sleep 15 & wait
               (( retries += 1 ))


### PR DESCRIPTION
This avoids getting spurious "No such file or directory" failures
on sdn pod log during startup

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1581584