### PR TITLE
removing experimental annotation on multus ds config. 

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -20,8 +20,6 @@ spec:
         component: network
         type: infra
         openshift.io/component: network
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       hostNetwork: true
       nodeSelector:

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -27,14 +27,13 @@ spec:
         type: infra
         openshift.io/component: network
         kubernetes.io/os: "linux"
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       # Requires fairly broad permissions - ability to read all services and network functions as well
       # as all pods.
       serviceAccountName: ovn-kubernetes-controller
       hostNetwork: true
       hostPID: true
+      priorityClassName: "system-cluster-critical"
       containers:
       # firewall rules for ovn - assumed to be setup
       # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6641 -j ACCEPT

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -27,16 +27,14 @@ spec:
         type: infra
         openshift.io/component: network
         kubernetes.io/os: "linux"
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       # Requires fairly broad permissions - ability to read all services and network functions as well
       # as all pods.
       serviceAccountName: ovn-kubernetes-node
       hostNetwork: true
       hostPID: true
+      priorityClassName: "system-node-critical"
       containers:
-
       # ovsdb-server and ovs-switchd daemons
       - name: ovs-daemons
         image: {{.OvnImage}}


### PR DESCRIPTION
This PR is created with respect to Bugzilla ID: [1726069](https://bugzilla.redhat.com/show_bug.cgi?id=1726069)

I'm paraphrasing the bug report: "Now that multus pods already use .spec.priorityClassName, they should not keep the experimental 'critical-pod' annotation"