### PR TITLE
Adds .svc and .svc.cluster.local to default noProxy

### DIFF
--- a/pkg/util/proxyconfig/merge.go
+++ b/pkg/util/proxyconfig/merge.go
@@ -23,6 +23,8 @@ func MergeUserSystemNoProxy(proxy *configv1.Proxy, infra *configv1.Infrastructur
 	set := sets.NewString(
 		"127.0.0.1",
 		"localhost",
+		".svc",
+		".cluster.local",
 	)
 
 	if len(infra.Status.APIServerURL) > 0 {


### PR DESCRIPTION
Fixes Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1743507

Previously, only the service cidr was added to the default noProxy list. This does not help when pods communicate with a service using a DNS name. This PR adds `.svc` and `svc.cluster.local` to the default noProxt list.

/assign @knobunc @bparees