### PR TITLE
Adding build support for archs other than amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-network-operator
 COPY . .
-RUN hack/build-go.sh
+RUN hack/build-go.sh; \
+    mkdir -p /tmp/build; \
+    cp /go/src/github.com/openshift/cluster-network-operator/_output/linux/$(go env GOARCH)/cluster-network-operator /tmp/build/; \
+    cp /go/src/github.com/openshift/cluster-network-operator/_output/linux/$(go env GOARCH)/cluster-network-renderer /tmp/build/
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-COPY --from=builder /go/src/github.com/openshift/cluster-network-operator/_output/linux/amd64/cluster-network-operator /usr/bin/
-COPY --from=builder /go/src/github.com/openshift/cluster-network-operator/_output/linux/amd64/cluster-network-renderer /usr/bin/
+COPY --from=builder /tmp/build/cluster-network-operator /usr/bin/
+COPY --from=builder /tmp/build/cluster-network-renderer /usr/bin/
 COPY manifests /manifests
 COPY bindata /bindata
 ENV OPERATOR_NAME=cluster-network-operator


### PR DESCRIPTION
This modifies the Dockerfile to add the build support for archs other than amd64, based on the commit: https://github.com/openshift/cluster-network-operator/commit/1c9828fdcacec9240aff3a402429df4c3e1dd2ef