### PR TITLE
Add toleration

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -295,9 +295,4 @@ spec:
         hostPath:
           path: /var/run/kubernetes
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-        effect: "NoSchedule"
-      - key: "node.kubernetes.io/not-ready"
-        operator: "Exists"
-        effect: "NoSchedule"
+      - operator: "Exists"

--- a/manifests/0000_70_cluster-network-operator_03_daemonset.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_daemonset.yaml
@@ -65,9 +65,4 @@ spec:
         runAsNonRoot: true
         runAsUser: 65534
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: Exists
-        effect: NoSchedule
-      - key: "node.kubernetes.io/not-ready"
-        operator: Exists
-        effect: NoSchedule
+      - operator: Exists


### PR DESCRIPTION
As of now, we are tolerating only `node-role.kubernetes.io/master` taint etc during scheduling stage. If we don't have the blanket toleration, there is a very good chance that these pods won't tolerate other taints that got added to the node, for example `disk-pressure` etc. The side-effect is that we will tolerate `NoExecute` taints as well

Please feel free to close this PR, if you think, you just need to tolerate the current taint(s) you have.

/cc @sjenning @derekwaynecarr 
