### PR TITLE
ovn-kubernetes: fix gateway mode, log level

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -99,8 +99,6 @@ spec:
           value: "3"
         - name: OVNKUBE_LOGLEVEL
           value: "4"
-        - name: OVN_GATEWAY_MODE
-          value: local
         - name: OVN_NET_CIDR
           valueFrom:
             configMapKeyRef:
@@ -161,7 +159,9 @@ spec:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVNKUBE_LOGLEVEL
-          value: "5"
+          value: "4"
+        - name: OVN_GATEWAY_MODE
+          value: local
         - name: OVN_NET_CIDR
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
#223 mistakenly added the `OVN_GATEWAY_MODE` variable to the ovn-controller container rather the ovnkube node container. (Alas, fixing this does not fix the dns-not-ready problem.)

Also, for no apparent reason, we were running ovnkube node with debug-level logging, while everything else was at "info" level.