### PR TITLE
run-locally.sh: fix -m without -n

### DIFF
--- a/hack/run-locally.sh
+++ b/hack/run-locally.sh
@@ -184,8 +184,8 @@ The following environment variables are honored:
 }
 
 PLUGIN_IMAGE="${PLUGIN_IMAGE:-}"
-NETWORK_PLUGIN=
-IMAGE_ENV_KEY=
+NETWORK_PLUGIN="OpenShiftSDN"
+IMAGE_ENV_KEY="NODE_IMAGE"
 CLUSTER_DIR="${CLUSTER_DIR:-}"
 INSTALLER_PATH="${INSTALLER_PATH:-}"
 INSTALL_CONFIG="${INSTALL_CONFIG:-}"
@@ -204,8 +204,6 @@ while getopts "c:f:i:m:n:w" opt; do
                     IMAGE_ENV_KEY="OVN_IMAGE"
                     ;;
                 sdn|OpenShiftSDN)
-                    NETWORK_PLUGIN="OpenShiftSDN"
-                    IMAGE_ENV_KEY="NODE_IMAGE"
                     ;;
                 *)
                     echo "Unknown network plugin ${OPTARG}" >&2


### PR DESCRIPTION
"`-m IMAGE`" only worked if you also specified "`-n PLUGIN`", even though the plugin would otherwise correctly default to `OpenShiftSDN`.