### PR TITLE
ovnkube: hook up the user IDs

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -62,6 +62,8 @@ spec:
             cpu: 100m
             memory: 300Mi
         env:
+        - name: OVS_USER_ID
+          value: "openvswitch:openvswitch"
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVN_LOG_NORTHD
@@ -112,6 +114,8 @@ spec:
             cpu: 100m
             memory: 300Mi
         env:
+        - name: OVS_USER_ID
+          value: "openvswitch:openvswitch"
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVN_LOG_NB
@@ -164,6 +168,8 @@ spec:
             cpu: 100m
             memory: 300Mi
         env:
+        - name: OVS_USER_ID
+          value: "openvswitch:openvswitch"
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVN_LOG_SB
@@ -215,6 +221,8 @@ spec:
             cpu: 100m
             memory: 300Mi
         env:
+        - name: OVS_USER_ID
+          value: "openvswitch:openvswitch"
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVN_MASTER

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -63,6 +63,8 @@ spec:
             cpu: 100m
             memory: 300Mi
         env:
+        - name: OVS_USER_ID
+          value: "openvswitch:openvswitch"
         - name: OVN_DAEMONSET_VERSION
           value: "3"
 
@@ -95,6 +97,8 @@ spec:
             cpu: 100m
             memory: 300Mi
         env:
+        - name: OVS_USER_ID
+          value: "openvswitch:openvswitch"
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVNKUBE_LOGLEVEL
@@ -156,6 +160,8 @@ spec:
             cpu: 100m
             memory: 300Mi
         env:
+        - name: OVS_USER_ID
+          value: "openvswitch:openvswitch"
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVNKUBE_LOGLEVEL


### PR DESCRIPTION
A recent update to the ovnkube.sh script allowed passing user IDs to underlying
daemons to run as a specific user.

This change passes the openvswitch user IDs when starting the container
images.  The user IDs come from the RPM install of the openvswitch and
OVN RPMs.

Signed-off-by: Aaron Conole <aconole@redhat.com>