### PR TITLE
openshift-sdn: daemonset improvements (exec, proxy healthz, journal)

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -60,6 +60,7 @@ spec:
           }
           trap quit SIGTERM
           /usr/share/openvswitch/scripts/ovs-ctl start --no-ovs-vswitchd --system-id=random
+          tail --follow=name /var/log/openvswitch/ovsdb-server.log &
 
           # Restrict the number of pthreads ovs-vswitchd creates to reduce the
           # amount of RSS it uses on hosts with many cores
@@ -69,12 +70,9 @@ spec:
               ovs-vsctl --no-wait set Open_vSwitch . other_config:n-revalidator-threads=4
               ovs-vsctl --no-wait set Open_vSwitch . other_config:n-handler-threads=10
           fi
-          /usr/share/openvswitch/scripts/ovs-ctl start --no-ovsdb-server --system-id=random
+          /usr/share/openvswitch/scripts/ovs-ctl load-kmod
 
-          tail --follow=name /var/log/openvswitch/ovs-vswitchd.log /var/log/openvswitch/ovsdb-server.log &
-          while true; do
-            sleep 10000
-          done
+          exec ovs-vswitchd unix:/var/run/openvswitch/db.sock -vconsole:info -vsyslog:info --mlockall --no-chdir --pidfile=/var/run/openvswitch/ovs-vswitchd.pid --syslog-method=unix:/dev/log
         securityContext:
           privileged: true
         volumeMounts:
@@ -90,6 +88,8 @@ spec:
           readOnly: true
         - mountPath: /etc/openvswitch
           name: host-config-openvswitch
+        - mountPath: /dev/log
+          name: host-dev-log
         resources:
           requests:
             cpu: 200m
@@ -117,6 +117,10 @@ spec:
       - name: host-config-openvswitch
         hostPath:
           path: /var/lib/openvswitch
+      - name: host-dev-log
+        hostPath:
+          path: /dev/log
+          type: Socket
       tolerations:
       - operator: "Exists"
 {{- end}}

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -47,6 +47,9 @@ spec:
           #!/bin/bash
           set -euo pipefail
 
+          # tee all output to the host's journal
+          exec 1> >(logger -p user.info --size 4096 -s -t openshift-sdn/${K8S_POD_NAME}) 2>&1
+
           # if another process is listening on the cni-server socket, wait until it exits
           trap 'kill $(jobs -p); rm -f /etc/cni/net.d/80-openshift-network.conf ; exit 0' TERM
           retries=0
@@ -119,6 +122,8 @@ spec:
         - mountPath: /etc/sysconfig/openshift-sdn
           name: etc-sysconfig-openshift-sdn
           readOnly: true
+        - mountPath: /dev/log
+          name: host-dev-log
         resources:
           requests:
             cpu: 100m
@@ -130,6 +135,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: K8S_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         ports:
         - name: healthz
           containerPort: 10256
@@ -144,6 +153,11 @@ spec:
             command: ["test", "-f", "/etc/cni/net.d/80-openshift-network.conf"]
           initialDelaySeconds: 5
           periodSeconds: 5
+        # this comes from the kube-proxy code
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
       nodeSelector:
         beta.kubernetes.io/os: linux
       volumes:
@@ -187,5 +201,9 @@ spec:
       - name: host-var-lib-cni-networks-openshift-sdn
         hostPath:
           path: /var/lib/cni/networks/openshift-sdn
+      - name: host-dev-log
+        hostPath:
+          path: /dev/log
+          type: Socket
       tolerations:
       - operator: Exists


### PR DESCRIPTION
Some daemonset improvements:
- Log sdn and ovs-vswitchd to the system journal, so logs persist long-term
- Exec ovs-vswitchd directly, so it's restarted quickly
- Add kube-proxy healthz as liveness probe, so any kube-proxy hangs will cause it to be restarted

The ovs-vswitchd command line is taken directly from what ovs-vsctl created.