### PR TITLE
Install standalone kube-proxy.

### DIFF
--- a/bindata/kube-proxy/000-ns.yaml
+++ b/bindata/kube-proxy/000-ns.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-kube-proxy
+  labels:
+    name: openshift-kube-proxy
+    openshift.io/run-level: "0"
+    openshift.io/cluster-monitoring: "true"
+  annotations:
+    openshift.io/node-selector: "" #override default node selector
+    openshift.io/description: "kubernetes service proxy"

--- a/bindata/kube-proxy/001-rbac.yaml
+++ b/bindata/kube-proxy/001-rbac.yaml
@@ -1,0 +1,44 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openshift-kube-proxy
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - endpoints
+  - services
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: [""]
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openshift-kube-proxy
+  namespace: openshift-kube-proxy
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openshift-kube-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-kube-proxy
+subjects:
+- kind: ServiceAccount
+  name: openshift-kube-proxy
+  namespace: openshift-kube-proxy

--- a/bindata/kube-proxy/kube-proxy.yaml
+++ b/bindata/kube-proxy/kube-proxy.yaml
@@ -1,0 +1,91 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  namespace: openshift-kube-proxy
+  name: proxy-config
+data:
+  kube-proxy-config.yaml: |-
+{{.KubeProxyConfig | indent 4}}
+
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: openshift-kube-proxy
+  namespace: openshift-kube-proxy
+  annotations:
+    kubernetes.io/description: |
+      This daemonset is the kubernetes service proxy (kube-proxy).
+    release.openshift.io/version: "{{.ReleaseVersion}}"
+spec:
+  selector:
+    matchLabels:
+      app: kube-proxy
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: kube-proxy
+        component: network
+        type: infra
+        openshift.io/component: network
+    spec:
+      serviceAccountName: openshift-kube-proxy
+      hostNetwork: true
+      priorityClassName: system-node-critical
+      containers:
+      - name: kube-proxy
+        image: {{.KubeProxyImage}}
+        command:
+        - /bin/bash
+        - -c
+        - exec /usr/bin/hyperkube kube-proxy --config=/config/kube-proxy-config.yaml --hostname-override "${K8S_NODE_NAME}"
+        securityContext:
+          privileged: true
+        env:
+        # Tell kube-proxy to talk to the apiserver directly.
+        - name: KUBERNETES_SERVICE_PORT
+          value: "{{.KUBERNETES_SERVICE_PORT}}"
+        - name: KUBERNETES_SERVICE_HOST
+          value: "{{.KUBERNETES_SERVICE_HOST}}"
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        volumeMounts:
+        # Because we don't actually run iptables locally, but chroot in to the host
+        - mountPath: /host
+          name: host-slash
+          readOnly: true
+        - mountPath: /config
+          name: config
+          readOnly: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        ports:
+        - name: healthz
+          containerPort: 10256
+        - name: metrics
+          containerPort: 9101
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      restartPolicy: Always
+      tolerations:
+      - operator: Exists
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+      - name: host-slash
+        hostPath:
+          path: /
+      - name: config
+        configMap:
+          name: proxy-config

--- a/bindata/kube-proxy/monitor.yaml
+++ b/bindata/kube-proxy/monitor.yaml
@@ -1,0 +1,70 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: kube-proxy
+  annotations:
+    networkoperator.openshift.io/ignore-errors: ""
+  name: monitor-kube-proxy
+  namespace: openshift-kube-proxy
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+  jobLabel: app
+  namespaceSelector:
+    matchNames:
+    - openshift-kube-proxy
+  selector:
+    matchLabels:
+      app: kube-proxy
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kube-proxy
+  name: openshift-kube-proxy
+  namespace: openshift-kube-proxy
+spec:
+  selector:
+    app: kube-proxy
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: 9101
+    protocol: TCP
+    targetPort: 9101
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-kube-proxy
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-kube-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/manifests/0000_70_cluster-network-operator_03_daemonset.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_daemonset.yaml
@@ -31,6 +31,8 @@ spec:
           value: "quay.io/openshift/origin-node:4.2"
         - name: HYPERSHIFT_IMAGE
           value: "quay.io/openshift/origin-hypershift:4.2"
+        - name: KUBE_PROXY_IMAGE
+          value: "quay.io/openshift/origin-kube-proxy:4.2"
         - name: MULTUS_IMAGE
           value: "quay.io/openshift/origin-multus-cni:4.2"
         - name: CNI_PLUGINS_SUPPORTED_IMAGE

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -10,6 +10,10 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-node:4.2
+  - name: kube-proxy
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-kube-proxy:4.2
   - name: hypershift
     from:
       kind: DockerImage

