### PR TITLE
Add Kuryr DNS modifications webhook

### DIFF
--- a/bindata/network/kuryr/006-service.yaml
+++ b/bindata/network/kuryr/006-service.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kuryr-dns-admission-controller
+  namespace: openshift-kuryr
+  labels:
+    app: kuryr-dns-admission-controller
+spec:
+  ports:
+  - port: 443
+    targetPort: 6443
+  selector:
+    app: kuryr-dns-admission-controller

--- a/bindata/network/kuryr/007-admission.secret.yaml
+++ b/bindata/network/kuryr/007-admission.secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{.AdmissionControllerSecret}}
+  namespace: openshift-kuryr
+data:
+  ca.crt: {{ .WebhookCA }}
+  ca.key: {{ .WebhookCAKey }}

--- a/bindata/network/kuryr/008-webhook.secret.yaml
+++ b/bindata/network/kuryr/008-webhook.secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{.WebhookSecret}}
+  namespace: openshift-kuryr
+data:
+  tls.crt: {{ .WebhookCert }}
+  tls.key: {{ .WebhookKey }}

--- a/bindata/network/kuryr/009-admission-controller.yaml
+++ b/bindata/network/kuryr/009-admission-controller.yaml
@@ -1,0 +1,59 @@
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: kuryr-dns-admission-controller
+  namespace: openshift-kuryr
+  labels:
+    app: kuryr-dns-admission-controller
+  annotations:
+    kubernetes.io/description: |
+      This daemon set launches the admisson controller that will force TPC DNS resolution for pods on each node.
+spec:
+  selector:
+    matchLabels:
+      app: kuryr-dns-admission-controller
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: kuryr-dns-admission-controller
+        namespace: openshift-kuryr
+        component: network
+        type: infra
+        openshift.io/component: network
+    spec:
+      containers:
+      - name: kuryr-dns-admission-controller
+        image: {{ .ControllerImage }}
+        command:
+        - kuryr-dns-webhook
+        args:
+        - --bind-address=0.0.0.0
+        - --port=6443
+        - --tls-private-key-file=/etc/webhook/tls.key
+        - --tls-cert-file=/etc/webhook/tls.crt
+        volumeMounts:
+        - name: webhook-certs
+          mountPath: /etc/webhook
+          readOnly: True
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 10m
+      priorityClassName: "system-cluster-critical"
+      restartPolicy: Always
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      volumes:
+      - name: webhook-certs
+        secret:
+          secretName: {{.WebhookSecret}}
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: Exists
+        effect: NoSchedule
+      - key: "node.kubernetes.io/not-ready"
+        operator: Exists
+        effect: NoSchedule

--- a/bindata/network/kuryr/010-webhook.yaml
+++ b/bindata/network/kuryr/010-webhook.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: kuryr-dns-admission-controller
+  labels:
+    app: kuryr-dns-admission-controller
+webhooks:
+  - name: kuryr-dns-admission-controller.openshift.io
+    clientConfig:
+      service:
+        name: kuryr-dns-admission-controller
+        namespace: openshift-kuryr
+        path: "/"
+      caBundle: {{ .WebhookCA }}
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: [""]
+        apiVersions: ["*"]
+        resources: ["pods"]

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -12,6 +12,10 @@ type KuryrBootstrapResult struct {
 	PodSecurityGroups []string
 	ClusterID         string
 	OpenStackCloud    clientconfig.Cloud
+	WebhookCA         string
+	WebhookCAKey      string
+	WebhookCert       string
+	WebhookKey        string
 }
 
 type BootstrapResult struct {

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -78,3 +78,9 @@ func TrustedCABundleConfigMap() types.NamespacedName {
 		Name:      TRUSTED_CA_BUNDLE_CONFIGMAP,
 	}
 }
+
+// KURYR_ADMISSION_CONTROLLER_SECRET is the name of the Secret that stores the admission controller CA and Key
+const KURYR_ADMISSION_CONTROLLER_SECRET = "kuryr-dns-admission-controller-secret"
+
+// KURYR_WEB_HOOK_SECRET is the name of the secret used in the kuryr-dns-admission-controller DaemonSet
+const KURYR_WEBHOOK_SECRET = "kuryr-webhook-secret"

--- a/pkg/network/kuryr.go
+++ b/pkg/network/kuryr.go
@@ -12,6 +12,7 @@ import (
 
 	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
+	"github.com/openshift/cluster-network-operator/pkg/names"
 	"github.com/openshift/cluster-network-operator/pkg/render"
 )
 
