### PR TITLE
manifests: the openshift-sdn type isn't actually required

### DIFF
--- a/manifests/0000_70_cluster-network-operator_01_crd.yaml
+++ b/manifests/0000_70_cluster-network-operator_01_crd.yaml
@@ -45,7 +45,6 @@ spec:
                   type: string
                 openshiftSDNConfig:
                   type: object
-                  required: ["mode"]
                   properties:
                     mode:
                       type: string


### PR DESCRIPTION
This makes it impossible to change the network configuration from what's in the cluster.

@weliang1 this should fix the issue you saw.