### PR TITLE
Give the ability to patch nodes to openshift-sdn

### DIFF
--- a/bindata/network/openshift-sdn/002-rbac.yaml
+++ b/bindata/network/openshift-sdn/002-rbac.yaml
@@ -17,7 +17,6 @@ rules:
 - apiGroups: [""]
   resources:
   - namespaces
-  - nodes
   - endpoints
   - services
   - pods
@@ -25,6 +24,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
 - apiGroups: ["extensions"]
   resources:
   - networkpolicies


### PR DESCRIPTION
This is needed for SDN-260, which is about tainting
nodes with a too small MTU, thus the need for update permission.