### PR TITLE
Kuryr: Disable kube-proxy

### DIFF
--- a/pkg/network/proxy.go
+++ b/pkg/network/proxy.go
@@ -16,13 +16,16 @@ import (
 
 // ShouldDeployKubeProxy determines if the desired network type should
 // install kube-proxy.
-// openshift-sdn and OVN-Kubernetes deploy their own kube-proxy. All other
+// openshift-sdn deploys its own kube-proxy. ovn-kubernetes and
+// Kuryr-Kubernetes handle services on their own. All other
 // network providers are assumed to require kube-proxy
 func ShouldDeployKubeProxy(conf *operv1.NetworkSpec) bool {
 	switch conf.DefaultNetwork.Type {
 	case operv1.NetworkTypeOpenShiftSDN:
 		return false
 	case operv1.NetworkTypeOVNKubernetes:
+		return false
+	case operv1.NetworkTypeKuryr:
 		return false
 	default:
 		return true

--- a/pkg/network/proxy_test.go
+++ b/pkg/network/proxy_test.go
@@ -101,6 +101,9 @@ func TestShouldDeployKubeProxy(t *testing.T) {
 	c.DefaultNetwork.Type = operv1.NetworkTypeOVNKubernetes
 	g.Expect(ShouldDeployKubeProxy(c)).To(BeFalse())
 
+	c.DefaultNetwork.Type = operv1.NetworkTypeKuryr
+	g.Expect(ShouldDeployKubeProxy(c)).To(BeFalse())
+
 	c.DefaultNetwork.Type = "Flannel"
 	g.Expect(ShouldDeployKubeProxy(c)).To(BeTrue())
 }


### PR DESCRIPTION
Kuryr handles services on its own, so it doesn't need kube-proxy. This
commit disables its deployment when Kuryr is configured.