### PR TITLE
Make srio-device-plugin tolerations match sriov-cni

### DIFF
--- a/bindata/network/additional-networks/sriov/sriov-device-plugin.yaml
+++ b/bindata/network/additional-networks/sriov/sriov-device-plugin.yaml
@@ -26,9 +26,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
+      - operator: Exists
       serviceAccountName: sriov-device-plugin
       containers:
       - name: sriov-device-plugin


### PR DESCRIPTION
As discussed in #165, the sriov-device-plugin pod needs the same tolerations as sriov-cni