### PR TITLE
Kuryr: Fix OpenShift API loadbalancer

### DIFF
--- a/pkg/platform/openstack/kuryr_bootstrap.go
+++ b/pkg/platform/openstack/kuryr_bootstrap.go
@@ -835,7 +835,7 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient client.Client) (*bootst
 			portIp := port.FixedIPs[0].IPAddress
 			log.Printf("Found port %s with IP %s", port.ID, portIp)
 			memberId, err := ensureOpenStackLbPoolMember(lbClient, port.Name, lbId,
-				poolId, portIp, workerSubnet.ID, 6443)
+				poolId, portIp, svcSubnetId, 6443)
 			if err != nil {
 				log.Printf("Failed to add port %s to LB pool %s: %s", port.ID, poolId, err)
 				continue


### PR DESCRIPTION
This PR solves two issues with the Octavia LB we create to cover `kubernetes.default` access to OpenShift API. One is allowing the traffic from service subnet (where Octavia LB VM sits) to masters subnet (where OpenShift API sits).

Second one makes sure LB members are added into service subnet, not the worker subnet, basically because the latter doesn't make any sense and puts Octavia into L2 mode which isn't supported.

I'm just editing this as GitHub doesn't seem to display this when listing PR's, so let's see if that triggers anything.