### PR TITLE
Bug 1737026: Making set internal to the statusManager and adding mutex for thread safety

### DIFF
--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -232,6 +232,7 @@ func (r *ReconcileOperConfig) Reconcile(request reconcile.Request) (reconcile.Re
 			Namespace: obj.GetNamespace(),
 		})
 	}
+
 	r.status.SetDaemonSets(daemonSets)
 	r.status.SetDeployments(deployments)
 	r.status.SetRelatedObjects(relatedObjects)

--- a/pkg/controller/proxyconfig/controller.go
+++ b/pkg/controller/proxyconfig/controller.go
@@ -259,7 +259,6 @@ func (r *ReconcileProxyConfig) Reconcile(request reconcile.Request) (reconcile.R
 			trustBundle.Namespace, trustBundle.Name, err)
 	}
 
-	// Reconciliation completed, so set status manager accordingly.
 	r.status.SetNotDegraded(statusmanager.ProxyConfig)
 
 	return reconcile.Result{}, nil

--- a/pkg/controller/statusmanager/status_manager_test.go
+++ b/pkg/controller/statusmanager/status_manager_test.go
@@ -81,7 +81,7 @@ func TestStatusManager_set(t *testing.T) {
 		Reason:  "Reason",
 		Message: "Message",
 	}
-	status.Set(false, condFail)
+	status.set(false, condFail)
 
 	co, err = getCO(client, "testing")
 	if err != nil {
@@ -96,7 +96,7 @@ func TestStatusManager_set(t *testing.T) {
 		Type:   configv1.OperatorProgressing,
 		Status: configv1.ConditionUnknown,
 	}
-	status.Set(false, condProgress)
+	status.set(false, condProgress)
 
 	co, err = getCO(client, "testing")
 	if err != nil {
@@ -110,7 +110,7 @@ func TestStatusManager_set(t *testing.T) {
 		Type:   configv1.OperatorDegraded,
 		Status: configv1.ConditionFalse,
 	}
-	status.Set(false, condNoFail)
+	status.set(false, condNoFail)
 
 	co, err = getCO(client, "testing")
 	if err != nil {
@@ -128,7 +128,7 @@ func TestStatusManager_set(t *testing.T) {
 		Type:   configv1.OperatorAvailable,
 		Status: configv1.ConditionTrue,
 	}
-	status.Set(false, condNoProgress, condAvailable)
+	status.set(false, condNoProgress, condAvailable)
 
 	co, err = getCO(client, "testing")
 	if err != nil {


### PR DESCRIPTION
This addresses bug: [1737026](https://bugzilla.redhat.com/show_bug.cgi?id=1737026)

I am not sure if this addresses the concerns you mentioned in the bug @danwinship , but in this case I made set internal and I added a mutex inside `set`. 

I inspired myself on `runningPodsLock` in pod.go from openshift/sdn. 