### PR TITLE
Put openshift-etcd netnamespace on netid 1

### DIFF
--- a/bindata/network/openshift-sdn/004-multitenant.yaml
+++ b/bindata/network/openshift-sdn/004-multitenant.yaml
@@ -55,7 +55,8 @@ netname: openshift-image-registry
 
 ---
 # Namespaces which are part of the "control plane" and need to reach each other:
-# - kube-system (etcd)
+# - kube-system
+# - openshift-etcd
 # - openshift-apiserver
 # - openshift-service-catalog-apiserver
 # - openshift-service-catalog-controller-manager
@@ -75,6 +76,14 @@ metadata:
   name: kube-system
 netid: 1
 netname: kube-system
+
+---
+apiVersion: network.openshift.io/v1
+kind: NetNamespace
+metadata:
+  name: openshift-etcd
+netid: 1
+netname: openshift-etcd
 
 ---
 apiVersion: network.openshift.io/v1


### PR DESCRIPTION
Currently multitenant is broken since apiserver cannot connect
to etcd

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1719653