### PR TITLE
Use the go-native flag for verbosity

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -81,7 +81,7 @@ spec:
           cp -f /opt/cni/bin/* /host/opt/cni/bin/
 
           # Launch the network process
-          exec /usr/bin/openshift-sdn --config=/config/sdn-config.yaml  --url-only-kubeconfig=/etc/kubernetes/kubeconfig --loglevel=${DEBUG_LOGLEVEL:-2}
+          exec /usr/bin/openshift-sdn --config=/config/sdn-config.yaml  --url-only-kubeconfig=/etc/kubernetes/kubeconfig --v=${DEBUG_LOGLEVEL:-2}
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
The 'loglevel' flag is getting removed from internal binaries to
eliminate some shared packages that are not necessary.

blocks https://github.com/openshift/origin/pull/23113