### PR TITLE
[WIP] Cluster Network Operator Should Result in No-Op for Unknown Network Types

### DIFF
--- a/pkg/controller/clusterconfig/clusterconfig_controller.go
+++ b/pkg/controller/clusterconfig/clusterconfig_controller.go
@@ -89,7 +89,7 @@ func (r *ReconcileClusterConfig) Reconcile(request reconcile.Request) (reconcile
 	}
 
 	if err := network.ValidateNetworkType(clusterConfig.Spec.NetworkType); err != nil {
-		log.Printf("Unsupported NetworkType specified: %v", err)
+		log.Printf("Failed to validate NetworkType: %v", err)
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controller/clusterconfig/clusterconfig_controller.go
+++ b/pkg/controller/clusterconfig/clusterconfig_controller.go
@@ -88,6 +88,11 @@ func (r *ReconcileClusterConfig) Reconcile(request reconcile.Request) (reconcile
 		return reconcile.Result{}, err
 	}
 
+	if err := network.ValidateNetworkType(clusterConfig.Spec.NetworkType); err != nil {
+		log.Printf("Unsupported NetworkType specified: %v", err)
+		return reconcile.Result{}, err
+	}
+
 	// Validate the cluster config
 	if err := network.ValidateClusterConfig(clusterConfig.Spec); err != nil {
 		log.Printf("Failed to validate Network.Spec: %v", err)

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -132,6 +132,11 @@ func (r *ReconcileOperConfig) Reconcile(request reconcile.Request) (reconcile.Re
 		return reconcile.Result{}, err
 	}
 
+	if err := network.ValidateNetworkType(string(operConfig.Spec.DefaultNetwork.Type)); err != nil {
+		log.Printf("Unsupport network type: %v", err)
+		return reconcile.Result{}, err
+	}
+
 	// Merge in the cluster configuration, in case the administrator has updated some "downstream" fields
 	// This will also commit the change back to the apiserver.
 	if err := r.MergeClusterConfig(context.TODO(), operConfig); err != nil {

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -133,7 +133,7 @@ func (r *ReconcileOperConfig) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	if err := network.ValidateNetworkType(string(operConfig.Spec.DefaultNetwork.Type)); err != nil {
-		log.Printf("Unsupport network type: %v", err)
+		log.Printf("Failed to validate NetworkType: %v", err)
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/network/cluster_config.go
+++ b/pkg/network/cluster_config.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"net"
+	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operv1 "github.com/openshift/api/operator/v1"
@@ -119,4 +120,27 @@ func StatusFromOperatorConfig(operConf *operv1.NetworkSpec) *configv1.NetworkSta
 	}
 
 	return &status
+}
+
+//ValidateNetworkType returns an error if network is not managed by
+//one of the supported types
+func ValidateNetworkType(networkType string) error {
+
+	if len(networkType) == 0 {
+		//not sure if this is a valid scenario
+		return nil
+	}
+
+	switch strings.ToLower(networkType) {
+	case strings.ToLower(string(operv1.NetworkTypeOpenShiftSDN)):
+		return nil
+	case strings.ToLower(string(operv1.NetworkTypeOVNKubernetes)):
+		return nil
+	case strings.ToLower(string(operv1.NetworkTypeKuryr)):
+		return nil
+	case strings.ToLower(string(operv1.NetworkTypeRaw)):
+		return nil
+	default:
+		return errors.Errorf("Unsupported NetworkType %s", networkType)
+	}
 }

--- a/pkg/network/cluster_config_test.go
+++ b/pkg/network/cluster_config_test.go
@@ -125,3 +125,19 @@ func TestStatusFromConfig(t *testing.T) {
 	status = StatusFromOperatorConfig(&crd.Spec)
 	g.Expect(status).To(BeNil())
 }
+
+func TestValidateNetworkType(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	supportedTypes := []string{"openshiftsdn", "ovnkubernetes", "kuryr", "raw", ""}
+	for _, networkType := range supportedTypes {
+		err := ValidateNetworkType(networkType)
+		g.Expect(err).NotTo(HaveOccurred())
+	}
+
+	unsupportedTypes := []string{"customsdn1", "customsnd2"}
+	for _, networkType := range unsupportedTypes {
+		err := ValidateNetworkType(networkType)
+		g.Expect(err).To(HaveOccurred())
+	}
+}


### PR DESCRIPTION
OpenShift Cluster Network Operator should result in a No-Op and not do anything if `NetworkType` is specified as anything other than `OpenShiftSDN`, `OVNKubernetes`, `Kuryr` and `Raw`. This will help third party network operators like Nuage to manage network in an OpenShift Cluster.

Like OpenShift Cluster Network Operator, Nuage SDN Operator also uses `Networks.config.openshift.io` and `Networks.operator.openshift.io` objects to manage networking in an OpenShift cluster. The operator that manages the network for an OpenShift cluster will depend on the `NetworkType` value specified during installation.