### PR TITLE
Fixes Bug 1757973: Removes external api server from default noProxy

### DIFF
--- a/pkg/util/proxyconfig/no_proxy.go
+++ b/pkg/util/proxyconfig/no_proxy.go
@@ -46,16 +46,6 @@ func MergeUserSystemNoProxy(proxy *configv1.Proxy, infra *configv1.Infrastructur
 		ic.Networking.MachineCIDR,
 	)
 
-	if len(infra.Status.APIServerURL) > 0 {
-		apiServerURL, err := url.Parse(infra.Status.APIServerURL)
-		if err != nil {
-			return "", fmt.Errorf("failed to parse api server url")
-		}
-		set.Insert(apiServerURL.Hostname())
-	} else {
-		return "", fmt.Errorf("api server url missing from infrastructure config '%s'", infra.Name)
-	}
-
 	if len(infra.Status.APIServerInternalURL) > 0 {
 		internalAPIServer, err := url.Parse(infra.Status.APIServerInternalURL)
 		if err != nil {

--- a/pkg/util/proxyconfig/no_proxy_test.go
+++ b/pkg/util/proxyconfig/no_proxy_test.go
@@ -116,8 +116,8 @@ func TestMergeUserSystemNoProxy(t *testing.T) {
 				cluster: cfgMapWithInstallConfig(cfgMapKey, cfgMapData),
 			},
 			want: ".cluster.local,.svc,.us-west-2.compute.internal,10.0.0.0/16,10.128.0.0/14,127.0.0.1," +
-				"169.254.169.254,172.30.0.0/16,api-int.test.cluster.com,api.test.cluster.com," +
-				"etcd-0.test.cluster.com,etcd-1.test.cluster.com,etcd-2.test.cluster.com,localhost",
+				"169.254.169.254,172.30.0.0/16,api-int.test.cluster.com,etcd-0.test.cluster.com," +
+				"etcd-1.test.cluster.com,etcd-2.test.cluster.com,localhost",
 			wantErr: false,
 		},
 		{name: "valid proxy config with gcp provider",
@@ -128,8 +128,8 @@ func TestMergeUserSystemNoProxy(t *testing.T) {
 				cluster: cfgMapWithInstallConfig(cfgMapKey, cfgMapData),
 			},
 			want: ".cluster.local,.svc,10.0.0.0/16,10.128.0.0/14,127.0.0.1,169.254.169.254,172.30.0.0/16," +
-				"api-int.test.cluster.com,api.test.cluster.com,etcd-0.test.cluster.com,etcd-1.test.cluster.com," +
-				"etcd-2.test.cluster.com,localhost,metadata,metadata.google.internal,metadata.google.internal.",
+				"api-int.test.cluster.com,etcd-0.test.cluster.com,etcd-1.test.cluster.com,etcd-2.test.cluster.com," +
+				"localhost,metadata,metadata.google.internal,metadata.google.internal.",
 			wantErr: false,
 		},
 		{name: "valid proxy config using us-east-1 aws region",
@@ -140,8 +140,8 @@ func TestMergeUserSystemNoProxy(t *testing.T) {
 				cluster: cfgMapWithInstallConfig(cfgMapKey, cfgMapData),
 			},
 			want: ".cluster.local,.ec2.internal,.svc,10.0.0.0/16,10.128.0.0/14,127.0.0.1," +
-				"169.254.169.254,172.30.0.0/16,api-int.test.cluster.com,api.test.cluster.com," +
-				"etcd-0.test.cluster.com,etcd-1.test.cluster.com,etcd-2.test.cluster.com,localhost",
+				"169.254.169.254,172.30.0.0/16,api-int.test.cluster.com,etcd-0.test.cluster.com," +
+				"etcd-1.test.cluster.com,etcd-2.test.cluster.com,localhost",
 			wantErr: false,
 		},
 		{name: "valid proxy config with single user noProxy",
@@ -152,8 +152,8 @@ func TestMergeUserSystemNoProxy(t *testing.T) {
 				cluster: cfgMapWithInstallConfig(cfgMapKey, cfgMapData),
 			},
 			want: ".cluster.local,.svc,.us-west-2.compute.internal,10.0.0.0/16,10.128.0.0/14,127.0.0.1," +
-				"169.254.169.254,172.30.0.0/16,172.30.0.1,api-int.test.cluster.com,api.test.cluster.com," +
-				"etcd-0.test.cluster.com,etcd-1.test.cluster.com,etcd-2.test.cluster.com,localhost",
+				"169.254.169.254,172.30.0.0/16,172.30.0.1,api-int.test.cluster.com,etcd-0.test.cluster.com," +
+				"etcd-1.test.cluster.com,etcd-2.test.cluster.com,localhost",
 			wantErr: false,
 		},
 		{name: "valid proxy config with multiple user noProxy",
@@ -165,7 +165,7 @@ func TestMergeUserSystemNoProxy(t *testing.T) {
 			},
 			want: ".cluster.local,.foo.test.com,.svc,.us-west-2.compute.internal,10.0.0.0/16,10.128.0.0/14,127.0.0.1," +
 				"169.254.169.254,172.30.0.0/16,172.30.0.1,199.161.0.0/16,api-int.test.cluster.com," +
-				"api.test.cluster.com,etcd-0.test.cluster.com,etcd-1.test.cluster.com,etcd-2.test.cluster.com,localhost",
+				"etcd-0.test.cluster.com,etcd-1.test.cluster.com,etcd-2.test.cluster.com,localhost",
 			wantErr: false,
 		},
 		{name: "invalid api server url",


### PR DESCRIPTION
External cluster resources such as routes should not be automatically no-proxied. We should provide cluster admins the choice on whether or not to proxy these connections. This PR removes the external api-server hostname from the default noProxy list.

/assign @bparees @deads2k @knobunc 