### PR TITLE
Bug 1735538: Adding cni-version to multus daemonset yaml

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -47,6 +47,7 @@ spec:
         - "--multus-kubeconfig-file-host=/etc/kubernetes/cni/net.d/multus.d/multus.kubeconfig"
         - "--namespace-isolation=true"
         - "--multus-log-level=verbose"
+        - "--cni-version=0.3.1"
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
This is a PR addressing bug [1735538](https://bugzilla.redhat.com/show_bug.cgi?id=1735538). 

Problem:

Multus is writing a CNI config file on the host, which today, is missing the `cniVersion` and leading to errors when attempting to delete pod networks.

Solution:

The multus `entrypoint.sh` parses the `--cni-version` passed, I thus assume the intention from the multus team is to pass the CNI version through the daemonset deployment spec like this.

The problem that remains is of course a hard-coded CNI version in multus (which will need to be updated manually). I could also just read the `cniVersion` from the SDN config file, but I am not sure that's better...........