### PR TITLE
OVN: use config file via ConfigMap rather than environment variables

### DIFF
--- a/bindata/network/ovn-kubernetes/000-ns.yaml
+++ b/bindata/network/ovn-kubernetes/000-ns.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  # NOTE: ovnkube.sh in the OVN image currently hardcodes this namespace name
   name: openshift-ovn-kubernetes
   labels:
     openshift.io/run-level: "0"

--- a/bindata/network/ovn-kubernetes/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/004-config.yaml
@@ -6,6 +6,5 @@ metadata:
   name: ovn-config
   namespace: openshift-ovn-kubernetes
 data:
-  net_cidr:   {{.OVN_cidr}}
-  svc_cidr:   {{.OVN_service_cidr}}
   k8s_apiserver: "{{.K8S_APISERVER}}"
+  namespace:  "openshift-ovn-kubernetes"

--- a/bindata/network/ovn-kubernetes/006-ovnkube-config.yaml
+++ b/bindata/network/ovn-kubernetes/006-ovnkube-config.yaml
@@ -1,0 +1,25 @@
+---
+# The config file used by ovnkube is passed as a configmap.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ovnkube-config
+  namespace: openshift-ovn-kubernetes
+data:
+  ovn_k8s.conf:   |-
+    [default]
+    mtu="{{.MTU}}"
+    cluster-subnets="{{.K8S_cluster_subnets}}"
+
+    [kubernetes]
+    service-cidr="{{.OVN_service_cidr}}"
+    ovn-config-namespace="openshift-ovn-kubernetes"
+    apiserver="{{.K8S_APISERVER}}"
+
+    [logging]
+    loglevel="{{.OVNKUBE_loglevel}}"
+
+    [gateway]
+    mode=local
+    nodeport=true
+

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -1,5 +1,5 @@
 # ovnkube-master
-# daemonset version 3
+# daemonset version 4
 # starts master daemons, each in a separate container
 # it is run on the master node(s)
 kind: Deployment
@@ -43,7 +43,7 @@ spec:
 
       # run-ovn-northd - v3
       - name: run-ovn-northd
-        image: {{.OvnImage}}
+        image: "{{.OvnImage}}"
 
         command: ["/root/ovnkube.sh", "run-ovn-northd"]
 
@@ -56,6 +56,8 @@ spec:
           name: host-var-lib-ovs
         - mountPath: /var/run/openvswitch/
           name: host-var-run-ovs
+        - mountPath: /var/run/ovn-config
+          name: ovn-config-mount
 
         resources:
           requests:
@@ -63,37 +65,16 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "3"
-        - name: OVN_LOG_NORTHD
-          value: "-vconsole:info"
-        - name: OVN_NET_CIDR
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: net_cidr
-        - name: OVN_SVC_CIDR
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: svc_cidr
+          value: "4"
         - name: K8S_NODE
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: K8S_APISERVER
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: k8s_apiserver
-        - name: OVN_KUBERNETES_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
       # end of container
 
       # nb-ovsdb - v3
       - name: nb-ovsdb
-        image: {{.OvnImage}}
+        image: "{{.OvnImage}}"
 
         command: ["/root/ovnkube.sh", "nb-ovsdb"]
 
@@ -106,6 +87,8 @@ spec:
           name: host-var-lib-ovs
         - mountPath: /var/run/openvswitch/
           name: host-var-run-ovs
+        - mountPath: /var/run/ovn-config
+          name: ovn-config-mount
 
         resources:
           requests:
@@ -113,37 +96,16 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "3"
-        - name: OVN_LOG_NB
-          value: "-vconsole:info -vfile:info"
-        - name: OVN_NET_CIDR
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: net_cidr
-        - name: OVN_SVC_CIDR
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: svc_cidr
+          value: "4"
         - name: K8S_NODE
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: K8S_APISERVER
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: k8s_apiserver
-        - name: OVN_KUBERNETES_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
       # end of container
 
       # sb-ovsdb - v3
       - name: sb-ovsdb
-        image: {{.OvnImage}}
+        image: "{{.OvnImage}}"
 
         command: ["/root/ovnkube.sh", "sb-ovsdb"]
 
@@ -158,6 +120,8 @@ spec:
           name: host-var-run-ovs
         - mountPath: /var/run/kubernetes/
           name: host-var-run-kubernetes
+        - mountPath: /var/run/ovn-config
+          name: ovn-config-mount
 
         resources:
           requests:
@@ -165,36 +129,15 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "3"
-        - name: OVN_LOG_SB
-          value: "-vconsole:info -vfile:info"
-        - name: OVN_NET_CIDR
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: net_cidr
-        - name: OVN_SVC_CIDR
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: svc_cidr
+          value: "4"
         - name: K8S_NODE
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: K8S_APISERVER
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: k8s_apiserver
-        - name: OVN_KUBERNETES_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
       # end of container
 
       - name: ovnkube-master
-        image: {{.OvnImage}}
+        image: "{{.OvnImage}}"
 
         command: ["/root/ovnkube.sh", "ovn-master"]
 
@@ -209,6 +152,10 @@ spec:
           name: host-var-run-ovs
         - mountPath: /var/run/kubernetes/
           name: host-var-run-kubernetes
+        - mountPath: /var/run/ovn-config
+          name: ovn-config-mount
+        - mountPath: /var/run/ovnkube-config
+          name: ovnkube-config-mount
 
         resources:
           requests:
@@ -216,34 +163,11 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "3"
-        - name: OVN_MASTER
-          value: "true"
-        - name: OVNKUBE_LOGLEVEL
           value: "4"
