### PR TITLE
Kuryr: Expand svc net to fix VRRP ports conflicts

### DIFF
--- a/pkg/network/kuryr_test.go
+++ b/pkg/network/kuryr_test.go
@@ -99,4 +99,22 @@ func TestValidateKuryr(t *testing.T) {
 		},
 	}
 	errExpect("clusterNetwork must have exactly 1 entry")
+
+	config.ServiceNetwork = []string{"172.30.0.0/16"}
+	config.ClusterNetwork = []operv1.ClusterNetworkEntry{
+		{
+			CIDR:       "172.31.0.0/16",
+			HostPrefix: 16,
+		},
+	}
+	errExpect("will overlap with cluster network")
+
+	config.ServiceNetwork = []string{"172.31.0.0/16"}
+	config.ClusterNetwork = []operv1.ClusterNetworkEntry{
+		{
+			CIDR:       "172.30.0.0/16",
+			HostPrefix: 16,
+		},
+	}
+	errExpect("will overlap with cluster network")
 }

--- a/pkg/util/ip/addr.go
+++ b/pkg/util/ip/addr.go
@@ -12,7 +12,7 @@ type IPPool struct {
 
 func (p *IPPool) Add(cidr net.IPNet) error {
 	for _, n := range p.cidrs {
-		if netsOverlap(n, cidr) {
+		if NetsOverlap(n, cidr) {
 			return errors.Errorf("CIDRs %s and %s overlap",
 				n.String(),
 				cidr.String())
@@ -22,8 +22,8 @@ func (p *IPPool) Add(cidr net.IPNet) error {
 	return nil
 }
 
-// netsOverlap return true if two nets overlap
-func netsOverlap(a, b net.IPNet) bool {
+// NetsOverlap return true if two nets overlap
+func NetsOverlap(a, b net.IPNet) bool {
 	// ignore different families
 	if len(a.IP) != len(b.IP) {
 		return false
@@ -62,4 +62,34 @@ func FirstUsableIP(subnet net.IPNet) net.IP {
 	// …and this will be second one (first usable)
 	ip[len(ip)-1] += 1
 	return ip
+}
+
+// This function returns subnet E of size twice the given subnet A (it just does `prefix -= 1`) and
+// the subnet that includes all the IP's A was expanded with to form E.
+func ExpandNet(subnet net.IPNet) (net.IPNet, net.IPNet) {
+	// First determine if `subnet` will be upper or lower half double the `subnet`
+	ones, _ := subnet.Mask.Size()
+	posByte := uint(ones / 8) // byte in which prefix ends
+	posBit := uint(ones % 8)  // bit in which prefix ends
+
+	rest := net.IPNet{IP: make(net.IP, 4), Mask: make(net.IPMask, 4)}
+	copy(rest.IP, subnet.IP)
+	copy(rest.Mask, subnet.Mask)
+	// To get the "other" part of expanded net we need to just toggle the last
+	// bit of the network part.
+	if posBit == 0 { // we need to look at previous byte here
+		rest.IP[posByte-1] ^= 1
+	} else {
+		rest.IP[posByte] ^= 1 << (8 - posBit)
+	}
+
+	// This will effectively do `prefix -= 1` on subnet by zeroing last set bit.
+	if posBit == 0 {
+		subnet.Mask[posByte-1] &^= 1
+	} else {
+		subnet.Mask[posByte] &^= 1 << (8 - posBit)
+	}
+	subnet.IP = subnet.IP.Mask(subnet.Mask) // mask it in case there was 1 at the bit that is now in network part.
+
+	return subnet, rest
 }


### PR DESCRIPTION
Octavia with the default Amphora driver uses two the IPs from the
service subnet for each loadbalancer, the second being used as VRRP
port. The issue with that is that OpenShift uses it's own IPAM and
doesn't know about Octavia's habits leading to conflicts if IP chosen by
OpenShift is already taken by one of Amphora VRRP ports.

To fix this the service network created in OpenStack will be expanded to
be twice bigger than the ServiceNetwork value from NetworkSpec. Then the
other half of it will be used for Amphora VRRP ports, while OpenShift
will only choose IP's from the half indicated by
NetworkSpec.ServiceNetwork.

Obviously this may lead to conflicts if expanded network overlaps with
ClusterNetwork, so validation is expanded to check that.