### PR TITLE
Fine-tune Kuryr port pools defaults

### DIFF
--- a/bindata/network/kuryr/003-config.yaml
+++ b/bindata/network/kuryr/003-config.yaml
@@ -67,10 +67,10 @@ data:
     worker_nodes_subnet = {{ default "\"\"" .WorkerNodesSubnet }}
 
     [vif_pool]
-    #ports_pool_max = 0
-    #ports_pool_min = 5
-    #ports_pool_batch = 10
-    #ports_pool_update_frequency = 20
+    ports_pool_max = 0
+    ports_pool_min = 1
+    ports_pool_batch = 3
+    ports_pool_update_frequency = 30
 
     [health_server]
     port = {{ default 8082 .ControllerProbesPort }}


### PR DESCRIPTION
OpenShift with new installer has an enourmous amount of namespaces
created initially. As Kuryr needs to prepare a new subnet for each
namespace and prepopulate it with ports, we get high rate of requests to
OpenStack Neutron, which affects performance even to the point of
killing the neutron API server.

To counteract that this commit lowers the default numbers of ports being
created for each pool.