### PR TITLE
manifests: change image references to 4.2

### DIFF
--- a/manifests/0000_70_cluster-network-operator_03_daemonset.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_daemonset.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: network-operator
-        image: docker.io/openshift/origin-cluster-network-operator:v4.0.0
+        image: quay.io/openshift/origin-cluster-network-operator:4.2
         command:
         - "/usr/bin/cluster-network-operator"
         - "--url-only-kubeconfig=/etc/kubernetes/kubeconfig"
@@ -28,21 +28,21 @@ spec:
         - name: RELEASE_VERSION
           value: "0.0.1-snapshot"
         - name: NODE_IMAGE
-          value: "docker.io/openshift/origin-node:v4.0.0"
+          value: "quay.io/openshift/origin-node:4.2"
         - name: HYPERSHIFT_IMAGE
-          value: "docker.io/openshift/origin-hypershift:v4.0.0"
+          value: "quay.io/openshift/origin-hypershift:4.2"
         - name: MULTUS_IMAGE
-          value: "quay.io/openshift/origin-multus-cni:v4.0.0"
+          value: "quay.io/openshift/origin-multus-cni:4.2"
         - name: CNI_PLUGINS_SUPPORTED_IMAGE
-          value: "quay.io/openshift/origin-container-networking-plugins-supported:v4.0.0"
+          value: "quay.io/openshift/origin-container-networking-plugins-supported:4.2"
         - name: CNI_PLUGINS_UNSUPPORTED_IMAGE
-          value: "quay.io/openshift/origin-container-networking-plugins-unsupported:v4.0.0"
+          value: "quay.io/openshift/origin-container-networking-plugins-unsupported:4.2"
         - name: SRIOV_CNI_IMAGE
-          value: "quay.io/openshift/origin-sriov-cni:v4.0.0"
+          value: "quay.io/openshift/origin-sriov-cni:4.2"
         - name: SRIOV_DEVICE_PLUGIN_IMAGE
-          value: "quay.io/openshift/origin-sriov-network-device-plugin:v4.0.0"
+          value: "quay.io/openshift/origin-sriov-network-device-plugin:4.2"
         - name: OVN_IMAGE
-          value: "quay.io/openshift/origin-ovn-kubernetes:v4.0.0"
+          value: "quay.io/openshift/origin-ovn-kubernetes:4.2"
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -5,36 +5,36 @@ spec:
   - name: cluster-network-operator
     from:
       kind: DockerImage
-      name: docker.io/openshift/origin-cluster-network-operator:v4.0.0
+      name: quay.io/openshift/origin-cluster-network-operator:4.2
   - name: node
     from:
       kind: DockerImage
-      name: docker.io/openshift/origin-node:v4.0.0
+      name: quay.io/openshift/origin-node:4.2
   - name: hypershift
     from:
       kind: DockerImage
-      name: docker.io/openshift/origin-hypershift:v4.0.0
+      name: quay.io/openshift/origin-hypershift:4.2
   - name: multus-cni
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-multus-cni:v4.0.0
+      name: quay.io/openshift/origin-multus-cni:4.2
   - name: container-networking-plugins-supported
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-container-networking-plugins-supported:v4.0.0
+      name: quay.io/openshift/origin-container-networking-plugins-supported:4.2
   - name: container-networking-plugins-unsupported
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-container-networking-plugins-unsupported:v4.0.0
+      name: quay.io/openshift/origin-container-networking-plugins-unsupported:4.2
   - name: sriov-cni
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-sriov-cni:v4.0.0
+      name: quay.io/openshift/origin-sriov-cni:4.2
   - name: sriov-network-device-plugin
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-sriov-network-device-plugin:v4.0.0
+      name: quay.io/openshift/origin-sriov-network-device-plugin:4.2
   - name: ovn-kubernetes
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-ovn-kubernetes:v4.0.0
+      name: quay.io/openshift/origin-ovn-kubernetes:4.2


### PR DESCRIPTION
This has no real effect - since the release tooling *always* replaces these with references to builds, but it helps for attach.sh and for documentation.