### PR TITLE
change the serverity level for alert NetworkPodsCrashLooping

### DIFF
--- a/bindata/network/openshift-sdn/alert-rules.yaml
+++ b/bindata/network/openshift-sdn/alert-rules.yaml
@@ -38,4 +38,4 @@ spec:
         rate(kube_pod_container_status_restarts_total{namespace="openshift-sdn"}[15m]) * 60 * 5 > 0
       for: 1h
       labels:
-        severity: critical
+        severity: warning


### PR DESCRIPTION
After talking with the monitoring team 'critical' was too high a severity level for rule NetworkPodsCrashLooping, 'warning' is more appropriate.