### PR TITLE
Make Kuryr connect to API through api-int LB

### DIFF
--- a/bindata/network/kuryr/004-daemon.yaml
+++ b/bindata/network/kuryr/004-daemon.yaml
@@ -42,6 +42,11 @@ spec:
       - name: kuryr-cni
         image: {{ .DaemonImage }}
         env:
+        # Tell daemon to talk to the apiserver directly.
+        - name: KUBERNETES_SERVICE_PORT_HTTPS
+          value: "{{.KUBERNETES_SERVICE_PORT}}"
+        - name: KUBERNETES_SERVICE_HOST
+          value: "{{.KUBERNETES_SERVICE_HOST}}"
         - name: CNI_DAEMON
           value: "True"
         - name: KUBERNETES_NODE_NAME

--- a/bindata/network/kuryr/005-controller.yaml
+++ b/bindata/network/kuryr/005-controller.yaml
@@ -38,6 +38,12 @@ spec:
             port: {{ default 8082 .ControllerProbesPort }}
           initialDelaySeconds: 15
 {{ end }}
+        env:
+        # Tell controller to talk to the apiserver directly.
+        - name: KUBERNETES_SERVICE_PORT_HTTPS
+          value: "{{.KUBERNETES_SERVICE_PORT}}"
+        - name: KUBERNETES_SERVICE_HOST
+          value: "{{.KUBERNETES_SERVICE_HOST}}"
         volumeMounts:
         - name: config-volume
           mountPath: "/etc/kuryr"

--- a/pkg/network/kuryr.go
+++ b/pkg/network/kuryr.go
@@ -53,6 +53,8 @@ func renderKuryr(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapR
 	data.Data["NodeImage"] = os.Getenv("NODE_IMAGE")
 	data.Data["DaemonImage"] = os.Getenv("KURYR_DAEMON_IMAGE")
 	data.Data["ControllerImage"] = os.Getenv("KURYR_CONTROLLER_IMAGE")
+	data.Data["KUBERNETES_SERVICE_HOST"] = os.Getenv("KUBERNETES_SERVICE_HOST")
+	data.Data["KUBERNETES_SERVICE_PORT"] = os.Getenv("KUBERNETES_SERVICE_PORT")
 
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/kuryr"), &data)
 	if err != nil {


### PR DESCRIPTION
Turns out we should use api-int loadbalancer to make Kuryr connect to
the OpenShift API. This commit implements that.