### PR TITLE
Macvlan interface support in network-operator

### DIFF
--- a/bindata/network/additional-networks/macvlan/macvlan.yaml
+++ b/bindata/network/additional-networks/macvlan/macvlan.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: {{.AdditionalNetworkName}}
+  namespace: default
+spec:
+  config: '{
+    "cniVersion": "0.3.0",
+    "type": "macvlan",
+    "master": "{{.Master}}",
+{{if (index . "Mode") }}
+    "mode": "{{.Mode}}",
+{{end}}{{if (index . "MTU") }}
+    "mtu": {{.MTU}},
+{{end}}
+    "ipam": {
+      "type": "{{.IPAM}}"
+      }
+  }'

--- a/manifests/0000_70_cluster-network-operator_01_crd.yaml
+++ b/manifests/0000_70_cluster-network-operator_01_crd.yaml
@@ -67,7 +67,7 @@ spec:
               type: array
               items:
                 type: object
-                required: ["type", "name", "rawCNIConfig"]
+                required: ["type", "name"]
                 properties:
                   type:
                     type: string
@@ -77,6 +77,19 @@ spec:
                     type: string
                   rawCNIConfig:
                     type: string
+                  macvlanConfig:
+                    type: object
+                    required: ["master"]
+                    properties:
+                      master:
+                        type: string
+                      ipam:
+                        type: string
+                      mode:
+                        type: string
+                      mtu:
+                        type: integer
+                        minimum: 0
             disableMultiNetwork:
               type: boolean
             deployKubeProxy:

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -72,6 +72,8 @@ func Canonicalize(conf *operv1.NetworkSpec) {
 		switch strings.ToLower(string(an.Type)) {
 		case strings.ToLower(string(operv1.NetworkTypeRaw)):
 			an.Type = operv1.NetworkTypeRaw
+		case strings.ToLower(string(operv1.NetworkTypeMacvlan)):
+			an.Type = operv1.NetworkTypeMacvlan
 		}
 	}
 }
@@ -262,6 +264,10 @@ func ValidateAdditionalNetworks(conf *operv1.NetworkSpec) [][]error {
 			if errs := validateRaw(&an); len(errs) > 0 {
 				out = append(out, errs)
 			}
+		case operv1.NetworkTypeMacvlan:
+			if errs := validateMacvlanConfig(&an); len(errs) > 0 {
+				out = append(out, errs)
+			}
 		default:
 			out = append(out, []error{errors.Errorf("unknown or unsupported NetworkType: %s", an.Type)})
 		}
@@ -294,6 +300,12 @@ func RenderAdditionalNetworks(conf *operv1.NetworkSpec, manifestDir string) ([]*
 			} else {
 				objs, err = renderRawCNIConfig(&an, manifestDir)
 			}
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, objs...)
+		case operv1.NetworkTypeMacvlan:
+			objs, err = renderMacvlanConfig(&an, manifestDir)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
This change introduces macvlan interface type in NetworkType and allows network-operator
to configure macvlan without to use RawCNIConfig.

Depends on https://github.com/openshift/api/pull/321

@dcbw @squeed @dougbtv @danwinship 