### PR TITLE
Condense CNI reference plugins images into a single image

### DIFF
--- a/bindata/network/multus/003-dhcp-daemon.yaml
+++ b/bindata/network/multus/003-dhcp-daemon.yaml
@@ -29,7 +29,7 @@ spec:
       - operator: Exists
       initContainers:
       - name: dhcp-daemon-initialization
-        image: {{.CNIPluginsSupportedImage}}
+        image: {{.CNIPluginsImage}}
         command: ["/bin/sh"]
         args: ["-c", "rm -f /var/run/cni/dhcp.sock"]
         volumeMounts:
@@ -38,7 +38,7 @@ spec:
       containers:
       - name: dhcp-daemon
         # Based on: https://github.com/s1061123/cni-dhcp-daemon/blob/master/Dockerfile
-        image: {{.CNIPluginsSupportedImage}}
+        image: {{.CNIPluginsImage}}
         imagePullPolicy: Always
         command: ["/usr/src/plugins/bin/dhcp"]
         args:

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -29,17 +29,8 @@ spec:
       - operator: Exists
       serviceAccountName: multus
       initContainers:
-      - name: cni-plugins-supported
-        image: {{.CNIPluginsSupportedImage}}
-        command: ["/bin/sh"]
-        args: ["-c", "cp -rf /usr/src/plugins/bin/* /host/opt/cni/bin"]
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /host/opt/cni/bin
-          name: cnibin
-      - name: cni-plugins-unsupported
-        image: {{.CNIPluginsUnsupportedImage}}
+      - name: cni-plugins
+        image: {{.CNIPluginsImage}}
         command: ["/bin/sh"]
         args: ["-c", "cp -rf /usr/src/plugins/bin/* /host/opt/cni/bin"]
         securityContext:

--- a/manifests/0000_70_cluster-network-operator_03_daemonset.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_daemonset.yaml
@@ -37,10 +37,8 @@ spec:
           value: "quay.io/openshift/origin-multus-cni:4.2"
         - name: MULTUS_ADMISSION_CONTROLLER_IMAGE
           value: "quay.io/openshift/origin-multus-admission-controller:4.2"
-        - name: CNI_PLUGINS_SUPPORTED_IMAGE
-          value: "quay.io/openshift/origin-container-networking-plugins-supported:4.2"
-        - name: CNI_PLUGINS_UNSUPPORTED_IMAGE
-          value: "quay.io/openshift/origin-container-networking-plugins-unsupported:4.2"
+        - name: CNI_PLUGINS_IMAGE
+          value: "quay.io/openshift/origin-container-networking-plugins:4.2"
         - name: OVN_IMAGE
           value: "quay.io/openshift/origin-ovn-kubernetes:4.2"
         - name: KURYR_DAEMON_IMAGE

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -26,14 +26,10 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-multus-admission-controller:4.2
-  - name: container-networking-plugins-supported
+  - name: container-networking-plugins
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-container-networking-plugins-supported:4.2
-  - name: container-networking-plugins-unsupported
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-container-networking-plugins-unsupported:4.2
+      name: quay.io/openshift/origin-container-networking-plugins:4.2
   - name: ovn-kubernetes
     from:
       kind: DockerImage

--- a/pkg/network/multus.go
+++ b/pkg/network/multus.go
@@ -17,8 +17,7 @@ func renderMultusConfig(manifestDir string, useDHCP bool) ([]*uns.Unstructured, 
 	data := render.MakeRenderData()
 	data.Data["ReleaseVersion"] = os.Getenv("RELEASE_VERSION")
 	data.Data["MultusImage"] = os.Getenv("MULTUS_IMAGE")
-	data.Data["CNIPluginsSupportedImage"] = os.Getenv("CNI_PLUGINS_SUPPORTED_IMAGE")
-	data.Data["CNIPluginsUnsupportedImage"] = os.Getenv("CNI_PLUGINS_UNSUPPORTED_IMAGE")
+	data.Data["CNIPluginsImage"] = os.Getenv("CNI_PLUGINS_IMAGE")
 	data.Data["KUBERNETES_SERVICE_HOST"] = os.Getenv("KUBERNETES_SERVICE_HOST")
 	data.Data["KUBERNETES_SERVICE_PORT"] = os.Getenv("KUBERNETES_SERVICE_PORT")
 	data.Data["RenderDHCP"] = useDHCP


### PR DESCRIPTION
This condenses the images for the container networking CNI reference plugins into a single image instead of having them in two images (with -supported & -unsupported suffixes).

I had ART update their build instructions, and their changes are available here @ https://gitlab.cee.redhat.com/openshift-art/ocp-build-data/merge_requests/172/diffs

Additionally, I have a pending PR for updating image mirroring in openshift/release here @ https://github.com/openshift/release/pull/4334

I believe this PR should be in a hold state until the openshift/release PR gets merged.

Also, quite happy to take any input on other changes should I have missed any, I tried to grep through and find any references to the -supported/-unsupported images to have them updated, but, any eyeballs are appreciated for sure.