### PR TITLE
Kuryr: Open just 6443 on masters SG

### DIFF
--- a/pkg/platform/openstack/kuryr_bootstrap.go
+++ b/pkg/platform/openstack/kuryr_bootstrap.go
@@ -944,9 +944,7 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient client.Client) (*bootst
 		}
 	}
 	// We need to open traffic from service subnet to masters for API LB to work.
-	// Port range is taken from how openshift/installer opens traffic to the API,
-	// though just 6443 should probably be enough for us.
-	err = ensureOpenStackSgRule(client, masterSgId, openStackSvcCIDR, 6443, 6445)
+	err = ensureOpenStackSgRule(client, masterSgId, openStackSvcCIDR, 6443, 6443)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to add rule opening traffic to masters from service subnet %s", conf.ServiceNetwork[0])
 	}


### PR DESCRIPTION
Seems like openshift/installer#2304 updates the SG opening traffic to
master to just open port 6443 instead of 6443-6445 range. I was
suspecting it's just a typo, but did the same on CNO just to be safe.
This commit mimics what the openshift/installer commit does.