### PR TITLE
Specify OVN_GATEWAY_MODE in ovnkube-node

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -101,6 +101,8 @@ spec:
           value: "3"
         - name: OVNKUBE_LOGLEVEL
           value: "4"
+        - name: OVN_GATEWAY_MODE
+          value: local
         - name: OVN_NET_CIDR
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
Needed to sync with https://github.com/ovn-org/ovn-kubernetes/commit/f3b2e19c and https://github.com/ovn-org/ovn-kubernetes/pull/741. Blocks https://github.com/openshift/ovn-kubernetes/pull/12