### PR TITLE
Multus should look for CNI configuration in a different directory than kubelet

### DIFF
--- a/bindata/network/kuryr/004-daemon.yaml
+++ b/bindata/network/kuryr/004-daemon.yaml
@@ -82,10 +82,10 @@ spec:
       volumes:
       - name: bin
         hostPath:
-          path: /var/lib/cni/bin
+          path: {{.CNIBinDir}}
       - name: net-conf
         hostPath:
-          path: /etc/kubernetes/cni/net.d
+          path: {{.CNIConfDir}}
       - name: config-volume
         configMap:
           name: kuryr-config

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -55,6 +55,7 @@ spec:
         command: ["/entrypoint.sh"]
         args:
         - "--multus-conf-file=auto"
+        - "--multus-autoconfig-dir=/host/var/run/multus/cni/net.d"
         - "--multus-kubeconfig-file-host=/etc/kubernetes/cni/net.d/multus.d/multus.kubeconfig"
         - "--namespace-isolation=true"
         - "--multus-log-level=verbose"
@@ -65,8 +66,10 @@ spec:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: cni
+        - name: system-cni-dir
           mountPath: /host/etc/cni/net.d
+        - name: multus-cni-dir
+          mountPath: /host/var/run/multus/cni/net.d
         - name: cnibin
           mountPath: /host/opt/cni/bin
         env:
@@ -75,9 +78,12 @@ spec:
         - name: KUBERNETES_SERVICE_HOST
           value: "{{.KUBERNETES_SERVICE_HOST}}"
       volumes:
-        - name: cni
+        - name: system-cni-dir
           hostPath:
-            path: /etc/kubernetes/cni/net.d
+            path: {{ .SystemCNIConfDir }}
+        - name: multus-cni-dir
+          hostPath:
+            path: {{ .MultusCNIConfDir }}
         - name: cnibin
           hostPath:
             path: /var/lib/cni/bin

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -115,7 +115,7 @@ spec:
         - mountPath: /host/opt/cni/bin
           name: host-cni-bin
         - mountPath: /etc/cni/net.d
-          name: host-cni-netd
+          name: host-cni-conf
         - mountPath: /var/lib/cni/networks/openshift-sdn
           name: host-var-lib-cni-networks-openshift-sdn
         # If iptables needs to load a module
@@ -191,10 +191,10 @@ spec:
           path: /
       - name: host-cni-bin
         hostPath:
-          path: /var/lib/cni/bin
-      - name: host-cni-netd
+          path: {{.CNIBinDir}}
+      - name: host-cni-conf
         hostPath:
-          path: /etc/kubernetes/cni/net.d
+          path: {{.CNIConfDir}}
       - name: host-var-lib-cni-networks-openshift-sdn
         hostPath:
           path: /var/lib/cni/networks/openshift-sdn

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -223,10 +223,10 @@ spec:
           path: /sys
       - name: host-cni-bin
         hostPath:
-          path: /var/lib/cni/bin
+          path: {{.CNIBinDir}}
       - name: host-cni-netd
         hostPath:
-          path: /etc/kubernetes/cni/net.d
+          path: {{.CNIConfDir}}
       - name: host-config-openvswitch
         hostPath:
           path: /etc/origin/openvswitch

