### PR TITLE
openshift-sdn: configure sdn readiness probe

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -138,6 +138,12 @@ spec:
           preStop:
             exec:
               command: ["rm","-f","/etc/cni/net.d/80-openshift-network.conf", "/host/opt/cni/bin/openshift-sdn"]
+        readinessProbe:
+          exec:
+            # openshift-sdn writes this file when it is ready to handle pod requests.
+            command: ["test", "-f", "/etc/cni/net.d/80-openshift-network.conf"]
+          initialDelaySeconds: 5
+          periodSeconds: 5
       nodeSelector:
         beta.kubernetes.io/os: linux
       volumes:


### PR DESCRIPTION
By checking to see that the sdn configuration file gets written out, we ensure the daemonset doesn't roll out a completely broken change.

It also slows down sdn rollouts slightly.