### PR TITLE
Bug 1751246: openshift-sdn: add better ovs liveness/readiness probe

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -99,15 +99,34 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /usr/share/openvswitch/scripts/ovs-ctl
-            - status
+            # Validate that ovs-vswitchd and ovsdb are running. These three commands check
+            # 1. that the pids in the pid file are up
+            # 2. that ovs-vswitchd is responding to queries
+            # 3. that ovsdb is responding to queries
+            # 4. if br0 is configured, that its management process is responding
+            - /bin/bash
+            - -c
+            - |
+              #!/bin/bash
+              /usr/share/openvswitch/scripts/ovs-ctl status > /dev/null &&
+              /usr/bin/ovs-appctl -T 5 ofproto/list > /dev/null &&
+              /usr/bin/ovs-vsctl -t 5 show > /dev/null &&
+              if /usr/bin/ovs-vsctl -t 5 br-exists br0; then /usr/bin/ovs-ofctl -t 5 -O OpenFlow13 probe br0; else true; fi
           initialDelaySeconds: 15
           periodSeconds: 5
         readinessProbe:
           exec:
             command:
-            - /usr/share/openvswitch/scripts/ovs-ctl
-            - status
+            # The same validation as above, but without checking for br0
+            # This is because it's created by openshift-sdn, so looking for it
+            # won't be very meaningful.
+            - /bin/bash
+            - -c
+            - |
+              #!/bin/bash
+              /usr/share/openvswitch/scripts/ovs-ctl status > /dev/null &&
+              /usr/bin/ovs-appctl -T 5 ofproto/list > /dev/null &&
+              /usr/bin/ovs-vsctl -t 5 show > /dev/null
           initialDelaySeconds: 15
           periodSeconds: 5
         lifecycle:


### PR DESCRIPTION
This changes the liveness/readiness probe for OVS to (hopefully) a more rigorous end-to-end check. The challenge is to find one that doesn't rely on br0 being present, which won't happen until openshift-sdn is up and running.

So, we do ovs-ctl status, which checks that the pidfiles have pids that are up and running. It also adds an ovs-appctl command to verify that the vswitchd is running, and a ovs-vsctl check to see that the DB is running.

/cc @orgcandman