### PR TITLE
Allow openshift-ovn-kubernetes-controller to use privileged SCC

### DIFF
--- a/bindata/network/ovn-kubernetes/003-rbac-controller.yaml
+++ b/bindata/network/ovn-kubernetes/003-rbac-controller.yaml
@@ -43,6 +43,13 @@ rules:
   - create
   - patch
   - update
+- apiGroups: ["security.openshift.io"]
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+  resourceNames:
+  - privileged
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Currently you can't create a privileged-ish pod when using ovn-kubernetes, because when the ovnkube master tries to patch the Pod with an annotation, it fails:

    time="2019-07-17T15:20:15Z" level=info msg="Setting annotations ovn={\\\"ip_address\\\":\\\"10.129.2.9/23\\\", \\\"mac_address\\\":\\\"0e:3a:8f:81:02:0a\\\", \\\"gateway_ip\\\": \\\"10.129.2.1\\\"} on pod lemon"
    time="2019-07-17T15:20:15Z" level=error msg="Error in setting annotation on pod lemon/foo: pods \"lemon\" is forbidden: unable to validate against any security context constraint: [spec.containers[0].securityContext.containers[0].hostPort: Invalid value: 8888: Host ports are not allowed to be used]"

It seems that you can only add an annotation to a security-context-constrained pod if you have access to an SCC that would allow you to create that pod? That seems surprising to me but also not necessarily wrong...

@smarterclayton or @deads2k or someone, can you confirm that this is the expected behavior and that this fix makes sense? (Is there no better way to say "has permission to annotate any pod"?)