### PR TITLE
Bug 1751070: Updates SimpleMacvlan to add AdditionalNetworkNamespace to template data

### DIFF
--- a/pkg/network/additional_networks.go
+++ b/pkg/network/additional_networks.go
@@ -128,6 +128,7 @@ func renderSimpleMacvlanConfig(conf *operv1.AdditionalNetworkDefinition, manifes
 	// render SimpleMacvlanConfig manifests
 	data := render.MakeRenderData()
 	data.Data["AdditionalNetworkName"] = conf.Name
+	data.Data["AdditionalNetworkNamespace"] = conf.Namespace
 
 	if conf.SimpleMacvlanConfig == nil {
 		// no additional config, just fill default IPAM

--- a/pkg/network/additional_networks_test.go
+++ b/pkg/network/additional_networks_test.go
@@ -22,8 +22,9 @@ var NetworkAttachmentConfigSimpleMacvlan = operv1.Network{
 	Spec: operv1.NetworkSpec{
 		AdditionalNetworks: []operv1.AdditionalNetworkDefinition{
 			{
-				Type: operv1.NetworkTypeSimpleMacvlan,
-				Name: "net-attach-1",
+				Type:      operv1.NetworkTypeSimpleMacvlan,
+				Name:      "net-attach-1",
+				Namespace: "foobar",
 				SimpleMacvlanConfig: &operv1.SimpleMacvlanConfig{
 					IPAMConfig: &operv1.IPAMConfig{
 						Type: operv1.IPAMTypeDHCP,
@@ -125,13 +126,13 @@ func TestRenderSimpleMacvlanConfig(t *testing.T) {
 		g.Expect(objs).To(HaveLen(1))
 		g.Expect(objs).To(
 			ContainElement(HaveKubernetesID(
-				"NetworkAttachmentDefinition", "default", cfg.Name)))
+				"NetworkAttachmentDefinition", "foobar", cfg.Name)))
 		expected := `
 {
 	"apiVersion": "k8s.cni.cncf.io/v1",
 	"kind": "NetworkAttachmentDefinition",
 	"metadata": {
-		"namespace": "default",
+		"namespace": "foobar",
 		"name": "net-attach-1"
 	},
 	"spec": {


### PR DESCRIPTION
SimpleMacvlan should respect the desired namespace in the additionalNetworks struct.

Updates SimpleMacvlan to set the namespace before it's rendered, alters test to specify a namespace instead of using default.