### PR TITLE
Adding status to configmap ca injector controller

### DIFF
--- a/pkg/controller/configmap_ca_injector/controller.go
+++ b/pkg/controller/configmap_ca_injector/controller.go
@@ -112,6 +112,8 @@ func (r *ReconcileConfigMapInjector) Reconcile(request reconcile.Request) (recon
 
 	if err != nil {
 		log.Println(err)
+		r.status.SetDegraded(statusmanager.InjectorConfig, "InvalidInjectorConfig",
+			fmt.Sprintf("Failed to validate trusted CA certificates in %s", trustedCAbundleConfigMap.Name))
 		return reconcile.Result{}, err
 	}
 	// Build a list of configMaps.
@@ -125,6 +127,8 @@ func (r *ReconcileConfigMapInjector) Reconcile(request reconcile.Request) (recon
 		err = r.client.List(context.TODO(), &client.ListOptions{LabelSelector: selector}, configMapList)
 		if err != nil {
 			log.Println(err)
+			r.status.SetDegraded(statusmanager.InjectorConfig, "ListConfigMapError",
+				fmt.Sprintf("Error getting the list of affected configmaps: %v", err))
 			return reconcile.Result{}, err
 		}
 		configMapsToChange = configMapList.Items
@@ -144,6 +148,8 @@ func (r *ReconcileConfigMapInjector) Reconcile(request reconcile.Request) (recon
 				log.Printf("ConfigMap '%s/%s' not found; reconciliation will be skipped", request.Namespace, request.Name)
 				return reconcile.Result{}, nil
 			}
+			r.status.SetDegraded(statusmanager.InjectorConfig, "ClusterConfigError",
+				fmt.Sprintf("failed to get configmap '%s/%s': %v", request.Namespace, request.Name, err))
 			log.Println(err)
 			return reconcile.Result{}, err
 		}
@@ -183,13 +189,18 @@ func (r *ReconcileConfigMapInjector) Reconcile(request reconcile.Request) (recon
 		if err != nil {
 			errs = append(errs, err)
 			if len(errs) > 5 {
+				r.status.SetDegraded(statusmanager.InjectorConfig, "ConfigMapUpdateFailure",
+					fmt.Sprintf("Too many errors seen when updating trusted CA configmaps"))
 				return reconcile.Result{}, fmt.Errorf("Too many errors attempting to update configmaps with CA cert. data")
 			}
 		}
 	}
 	if len(errs) > 0 {
+		r.status.SetDegraded(statusmanager.InjectorConfig, "ConfigmapUpdateFailure",
+			fmt.Sprintf("some configmaps didn't fully update with CA cert. data"))
 		return reconcile.Result{}, fmt.Errorf("some configmaps didn't fully update with CA cert. data")
 	}
+	r.status.SetNotDegraded(statusmanager.InjectorConfig)
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/controller/configmap_ca_injector/controller.go
+++ b/pkg/controller/configmap_ca_injector/controller.go
@@ -102,6 +102,7 @@ func (r *ReconcileConfigMapInjector) Reconcile(request reconcile.Request) (recon
 	err := r.client.Get(context.TODO(), trustedCAbundleConfigMapName, trustedCAbundleConfigMap)
 	if err != nil {
 		if errors.IsNotFound(err) {
+			log.Println("proxy not found; reconciliation will be skipped", "request", request)
 			return reconcile.Result{}, nil
 		}
 		log.Println(err)
@@ -110,6 +111,7 @@ func (r *ReconcileConfigMapInjector) Reconcile(request reconcile.Request) (recon
 	_, trustedCAbundleData, err := validation.TrustBundleConfigMap(trustedCAbundleConfigMap)
 
 	if err != nil {
+		log.Println(err)
 		return reconcile.Result{}, err
 	}
 	// Build a list of configMaps.
@@ -138,10 +140,11 @@ func (r *ReconcileConfigMapInjector) Reconcile(request reconcile.Request) (recon
 		}
 		err = r.client.Get(context.TODO(), requestedCAbundleConfigMapName, requestedCAbundleConfigMap)
 		if err != nil {
-			log.Println(err)
 			if apierrors.IsNotFound(err) {
+				log.Printf("ConfigMap '%s/%s' not found; reconciliation will be skipped", request.Namespace, request.Name)
 				return reconcile.Result{}, nil
 			}
+			log.Println(err)
 			return reconcile.Result{}, err
 		}
 		configMapsToChange = append(configMapsToChange, *requestedCAbundleConfigMap)

--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -28,6 +28,7 @@ const (
 	ClusterConfig StatusLevel = iota
 	OperatorConfig
 	ProxyConfig
+	InjectorConfig
 	PodDeployment
 	maxStatusLevel
 )


### PR DESCRIPTION
To help debug potential issues with the configmap ca injector add statusmanager and more clearly log some errors 