### PR TITLE
openshift-sdn: add kube-proxy liveness probe

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -143,6 +143,11 @@ spec:
           preStop:
             exec:
               command: ["rm","-f","/etc/cni/net.d/80-openshift-network.conf", "/host/opt/cni/bin/openshift-sdn"]
+        # this comes from the kube-proxy code
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
         readinessProbe:
           exec:
             # openshift-sdn writes this file when it is ready to handle pod requests.


### PR DESCRIPTION
The kube-proxy code exposes a liveness endpoint. Configure the pod to use that.