### PR TITLE
Bug 1748354: Kuryr: Add external_svc_net to kuryr.conf

### DIFF
--- a/bindata/network/kuryr/003-config.yaml
+++ b/bindata/network/kuryr/003-config.yaml
@@ -48,6 +48,7 @@ data:
     project = {{ default "\"\"" $AuthInfo.ProjectID }}
     pod_security_groups = {{ default "default" .PodSecurityGroups }}
     resource_tags = {{ default "" .ResourceTags }}
+    external_svc_net = {{ .ExternalNetwork }}
     #network_device_mtu = 1500
 
     [neutron]

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -10,6 +10,7 @@ type KuryrBootstrapResult struct {
 	WorkerNodesRouter string
 	WorkerNodesSubnet string
 	PodSecurityGroups []string
+	ExternalNetwork   string
 	ClusterID         string
 	OpenStackCloud    clientconfig.Cloud
 	WebhookCA         string

--- a/pkg/network/kuryr.go
+++ b/pkg/network/kuryr.go
@@ -42,6 +42,7 @@ func renderKuryr(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapR
 	data.Data["WorkerNodesRouter"] = b.WorkerNodesRouter
 	data.Data["PodSubnetpool"] = b.PodSubnetpool
 	data.Data["ServiceSubnet"] = b.ServiceSubnet
+	data.Data["ExternalNetwork"] = b.ExternalNetwork
 	data.Data["OpenStackCloud"] = b.OpenStackCloud
 	// FIXME(dulek): Move that logic to the template once it's known how to dereference pointers there.
 	data.Data["OpenStackInsecureAPI"] = b.OpenStackCloud.Verify != nil && !*b.OpenStackCloud.Verify


### PR DESCRIPTION
Seems like setting `external_svc_net` was ommitted in initial
implementation of preparing kuryr.conf. This breaks Kuryr's support for
LoadBalancer services. This commit fixes it by fetching the external
network ID from the external-router created by the installer and passing
it to kuryr.conf.