### PR TITLE
Slightly improve Progressing statuses

### DIFF
--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -174,12 +174,12 @@ func (status *StatusManager) SetFromPods() {
 			continue
 		}
 
-		if ds.Status.NumberUnavailable > 0 {
+		if ds.Status.UpdatedNumberScheduled < ds.Status.DesiredNumberScheduled {
+			progressing = append(progressing, fmt.Sprintf("DaemonSet %q update is rolling out (%d out of %d updated)", dsName.String(), ds.Status.UpdatedNumberScheduled, ds.Status.DesiredNumberScheduled))
+		} else if ds.Status.NumberUnavailable > 0 {
 			progressing = append(progressing, fmt.Sprintf("DaemonSet %q is not available (awaiting %d nodes)", dsName.String(), ds.Status.NumberUnavailable))
 		} else if ds.Status.NumberAvailable == 0 { // NOTE: update this if we ever expect empty (unscheduled) daemonsets ~cdc
 			progressing = append(progressing, fmt.Sprintf("DaemonSet %q is not yet scheduled on any nodes", dsName.String()))
-		} else if ds.Status.UpdatedNumberScheduled < ds.Status.DesiredNumberScheduled {
-			progressing = append(progressing, fmt.Sprintf("DaemonSet %q update is rolling out (%d out of %d updated)", dsName.String(), ds.Status.UpdatedNumberScheduled, ds.Status.DesiredNumberScheduled))
 		} else if ds.Generation > ds.Status.ObservedGeneration {
 			progressing = append(progressing, fmt.Sprintf("DaemonSet %q update is being processed (generation %d, observed generation %d)", dsName.String(), ds.Generation, ds.Status.ObservedGeneration))
 		}


### PR DESCRIPTION
Before, during an upgrade, the status would go:

    DaemonSet %q update is rolling out (0 out of 3 updated)
    ...
    DaemonSet %q is not available (awaiting 1 nodes)
    ...
    DaemonSet %q update is rolling out (1 out of 3 updated)
    ...
    DaemonSet %q is not available (awaiting 1 nodes)
    ...
    DaemonSet %q update is rolling out (2 out of 3 updated)
    ...
    DaemonSet %q is not available (awaiting 1 nodes)
    ...

Fix it to make the "update is rolling out" status take precedence over
the "not available" status.