### PR TITLE
Bug 1746360: openshift-sdn: allow empty mode

### DIFF
--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -89,7 +89,7 @@ func validateOpenShiftSDN(conf *operv1.NetworkSpec) []error {
 
 	sc := conf.DefaultNetwork.OpenShiftSDNConfig
 	if sc != nil {
-		if sdnPluginName(sc.Mode) == "" {
+		if sc.Mode != "" && sdnPluginName(sc.Mode) == "" {
 			out = append(out, errors.Errorf("invalid openshift-sdn mode %q", sc.Mode))
 		}
 


### PR DESCRIPTION
We can fill a sensible default anyways. So this is just confusing and user-unfriendly.