@@ -55,6 +56,14 @@ func renderKuryr(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapR
 	data.Data["ControllerImage"] = os.Getenv("KURYR_CONTROLLER_IMAGE")
 	data.Data["KUBERNETES_SERVICE_HOST"] = os.Getenv("KUBERNETES_SERVICE_HOST")
 	data.Data["KUBERNETES_SERVICE_PORT"] = os.Getenv("KUBERNETES_SERVICE_PORT")
+
+	// DNS mutating webhook
+	data.Data["AdmissionControllerSecret"] = names.KURYR_ADMISSION_CONTROLLER_SECRET
+	data.Data["WebhookSecret"] = names.KURYR_WEBHOOK_SECRET
+	data.Data["WebhookCA"] = b.WebhookCA
+	data.Data["WebhookCAKey"] = b.WebhookCAKey
+	data.Data["WebhookCert"] = b.WebhookCert
+	data.Data["WebhookKey"] = b.WebhookKey
 
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/kuryr"), &data)
 	if err != nil {

--- a/pkg/platform/openstack/kuryr_bootstrap.go
+++ b/pkg/platform/openstack/kuryr_bootstrap.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"context"
+	b64 "encoding/base64"
 	"fmt"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
 	"k8s.io/api/core/v1"
@@ -27,6 +28,8 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 	"github.com/gophercloud/utils/openstack/clientconfig"
+	"github.com/openshift/cluster-network-operator/pkg/names"
+	"github.com/openshift/cluster-network-operator/pkg/platform/openstack/util/cert"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -51,6 +54,7 @@ const (
 	MinOctaviaVersionWithTimeouts   = "v2.1"
 	KubernetesEndpointsName         = "kubernetes"
 	KubernetesEndpointsNamespace    = "default"
+	KuryrNamespace                  = "openshift-kuryr"
 )
 
 func GetClusterID(kubeClient client.Client) (string, error) {
@@ -702,6 +706,58 @@ func generateName(name, clusterID string) string {
 	return fmt.Sprintf("%s-%s", clusterID, name)
 }
 
+func ensureCA(kubeClient client.Client) ([]byte, []byte, error) {
+	secret := &v1.Secret{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		ObjectMeta: metav1.ObjectMeta{Name: names.KURYR_ADMISSION_CONTROLLER_SECRET},
+	}
+	err := kubeClient.Get(context.TODO(), client.ObjectKey{Namespace: KuryrNamespace, Name: names.KURYR_ADMISSION_CONTROLLER_SECRET}, secret)
+	if err != nil {
+		caBytes, keyBytes, err := cert.GenerateCA("Kuryr")
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "Failed to generate CA.")
+		}
+		return caBytes, keyBytes, nil
+	} else {
+		crtContent, crtok := secret.Data["ca.crt"]
+		keyContent, keyok := secret.Data["ca.key"]
+		if !crtok || !keyok {
+			caBytes, keyBytes, err := cert.GenerateCA("Kuryr")
+			if err != nil {
+				return nil, nil, errors.Wrapf(err, "Failed to generate CA.")
+			}
+			return caBytes, keyBytes, nil
+		}
+		return crtContent, keyContent, nil
+	}
+}
+
+func ensureCertificate(kubeClient client.Client, caPEM []byte, privateKey []byte) ([]byte, []byte, error) {
+	secret := &v1.Secret{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		ObjectMeta: metav1.ObjectMeta{Name: names.KURYR_WEBHOOK_SECRET},
+	}
+	err := kubeClient.Get(context.TODO(), client.ObjectKey{Namespace: KuryrNamespace, Name: names.KURYR_WEBHOOK_SECRET}, secret)
+	if err != nil {
+		caBytes, keyBytes, err := cert.GenerateCertificate("Kuryr", []string{"kuryr-dns-admission-controller.openshift-kuryr", "kuryr-dns-admission-controller.openshift-kuryr.svc"}, caPEM, privateKey)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "Failed to generate CA.")
+		}
+		return caBytes, keyBytes, nil
+	} else {
+		crtContent, crtok := secret.Data["tls.crt"]
+		keyContent, keyok := secret.Data["tls.key"]
+		if !crtok || !keyok {
+			caBytes, keyBytes, err := cert.GenerateCertificate("Kuryr", []string{"kuryr-dns-admission-controller.openshift-kuryr", "kuryr-dns-admission-controller.openshift-kuryr.svc"}, caPEM, privateKey)
+			if err != nil {
+				return nil, nil, errors.Wrapf(err, "Failed to generate CA.")
+			}
+			return caBytes, keyBytes, nil
+		}
+		return crtContent, keyContent, nil
+	}
+}
+
 // Logs into OpenStack and creates all the resources that are required to run
 // Kuryr based on conf NetworkConfigSpec. Basically this includes service
 // network and subnet, pods subnetpool, security group and load balancer for
