### PR TITLE
Stop unnecessary status updates, make necessary ones less verbose

### DIFF
--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -93,7 +93,7 @@ func (status *StatusManager) Set(reachedAvailableLevel bool, conditions ...confi
 		},
 	)
 
-	if reflect.DeepEqual(oldStatus, co.Status) {
+	if reflect.DeepEqual(*oldStatus, co.Status) {
 		return
 	}
 

--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -97,7 +97,7 @@ func (status *StatusManager) Set(reachedAvailableLevel bool, conditions ...confi
 		return
 	}
 
-	buf, err := yaml.Marshal(co.Status)
+	buf, err := yaml.Marshal(co.Status.Conditions)
 	if err != nil {
 		buf = []byte(fmt.Sprintf("(failed to convert to YAML: %s)", err))
 	}
@@ -105,14 +105,14 @@ func (status *StatusManager) Set(reachedAvailableLevel bool, conditions ...confi
 		if err := status.client.Create(context.TODO(), co); err != nil {
 			log.Printf("Failed to create ClusterOperator %q: %v", co.Name, err)
 		} else {
-			log.Printf("Created ClusterOperator with status:\n%s", string(buf))
+			log.Printf("Created ClusterOperator with conditions:\n%s", string(buf))
 		}
 	} else {
 		err = status.client.Status().Update(context.TODO(), co)
 		if err != nil {
 			log.Printf("Failed to update ClusterOperator %q: %v", co.Name, err)
 		} else {
-			log.Printf("Updated ClusterOperator with status:\n%s", string(buf))
+			log.Printf("Updated ClusterOperator with conditions:\n%s", string(buf))
 		}
 	}
 }


### PR DESCRIPTION
When we update the ClusterOperator.Status we log the YAML of it. But this is mostly because it's interesting to see the conditions; we don't want to see the list of related objects every time, since it never changes (and just forces the part that you do care about to scroll off the screen). So just log `co.Status.Conditions` instead.

Then while trying to figure out why we still logged the status even when nothing changed, I discovered that we were dumb. A `ClusterOperator` will never be equal to a `*ClusterOperator`...