### PR TITLE
Set version on network cluster operator with kuryr SDN

### DIFF
--- a/bindata/network/kuryr/004-daemon.yaml
+++ b/bindata/network/kuryr/004-daemon.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     kubernetes.io/description: |
       This DaemonSet launches the kuryr-daemon component.
+    release.openshift.io/version: "{{.ReleaseVersion}}"
 spec:
   selector:
     matchLabels:

--- a/bindata/network/kuryr/005-controller.yaml
+++ b/bindata/network/kuryr/005-controller.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     kubernetes.io/description: |
       This deployment launches the kuryr-controller component.
+    release.openshift.io/version: "{{.ReleaseVersion}}"
 spec:
   selector:
     matchLabels:

--- a/bindata/network/kuryr/009-admission-controller.yaml
+++ b/bindata/network/kuryr/009-admission-controller.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     kubernetes.io/description: |
       This daemon set launches the admisson controller that will force TPC DNS resolution for pods on each node.
+    release.openshift.io/version: "{{.ReleaseVersion}}"
 spec:
   selector:
     matchLabels:

--- a/pkg/network/kuryr.go
+++ b/pkg/network/kuryr.go
@@ -33,6 +33,7 @@ func renderKuryr(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapR
 	objs := []*uns.Unstructured{}
 
 	data := render.MakeRenderData()
+	data.Data["ReleaseVersion"] = os.Getenv("RELEASE_VERSION")
 
 	// general kuryr options
 	data.Data["ResourceTags"] = "openshiftClusterID=" + b.ClusterID


### PR DESCRIPTION
This PR ensures the VERSION field is set on the network cluster
operator config object by adding it to the different kuryr
components, i.e., the kuryr-controller and admission-controller
deployments, and kuryr-cni daemon set.