### PR TITLE
More ovn-kubernetes fixes

### DIFF
--- a/bindata/network/ovn-kubernetes/003-rbac-controller.yaml
+++ b/bindata/network/ovn-kubernetes/003-rbac-controller.yaml
@@ -57,3 +57,33 @@ subjects:
 - kind: ServiceAccount
   name: ovn-kubernetes-controller
   namespace: openshift-ovn-kubernetes
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openshift-ovn-kubernetes-sbdb
+  namespace: openshift-ovn-kubernetes
+rules:
+- apiGroups: [""]
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - update
+  - patch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift-ovn-kubernetes-sbdb
+  namespace: openshift-ovn-kubernetes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift-ovn-kubernetes-sbdb
+subjects:
+- kind: ServiceAccount
+  name: ovn-kubernetes-controller
+  namespace: openshift-ovn-kubernetes

--- a/bindata/network/ovn-kubernetes/005-service.yaml
+++ b/bindata/network/ovn-kubernetes/005-service.yaml
@@ -6,7 +6,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: ovnkube-master
+  name: ovnkube-db
   namespace: openshift-ovn-kubernetes
 spec:
   ports:
@@ -21,5 +21,3 @@ spec:
   sessionAffinity: None
   clusterIP: None
   type: ClusterIP
-  selector:
-    name: ovnkube-master

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -86,6 +86,10 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         ports:
         - name: healthz
           containerPort: 10257
@@ -144,6 +148,10 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         ports:
         - name: healthz
           containerPort: 10256
@@ -204,6 +212,10 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         ports:
         - name: healthz
           containerPort: 10255
@@ -265,6 +277,10 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         ports:
         - name: healthz
           containerPort: 10254

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -120,6 +120,10 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
 
         ports:
         - name: healthz
@@ -186,6 +190,10 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
 
         ports:
         - name: healthz


### PR DESCRIPTION
1. At some point the `ovnkube-master` service got renamed to `ovnkube-db`, and `ovnkube.sh` changed to manually create its Endpoints after the sbdb comes up, rather than having them be created automatically by kubernetes. So update the Service and our RBAC permissions for that.
2. `ovnkube.sh` no longer hardcodes the namespace, so update to pass in the correct namespace in the pods

(Note that these changes only touch files that are ovn-kubernetes-only, so this PR has no effect on 4.1.)