--- a/pkg/network/kuryr.go
+++ b/pkg/network/kuryr.go
@@ -53,6 +53,8 @@ func renderKuryr(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapR
 	data.Data["NodeImage"] = os.Getenv("NODE_IMAGE")
 	data.Data["DaemonImage"] = os.Getenv("KURYR_DAEMON_IMAGE")
 	data.Data["ControllerImage"] = os.Getenv("KURYR_CONTROLLER_IMAGE")
+	data.Data["CNIConfDir"] = pluginCNIConfDir(conf)
+	data.Data["CNIBinDir"] = CNIBinDir
 
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/kuryr"), &data)
 	if err != nil {

--- a/pkg/network/kuryr_test.go
+++ b/pkg/network/kuryr_test.go
@@ -51,6 +51,8 @@ func TestRenderKuryr(t *testing.T) {
 	errs := validateKuryr(config)
 	g.Expect(errs).To(HaveLen(0))
 
+	FillDefaults(config, nil)
+
 	objs, err := renderKuryr(config, &FakeBootstrapResult, manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-kuryr", "kuryr-cni")))

--- a/pkg/network/multus.go
+++ b/pkg/network/multus.go
@@ -4,10 +4,43 @@ import (
 	"os"
 	"path/filepath"
 
+	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/render"
 	"github.com/pkg/errors"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+const (
+	SystemCNIConfDir = "/etc/kubernetes/cni/net.d"
+	MultusCNIConfDir = "/var/run/multus/cni/net.d"
+	CNIBinDir        = "/var/lib/cni/bin"
+)
+
+// RenderMultus generates the manifests of Multus
+func RenderMultus(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Unstructured, error) {
+	if *conf.DisableMultiNetwork {
+		return nil, nil
+	}
+
+	var err error
+	out := []*uns.Unstructured{}
+	objs := []*uns.Unstructured{}
+
+	// enabling Multus always renders the CRD since Multus uses it
+	objs, err = renderAdditionalNetworksCRD(manifestDir)
+	if err != nil {
+		return nil, err
+	}
+	out = append(out, objs...)
+
+	usedhcp := UseDHCP(conf)
+	objs, err = renderMultusConfig(manifestDir, usedhcp)
+	if err != nil {
+		return nil, err
+	}
+	out = append(out, objs...)
+	return out, nil
+}
 
 // renderMultusConfig returns the manifests of Multus
 func renderMultusConfig(manifestDir string, useDHCP bool) ([]*uns.Unstructured, error) {
@@ -22,6 +55,8 @@ func renderMultusConfig(manifestDir string, useDHCP bool) ([]*uns.Unstructured, 
 	data.Data["KUBERNETES_SERVICE_HOST"] = os.Getenv("KUBERNETES_SERVICE_HOST")
 	data.Data["KUBERNETES_SERVICE_PORT"] = os.Getenv("KUBERNETES_SERVICE_PORT")
 	data.Data["RenderDHCP"] = useDHCP
+	data.Data["MultusCNIConfDir"] = MultusCNIConfDir
+	data.Data["SystemCNIConfDir"] = SystemCNIConfDir
 
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/multus"), &data)
 	if err != nil {
@@ -29,4 +64,14 @@ func renderMultusConfig(manifestDir string, useDHCP bool) ([]*uns.Unstructured, 
 	}
 	objs = append(objs, manifests...)
 	return objs, nil
+}
+
+// pluginCNIDir is the directory where plugins should install their CNI
+// configuration file. By default, it is where multus looks, unless multus
+// is disabled
+func pluginCNIConfDir(conf *operv1.NetworkSpec) string {
+	if *conf.DisableMultiNetwork {
+		return SystemCNIConfDir
+	}
+	return MultusCNIConfDir
 }

--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -37,6 +37,8 @@ func renderOpenShiftSDN(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Un
 	data.Data["KUBERNETES_SERVICE_HOST"] = os.Getenv("KUBERNETES_SERVICE_HOST")
 	data.Data["KUBERNETES_SERVICE_PORT"] = os.Getenv("KUBERNETES_SERVICE_PORT")
 	data.Data["Mode"] = c.Mode
+	data.Data["CNIConfDir"] = pluginCNIConfDir(conf)
+	data.Data["CNIBinDir"] = CNIBinDir
 
 	clusterNetwork, err := clusterNetwork(conf)
 	if err != nil {

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -34,6 +34,8 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.U
 	data.Data["HypershiftImage"] = os.Getenv("HYPERSHIFT_IMAGE")
 	data.Data["K8S_APISERVER"] = fmt.Sprintf("https://%s:%s", os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT"))
 	data.Data["MTU"] = c.MTU
+	data.Data["CNIConfDir"] = pluginCNIConfDir(conf)
+	data.Data["CNIBinDir"] = CNIBinDir
 
 	var ippools string
 	for _, net := range conf.ClusterNetwork {

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -317,29 +317,3 @@ func RenderAdditionalNetworks(conf *operv1.NetworkSpec, manifestDir string) ([]*
 
 	return out, nil
 }
-
-// RenderMultus generates the manifests of Multus
-func RenderMultus(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Unstructured, error) {
-	if *conf.DisableMultiNetwork {
-		return nil, nil
-	}
-
-	var err error
-	out := []*uns.Unstructured{}
-	objs := []*uns.Unstructured{}
-
-	// enabling Multus always renders the CRD since Multus uses it
-	objs, err = renderAdditionalNetworksCRD(manifestDir)
-	if err != nil {
-		return nil, err
-	}
-	out = append(out, objs...)
-
-	usedhcp := UseDHCP(conf)
-	objs, err = renderMultusConfig(manifestDir, usedhcp)
-	if err != nil {
-		return nil, err
-	}
-	out = append(out, objs...)
-	return out, nil
-}


### PR DESCRIPTION
This changes Multus to look for "default" CNI configurations in a different directory than where it writes it's file for CRIO. It also updates all plugins to write to that directory (when multus is enabled).