### PR TITLE
Bug 1752453: Multus should execute CNI plugins in /opt/multus/bin

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -48,6 +48,7 @@ spec:
         - "--namespace-isolation=true"
         - "--multus-log-level=verbose"
         - "--cni-version=0.3.1"
+        - "--additional-bin-dir=/opt/multus/bin"
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
In previous versions Multus allowed the execution of CNI plugins
in /opt/multus/bin. This has been utilized in other places and
was otherwise removed previously. This re-enables this functionality.

This likely also needs backport to 4.2