### PR TITLE
Revert "openshift-sdn: ovs shutdown ordering."

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -71,9 +71,10 @@ spec:
           fi
           /usr/share/openvswitch/scripts/ovs-ctl start --no-ovsdb-server --system-id=random
 
-          tail -F --pid=$(cat /var/run/openvswitch/ovs-vswitchd.pid) /var/log/openvswitch/ovs-vswitchd.log &
-          tail -F --pid=$(cat /var/run/openvswitch/ovsdb-server.pid) /var/log/openvswitch/ovsdb-server.log &
-          wait
+          tail --follow=name /var/log/openvswitch/ovs-vswitchd.log /var/log/openvswitch/ovsdb-server.log &
+          while true; do
+            sleep 10000
+          done
         securityContext:
           privileged: true
         volumeMounts:
@@ -101,18 +102,6 @@ spec:
             - status
           initialDelaySeconds: 15
           periodSeconds: 5
-        readinessProbe:
-          exec:
-            command:
-            - /usr/share/openvswitch/scripts/ovs-ctl
-            - status
-          initialDelaySeconds: 15
-          periodSeconds: 5
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/usr/share/openvswitch/scripts/ovs-ctl", "stop"]
-        terminationGracePeriodSeconds: 10
       nodeSelector:
         beta.kubernetes.io/os: linux
       volumes:


### PR DESCRIPTION
This reverts commit 6a3ff5cf3d1130318b640c806a958bf736db6fc7, #181.

I'm not clear on the connection, but this change seems to have [increased the likelihood of fatal upgrade timouts][1], and that's blocking org-wide master progress.  Ideally we'd fix [the underlying issue][2], but this reversion should help unblock master CI while we work on that.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1715515
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1714699