### PR TITLE
Kuryr: Set region_name in kuryr.conf

### DIFF
--- a/bindata/network/kuryr/003-config.yaml
+++ b/bindata/network/kuryr/003-config.yaml
@@ -64,6 +64,7 @@ data:
     project_name = {{ default "\"\"" $AuthInfo.ProjectName }}
     user_domain_name = {{ default "\"\"" $AuthInfo.UserDomainName }}
     user_domain_id = {{ default "\"\"" $AuthInfo.UserDomainID }}
+    region_name = {{ default "\"\"" .OpenStackCloud.RegionName }}
 
     [pod_vif_nested]
     worker_nodes_subnet = {{ default "\"\"" .WorkerNodesSubnet }}


### PR DESCRIPTION
With recent change to kuryr-lib it is possible to specify OpenStack
cloud region name that should be used by Kuryr. This commit implements
that by setting that option in kuryr.conf.