### PR TITLE
run-locally.sh fixes

### DIFF
--- a/hack/run-locally.sh
+++ b/hack/run-locally.sh
@@ -35,7 +35,7 @@ function override_install_manifests() {
 function setup_operator_env() {
     if [[ manifests/0000_07_cluster-network-operator_03_daemonset.yaml -nt "${CLUSTER_DIR}/env.sh" ]]; then
         echo "Copying environment variables from manifest to ${CLUSTER_DIR}/env.sh"
-        oc --kubeconfig=hack/null-kubeconfig convert --local=true -f manifests/0000_07_cluster-network-operator_03_daemonset.yaml -ojsonpath='{range .spec.template.spec.containers[0].env[?(@.value)]}{.name}{"="}{.value}{"\n"}' > "${CLUSTER_DIR}/env.sh"
+        oc --kubeconfig=hack/null-kubeconfig patch --local=true -f manifests/0000_07_cluster-network-operator_03_daemonset.yaml -p '{}' -ojsonpath='{range .spec.template.spec.containers[0].env[?(@.value)]}{.name}{"="}{.value}{"\n"}' > "${CLUSTER_DIR}/env.sh"
     fi
     sed -i -e "s/^RELEASE_VERSION=.*/RELEASE_VERSION=${RELEASE_VERSION}/" "${CLUSTER_DIR}/env.sh"
 }


### PR DESCRIPTION
Two unrelated fixes:
- Get `RELEASE_VERSION` from the cluster rather than the local tree. There was discussion about this in #146 and I was arguing that we have to get the image variables from the local tree, and Casey was arguing that we have to get the version from the cluster, and we were both right. #146 was getting the version from the `DaemonSet` when taking over an existing cluster, but you need to get the right version even when starting a new cluster if you want it to come up fully and error-free, so this changes the script to parse it out of the `ClusterVersion` resource.
- Use `kubectl patch` rather than `kubectl convert` as our hacky "run a JSONPath expression on a YAML file" command, since the latter is now deprecated and prints a warning