### PR TITLE
OpenStack: Adjust kuryr default configuration

### DIFF
--- a/bindata/network/kuryr/003-config.yaml
+++ b/bindata/network/kuryr/003-config.yaml
@@ -16,6 +16,7 @@ data:
     daemon_enabled = true
     docker_mode = true
     netns_proc_dir = /host_proc
+    vif_annotation_timeout = 120
 
     [ingress]
     #l7_router_uuid = <None>
@@ -73,7 +74,7 @@ data:
     ports_pool_update_frequency = 30
 
     [health_server]
-    port = {{ default 8082 .ControllerProbesPort }}
+    port = {{ default 8091 .ControllerProbesPort }}
 
     [cni_health_server]
     port = {{ default 8090 .DaemonProbesPort }}

--- a/bindata/network/kuryr/005-controller.yaml
+++ b/bindata/network/kuryr/005-controller.yaml
@@ -27,17 +27,17 @@ spec:
         name: controller
 {{ if (default true .ControllerEnableProbes) eq "true" }}
         readinessProbe:
-          failureThreshold: 10
           httpGet:
             path: /ready
-            port: {{ default 8082 .ControllerProbesPort }}
+            port: {{ default 8091 .ControllerProbesPort }}
             scheme: HTTP
-          timeoutSeconds: 5
+          timeoutSeconds: 15
+          periodSeconds: 20
         livenessProbe:
           failureThreshold: 10
           httpGet:
             path: /alive
-            port: {{ default 8082 .ControllerProbesPort }}
+            port: {{ default 8091 .ControllerProbesPort }}
           initialDelaySeconds: 15
 {{ end }}
         env:

--- a/pkg/network/kuryr.go
+++ b/pkg/network/kuryr.go
@@ -155,7 +155,7 @@ func fillKuryrDefaults(conf *operv1.NetworkSpec) {
 	}
 
 	if kc.ControllerProbesPort == nil {
-		var port uint32 = 8082
+		var port uint32 = 8091
 		kc.ControllerProbesPort = &port
 	}
 

--- a/pkg/network/kuryr_test.go
+++ b/pkg/network/kuryr_test.go
@@ -142,7 +142,7 @@ func TestFillKuryrDefaults(t *testing.T) {
 	crd := KuryrConfig.DeepCopy()
 	conf := &crd.Spec
 
-	c := uint32(8082)
+	c := uint32(8091)
 	d := uint32(8090)
 	expected := operv1.NetworkSpec{
 		ServiceNetwork: []string{"172.30.0.0/16"},


### PR DESCRIPTION
This PR updates some default configuration for kuryr, such as:
- Port to be used for the kuryr-controller healthcheck if not stated
- Kuryr-controller healthcheck tuning to avoid unneeded restarts
- Default waiting time for ports to become active (increasing default
value to limit kuryr-cni restarts)