### PR TITLE
Bug 1754606: [release-4.2] Correct the way nodes are computed for alert ClusterIPTablesStale

### DIFF
--- a/bindata/network/openshift-sdn/alert-rules.yaml
+++ b/bindata/network/openshift-sdn/alert-rules.yaml
@@ -67,7 +67,10 @@ spec:
       annotations:
         message: The average time between iptables resyncs is too high. NOTE - There is some scrape delay and other offsets, 90s isn't exact but it is still too high.
       expr: |
-        time() - (sum(kubeproxy_sync_proxy_rules_last_timestamp_seconds) / :kube_pod_info_node_count:) > 90
+        quantile(0.95,
+            timestamp(kubeproxy_sync_proxy_rules_last_timestamp_seconds)
+            - on(pod) kubeproxy_sync_proxy_rules_last_timestamp_seconds
+            * on(pod) group_right kube_pod_info{namespace="openshift-sdn",  pod=~"sdn-[^-]*"}) > 90
       for: 20m
       labels:
         severity: warning


### PR DESCRIPTION
Change `kube_pod_info_node_count` to `sum(kube_pod_info{namespace="openshift-sdn", pod=~"ovs.*"})`

this more accuratly computes the alert by returning the number of nodes that have an ovs pod running.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1754592
