### PR TITLE
add the api group to the override spec

### DIFF
--- a/hack/overrides-patch.yaml
+++ b/hack/overrides-patch.yaml
@@ -6,5 +6,6 @@
   value:
     kind: Deployment
     name: network-operator
+    group: operator.openshift.io
     namespace: openshift-network-operator
     unmanaged: true


### PR DESCRIPTION
When attempting to use `hack/run-locally.sh` to attach to a running cluster you get a failure
patching the clusterversion

...validation failure list:
spec.overrides.group in body is required

adding the api group to the overrides-patch.yaml