### PR TITLE
Don't require clusterNetwork and serviceNetwork to be set in operator type

### DIFF
--- a/manifests/0000_70_cluster-network-operator_01_crd.yaml
+++ b/manifests/0000_70_cluster-network-operator_01_crd.yaml
@@ -20,7 +20,7 @@ spec:
       properties:
         spec:
           type: object
-          required: ["clusterNetwork", "serviceNetwork", "defaultNetwork"]
+          required: ["defaultNetwork"]
           properties:
             clusterNetwork:
               type: array


### PR DESCRIPTION
Currently if you follow [our documentation on configuring multitenant, etc](https://docs.openshift.com/container-platform/4.1/installing/installing_aws/installing-aws-network-customizations.html#modifying-nwoperator-config-startup_installing-aws-network-customizations) it doesn't actually work because we claim you can write out a partial operator config, but we install a CRD that won't accept the partial config. Or maybe it worked somehow in 4.1 but doesn't in 4.2? Anyway, easy fix...