### PR TITLE
Bug 1666223 - Remove temporary hack around vxlanPort serialization

### DIFF
--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -1,8 +1,6 @@
 package network
 
 import (
-	"encoding/json"
-	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -202,23 +200,6 @@ func controllerConfig(conf *operv1.NetworkSpec) (string, error) {
 	}
 
 	buf, err := yaml.Marshal(cfg)
-	if err != nil {
-		return "", err
-	}
-
-	// HACK: danw changed the capitalization of VXLANPort, but it's not yet
-	// merged in to origin. So just set both.
-	// Remove when origin merges api.
-	obj := &uns.Unstructured{}
-	err = yaml.Unmarshal(buf, obj)
-	if err != nil {
-		return "", err
-	}
-	p := json.Number(fmt.Sprintf("%d", *c.VXLANPort))
-
-	uns.SetNestedField(obj.Object, p, "network", "vxLANPort")
-
-	buf, err = yaml.Marshal(obj)
 	return string(buf), err
 }
 

--- a/pkg/network/openshift_sdn_test.go
+++ b/pkg/network/openshift_sdn_test.go
@@ -349,7 +349,6 @@ network:
     hostSubnetLength: 8
   networkPluginName: redhat/openshift-ovs-networkpolicy
   serviceNetworkCIDR: 172.30.0.0/16
-  vxLANPort: 4789
   vxlanPort: 4789
 resourceQuota:
   concurrentSyncs: 0


### PR DESCRIPTION
Reverts #26 because origin bumped its copy of openshift/api a long time ago