-        - name: OVN_NET_CIDR
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: net_cidr
-        - name: OVN_SVC_CIDR
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: svc_cidr
         - name: K8S_NODE
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: K8S_APISERVER
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: k8s_apiserver
-        - name: OVN_KUBERNETES_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
       # end of container
 
       nodeSelector:
@@ -262,6 +186,13 @@ spec:
       - name: host-var-run-kubernetes
         hostPath:
           path: /var/run/kubernetes
+      - configMap:
+          name: ovn-config
+        name: ovn-config-mount
+      - configMap:
+          name: ovnkube-config
+        name: ovnkube-config-mount
+
       tolerations:
       - key: "node-role.kubernetes.io/master"
         operator: "Exists"

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -1,6 +1,6 @@
 ---
 # ovnkube-node
-# daemonset version 3
+# daemonset version 4
 # starts node daemons for ovs and ovn, each in a separate container
 # it is run on all nodes
 kind: DaemonSet
@@ -37,9 +37,17 @@ spec:
       containers:
       # ovsdb-server and ovs-switchd daemons
       - name: ovs-daemons
-        image: {{.OvnImage}}
+        image: "{{.OvnImage}}"
 
         command: ["/root/ovnkube.sh", "ovs-server"]
+
+        livenessProbe:
+          exec:
+            command:
+            - /usr/share/openvswitch/scripts/ovs-ctl
+            - status
+          initialDelaySeconds: 15
+          periodSeconds: 5
 
         securityContext:
           # Permission could be reduced by selecting an appropriate SELinux policy
@@ -58,14 +66,15 @@ spec:
           readOnly: true
         - mountPath: /etc/openvswitch
           name: host-config-openvswitch
+        - mountPath: /var/run/ovn-config
+          name: ovn-config-mount
         resources:
           requests:
             cpu: 100m
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "3"
-
+          value: "4"
 
       # firewall rules for ovn - assumed to be setup
       # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6641 -j ACCEPT
@@ -75,7 +84,7 @@ spec:
       # The network container launches the ovn-k8s-cni-overlay process, the kube-proxy, and the local DNS service.
       # It relies on an up to date node-config.yaml being present.
       - name: ovn-controller
-        image: {{.OvnImage}}
+        image: "{{.OvnImage}}"
 
         command: ["/root/ovnkube.sh", "ovn-controller"]
 
@@ -89,6 +98,8 @@ spec:
           name: host-var-lib-ovs
         - mountPath: /var/run/openvswitch/
           name: host-var-run-ovs
+        - mountPath: /var/run/ovn-config
+          name: ovn-config-mount
 
         resources:
           requests:
@@ -96,35 +107,14 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "3"
-        - name: OVNKUBE_LOGLEVEL
           value: "4"
-        - name: OVN_NET_CIDR
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: net_cidr
-        - name: OVN_SVC_CIDR
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: svc_cidr
         - name: K8S_NODE
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: K8S_APISERVER
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: k8s_apiserver
-        - name: OVN_KUBERNETES_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
 
       - name: ovn-node
-        image: {{.OvnImage}}
+        image: "{{.OvnImage}}"
 
         command: ["/root/ovnkube.sh", "ovn-node"]
 
@@ -150,6 +140,10 @@ spec:
           name: host-cni-netd
         - mountPath: /var/lib/cni/networks/ovn-k8s-cni-overlay
           name: host-var-lib-cni-networks-ovn-kubernetes
+        - mountPath: /var/run/ovn-config
+          name: ovn-config-mount
+        - mountPath: /var/run/ovnkube-config
+          name: ovnkube-config-mount
 
         resources:
           requests:
@@ -157,35 +151,11 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_DAEMONSET_VERSION
-          value: "3"
-        - name: OVNKUBE_LOGLEVEL
           value: "4"
-        - name: OVN_GATEWAY_MODE
-          value: local
-        - name: OVN_NET_CIDR
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: net_cidr
-        - name: OVN_SVC_CIDR
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: svc_cidr
         - name: K8S_NODE
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: K8S_APISERVER
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: k8s_apiserver
-        - name: OVN_KUBERNETES_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-
         lifecycle:
           preStop:
             exec:
@@ -233,5 +203,11 @@ spec:
       - name: host-var-lib-cni-networks-ovn-kubernetes
         hostPath:
           path: /var/lib/cni/networks/ovn-k8s-cni-overlay
+      - configMap:
+          name: ovn-config
+        name: ovn-config-mount
+      - configMap:
+          name: ovnkube-config
+        name: ovnkube-config-mount
       tolerations:
       - operator: "Exists"

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -41,7 +41,6 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.U
 		}
 		ippools += fmt.Sprintf("%s/%d", net.CIDR, net.HostPrefix)
 	}
-	data.Data["OVN_cidr"] = ippools
 
 	var svcpools string
 	for _, net := range conf.ServiceNetwork {
@@ -51,6 +50,10 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.U
 		svcpools += fmt.Sprintf("%s", net)
 	}
 	data.Data["OVN_service_cidr"] = svcpools
+
+	// ovnkube config file
+	data.Data["K8S_cluster_subnets"] = ippools
+	data.Data["OVNKUBE_loglevel"] = 4
 
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/ovn-kubernetes"), &data)
 	if err != nil {


### PR DESCRIPTION
Create a new daemonset version that passes the ovn-config configMap
into the container as a file. Modify master and node daemonsets.

Create a ovnkube config file using a configMap.

This must merge after https://github.com/ovn-org/ovn-kubernetes/pull/748
which sets up daemonset version 4

SDN-456
https://jira.coreos.com/browse/SDN-456

Signed-off-by: Phil Cameron <pcameron@redhat.com>