### PR TITLE
sdn-ovs: allow ovs daemons to run as non-root

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -35,6 +35,8 @@ spec:
         - |
           #!/bin/bash
           set -euo pipefail
+          chown -R openvswitch:openvswitch /var/run/openvswitch
+          chown -R openvswitch:openvswitch /etc/openvswitch
 
           # if another process is listening on the cni-server socket, wait until it exits
           trap 'kill $(jobs -p); exit 0' TERM
@@ -59,7 +61,7 @@ spec:
               exit 0
           }
           trap quit SIGTERM
-          /usr/share/openvswitch/scripts/ovs-ctl start --no-ovs-vswitchd --system-id=random
+          /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --no-ovs-vswitchd --system-id=random
 
           # Restrict the number of pthreads ovs-vswitchd creates to reduce the
           # amount of RSS it uses on hosts with many cores
@@ -69,7 +71,7 @@ spec:
               ovs-vsctl --no-wait set Open_vSwitch . other_config:n-revalidator-threads=4
               ovs-vsctl --no-wait set Open_vSwitch . other_config:n-handler-threads=10
           fi
-          /usr/share/openvswitch/scripts/ovs-ctl start --no-ovsdb-server --system-id=random
+          /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --no-ovsdb-server --system-id=random
 
           tail -F --pid=$(cat /var/run/openvswitch/ovs-vswitchd.pid) /var/log/openvswitch/ovs-vswitchd.log &
           tail -F --pid=$(cat /var/run/openvswitch/ovsdb-server.pid) /var/log/openvswitch/ovsdb-server.log &


### PR DESCRIPTION
The two chowns are to set the ownership from the host mounted
volumes, since they may be incorrectly mapped.

sdn-33
ref: https://jira.coreos.com/browse/SDN-33

Signed-off-by: Aaron Conole <aconole@redhat.com>