### PR TITLE
cmd: exit 0 on graceful shutdown

### DIFF
--- a/cmd/cluster-network-operator/main.go
+++ b/cmd/cluster-network-operator/main.go
@@ -109,5 +109,7 @@ func main() {
 	log.Print("Starting the Cmd.")
 
 	// Start the Cmd
-	log.Fatal(mgr.Start(signals.SetupSignalHandler()))
+	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
No sense in generating spurious error messages.