### PR TITLE
kuryr: get CNI loopback plugin from CNIPluginsImage

### DIFF
--- a/bindata/network/kuryr/004-daemon.yaml
+++ b/bindata/network/kuryr/004-daemon.yaml
@@ -24,15 +24,14 @@ spec:
       priorityClassName: system-node-critical
       initContainers:
       - name: install-cni-plugins
-        image: {{ .NodeImage }}
+        image: {{ .CNIPluginsImage }}
         command:
         - /bin/bash
         - -c
         - |
           #!/bin/bash
           set -ex
-          # Take over network functions on the node
-          cp -Rf /opt/cni/bin/* /host-cni-bin/
+          cp -f /usr/src/plugins/bin/loopback /host-cni-bin/
         volumeMounts:
         - name: bin
           mountPath: /host-cni-bin

--- a/pkg/network/kuryr.go
+++ b/pkg/network/kuryr.go
@@ -50,7 +50,7 @@ func renderKuryr(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapR
 	data.Data["ControllerEnableProbes"] = true
 	data.Data["ControllerProbesPort"] = c.ControllerProbesPort
 
-	data.Data["NodeImage"] = os.Getenv("NODE_IMAGE")
+	data.Data["CNIPluginsImage"] = os.Getenv("CNI_PLUGINS_IMAGE")
 	data.Data["DaemonImage"] = os.Getenv("KURYR_DAEMON_IMAGE")
 	data.Data["ControllerImage"] = os.Getenv("KURYR_CONTROLLER_IMAGE")
 	data.Data["KUBERNETES_SERVICE_HOST"] = os.Getenv("KUBERNETES_SERVICE_HOST")


### PR DESCRIPTION
With the merge of #237 kuryr can now get the CNI plugins it needs from the official image rather than stealing them from the SDN image.

I'm not sure how to test this, but someone should before merging it.