### PR TITLE
Kuryr: Use ens3 as link_iface in kuryr.conf

### DIFF
--- a/bindata/network/kuryr/003-config.yaml
+++ b/bindata/network/kuryr/003-config.yaml
@@ -10,7 +10,7 @@ data:
 
     [binding]
     default_driver = kuryr.lib.binding.drivers.vlan
-    link_iface = eth0
+    link_iface = ens3
 
     [cni_daemon]
     daemon_enabled = true


### PR DESCRIPTION
Seems like RHCOS VM's use ens3 as the name of the Neutron interface they
get. In order for Kuryr to correctly attach subports to that interface
this commit sets [binding]link_iface=ens3 in kuryr.conf.