### PR TITLE
openshift-sdn: make host mount read-only

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -110,6 +110,7 @@ spec:
           name: host-var-run-openshift-sdn
         - mountPath: /host
           name: host-slash
+          readOnly: true
         # CNI related mounts which we take over
         - mountPath: /host/opt/cni/bin
           name: host-cni-bin


### PR DESCRIPTION
Should be no need for this to be writable.