### PR TITLE
Fixes Bug 1740027: Checks length of values in noProxy merge

### DIFF
--- a/pkg/util/proxyconfig/merge.go
+++ b/pkg/util/proxyconfig/merge.go
@@ -20,23 +20,36 @@ import (
 // provided, a comma-separated string of cluster-wide noProxy settings
 // are returned.
 func MergeUserSystemNoProxy(proxy *configv1.Proxy, infra *configv1.Infrastructure, network *configv1.Network, cluster *corev1.ConfigMap) (string, error) {
-	apiServerURL, err := url.Parse(infra.Status.APIServerURL)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse API server URL")
-	}
-
-	internalAPIServer, err := url.Parse(infra.Status.APIServerInternalURL)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse API server internal URL")
-	}
-
 	set := sets.NewString(
 		"127.0.0.1",
 		"localhost",
-		network.Status.ServiceNetwork[0],
-		apiServerURL.Hostname(),
-		internalAPIServer.Hostname(),
 	)
+
+	if len(infra.Status.APIServerURL) > 0 {
+		apiServerURL, err := url.Parse(infra.Status.APIServerURL)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse api server url")
+		}
+		set.Insert(apiServerURL.Hostname())
+	} else {
+		return "", fmt.Errorf("api server url missing from infrastructure config '%s'", infra.Name)
+	}
+
+	if len(infra.Status.APIServerInternalURL) > 0 {
+		internalAPIServer, err := url.Parse(infra.Status.APIServerInternalURL)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse internal api server internal url")
+		}
+		set.Insert(internalAPIServer.Hostname())
+	} else {
+		return "", fmt.Errorf("internal api server url missing from infrastructure config '%s'", infra.Name)
+	}
+
+	if len(network.Status.ServiceNetwork) > 0 {
+		set.Insert(network.Status.ServiceNetwork[0])
+	} else {
+		return "", fmt.Errorf("serviceNetwork missing from network '%s' status", network.Name)
+	}
 
 	// TODO: This will be flexible when master machine management is more dynamic.
 	type installConfig struct {
@@ -61,18 +74,26 @@ func MergeUserSystemNoProxy(proxy *configv1.Proxy, infra *configv1.Infrastructur
 		set.Insert("169.254.169.254", ic.Networking.MachineCIDR)
 	}
 
-	replicas, err := strconv.Atoi(ic.ControlPlane.Replicas)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse install config replicas: %v", err)
+	if len(ic.ControlPlane.Replicas) > 0 {
+		replicas, err := strconv.Atoi(ic.ControlPlane.Replicas)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse install config replicas: %v", err)
+		}
+		for i := int64(0); i < int64(replicas); i++ {
+			etcdHost := fmt.Sprintf("etcd-%d.%s", i, infra.Status.EtcdDiscoveryDomain)
+			set.Insert(etcdHost)
+		}
+	} else {
+		return "", fmt.Errorf("controlplane replicas missing from install config configmap '%s/%s'",
+			cluster.Namespace, cluster.Name)
 	}
 
-	for i := int64(0); i < int64(replicas); i++ {
-		etcdHost := fmt.Sprintf("etcd-%d.%s", i, infra.Status.EtcdDiscoveryDomain)
-		set.Insert(etcdHost)
-	}
-
-	for _, clusterNetwork := range network.Status.ClusterNetwork {
-		set.Insert(clusterNetwork.CIDR)
+	if len(network.Status.ClusterNetwork) > 0 {
+		for _, clusterNetwork := range network.Status.ClusterNetwork {
+			set.Insert(clusterNetwork.CIDR)
+		}
+	} else {
+		return "", fmt.Errorf("clusterNetwork missing from network `%s` status", network.Name)
 	}
 
 	if len(proxy.Spec.NoProxy) > 0 {


### PR DESCRIPTION
Previously, values of dependent resources (i.e. network) were assumed to be present. This PR checks the presence of the value before using it in the noProxy merge function.

/assign @squeed @bparees 