### PR TITLE
Bug 1751756: Kuryr: Add health monitor to Octavia load balancer

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -972,6 +972,7 @@
     "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/apiversions",
     "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners",
     "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers",
+    "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors",
     "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools",
     "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags",
     "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers",


### PR DESCRIPTION
Kuryr bootstrap process creates an Octavia loadbalancer that serves as
OpenShift API endpoint for the pods (i.e. kubernetes.default service on
the first IP of service subnet). It turns out during beginning of the
installation phase, the master nodes will not yet provide API access,
only bootstrap node will.

In order to support such situation this commit adds the bootstrap node
to the loadbalancer pool. Also to make sure the LB will point to correct
addresses, a health monitor is added to the pool. This ensures that the
master nodes will only get added to the LB when they're up.

Besides that it sets weight for load balancer members to prioritize genuine master nodes in favor of bootstrap node.