### PR TITLE
openshift-sdn: log ovs and sdn to the system journal

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -69,9 +69,11 @@ spec:
               ovs-vsctl --no-wait set Open_vSwitch . other_config:n-revalidator-threads=4
               ovs-vsctl --no-wait set Open_vSwitch . other_config:n-handler-threads=10
           fi
-          /usr/share/openvswitch/scripts/ovs-ctl start --no-ovsdb-server --system-id=random
 
-          tail --follow=name /var/log/openvswitch/ovs-vswitchd.log /var/log/openvswitch/ovsdb-server.log &
+          /usr/share/openvswitch/scripts/ovs-ctl load-kmod
+          ovs-vswitchd unix:/var/run/openvswitch/db.sock -vconsole:info -vsyslog:info -vfile:info --mlockall --no-chdir --log-file=/var/log/openvswitch/ovs-vswitchd.log --pidfile=/var/run/openvswitch/ovs-vswitchd.pid --detach --monitor --syslog-method=unix:/dev/log
+
+          tail --follow=name /var/log/openvswitch/ovsdb-server.log &
           while true; do
             sleep 10000
           done
@@ -90,6 +92,8 @@ spec:
           readOnly: true
         - mountPath: /etc/openvswitch
           name: host-config-openvswitch
+        - mountPath: /dev/log
+          name: host-dev-log
         resources:
           requests:
             cpu: 200m
@@ -117,6 +121,10 @@ spec:
       - name: host-config-openvswitch
         hostPath:
           path: /var/lib/openvswitch
+      - name: host-dev-log
+        hostPath:
+          path: /dev/log
+          type: Socket
       tolerations:
       - operator: "Exists"
 {{- end}}

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -46,6 +46,8 @@ spec:
         - |
           #!/bin/bash
           set -euo pipefail
+          # tee all output to the host's journal
+          exec 1> >(logger -p user.info --size 4096 -s -t openshift-sdn/${K8S_POD_NAME}) 2>&1
 
           # if another process is listening on the cni-server socket, wait until it exits
           trap 'kill $(jobs -p); rm -f /etc/cni/net.d/80-openshift-network.conf ; exit 0' TERM
@@ -124,6 +126,8 @@ spec:
         - mountPath: /etc/sysconfig
           name: etc-sysconfig
           readOnly: true
+        - mountPath: /dev/log
+          name: host-dev-log
         resources:
           requests:
             cpu: 100m
@@ -135,6 +139,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: K8S_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         ports:
         - name: healthz
           containerPort: 10256
@@ -192,5 +200,9 @@ spec:
       - name: host-var-lib-cni-networks-openshift-sdn
         hostPath:
           path: /var/lib/cni/networks/openshift-sdn
+      - name: host-dev-log
+        hostPath:
+          path: /dev/log
+          type: Socket
       tolerations:
       - operator: Exists


### PR DESCRIPTION
For SDN, use a bash hack to redirect all stderr and stdout to the system journal, so that logs are preserved via journald. For OVS, use the native syslog support.

Philosophically, this is because the sdn processes, although distributed via a daemonset, really are "node" components.