### PR TITLE
Bug 1752905: Kuryr: Allow usage of SCC's to allow pod update

### DIFF
--- a/bindata/network/kuryr/001-rbac.yaml
+++ b/bindata/network/kuryr/001-rbac.yaml
@@ -48,6 +48,11 @@ rules:
   resources:
   - routes
   verbs: ["*"]
+- apiGroups: ["security.openshift.io"]
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
 
 ---
 apiVersion: v1


### PR DESCRIPTION
Kuryr ClusterRole was missing "use" verb for SecurityContextConstraints,
making us unable to edit pods outside of `openshift.io/run-level: "0"`
namespaces. This commit adds that permission.