### PR TITLE
openshift-sdn: ovs shutdown ordering.

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -71,10 +71,9 @@ spec:
           fi
           /usr/share/openvswitch/scripts/ovs-ctl start --no-ovsdb-server --system-id=random
 
-          tail --follow=name /var/log/openvswitch/ovs-vswitchd.log /var/log/openvswitch/ovsdb-server.log &
-          while true; do
-            sleep 10000
-          done
+          tail -F --pid=$(cat /var/run/openvswitch/ovs-vswitchd.pid) /var/log/openvswitch/ovs-vswitchd.log &
+          tail -F --pid=$(cat /var/run/openvswitch/ovsdb-server.pid) /var/log/openvswitch/ovsdb-server.log &
+          wait
         securityContext:
           privileged: true
         volumeMounts:
@@ -102,6 +101,18 @@ spec:
             - status
           initialDelaySeconds: 15
           periodSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - /usr/share/openvswitch/scripts/ovs-ctl
+            - status
+          initialDelaySeconds: 15
+          periodSeconds: 5
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/usr/share/openvswitch/scripts/ovs-ctl", "stop"]
+        terminationGracePeriodSeconds: 10
       nodeSelector:
         beta.kubernetes.io/os: linux
       volumes:


### PR DESCRIPTION
When looking in to other bugs, I saw a lot of errors from kubelet:

Pod "ovs-XXX" is terminated, but some containers are still running.

It looks like the SIGTERM isn't being respected. Let's fix this two ways: Stop running tail in an infinite loop (which might cause the signal to be ignored), and tell the kubelet to stop OVS explicitly.