### PR TITLE
modify default failureThreshold for kuryr components

### DIFF
--- a/bindata/network/kuryr/004-daemon.yaml
+++ b/bindata/network/kuryr/004-daemon.yaml
@@ -71,6 +71,7 @@ spec:
           mountPath: /var/run/openvswitch
 {{ if (default true .DaemonEnableProbes) eq "true" }}
         readinessProbe:
+          failureThreshold: 10
           httpGet:
             path: /ready
             port: {{ default 8090 .DaemonProbesPort }}
@@ -78,6 +79,7 @@ spec:
           initialDelaySeconds: 15
           timeoutSeconds: 5
         livenessProbe:
+          failureThreshold: 10
           httpGet:
             path: /alive
             port: {{ default 8090 .DaemonProbesPort }}

--- a/bindata/network/kuryr/005-controller.yaml
+++ b/bindata/network/kuryr/005-controller.yaml
@@ -27,12 +27,14 @@ spec:
         name: controller
 {{ if (default true .ControllerEnableProbes) eq "true" }}
         readinessProbe:
+          failureThreshold: 10
           httpGet:
             path: /ready
             port: {{ default 8082 .ControllerProbesPort }}
             scheme: HTTP
           timeoutSeconds: 5
         livenessProbe:
+          failureThreshold: 10
           httpGet:
             path: /alive
             port: {{ default 8082 .ControllerProbesPort }}


### PR DESCRIPTION
Default failureThreshold for healtchecks is 3. This PR increases
that default value for the kuryr-controller and kuryr-cni pods
to reduce the number of unneeded restarts during the installation