### PR TITLE
Enable Kuryr HA

### DIFF
--- a/bindata/network/kuryr/003-config.yaml
+++ b/bindata/network/kuryr/003-config.yaml
@@ -26,7 +26,7 @@ data:
     ssl_ca_crt_file = /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     token_file = /var/run/secrets/kubernetes.io/serviceaccount/token
     ssl_verify_server_crt = true
-    controller_ha = false
+    controller_ha = true
     controller_ha_elector_port = 16401
     watch_retry_timeout = 3600
     pod_vif_driver = nested-vlan

--- a/bindata/network/kuryr/005-controller.yaml
+++ b/bindata/network/kuryr/005-controller.yaml
@@ -1,11 +1,11 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: kuryr-controller
   namespace: openshift-kuryr
   annotations:
     kubernetes.io/description: |
-      This deployment launches the kuryr-controller component.
+      This daemonset launches the kuryr-controller component.
     release.openshift.io/version: "{{.ReleaseVersion}}"
 spec:
   selector:
@@ -51,6 +51,16 @@ spec:
         volumeMounts:
         - name: config-volume
           mountPath: "/etc/kuryr"
+      - image: {{ .LeaderElectorImage }}
+        name: leader-elector
+        args:
+        - "--election=kuryr-controller"
+        - "--http=0.0.0.0:16401"
+        - "--election-namespace=kuryr"
+        - "--ttl=5s"
+        ports:
+        - containerPort: 16401
+          protocol: TCP
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:

--- a/manifests/0000_70_cluster-network-operator_03_daemonset.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_daemonset.yaml
@@ -45,6 +45,8 @@ spec:
           value: "quay.io/openshift/origin-kuryr-cni:4.2"
         - name: KURYR_CONTROLLER_IMAGE
           value: "quay.io/openshift/origin-kuryr-controller:4.2"
+        - name: LEADER_ELECTOR_IMAGE
+          value: "quay.io/openshift/origin-leader-elector:4.2"
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -42,3 +42,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-kuryr-controller:4.2
+  - name: leader-elector
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-leader-elector:v4.2

--- a/pkg/network/kuryr.go
+++ b/pkg/network/kuryr.go
@@ -58,6 +58,7 @@ func renderKuryr(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapR
 	data.Data["CNIPluginsImage"] = os.Getenv("CNI_PLUGINS_IMAGE")
 	data.Data["DaemonImage"] = os.Getenv("KURYR_DAEMON_IMAGE")
 	data.Data["ControllerImage"] = os.Getenv("KURYR_CONTROLLER_IMAGE")
+	data.Data["LeaderElectorImage"] = os.Getenv("LEADER_ELECTOR_IMAGE")
 	data.Data["KUBERNETES_SERVICE_HOST"] = os.Getenv("KUBERNETES_SERVICE_HOST")
 	data.Data["KUBERNETES_SERVICE_PORT"] = os.Getenv("KUBERNETES_SERVICE_PORT")
 	data.Data["CNIConfDir"] = pluginCNIConfDir(conf)

--- a/pkg/network/kuryr_test.go
+++ b/pkg/network/kuryr_test.go
@@ -65,7 +65,7 @@ func TestRenderKuryr(t *testing.T) {
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "kuryr")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ServiceAccount", "openshift-kuryr", "kuryr")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRoleBinding", "", "kuryr")))
-	g.Expect(objs).To(ContainElement(HaveKubernetesID("Deployment", "openshift-kuryr", "kuryr-controller")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-kuryr", "kuryr-controller")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-kuryr", "kuryr-cni")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ConfigMap", "openshift-kuryr", "kuryr-config")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("CustomResourceDefinition", "", "kuryrnets.openstack.org")))


### PR DESCRIPTION
This commit aims to make kuryr-controller instances to be running in A/P
HA mode. This means kuryr-controller will now run as DaemonSet on every
master node.