--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -54,6 +54,7 @@ func renderOpenShiftSDN(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Un
 	kpcDefaults := map[string][]string{
 		"metrics-bind-address":    {"0.0.0.0"},
 		"metrics-port":            {"9101"},
+		"healthz-port":            {"10256"},
 		"proxy-mode":              {"iptables"},
 		"iptables-masquerade-bit": {"0"},
 	}
@@ -139,14 +140,6 @@ func fillOpenShiftSDNDefaults(conf, previous *operv1.NetworkSpec, hostMTU int) {
 
 	if conf.KubeProxyConfig.ProxyArguments == nil {
 		conf.KubeProxyConfig.ProxyArguments = map[string][]string{}
-	}
-
-	if conf.KubeProxyConfig.ProxyArguments["metrics-bind-address"] == nil {
-		conf.KubeProxyConfig.ProxyArguments["metrics-bind-address"] = []string{"0.0.0.0"}
-	}
-
-	if conf.KubeProxyConfig.ProxyArguments["metrics-port"] == nil {
-		conf.KubeProxyConfig.ProxyArguments["metrics-port"] = []string{"9101"}
 	}
 
 	sc := conf.DefaultNetwork.OpenShiftSDNConfig
@@ -255,6 +248,10 @@ func nodeConfig(conf *operv1.NetworkSpec) (string, error) {
 		IPTablesSyncPeriod: conf.KubeProxyConfig.IptablesSyncPeriod,
 		ProxyArguments:     conf.KubeProxyConfig.ProxyArguments,
 	}
+
+	result.ProxyArguments["metrics-bind-address"] = []string{"0.0.0.0"}
+	result.ProxyArguments["metrics-port"] = []string{"9101"}
+	result.ProxyArguments["healthz-port"] = []string{"10256"}
 
 	buf, err := yaml.Marshal(result)
 	return string(buf), err

--- a/pkg/network/proxy_test.go
+++ b/pkg/network/proxy_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	operv1 "github.com/openshift/api/operator/v1"
+	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	. "github.com/onsi/gomega"
 )
@@ -25,10 +26,6 @@ var config = operv1.NetworkSpec{
 			// duration
 			"iptables-min-sync-period": {"2m"},
 
-			// special address+port combo
-			"metrics-bind-address": {"1.2.3.4"},
-			"metrics-port":         {"999"},
-
 			// optional int
 			"iptables-masquerade-bit": {"14"},
 
@@ -38,15 +35,19 @@ var config = operv1.NetworkSpec{
 	},
 }
 
-func TestRenderKubeProxy(t *testing.T) {
+func TestKubeProxyConfig(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	errs := validateKubeProxy(&config)
 	g.Expect(errs).To(HaveLen(0))
 
-	cfg, err := kubeProxyConfiguration(&config, nil)
+	cfg, err := kubeProxyConfiguration(&config, map[string][]string{
+		// special address+port combo
+		"metrics-bind-address": {"1.2.3.4"},
+		"metrics-port":         {"999"},
+	})
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(cfg).To(Equal(`apiVersion: kubeproxy.config.k8s.io/v1alpha1
+	g.Expect(cfg).To(MatchYAML(`apiVersion: kubeproxy.config.k8s.io/v1alpha1
 bindAddress: 0.0.0.0
 clientConnection:
   acceptContentTypes: ""
@@ -84,4 +85,158 @@ portRange: ""
 resourceContainer: ""
 udpIdleTimeout: 0s
 `))
+}
+
+func TestShouldDeployKubeProxy(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	c := &operv1.NetworkSpec{
+		DefaultNetwork: operv1.DefaultNetworkDefinition{
+			Type: operv1.NetworkTypeOpenShiftSDN,
+		},
+	}
+
+	g.Expect(ShouldDeployKubeProxy(c)).To(BeFalse())
+
+	c.DefaultNetwork.Type = operv1.NetworkTypeOVNKubernetes
+	g.Expect(ShouldDeployKubeProxy(c)).To(BeFalse())
+
+	c.DefaultNetwork.Type = "Flannel"
+	g.Expect(ShouldDeployKubeProxy(c)).To(BeTrue())
+}
+
+func TestValidateKubeProxy(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// Check that the empty case validates
+	c := &operv1.NetworkSpec{}
+	g.Expect(validateKubeProxy(c)).To(BeEmpty())
+
+	// Check that the default openshift-sdn config validates
+	g.Expect(validateKubeProxy(&OpenShiftSDNConfig.Spec)).To(BeEmpty())
+
+	// Check that some reasonable values validate
+	c = &operv1.NetworkSpec{
+		KubeProxyConfig: &operv1.ProxyConfig{
+			BindAddress:        "1.2.3.4",
+			IptablesSyncPeriod: "30s",
+			ProxyArguments: map[string][]string{
+				"foo": {"bar"},
+			},
+		},
+	}
+	g.Expect(validateKubeProxy(c)).To(BeEmpty())
+
+	// Break something
+	c.KubeProxyConfig.BindAddress = "invalid"
+	c.KubeProxyConfig.IptablesSyncPeriod = "asdf"
+	c.KubeProxyConfig.ProxyArguments["healthz-port"] = []string{"9101"}
+	c.KubeProxyConfig.ProxyArguments["metrics-port"] = []string{"10256"}
+	g.Expect(validateKubeProxy(c)).To(HaveLen(4))
+}
+
+func TestFillKubeProxyDefaults(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	c := &operv1.NetworkSpec{
+		ClusterNetwork: []operv1.ClusterNetworkEntry{
+			{
+				CIDR:       "192.168.0.0/14",
+				HostPrefix: 23,
+			},
+		},
+	}
+
+	FillKubeProxyDefaults(c, nil)
+	tt := true
+	g.Expect(c).To(Equal(&operv1.NetworkSpec{
+		ClusterNetwork: []operv1.ClusterNetworkEntry{
+			{
+				CIDR:       "192.168.0.0/14",
+				HostPrefix: 23,
+			},
+		},
+		DeployKubeProxy: &tt,
+		KubeProxyConfig: &operv1.ProxyConfig{
+			BindAddress: "0.0.0.0",
+		},
+	}))
+}
+
+func TestRenderKubeProxy(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	c := &operv1.NetworkSpec{
+		ClusterNetwork: []operv1.ClusterNetworkEntry{
+			{
+				CIDR:       "192.168.0.0/14",
+				HostPrefix: 23,
+			},
+		},
+		DefaultNetwork: operv1.DefaultNetworkDefinition{Type: "Flannel"},
+		KubeProxyConfig: &operv1.ProxyConfig{
+			IptablesSyncPeriod: "42s",
+		},
+	}
+
+	FillKubeProxyDefaults(c, nil)
+
+	objs, err := RenderStandaloneKubeProxy(c, manifestDir)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(objs).To(HaveLen(10))
+
+	// Make sure the arguments to kube-proxy are reasonable
+	found := false
+	for _, obj := range objs {
+		if obj.GetAPIVersion() == "v1" && obj.GetKind() == "ConfigMap" && obj.GetName() == "proxy-config" {
+			if found == true {
+				t.Fatal("Two kube-proxy configmaps!?")
+			}
+			found = true
+
+			val, ok, err := uns.NestedString(obj.Object, "data", "kube-proxy-config.yaml")
+			g.Expect(ok).To(BeTrue())
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(val).To(MatchYAML(`
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+bindAddress: 0.0.0.0
+clientConnection:
+  acceptContentTypes: ""
+  burst: 0
+  contentType: ""
+  kubeconfig: ""
+  qps: 0
+clusterCIDR: 192.168.0.0/14
+configSyncPeriod: 0s
+conntrack:
+  max: null
+  maxPerCore: null
+  min: null
+  tcpCloseWaitTimeout: null
+  tcpEstablishedTimeout: null
+enableProfiling: false
+healthzBindAddress: 0.0.0.0:10256
+hostnameOverride: ""
+iptables:
+  masqueradeAll: false
+  masqueradeBit: null
+  minSyncPeriod: 0s
+  syncPeriod: 42s
+ipvs:
+  excludeCIDRs: null
+  minSyncPeriod: 0s
+  scheduler: ""
+  syncPeriod: 0s
+kind: KubeProxyConfiguration
+metricsBindAddress: 0.0.0.0:9101
+mode: iptables
+nodePortAddresses: null
+oomScoreAdj: null
+portRange: ""
+resourceContainer: ""
+udpIdleTimeout: 0s`))
+		}
+	}
+	g.Expect(found).To(BeTrue())
 }


### PR DESCRIPTION
This installs a standalone kube-proxy when needed. This is whenever we're not installing a network that is known to include it itself. This means that kube-proxy will be installed for third-party network plugins.