### PR TITLE
Fixes Bug 1754049: Adds GCP metadata hostnames to default noProxy

### DIFF
--- a/pkg/controller/proxyconfig/validation.go
+++ b/pkg/controller/proxyconfig/validation.go
@@ -60,7 +60,7 @@ func (r *ReconcileProxyConfig) ValidateProxyConfig(proxyConfig *configv1.ProxySp
 		if proxyConfig.NoProxy != noProxyWildcard {
 			for _, v := range strings.Split(proxyConfig.NoProxy, ",") {
 				v = strings.TrimSpace(v)
-				errDomain := validation.DomainName(v, false)
+				errDomain := validation.DomainName(v, true)
 				_, _, errCIDR := net.ParseCIDR(v)
 				if errDomain != nil && errCIDR != nil {
 					return fmt.Errorf("invalid noProxy: %v", v)

--- a/pkg/util/proxyconfig/no_proxy.go
+++ b/pkg/util/proxyconfig/no_proxy.go
@@ -87,6 +87,10 @@ func MergeUserSystemNoProxy(proxy *configv1.Proxy, infra *configv1.Infrastructur
 		} else {
 			set.Insert(fmt.Sprintf(".%s.compute.internal", region))
 		}
+	case configv1.GCPPlatformType:
+		// From https://cloud.google.com/vpc/docs/special-configurations add GCP metadata.
+		// "metadata.google.internal." added due to https://bugzilla.redhat.com/show_bug.cgi?id=1754049
+		set.Insert("metadata", "metadata.google.internal", "metadata.google.internal.")
 	}
 
 	if len(ic.ControlPlane.Replicas) > 0 {


### PR DESCRIPTION
Adds GCP metadata hostnames to default noProxy based on GCP [doc recommendations](https://cloud.google.com/vpc/docs/special-configurations).