### PR TITLE
Bug 1732598: Alternate CNI config dir

### DIFF
--- a/bindata/network/kuryr/004-daemon.yaml
+++ b/bindata/network/kuryr/004-daemon.yaml
@@ -89,10 +89,10 @@ spec:
       volumes:
       - name: bin
         hostPath:
-          path: /var/lib/cni/bin
+          path: {{.CNIBinDir}}
       - name: net-conf
         hostPath:
-          path: /etc/kubernetes/cni/net.d
+          path: {{.CNIConfDir}}
       - name: config-volume
         configMap:
           name: kuryr-config

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -44,6 +44,7 @@ spec:
         command: ["/entrypoint.sh"]
         args:
         - "--multus-conf-file=auto"
+        - "--multus-autoconfig-dir=/host/var/run/multus/cni/net.d"
         - "--multus-kubeconfig-file-host=/etc/kubernetes/cni/net.d/multus.d/multus.kubeconfig"
         - "--namespace-isolation=true"
         - "--multus-log-level=verbose"
@@ -55,8 +56,10 @@ spec:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: cni
+        - name: system-cni-dir
           mountPath: /host/etc/cni/net.d
+        - name: multus-cni-dir
+          mountPath: /host/var/run/multus/cni/net.d
         - name: cnibin
           mountPath: /host/opt/cni/bin
         env:
@@ -65,9 +68,12 @@ spec:
         - name: KUBERNETES_SERVICE_HOST
           value: "{{.KUBERNETES_SERVICE_HOST}}"
       volumes:
-        - name: cni
+        - name: system-cni-dir
           hostPath:
-            path: /etc/kubernetes/cni/net.d
+            path: {{ .SystemCNIConfDir }}
+        - name: multus-cni-dir
+          hostPath:
+            path: {{ .MultusCNIConfDir }}
         - name: cnibin
           hostPath:
             path: /var/lib/cni/bin

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -46,6 +46,7 @@ spec:
         - "--multus-conf-file=auto"
         - "--multus-autoconfig-dir=/host/var/run/multus/cni/net.d"
         - "--multus-kubeconfig-file-host=/etc/kubernetes/cni/net.d/multus.d/multus.kubeconfig"
+        - "--cleanup-config-on-exit=true"
         - "--namespace-isolation=true"
         - "--multus-log-level=verbose"
         - "--cni-version=0.3.1"

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -130,7 +130,7 @@ spec:
         - mountPath: /host/opt/cni/bin
           name: host-cni-bin
         - mountPath: /etc/cni/net.d
-          name: host-cni-netd
+          name: host-cni-conf
         - mountPath: /var/lib/cni/networks/openshift-sdn
           name: host-var-lib-cni-networks-openshift-sdn
         # If iptables needs to load a module
@@ -206,10 +206,10 @@ spec:
           path: /
       - name: host-cni-bin
         hostPath:
-          path: /var/lib/cni/bin
-      - name: host-cni-netd
+          path: {{.CNIBinDir}}
+      - name: host-cni-conf
         hostPath:
-          path: /etc/kubernetes/cni/net.d
+          path: {{.CNIConfDir}}
       - name: host-var-lib-cni-networks-openshift-sdn
         hostPath:
           path: /var/lib/cni/networks/openshift-sdn

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -223,10 +223,10 @@ spec:
           path: /sys
       - name: host-cni-bin
         hostPath:
-          path: /var/lib/cni/bin
+          path: {{.CNIBinDir}}
       - name: host-cni-netd
         hostPath:
-          path: /etc/kubernetes/cni/net.d
+          path: {{.CNIConfDir}}
       - name: host-config-openvswitch
         hostPath:
           path: /etc/origin/openvswitch

