### PR TITLE
pkg/apply: copy over auto-generated imagePullSecrets for ServiceAccounts

### DIFF
--- a/pkg/apply/merge.go
+++ b/pkg/apply/merge.go
@@ -95,6 +95,14 @@ func MergeServiceAccountForUpdate(current, updated *uns.Unstructured) error {
 		if ok {
 			uns.SetNestedField(updated.Object, curSecrets, "secrets")
 		}
+
+		curImagePullSecrets, ok, err := uns.NestedSlice(current.Object, "imagePullSecrets")
+		if err != nil {
+			return err
+		}
+		if ok {
+			uns.SetNestedField(updated.Object, curImagePullSecrets, "imagePullSecrets")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This was resulting in pointless object churn as we deleted the pull secrets, then the controller immediately re-added them.