### PR TITLE
Introduce gosec for security checks

### DIFF
--- a/cmd/cluster-network-renderer/main.go
+++ b/cmd/cluster-network-renderer/main.go
@@ -86,6 +86,7 @@ func readConfigObject(path string) (*operv1.Network, error) {
 
 // writeObjects serializes the list of objects as a single yaml file
 func writeObjects(path string, objs []*uns.Unstructured) error {
+	// #nosec
 	fp, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return errors.Wrapf(err, "could not open output file %s", path)

--- a/hack/test-sec.sh
+++ b/hack/test-sec.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE}")/init.sh"
+
+# Check for `go` binary and set ${GOPATH}.
+setup_env
+
+cd ${GOPATH}/src/${CNO_GO_PKG}
+
+if [[ ! $(which go) ]]; then
+  echo "go not found on PATH. To install:"
+  echo "https://golang.org/dl/"
+  exit 1
+fi
+if [[ ! $(which gosec) ]]; then
+  echo "gosec not found on PATH. To install:"
+  echo "go get -u github.com/securego/gosec/cmd/gosec"
+  exit 1
+fi
+
+gosec -severity medium --confidence medium \
+    -exclude G304 \
+    -quiet ./...
+retcode=$?
+
+exit $retcode


### PR DESCRIPTION
gosec does static code analysis and checks for common security issues in golang codebases.

This PR introduces the tool, and sets it up as a test target in the Makefile; it also fixes a couple of warnings that were found.