### PR TITLE
additional-networks: make NetworkAttachmentDefinition CRD singular/plural consistent

### DIFF
--- a/bindata/network/additional-networks/crd/001-crd.yaml
+++ b/bindata/network/additional-networks/crd/001-crd.yaml
@@ -8,8 +8,9 @@ spec:
   version: v1
   scope: Namespaced
   names:
-    plural: network-attachment-definitions
-    singular: network-attachment-definition
+    plural: networkattachmentdefinitions
+    singular: networkattachmentdefinition
     kind: NetworkAttachmentDefinition
     shortNames:
     - net-attach-def
+    - network-attachment-definition


### PR DESCRIPTION
While this conflicts with the usptream NPWG specification, it makes
the singular/plural names consistent with other CRDs in OpenShift
and elsewhere.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1700592