### PR TITLE
Adds aws service endpoints to default noProxy

### DIFF
--- a/pkg/util/proxyconfig/no_proxy.go
+++ b/pkg/util/proxyconfig/no_proxy.go
@@ -81,6 +81,10 @@ func MergeUserSystemNoProxy(proxy *configv1.Proxy, infra *configv1.Infrastructur
 	// TODO: Add support for additional cloud providers.
 	switch infra.Status.PlatformStatus.Type {
 	case configv1.AWSPlatformType:
+		// Bypass proxy to aws service api endpoints: https://docs.aws.amazon.com/general/latest/gr/rande.html
+		// Note: Can't be region scoped due to Route53.
+		set.Insert(".amazonaws.com")
+		// AWS doesn't have a consistent naming scheme for all regions.
 		region := infra.Status.PlatformStatus.AWS.Region
 		if region == "us-east-1" {
 			set.Insert(".ec2.internal")

--- a/pkg/util/proxyconfig/no_proxy_test.go
+++ b/pkg/util/proxyconfig/no_proxy_test.go
@@ -103,7 +103,7 @@ func TestMergeUserSystemNoProxy(t *testing.T) {
 				network: netConfig("10.128.0.0/14", "172.30.0.0/16"),
 				cluster: cfgMapWithInstallConfig(cfgMapKey, cfgMapData),
 			},
-			want: ".cluster.local,.svc,.us-west-2.compute.internal,10.0.0.0/16,10.128.0.0/14,127.0.0.1," +
+			want: ".amazonaws.com,.cluster.local,.svc,.us-west-2.compute.internal,10.0.0.0/16,10.128.0.0/14,127.0.0.1," +
 				"169.254.169.254,172.30.0.0/16,api-int.test.cluster.com,api.test.cluster.com," +
 				"etcd-0.test.cluster.com,etcd-1.test.cluster.com,etcd-2.test.cluster.com,localhost",
 			wantErr: false,
@@ -115,7 +115,7 @@ func TestMergeUserSystemNoProxy(t *testing.T) {
 				network: netConfig("10.128.0.0/14", "172.30.0.0/16"),
 				cluster: cfgMapWithInstallConfig(cfgMapKey, cfgMapData),
 			},
-			want: ".cluster.local,.ec2.internal,.svc,10.0.0.0/16,10.128.0.0/14,127.0.0.1," +
+			want: ".amazonaws.com,.cluster.local,.ec2.internal,.svc,10.0.0.0/16,10.128.0.0/14,127.0.0.1," +
 				"169.254.169.254,172.30.0.0/16,api-int.test.cluster.com,api.test.cluster.com," +
 				"etcd-0.test.cluster.com,etcd-1.test.cluster.com,etcd-2.test.cluster.com,localhost",
 			wantErr: false,
@@ -127,7 +127,7 @@ func TestMergeUserSystemNoProxy(t *testing.T) {
 				network: netConfig("10.128.0.0/14", "172.30.0.0/16"),
 				cluster: cfgMapWithInstallConfig(cfgMapKey, cfgMapData),
 			},
-			want: ".cluster.local,.svc,.us-west-2.compute.internal,10.0.0.0/16,10.128.0.0/14,127.0.0.1," +
+			want: ".amazonaws.com,.cluster.local,.svc,.us-west-2.compute.internal,10.0.0.0/16,10.128.0.0/14,127.0.0.1," +
 				"169.254.169.254,172.30.0.0/16,172.30.0.1,api-int.test.cluster.com,api.test.cluster.com," +
 				"etcd-0.test.cluster.com,etcd-1.test.cluster.com,etcd-2.test.cluster.com,localhost",
 			wantErr: false,
@@ -139,7 +139,7 @@ func TestMergeUserSystemNoProxy(t *testing.T) {
 				network: netConfig("10.128.0.0/14", "172.30.0.0/16"),
 				cluster: cfgMapWithInstallConfig(cfgMapKey, cfgMapData),
 			},
-			want: ".cluster.local,.foo.test.com,.svc,.us-west-2.compute.internal,10.0.0.0/16,10.128.0.0/14,127.0.0.1," +
+			want: ".amazonaws.com,.cluster.local,.foo.test.com,.svc,.us-west-2.compute.internal,10.0.0.0/16,10.128.0.0/14,127.0.0.1," +
 				"169.254.169.254,172.30.0.0/16,172.30.0.1,199.161.0.0/16,api-int.test.cluster.com," +
 				"api.test.cluster.com,etcd-0.test.cluster.com,etcd-1.test.cluster.com,etcd-2.test.cluster.com,localhost",
 			wantErr: false,


### PR DESCRIPTION
Previously, calls to AWS API endpoints were being proxied, when they shouldn't be. This PR adds the AWS service endpoint subdomain to the default `noProxy` list for AWS platform types.