### PR TITLE
Removed deprecated version 1 and version 2 from ovnkube.sh

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -217,8 +217,6 @@ spec:
         env:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
-        - name: OVN_MASTER
-          value: "true"
         - name: OVNKUBE_LOGLEVEL
           value: "4"
         - name: OVN_NET_CIDR


### PR DESCRIPTION
OVN_MASTER is removed as part of this cleanup.

OVN ovnkube.sh remove version 1,2 support
https://jira.coreos.com/browse/SDN-495

Signed-off-by: Phil Cameron <pcameron@redhat.com>