### PR TITLE
Kuryr: Fix [neutron_defaults]resource_tags setting

### DIFF
--- a/bindata/network/kuryr/003-config.yaml
+++ b/bindata/network/kuryr/003-config.yaml
@@ -46,7 +46,7 @@ data:
     service_subnet = {{ .ServiceSubnet }}
     project = {{ default "\"\"" $AuthInfo.ProjectID }}
     pod_security_groups = {{ default "default" .PodSecurityGroups }}
-    resource_tags = [{{ default "" .ResourceTags }}]
+    resource_tags = {{ default "" .ResourceTags }}
     #network_device_mtu = 1500
 
     [neutron]


### PR DESCRIPTION
Turns out that in .ini-like files you don't use "[]" to mark a list, you
just add options separated by a comma. This commit removes "[]"
mistakendly used on resource_tags option, so the tags will have a
correct form of just `openshiftClusterID=<cluster-id>`.