### PR TITLE
Make Kuryr pods labels unambiguous

### DIFF
--- a/bindata/network/kuryr/004-daemon.yaml
+++ b/bindata/network/kuryr/004-daemon.yaml
@@ -7,11 +7,14 @@ metadata:
     kubernetes.io/description: |
       This DaemonSet launches the kuryr-daemon component.
 spec:
+  selector:
+    matchLabels:
+      app: kuryr-cni
   template:
     metadata:
       name: kuryr-cni
       labels:
-        app: kuryr
+        app: kuryr-cni
         component: network
         type: infra
         openshift.io/component: network

--- a/bindata/network/kuryr/005-controller.yaml
+++ b/bindata/network/kuryr/005-controller.yaml
@@ -7,11 +7,14 @@ metadata:
     kubernetes.io/description: |
       This deployment launches the kuryr-controller component.
 spec:
+  selector:
+    matchLabels:
+      app: kuryr-controller
   template:
     metadata:
       name: kuryr-controller
       labels:
-        app: kuryr
+        app: kuryr-controller
         component: network
         type: infra
         openshift.io/component: network


### PR DESCRIPTION
Commit changes the labels of Kuryr pods to make sure we distinguish
kuryr-cni and kuryr-controller. Also selector field is added as it seems
to be required.