### PR TITLE
Refactors noProxy merge func

### DIFF
--- a/pkg/controller/proxyconfig/status.go
+++ b/pkg/controller/proxyconfig/status.go
@@ -12,7 +12,8 @@ import (
 
 // syncProxyStatus computes the current status of proxy and
 // updates status of any changes since last sync.
-func (r *ReconcileProxyConfig) syncProxyStatus(proxy *configv1.Proxy, infra *configv1.Infrastructure, network *configv1.Network, cluster *corev1.ConfigMap) error {
+func (r *ReconcileProxyConfig) syncProxyStatus(proxy *configv1.Proxy, infra *configv1.Infrastructure,
+	network *configv1.Network, dns *configv1.DNS, cluster *corev1.ConfigMap) error {
 	var err error
 	var noProxy string
 	updated := proxy.DeepCopy()
@@ -21,7 +22,7 @@ func (r *ReconcileProxyConfig) syncProxyStatus(proxy *configv1.Proxy, infra *con
 		if proxy.Spec.NoProxy == noProxyWildcard {
 			noProxy = proxy.Spec.NoProxy
 		} else {
-			noProxy, err = proxyconfig.MergeUserSystemNoProxy(proxy, infra, network, cluster)
+			noProxy, err = proxyconfig.MergeUserSystemNoProxy(proxy, infra, network, dns, cluster)
 			if err != nil {
 				return fmt.Errorf("failed to merge user/system noProxy settings: %v", err)
 			}

--- a/pkg/util/proxyconfig/merge.go
+++ b/pkg/util/proxyconfig/merge.go
@@ -2,8 +2,6 @@ package proxyconfig
 
 import (
 	"fmt"
-	"net/url"
-	"strconv"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -19,31 +17,12 @@ import (
 // string of noProxy settings. If no user supplied noProxy settings are
 // provided, a comma-separated string of cluster-wide noProxy settings
 // are returned.
-func MergeUserSystemNoProxy(proxy *configv1.Proxy, infra *configv1.Infrastructure, network *configv1.Network, cluster *corev1.ConfigMap) (string, error) {
+func MergeUserSystemNoProxy(proxy *configv1.Proxy, infra *configv1.Infrastructure, network *configv1.Network,
+	dns *configv1.DNS, cluster *corev1.ConfigMap) (string, error) {
 	set := sets.NewString(
 		"127.0.0.1",
 		"localhost",
 	)
-
-	if len(infra.Status.APIServerURL) > 0 {
-		apiServerURL, err := url.Parse(infra.Status.APIServerURL)
-		if err != nil {
-			return "", fmt.Errorf("failed to parse api server url")
-		}
-		set.Insert(apiServerURL.Hostname())
-	} else {
-		return "", fmt.Errorf("api server url missing from infrastructure config '%s'", infra.Name)
-	}
-
-	if len(infra.Status.APIServerInternalURL) > 0 {
-		internalAPIServer, err := url.Parse(infra.Status.APIServerInternalURL)
-		if err != nil {
-			return "", fmt.Errorf("failed to parse internal api server internal url")
-		}
-		set.Insert(internalAPIServer.Hostname())
-	} else {
-		return "", fmt.Errorf("internal api server url missing from infrastructure config '%s'", infra.Name)
-	}
 
 	if len(network.Status.ServiceNetwork) > 0 {
 		set.Insert(network.Status.ServiceNetwork[0])
@@ -51,11 +30,14 @@ func MergeUserSystemNoProxy(proxy *configv1.Proxy, infra *configv1.Infrastructur
 		return "", fmt.Errorf("serviceNetwork missing from network '%s' status", network.Name)
 	}
 
+	if len(dns.Spec.BaseDomain) > 0 {
+		set.Insert("." + dns.Spec.BaseDomain)
+	} else {
+		return "", fmt.Errorf("dns '%s' is missing baseDomain", dns.Name)
+	}
+
 	// TODO: This will be flexible when master machine management is more dynamic.
 	type installConfig struct {
-		ControlPlane struct {
-			Replicas string `json:"replicas"`
-		} `json:"controlPlane"`
 		Networking struct {
 			MachineCIDR string `json:"machineCIDR"`
 		} `json:"networking"`
@@ -72,20 +54,6 @@ func MergeUserSystemNoProxy(proxy *configv1.Proxy, infra *configv1.Infrastructur
 	switch infra.Status.PlatformStatus.Type {
 	case configv1.AWSPlatformType, configv1.GCPPlatformType, configv1.AzurePlatformType, configv1.OpenStackPlatformType:
 		set.Insert("169.254.169.254", ic.Networking.MachineCIDR)
-	}
-
-	if len(ic.ControlPlane.Replicas) > 0 {
-		replicas, err := strconv.Atoi(ic.ControlPlane.Replicas)
-		if err != nil {
-			return "", fmt.Errorf("failed to parse install config replicas: %v", err)
-		}
-		for i := int64(0); i < int64(replicas); i++ {
-			etcdHost := fmt.Sprintf("etcd-%d.%s", i, infra.Status.EtcdDiscoveryDomain)
-			set.Insert(etcdHost)
-		}
-	} else {
-		return "", fmt.Errorf("controlplane replicas missing from install config configmap '%s/%s'",
-			cluster.Namespace, cluster.Name)
 	}
 
 	if len(network.Status.ClusterNetwork) > 0 {


### PR DESCRIPTION
Previously `MergeUserSystemNoProxy()` was including specific api-server and etcd dns names when creating the default noProxy list. This PR uses the cluster's `baseDomain` from the openshift `config.DNS` API as a noProxy entry. For example:
```
$ oc get proxy/cluster -o yaml
<SNIP>
status:
  httpProxy: http://admin:admin@35.196.128.173:3128
  noProxy: .dhansen.devcluster.openshift.com,10.0.0.0/16,10.128.0.0/14,127.0.0.1,169.254.169.254,172.30.0.0/16,example.com,localhost
```

This approach will cover etcd and api-server names and any additional names added to the cluster's base domain. For example, the cluster-ingress-operator creates a wildcard alias record for routes. For example:
```
*.apps.dhansen.devcluster.openshift.com.
```
These routes should not be proxied. 

/assign @bparees @knobunc 