### PR TITLE
Add readinessProbe to ovn-kubernetes

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -187,6 +187,12 @@ spec:
           preStop:
             exec:
               command: ["rm","-f","/etc/cni/net.d/10-ovn-kubernetes.conf", "/host/opt/cni/bin/ovn-k8s-cni-overlay"]
+        readinessProbe:
+          exec:
+            # ovnkube --node writes this file when it is ready to handle pod requests.
+            command: ["test", "-f", "/etc/cni/net.d/10-ovn-kubernetes.conf"]
+          initialDelaySeconds: 5
+          periodSeconds: 5
 
       nodeSelector:
         beta.kubernetes.io/os: "linux"


### PR DESCRIPTION
Copied the readinessProbe from OpenShiftSDN and modified for ovn

SDN-447 - OVN: exec-based readiness probe
https://jira.coreos.com/browse/SDN-447

Signed-off-by: Phil Cameron <pcameron@redhat.com>