### PR TITLE
Slightly simplify unidling config code

### DIFF
--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -48,17 +48,13 @@ func renderOpenShiftSDN(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Un
 		"metrics-bind-address":    {"0.0.0.0"},
 		"metrics-port":            {"9101"},
 		"healthz-port":            {"10256"},
-		"proxy-mode":              {"unidling+iptables"},
+		"proxy-mode":              {"iptables"},
 		"iptables-masquerade-bit": {"0"},
 	}
-	if !*c.EnableUnidling {
-		kpcDefaults["proxy-mode"][0] = "iptables"
-	}
 
-	// Always set the proxy-mode, even if the user specified it
-	// We already validated that proxy-mode was either unset or iptables.
 	kpcOverrides := map[string]operv1.ProxyArgumentList{}
 	if *c.EnableUnidling {
+		// We already validated that proxy-mode was either unset or iptables.
 		kpcOverrides["proxy-mode"] = operv1.ProxyArgumentList{"unidling+iptables"}
 	}
 


### PR DESCRIPTION
I didn't want to do another round of back and forth on Friday evening when we were trying to get stuff in before the deadline and wrestling with e2e-aws flakes, but this was annoying me. The override correctly handles all cases without needing to modify the defaults. (Also, the comment about having already validated proxy-mode should be inside the `if`, not outside it, since the comment is only true if the `if` condition is true.)