@@ -937,6 +993,16 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient client.Client) (*bootst
 		return nil, errors.Wrap(err, "failed to delete unused members from OpenShist API loadbalancer pool")
 	}
 
+	log.Print("Ensuring certificates")
+	ca, key, err := ensureCA(kubeClient)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to ensure CA")
+	}
+	webhookCert, webhookKey, err := ensureCertificate(kubeClient, ca, key)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to ensure Certificate")
+	}
+
 	log.Print("Kuryr bootstrap finished")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed get OpenShift cluster ID")
@@ -951,6 +1017,10 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient client.Client) (*bootst
 			PodSecurityGroups: []string{podSgId},
 			ClusterID:         clusterID,
 			OpenStackCloud:    cloud,
+			WebhookCA:         b64.StdEncoding.EncodeToString(ca),
+			WebhookCAKey:      b64.StdEncoding.EncodeToString(key),
+			WebhookKey:        b64.StdEncoding.EncodeToString(webhookKey),
+			WebhookCert:       b64.StdEncoding.EncodeToString(webhookCert),
 		}}
 	return &res, nil
 }

--- a/pkg/platform/openstack/util/cert/cert.go
+++ b/pkg/platform/openstack/util/cert/cert.go
@@ -1,0 +1,106 @@
+package cert
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"math/big"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func GenerateCA(networkName string) ([]byte, []byte, error) {
+	log.Print("Generating Webhook CA")
+	caTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: fmt.Sprintf("%s-ca@%d", networkName, time.Now().Unix()),
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to genarate CA private key")
+	}
+	caBytes, err := x509.CreateCertificate(rand.Reader, &caTemplate, &caTemplate, &caPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to create CA")
+	}
+
+	caPEM := bytes.Buffer{}
+	if err := pem.Encode(&caPEM, &pem.Block{Type: "CERTIFICATE", Bytes: caBytes}); err != nil {
+		return nil, nil, errors.Wrap(err, "failed to PEM encode CA")
+	}
+
+	caKeyPEM := bytes.Buffer{}
+	if err := pem.Encode(&caKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(caPrivKey)}); err != nil {
+		return nil, nil, errors.Wrap(err, "failed to PEM encode ca private key")
+	}
+
+	return caPEM.Bytes(), caKeyPEM.Bytes(), nil
+}
+
+func GenerateCertificate(networkName string, dnsNames []string, caPEM []byte, caPrivateKey []byte) ([]byte, []byte, error) {
+	log.Print("Generating Webhook certificate")
+	cert := x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			CommonName: fmt.Sprintf("%s@%d", networkName, time.Now().Unix()),
+		},
+		DNSNames:     dnsNames,
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(10, 0, 0),
+		SubjectKeyId: []byte{1, 2, 3, 4, 6},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+
+	cablock, _ := pem.Decode([]byte(caPEM))
+	if cablock == nil {
+		return nil, nil, errors.Errorf("failed to decode certificate PEM")
+	}
+	ca, err := x509.ParseCertificate(cablock.Bytes)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to parse certificate PEM")
+	}
+
+	block, _ := pem.Decode([]byte(caPrivateKey))
+	if block == nil {
+		return nil, nil, errors.Errorf("failed to decode private key PEM")
+	}
+	privateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to parse certificate PEM")
+	}
+
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to genarate Cert private key")
+	}
+	certBytes, err := x509.CreateCertificate(rand.Reader, &cert, ca, &certPrivKey.PublicKey, privateKey)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to create Service certificate")
+	}
+
+	certKeyPEM := bytes.Buffer{}
+	if err := pem.Encode(&certKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(certPrivKey)}); err != nil {
+		return nil, nil, errors.Wrap(err, "failed to PEM encode cert private key")
+	}
+	certPEM := bytes.Buffer{}
+	if err := pem.Encode(&certPEM, &pem.Block{Type: "CERTIFICATE", Bytes: certBytes}); err != nil {
+		return nil, nil, errors.Wrap(err, "failed to PEM encode cert")
+	}
+	return certPEM.Bytes(), certKeyPEM.Bytes(), nil
+}


### PR DESCRIPTION
Due to Octavia not supporting UDP listeners in Queens version,
coredns deployments that uses UDP are not supported as well.
This PR creates a mutating webhook to inject a dnsConfig option,
"use-vc", to pods deployments, so TCP is used instead of UDP
for dns resolution.