### PR TITLE
Adds cvo opt-in annotation for proxy

### DIFF
--- a/manifests/0000_70_cluster-network-operator_03_daemonset.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_daemonset.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: openshift-network-operator
   labels:
     name: network-operator
+  annotations:
+    config.openshift.io/inject-proxy: network-operator
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Required by https://github.com/openshift/cluster-network-operator/pull/277

Adds cvo proxy opt-in annotation to inject proxy env var's from https://github.com/openshift/cluster-version-operator/pull/224.

/assign @squeed @bparees 