### PR TITLE
adding additional sdn alerts to prometheus

### DIFF
--- a/bindata/network/openshift-sdn/alert-rules.yaml
+++ b/bindata/network/openshift-sdn/alert-rules.yaml
@@ -39,3 +39,35 @@ spec:
       for: 1h
       labels:
         severity: warning
+    - alert: IPTableSyncSDNPod
+      annotations:
+        message: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node {{"}}"}} takes too long to sync iptables rules.
+      expr: |
+        histogram_quantile(.95, kubeproxy_sync_proxy_rules_duration_seconds_bucket) * on(pod) group_right kube_pod_info{namespace="openshift-sdn",  pod=~"sdn-[^-]*"} > 15
+      labels:
+        severity: warning
+    - alert: IPTableSyncCluster
+      annotations:
+        message: The average time for SDN pods to sync iptables is too high.
+      expr: |
+        histogram_quantile(0.95, sum(rate(kubeproxy_sync_proxy_rules_duration_seconds_bucket[5m])) by (le)) > 10
+      labels:
+        severity: warning
+    - alert: NodeIPTablesStale
+    # there is some scrape delay and some other offset 120 is not really 120s but it is still too long
+      annotations:
+        message: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node {{"}}"}} has gone too long without syncing iptables rules. NOTE - There is some scrape delay and other offsets, 120s isn't exact but it is still too high.
+      expr: |
+        (time() - kubeproxy_sync_proxy_rules_last_timestamp_seconds) * on(pod) group_right kube_pod_info{namespace="openshift-sdn",  pod=~"sdn-[^-]*"} > 120
+      for: 20m
+      labels:
+        severity: warning
+    - alert: ClusterIPTablesStale
+    # there is some scrape delay and some other offset 90 i not really 90s but it is still too long
+      annotations:
+        message: The average time between iptables resyncs is too high. NOTE - There is some scrape delay and other offsets, 90s isn't exact but it is still too high.
+      expr: |
+        time() - (sum(kubeproxy_sync_proxy_rules_last_timestamp_seconds) / :kube_pod_info_node_count:) > 90
+      for: 20m
+      labels:
+        severity: warning


### PR DESCRIPTION
IPTableSyncSDNPod - fires when it takes an sdn pod more then 15s to sync 95% of the iptables rules
IPTableSyncCluster - fires when it takes the whole cluster on average more then 10s to refresh iptables rules

iptables taking a long time to sync would be a useful in debugging network issues, could be symptomatic of a number of network issues

NodeIPTablesStale - fires when an individual sdn pod has not synced iptables for 120s
ClusterIPTablesStale - fires when the average refresh rate of the cluster if 90s

NOTE: 90s and 120s are not really the time for refresh, there are a few offsets including a scrape delay that could not be fully tracked down but these values should be sufficiently high

not syncing iptables rules reflects that the sdn pods are starved for resources and could be the cause of network issues

part of https://jira.coreos.com/browse/SDN-406