### PR TITLE
openshift-sdn: get CNI loopback and host-local plugins from CNIPluginsImage

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -37,6 +37,21 @@ spec:
       hostNetwork: true
       hostPID: true
       priorityClassName: system-node-critical
+      initContainers:
+      - name: install-cni-plugins
+        image: {{ .CNIPluginsImage }}
+        command:
+        - /bin/bash
+        - -c
+        - |
+          #!/bin/bash
+          set -ex
+          cp -f /usr/src/plugins/bin/{loopback,host-local} /host/opt/cni/bin
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: host-cni-bin
+        securityContext:
+          privileged: true
       containers:
       - name: sdn
         image: {{.NodeImage}}
@@ -78,7 +93,7 @@ spec:
 
           # Take over network functions on the node
           rm -f /etc/cni/net.d/80-openshift-network.conf
-          cp -f /opt/cni/bin/* /host/opt/cni/bin/
+          cp -f /opt/cni/bin/openshift-sdn /host/opt/cni/bin/
 
           # Launch the network process
           exec /usr/bin/openshift-sdn --proxy-config=/config/kube-proxy-config.yaml --url-only-kubeconfig=/etc/kubernetes/kubeconfig --v=${DEBUG_LOGLEVEL:-2}

--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -33,6 +33,7 @@ func renderOpenShiftSDN(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Un
 	data.Data["ReleaseVersion"] = os.Getenv("RELEASE_VERSION")
 	data.Data["InstallOVS"] = (c.UseExternalOpenvswitch == nil || *c.UseExternalOpenvswitch == false)
 	data.Data["NodeImage"] = os.Getenv("NODE_IMAGE")
+	data.Data["CNIPluginsImage"] = os.Getenv("CNI_PLUGINS_IMAGE")
 	data.Data["SDNControllerImage"] = os.Getenv("SDN_CONTROLLER_IMAGE")
 	data.Data["KUBERNETES_SERVICE_HOST"] = os.Getenv("KUBERNETES_SERVICE_HOST")
 	data.Data["KUBERNETES_SERVICE_PORT"] = os.Getenv("KUBERNETES_SERVICE_PORT")


### PR DESCRIPTION
Sets us up to stop building those plugins in the openshift-sdn image