--- a/pkg/network/kuryr.go
+++ b/pkg/network/kuryr.go
@@ -60,6 +60,8 @@ func renderKuryr(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapR
 	data.Data["ControllerImage"] = os.Getenv("KURYR_CONTROLLER_IMAGE")
 	data.Data["KUBERNETES_SERVICE_HOST"] = os.Getenv("KUBERNETES_SERVICE_HOST")
 	data.Data["KUBERNETES_SERVICE_PORT"] = os.Getenv("KUBERNETES_SERVICE_PORT")
+	data.Data["CNIConfDir"] = pluginCNIConfDir(conf)
+	data.Data["CNIBinDir"] = CNIBinDir
 
 	// DNS mutating webhook
 	data.Data["AdmissionControllerSecret"] = names.KURYR_ADMISSION_CONTROLLER_SECRET

--- a/pkg/network/kuryr_test.go
+++ b/pkg/network/kuryr_test.go
@@ -51,6 +51,8 @@ func TestRenderKuryr(t *testing.T) {
 	errs := validateKuryr(config)
 	g.Expect(errs).To(HaveLen(0))
 
+	FillDefaults(config, nil)
+
 	objs, err := renderKuryr(config, &FakeBootstrapResult, manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-kuryr", "kuryr-cni")))

--- a/pkg/network/multus.go
+++ b/pkg/network/multus.go
@@ -4,10 +4,43 @@ import (
 	"os"
 	"path/filepath"
 
+	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/render"
 	"github.com/pkg/errors"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+const (
+	SystemCNIConfDir = "/etc/kubernetes/cni/net.d"
+	MultusCNIConfDir = "/var/run/multus/cni/net.d"
+	CNIBinDir        = "/var/lib/cni/bin"
+)
+
+// RenderMultus generates the manifests of Multus
+func RenderMultus(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Unstructured, error) {
+	if *conf.DisableMultiNetwork {
+		return nil, nil
+	}
+
+	var err error
+	out := []*uns.Unstructured{}
+	objs := []*uns.Unstructured{}
+
+	// enabling Multus always renders the CRD since Multus uses it
+	objs, err = renderAdditionalNetworksCRD(manifestDir)
+	if err != nil {
+		return nil, err
+	}
+	out = append(out, objs...)
+
+	usedhcp := UseDHCP(conf)
+	objs, err = renderMultusConfig(manifestDir, usedhcp)
+	if err != nil {
+		return nil, err
+	}
+	out = append(out, objs...)
+	return out, nil
+}
 
 // renderMultusConfig returns the manifests of Multus
 func renderMultusConfig(manifestDir string, useDHCP bool) ([]*uns.Unstructured, error) {
@@ -21,6 +54,8 @@ func renderMultusConfig(manifestDir string, useDHCP bool) ([]*uns.Unstructured, 
 	data.Data["KUBERNETES_SERVICE_HOST"] = os.Getenv("KUBERNETES_SERVICE_HOST")
 	data.Data["KUBERNETES_SERVICE_PORT"] = os.Getenv("KUBERNETES_SERVICE_PORT")
 	data.Data["RenderDHCP"] = useDHCP
+	data.Data["MultusCNIConfDir"] = MultusCNIConfDir
+	data.Data["SystemCNIConfDir"] = SystemCNIConfDir
 
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/multus"), &data)
 	if err != nil {
@@ -28,4 +63,14 @@ func renderMultusConfig(manifestDir string, useDHCP bool) ([]*uns.Unstructured, 
 	}
 	objs = append(objs, manifests...)
 	return objs, nil
+}
+
+// pluginCNIDir is the directory where plugins should install their CNI
+// configuration file. By default, it is where multus looks, unless multus
+// is disabled
+func pluginCNIConfDir(conf *operv1.NetworkSpec) string {
+	if *conf.DisableMultiNetwork {
+		return SystemCNIConfDir
+	}
+	return MultusCNIConfDir
 }

--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -38,6 +38,8 @@ func renderOpenShiftSDN(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Un
 	data.Data["KUBERNETES_SERVICE_HOST"] = os.Getenv("KUBERNETES_SERVICE_HOST")
 	data.Data["KUBERNETES_SERVICE_PORT"] = os.Getenv("KUBERNETES_SERVICE_PORT")
 	data.Data["Mode"] = c.Mode
+	data.Data["CNIConfDir"] = pluginCNIConfDir(conf)
+	data.Data["CNIBinDir"] = CNIBinDir
 
 	clusterNetwork, err := clusterNetwork(conf)
 	if err != nil {

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -33,6 +33,8 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.U
 	data.Data["OvnImage"] = os.Getenv("OVN_IMAGE")
 	data.Data["K8S_APISERVER"] = fmt.Sprintf("https://%s:%s", os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT"))
 	data.Data["MTU"] = c.MTU
+	data.Data["CNIConfDir"] = pluginCNIConfDir(conf)
+	data.Data["CNIBinDir"] = CNIBinDir
 
 	var ippools string
 	for _, net := range conf.ClusterNetwork {

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -372,32 +372,6 @@ func RenderAdditionalNetworks(conf *operv1.NetworkSpec, manifestDir string) ([]*
 	return out, nil
 }
 
-// RenderMultus generates the manifests of Multus
-func RenderMultus(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Unstructured, error) {
-	if *conf.DisableMultiNetwork {
-		return nil, nil
-	}
-
-	var err error
-	out := []*uns.Unstructured{}
-	objs := []*uns.Unstructured{}
-
-	// enabling Multus always renders the CRD since Multus uses it
-	objs, err = renderAdditionalNetworksCRD(manifestDir)
-	if err != nil {
-		return nil, err
-	}
-	out = append(out, objs...)
-
-	usedhcp := UseDHCP(conf)
-	objs, err = renderMultusConfig(manifestDir, usedhcp)
-	if err != nil {
-		return nil, err
-	}
-	out = append(out, objs...)
-	return out, nil
-}
-
 // RenderMultusAdmissionController generates the manifests of Multus Admission Controller
 func RenderMultusAdmissionController(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Unstructured, error) {
 	if *conf.DisableMultiNetwork {


### PR DESCRIPTION
#299 has been used to work around the CRIO + Multus CNI configuration issues. However, this caused collateral damage to Kuryr and OpenShift upgrades. #299 was reverted with #310 -- this PR adds the commit for the alternate CNI configuration direct from #299 back, as well as a commit for updating the Multus entrypoint parameters.

**UPDATE**: Notably different from #299 is that this *no longer performs a CRIO restart*.

----

It's been observed that with #299 in place, openshift-sdn and Kuryr were having trouble with write operations to the directories within `/run` -- notably #299 uses `/var/run/multus/cni/net.d` as an alternate configuration directory.

Additionally, some selinux logs were gathered both with the denials, and also with an experiment where selinux permissive mode was enabled, those logs are available @ https://pastebin.com/iGvBec6u

Luis Tomas has also noted that it "seems the process being denied has container_t label, while the directory has var_run_t" with:

```
scontext=system_u:system_r:container_t:s0:c0,c912 tcontext=system_u:object_r:var_run_t:s0
```

As an initial attempt: This moves the alternate configuration directory inside the `/etc/.../net.d` into a new directory named `sourceconfig.d`.

Further from that, I'm also looking into how I might address the selinux options, however, I need input from those that wield greater selinux powers than I.

