### PR TITLE
Kuryr: Fix setting status on Network CRD

### DIFF
--- a/pkg/network/cluster_config.go
+++ b/pkg/network/cluster_config.go
@@ -91,6 +91,8 @@ func StatusFromOperatorConfig(operConf *operv1.NetworkSpec) *configv1.NetworkSta
 		// continue
 	case operv1.NetworkTypeOVNKubernetes:
 		// continue
+	case operv1.NetworkTypeKuryr:
+		// continue
 	default:
 		return nil
 	}


### PR DESCRIPTION
Looks like due to an overlook we haven't enabled setting status on
Network CRD when running with Kuryr. This made the certificates
presented by openshfit-apiserver lack the IP as Common Name, causing SSL
validation to fail when trying to call API using the IP.

This commit fixes that by making sure StatusFromOperatorConfig() is not
returning nil when Kuryr is configured.