### PR TITLE
openshift-sdn: give sdn-controller the ability to patch nodes.

### DIFF
--- a/bindata/network/openshift-sdn/003-rbac-controller.yaml
+++ b/bindata/network/openshift-sdn/003-rbac-controller.yaml
@@ -39,6 +39,12 @@ rules:
   - list
   - get
   - watch
+- apiGroups: [""]
+  resources:
+  - "nodes/status"
+  verbs:
+  - patch
+  - update
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
We need this to remove the NetworkUnavailable status that the GCP cloud-provider always sets. This is because it requires routes to be programmed, but we have it configured to not actually program routes.