### PR TITLE
ovn-kubernetes: run binaries directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,30 @@ spec:
       mtu: 1400
 ```
 
+Additionally, you can configure per-node verbosity for ovn-kubernetes. This is useful
+if you want to debug an issue, and can reproduce it on a single node. To do this,
+create a special ConfigMap with keys based on the Node's name:
+
+```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: env-overrides
+  namespace: openshift-ovn-kubernetes
+  annotations:
+data:
+# to set the node processes on a single node to verbose
+# replace this with the node's name (from oc get nodes)
+  ip-10-0-135-96.us-east-2.compute.internal: |
+    OVN_KUBE_LOG_LEVEL=5
+    OVN_LOG_LEVEL=dbg
+    OVS_LOG_LEVEL=dbg
+# To adjust master log levels, use _master
+  _master: |
+    OVN_KUBE_LOG_LEVEL=5
+    OVN_LOG_LEVEL=dbg
+```
+
 ### Configuring Kuryr-Kubernetes
 Kuryr-Kubernetes is a CNI plugin that uses OpenStack Neutron to network OpenShift Pods, and OpenStack Octavia to create load balancers for Services. In general it is useful when OpenShift is running on an OpenStack cluster, as you can use the same SDN (OpenStack Neutron) to provide networking for both the VMs OpenShift is running on, and the Pods created by OpenShift. In such case avoidance of double encapsulation gives you two advantages: improved performace (in terms of both latency and throughput) and lower complexity of the networking architecture.
 

--- a/bindata/network/ovn-kubernetes/005-service.yaml
+++ b/bindata/network/ovn-kubernetes/005-service.yaml
@@ -9,15 +9,17 @@ metadata:
   name: ovnkube-db
   namespace: openshift-ovn-kubernetes
 spec:
+  selector:
+    name: ovnkube-master
   ports:
   - name: north
-    port: 9641
+    port: {{.OVN_NB_PORT}}
     protocol: TCP
-    targetPort: 9641
+    targetPort: {{.OVN_NB_PORT}}
   - name: south
-    port: 9642
+    port: {{.OVN_SB_PORT}}
     protocol: TCP
-    targetPort: 9642
+    targetPort: {{.OVN_SB_PORT}}
   sessionAffinity: None
   clusterIP: None
   type: ClusterIP

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -1,12 +1,7 @@
-# ovnkube-master
-# daemonset version 3
-# starts master daemons, each in a separate container
-# it is run on the master node(s)
 kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: ovnkube-master
-  # namespace set up by install
   namespace: openshift-ovn-kubernetes
   annotations:
     kubernetes.io/description: |
@@ -19,6 +14,11 @@ spec:
       name: ovnkube-master
   strategy:
     type: RollingUpdate
+    rollingUpdate:
+      # by default, Deployments spin up the new pod before terminating the old one
+      # but we don't want that - because ovsdb holds the lock.
+      maxSurge: 0
+      maxUnavailable: 1
   template:
     metadata:
       labels:
@@ -28,215 +28,178 @@ spec:
         openshift.io/component: network
         kubernetes.io/os: "linux"
     spec:
-      # Requires fairly broad permissions - ability to read all services and network functions as well
-      # as all pods.
       serviceAccountName: ovn-kubernetes-controller
       hostNetwork: true
-      hostPID: true
       priorityClassName: "system-cluster-critical"
+      # volumes in all containers:
+      # (container) -> (host)
+      # /etc/openvswitch -> /var/lib/ovn/etc - ovsdb data
+      # /var/lib/openvswitch -> /var/lib/ovn/data - ovsdb pki state
+      # /run/openvswitch -> tmpfs - sockets & pids
+      # /env -> configmap env-overrides - debug overrides
       containers:
-      # firewall rules for ovn - assumed to be setup
-      # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6641 -j ACCEPT
-      # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6642 -j ACCEPT
-      # ovs flow for ovn (geneve)
-      # /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol
-
-      # run-ovn-northd - v3
-      - name: run-ovn-northd
+      # ovn-northd: convert network objects in nbdb to flows in sbdb
+      - name: northd
         image: {{.OvnImage}}
-
-        command: ["/root/ovnkube.sh", "run-ovn-northd"]
-
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          if [[ -f /env/_master ]]; then
+            set -o allexport
+            source /env/_master
+            set +o allexport
+          fi
+          exec ovn-northd --no-chdir "-vconsole:${OVN_LOG_LEVEL}" -vfile:off --pidfile=/var/run/openvswitch/ovn-northd.pid
+        env:
+        - name: OVN_LOG_LEVEL
+          value: info
         volumeMounts:
-        # ovn db is stored in the pod in /etc/openvswitch (default ovs tool location)
-        # and on the host in /var/lib/openvswitch/
         - mountPath: /etc/openvswitch/
-          name: host-var-lib-ovs
+          name: etc-openvswitch
         - mountPath: /var/lib/openvswitch/
-          name: host-var-lib-ovs
-        - mountPath: /var/run/openvswitch/
-          name: host-var-run-ovs
-
+          name: var-lib-openvswitch
+        - mountPath: /run/openvswitch/
+          name: run-openvswitch
+        - mountPath: /env
+          name: env-overrides
         resources:
           requests:
             cpu: 100m
             memory: 300Mi
-        env:
-        - name: OVN_DAEMONSET_VERSION
-          value: "3"
-        - name: OVN_LOG_NORTHD
-          value: "-vconsole:info"
-        - name: OVN_NB_PORT
-          value: "9641"
-        - name: OVN_SB_PORT
-          value: "9642"
-        - name: OVN_NET_CIDR
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: net_cidr
-        - name: OVN_SVC_CIDR
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: svc_cidr
-        - name: K8S_NODE
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: K8S_APISERVER
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: k8s_apiserver
-        - name: OVN_KUBERNETES_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-      # end of container
 
-      # nb-ovsdb - v3
-      - name: nb-ovsdb
+      # nbdb: the northbound, or logical network object DB
+      - name: nbdb
         image: {{.OvnImage}}
-
-        command: ["/root/ovnkube.sh", "nb-ovsdb"]
-
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          if [[ -f /env/_master ]]; then
+            set -o allexport
+            source /env/_master
+            set +o allexport
+          fi
+          exec /usr/share/openvswitch/scripts/ovn-ctl run_nb_ovsdb \
+            --no-monitor \
+            --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off"
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - |
+                retries=0
+                while ! ovn-nbctl -t 5 set-connection ptcp:{{.OVN_NB_PORT}} -- set connection . inactivity_probe=0; do
+                  (( retries += 1 ))
+                  if [[ "${retries}" -gt 40 ]]; then
+                    echo "too many failed ovn-nbctl attempts, giving up"
+                    exit 1
+                  fi
+                  sleep 2
+                done
+        env:
+        - name: OVN_LOG_LEVEL
+          value: info
         volumeMounts:
-        # ovn db is stored in the pod in /etc/openvswitch (default ovs tool location)
-        # and on the host in /var/lib/openvswitch/
         - mountPath: /etc/openvswitch/
-          name: host-var-lib-ovs
+          name: etc-openvswitch
         - mountPath: /var/lib/openvswitch/
-          name: host-var-lib-ovs
-        - mountPath: /var/run/openvswitch/
-          name: host-var-run-ovs
-
+          name: var-lib-openvswitch
+        - mountPath: /run/openvswitch/
+          name: run-openvswitch
+        - mountPath: /env
+          name: env-overrides
         resources:
           requests:
             cpu: 100m
             memory: 300Mi
-        env:
-        - name: OVN_DAEMONSET_VERSION
-          value: "3"
-        - name: OVN_LOG_NB
-          value: "-vconsole:info -vfile:info"
-        - name: OVN_NB_PORT
-          value: "9641"
-        - name: OVN_SB_PORT
-          value: "9642"
-        - name: OVN_NET_CIDR
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: net_cidr
-        - name: OVN_SVC_CIDR
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: svc_cidr
-        - name: K8S_NODE
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: K8S_APISERVER
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: k8s_apiserver
-        - name: OVN_KUBERNETES_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-      # end of container
 
-      # sb-ovsdb - v3
-      - name: sb-ovsdb
+      # sbdb: the southbound, or flow DB
+      - name: sbdb
         image: {{.OvnImage}}
-
-        command: ["/root/ovnkube.sh", "sb-ovsdb"]
-
-        volumeMounts:
-        # ovn db is stored in the pod in /etc/openvswitch (default ovs tool location)
-        # and on the host in /var/lib/openvswitch/
-        - mountPath: /etc/openvswitch/
-          name: host-var-lib-ovs
-        - mountPath: /var/lib/openvswitch/
-          name: host-var-lib-ovs
-        - mountPath: /var/run/openvswitch/
-          name: host-var-run-ovs
-        - mountPath: /var/run/kubernetes/
-          name: host-var-run-kubernetes
-
-        resources:
-          requests:
-            cpu: 100m
-            memory: 300Mi
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          if [[ -f "/env/_master" ]]; then
+            set -o allexport
+            source "/env/_master"
+            set +o allexport
+          fi
+          exec /usr/share/openvswitch/scripts/ovn-ctl run_sb_ovsdb \
+            --no-monitor \
+            --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off"
         env:
-        - name: OVN_DAEMONSET_VERSION
-          value: "3"
-        - name: OVN_LOG_SB
-          value: "-vconsole:info -vfile:info"
-        - name: OVN_NB_PORT
-          value: "9641"
-        - name: OVN_SB_PORT
-          value: "9642"
-        - name: OVN_NET_CIDR
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: net_cidr
-        - name: OVN_SVC_CIDR
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: svc_cidr
-        - name: K8S_NODE
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: K8S_APISERVER
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: k8s_apiserver
-        - name: OVN_KUBERNETES_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-      # end of container
+        - name: OVN_LOG_LEVEL
+          value: info
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - |
+                retries=0
+                while ! ovn-sbctl -t 5 set-connection ptcp:{{.OVN_SB_PORT}} -- set connection . inactivity_probe=0; do
+                  (( retries += 1 ))
+                  if [[ "${retries}" -gt 40 ]]; then
+                    echo "too many failed ovn-sbctl attempts, giving up"
+                    exit 1
+                  fi
+                  sleep 2
+                done
+        volumeMounts:
+        - mountPath: /etc/openvswitch/
+          name: etc-openvswitch
+        - mountPath: /var/lib/openvswitch/
+          name: var-lib-openvswitch
+        - mountPath: /run/openvswitch/
+          name: run-openvswitch
+        - mountPath: /env
+          name: env-overrides
 
+      # ovnkube master: convert kubernetes objects in to nbdb logical network components
       - name: ovnkube-master
         image: {{.OvnImage}}
-
-        command: ["/root/ovnkube.sh", "ovn-master"]
-
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          if [[ -f "/env/_master" ]]; then
+            set -o allexport
+            source "/env/_master"
+            set +o allexport
+          fi
+          exec /usr/bin/ovnkube \
+            --init-master "${K8S_NODE}" \
+            --cluster-subnets "${OVN_NET_CIDR}" \
+            --k8s-service-cidr "${OVN_SVC_CIDR}" \
+            --k8s-apiserver "{{.K8S_APISERVER}}" \
+            --nodeport \
+            --loglevel "${OVN_KUBE_LOG_LEVEL}" \
+            --logfile /dev/stdout
         volumeMounts:
-        # ovn db is stored in the pod in /etc/openvswitch (default ovs tool location)
-        # and on the host in /var/lib/openvswitch/
         - mountPath: /etc/openvswitch/
-          name: host-var-lib-ovs
+          name: etc-openvswitch
         - mountPath: /var/lib/openvswitch/
-          name: host-var-lib-ovs
-        - mountPath: /var/run/openvswitch/
-          name: host-var-run-ovs
-        - mountPath: /var/run/kubernetes/
-          name: host-var-run-kubernetes
-
+          name: var-lib-openvswitch
+        - mountPath: /run/openvswitch/
+          name: run-openvswitch
+        - mountPath: /env
+          name: env-overrides
         resources:
           requests:
             cpu: 100m
             memory: 300Mi
         env:
-        - name: OVN_DAEMONSET_VERSION
-          value: "3"
-        - name: OVN_MASTER
-          value: "true"
-        - name: OVNKUBE_LOGLEVEL
+        - name: OVN_KUBE_LOG_LEVEL
           value: "4"
-        - name: OVN_NB_PORT
-          value: "9641"
-        - name: OVN_SB_PORT
-          value: "9642"
         - name: OVN_NET_CIDR
           valueFrom:
             configMapKeyRef:
@@ -251,37 +214,26 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: K8S_APISERVER
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: k8s_apiserver
-        - name: OVN_KUBERNETES_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-      # end of container
-
       nodeSelector:
         node-role.kubernetes.io/master: ""
         beta.kubernetes.io/os: "linux"
       volumes:
-      - name: host-modules
+      - name: etc-openvswitch
         hostPath:
-          path: /lib/modules
-      - name: host-var-lib-ovs
+          path: /var/lib/ovn/etc
+      - name: var-lib-openvswitch
         hostPath:
-          path: /var/lib/openvswitch
-      - name: host-var-run-ovs
-        hostPath:
-          path: /var/run/openvswitch
-      - name: host-var-run-kubernetes
-        hostPath:
-          path: /var/run/kubernetes
+          path: /var/lib/ovn/data
+      - name: run-openvswitch
+        emptyDir: {}
+      - name: env-overrides
+        configMap:
+          name: env-overrides
+          optional: true
       tolerations:
       - key: "node-role.kubernetes.io/master"
         operator: "Exists"
-        effect: "NoSchedule"
       - key: "node.kubernetes.io/not-ready"
         operator: "Exists"
-        effect: "NoSchedule"
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -1,13 +1,7 @@
----
-# ovnkube-node
-# daemonset version 3
-# starts node daemons for ovs and ovn, each in a separate container
-# it is run on all nodes
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: ovnkube-node
-  # namespace set up by install
   namespace: openshift-ovn-kubernetes
   annotations:
     kubernetes.io/description: |
@@ -28,204 +22,261 @@ spec:
         openshift.io/component: network
         kubernetes.io/os: "linux"
     spec:
-      # Requires fairly broad permissions - ability to read all services and network functions as well
-      # as all pods.
       serviceAccountName: ovn-kubernetes-node
       hostNetwork: true
       hostPID: true
       priorityClassName: "system-node-critical"
+      # volumes in all containers:
+      # (container) -> (host)
+      # /etc/openvswitch -> /var/lib/openvswitch/etc - ovsdb system id
+      # /var/lib/openvswitch -> /var/lib/openvswitch/data - ovsdb data
+      # /run/openvswitch -> tmpfs - ovsdb sockets
+      # /env -> configmap env-overrides - debug overrides
       containers:
-      # ovsdb-server and ovs-switchd daemons
+      # ovsdb and ovs-vswitchd
       - name: ovs-daemons
         image: {{.OvnImage}}
+        command:
+        - /bin/bash
+        - -c
+        - |
+          #!/bin/bash
+          set -euo pipefail
+          if [[ -f "/env/${K8S_NODE}" ]]; then
+            set -o allexport
+            source "/env/${K8S_NODE}"
+            set +o allexport
+          fi
+          chown -R openvswitch:openvswitch /run/openvswitch
+          chown -R openvswitch:openvswitch /etc/openvswitch
+          function quit {
+              /usr/share/openvswitch/scripts/ovs-ctl stop
+              exit 0
+          }
+          trap quit SIGTERM
+          /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --system-id=random
+          ovs-appctl vlog/set "file:${OVS_LOG_LEVEL}"
 
-        command: ["/root/ovnkube.sh", "ovs-server"]
-
+          tail -F --pid=$(cat /var/run/openvswitch/ovs-vswitchd.pid) /var/log/openvswitch/ovs-vswitchd.log &
+          tail -F --pid=$(cat /var/run/openvswitch/ovsdb-server.pid) /var/log/openvswitch/ovsdb-server.log &
+          wait
+        env:
+        - name: OVS_LOG_LEVEL
+          value: info
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         securityContext:
-          # Permission could be reduced by selecting an appropriate SELinux policy
           privileged: true
-
         volumeMounts:
         - mountPath: /lib/modules
           name: host-modules
           readOnly: true
-        - mountPath: /run/openvswitch
-          name: host-run-ovs
-        - mountPath: /var/run/openvswitch
-          name: host-var-run-ovs
         - mountPath: /sys
           name: host-sys
           readOnly: true
+        - mountPath: /run/openvswitch
+          name: run-openvswitch
         - mountPath: /etc/openvswitch
-          name: host-config-openvswitch
+          name: etc-openvswitch
+        - mountPath: /var/lib/openvswitch
+          name: var-lib-openvswitch
+        - mountPath: /env
+          name: env-overrides
         resources:
           requests:
             cpu: 100m
             memory: 300Mi
-        env:
-        - name: OVN_DAEMONSET_VERSION
-          value: "3"
-
-
-      # firewall rules for ovn - assumed to be setup
-      # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6641 -j ACCEPT
-      # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6642 -j ACCEPT
-      # ovs flow for ovn (geneve)
-      # /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol
-      # The network container launches the ovn-k8s-cni-overlay process, the kube-proxy, and the local DNS service.
-      # It relies on an up to date node-config.yaml being present.
-      - name: ovn-controller
-        image: {{.OvnImage}}
-
-        command: ["/root/ovnkube.sh", "ovn-controller"]
-
-        securityContext:
-          # Permission could be reduced by selecting an appropriate SELinux policy
-          privileged: true
-
-        volumeMounts:
-        # Directory which contains the host configuration.
-        - mountPath: /var/lib/openvswitch/
-          name: host-var-lib-ovs
-        - mountPath: /var/run/openvswitch/
-          name: host-var-run-ovs
-
-        resources:
-          requests:
-            cpu: 100m
-            memory: 300Mi
-        env:
-        - name: OVN_DAEMONSET_VERSION
-          value: "3"
-        - name: OVNKUBE_LOGLEVEL
-          value: "4"
-        - name: OVN_NB_PORT
-          value: "9641"
-        - name: OVN_SB_PORT
-          value: "9642"
-        - name: OVN_NET_CIDR
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: net_cidr
-        - name: OVN_SVC_CIDR
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: svc_cidr
-        - name: K8S_NODE
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: K8S_APISERVER
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: k8s_apiserver
-        - name: OVN_KUBERNETES_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-
-      - name: ovn-node
-        image: {{.OvnImage}}
-
-        command: ["/root/ovnkube.sh", "ovn-node"]
-
-        securityContext:
-          # Permission could be reduced by selecting an appropriate SELinux policy
-          privileged: true
-
-        volumeMounts:
-        - mountPath: /host
-          name: host-slash
-          readOnly: true
-        # Directory which contains the host configuration.
-        - mountPath: /var/lib/openvswitch/
-          name: host-var-lib-ovs
-        - mountPath: /var/run/openvswitch/
-          name: host-var-run-ovs
-        - mountPath: /var/run/ovn-kubernetes/
-          name: host-var-run-ovn-kubernetes
-        # CNI related mounts which we take over
-        - mountPath: /host/opt/cni/bin
-          name: host-cni-bin
-        - mountPath: /etc/cni/net.d
-          name: host-cni-netd
-        - mountPath: /var/lib/cni/networks/ovn-k8s-cni-overlay
-          name: host-var-lib-cni-networks-ovn-kubernetes
-
-        resources:
-          requests:
-            cpu: 100m
-            memory: 300Mi
-        env:
-        - name: OVN_DAEMONSET_VERSION
-          value: "3"
-        - name: OVNKUBE_LOGLEVEL
-          value: "4"
-        - name: OVN_NB_PORT
-          value: "9641"
-        - name: OVN_SB_PORT
-          value: "9642"
-        - name: OVN_GATEWAY_MODE
-          value: local
-        - name: OVN_NET_CIDR
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: net_cidr
-        - name: OVN_SVC_CIDR
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: svc_cidr
-        - name: K8S_NODE
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: K8S_APISERVER
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: k8s_apiserver
-        - name: OVN_KUBERNETES_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-
+        terminationMessagePolicy: FallbackToLogsOnError
+        livenessProbe:
+          exec:
+            command:
+            - /usr/share/openvswitch/scripts/ovs-ctl
+            - status
+          initialDelaySeconds: 15
+          periodSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - /usr/share/openvswitch/scripts/ovs-ctl
+            - status
+          initialDelaySeconds: 15
+          periodSeconds: 5
         lifecycle:
           preStop:
             exec:
-              command: ["rm","-f","/etc/cni/net.d/10-ovn-kubernetes.conf", "/host/opt/cni/bin/ovn-k8s-cni-overlay"]
+              command: ["/usr/share/openvswitch/scripts/ovs-ctl", "stop"]
+        terminationGracePeriodSeconds: 10
+
+      # ovn-controller: programs the vswitch with flows from the sbdb
+      - name: ovn-controller
+        image: {{.OvnImage}}
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          if [[ -f "/env/${K8S_NODE}" ]]; then
+            set -o allexport
+            source "/env/${K8S_NODE}"
+            set +o allexport
+          fi
+          exec ovn-controller unix:/var/run/openvswitch/db.sock -vfile:off \
+            --no-chdir --pidfile=/var/run/openvswitch/ovn-controller.pid \
+            -vconsole:"${OVN_LOG_LEVEL}"
+        securityContext:
+          privileged: true
+        env:
+        - name: OVN_LOG_LEVEL
+          value: info
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        volumeMounts:
+        - mountPath: /run/openvswitch
+          name: run-openvswitch
+        - mountPath: /etc/openvswitch
+          name: etc-openvswitch
+        - mountPath: /var/lib/openvswitch
+          name: var-lib-openvswitch
+        - mountPath: /env
+          name: env-overrides
+        terminationMessagePolicy: FallbackToLogsOnError
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+
+      # ovnkube-node: does node-level bookkeeping and configuration
+      - name: ovnkube-node
+        image: {{.OvnImage}}
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          if [[ -f "/env/${K8S_NODE}" ]]; then
+            set -o allexport
+            source "/env/${K8S_NODE}"
+            set +o allexport
+          fi
+          cp -f /usr/libexec/cni/ovn-k8s-cni-overlay /cni-bin-dir/
+          retries=0
+          while true; do
+            db_ip=$(kubectl get ep ovnkube-db -o jsonpath='{.subsets[0].addresses[0].ip}')
+            if [[ -n "${db_ip}" ]]; then
+              break
+            fi
+            (( retries += 1 ))
+            if [[ "${retries}" -gt 40 ]]; then
+              echo "db endpoint never came up"
+              exit 1
+            fi
+            echo "waiting for db endpoint"
+            sleep 5
+          done
+          exec /usr/bin/ovnkube --init-node "${K8S_NODE}" \
+            --cluster-subnets "${OVN_NET_CIDR}" \
+            --k8s-service-cidr "${OVN_SVC_CIDR}" \
+            --k8s-apiserver "{{.K8S_APISERVER}}" \
+            --nb-address "tcp://${db_ip}:{{.OVN_NB_PORT}}" \
+            --sb-address "tcp://${db_ip}:{{.OVN_SB_PORT}}" \
+            --nodeport --gateway-mode local \
+            --pidfile /var/run/openvswitch/ovnkube-node.pid \
+            --loglevel "${OVN_KUBE_LOG_LEVEL}" --logfile /dev/stdout
+        env:
+        - name: OVN_KUBE_LOG_LEVEL
+          value: "4"
+        # for kubectl
+        - name: KUBERNETES_SERVICE_PORT
+          value: "{{.KUBERNETES_SERVICE_PORT}}"
+        - name: KUBERNETES_SERVICE_HOST
+          value: "{{.KUBERNETES_SERVICE_HOST}}"
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        securityContext:
+          privileged: true
+        volumeMounts:
+        # for the iptables wrapper
+        - mountPath: /host
+          name: host-slash
+          readOnly: true
+        # for the CNI server socket
+        - mountPath: /run/ovn-kubernetes/
+          name: host-run-ovn-kubernetes
+        # accessing bind-mounted net namespaces
+        - mountPath: /run/netns
+          name: host-run-netns
+          readOnly: true
+        # for installing the CNI plugin binary
+        - mountPath: /cni-bin-dir
+          name: host-cni-bin
+        # for installing the CNI configuration file
+        - mountPath: /etc/cni/net.d
+          name: host-cni-netd
+        # Where we store IP allocations
+        - mountPath: /var/lib/cni/networks/ovn-k8s-cni-overlay
+          name: host-var-lib-cni-networks-ovn-kubernetes
+        - mountPath: /run/openvswitch
+          name: run-openvswitch
+        - mountPath: /etc/openvswitch
+          name: etc-openvswitch
+        - mountPath: /var/lib/openvswitch
+          name: var-lib-openvswitch
+        - mountPath: /env
+          name: env-overrides
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        lifecycle:
+          preStop:
+            exec:
+              command: ["rm","-f","/etc/cni/net.d/10-ovn-kubernetes.conf"]
         readinessProbe:
           exec:
-            # ovnkube --node writes this file when it is ready to handle pod requests.
             command: ["test", "-f", "/etc/cni/net.d/10-ovn-kubernetes.conf"]
           initialDelaySeconds: 5
           periodSeconds: 5
-
       nodeSelector:
         beta.kubernetes.io/os: "linux"
       volumes:
+      # used for iptables wrapper scripts
       - name: host-slash
         hostPath:
           path: /
       - name: host-modules
         hostPath:
           path: /lib/modules
-      - name: host-var-lib-ovs
+      - name: host-run-netns
         hostPath:
-          path: /var/lib/openvswitch
-      - name: host-run-ovs
+          path: /run/netns
+      - name: var-lib-openvswitch
         hostPath:
-          path: /run/openvswitch
-      - name: host-var-run-ovs
+          path: /var/lib/openvswitch/data
+      - name: etc-openvswitch
         hostPath:
-          path: /var/run/openvswitch
-      - name: host-var-run-ovn-kubernetes
+          path: /var/lib/openvswitch/etc
+      - name: run-openvswitch
+        emptyDir: {}
+      # For CNI server
+      - name: host-run-ovn-kubernetes
         hostPath:
-          path: /var/run/ovn-kubernetes
+          path: /run/ovn-kubernetes
       - name: host-sys
         hostPath:
           path: /sys
@@ -235,11 +286,12 @@ spec:
       - name: host-cni-netd
         hostPath:
           path: {{.CNIConfDir}}
-      - name: host-config-openvswitch
-        hostPath:
-          path: /etc/origin/openvswitch
       - name: host-var-lib-cni-networks-ovn-kubernetes
         hostPath:
           path: /var/lib/cni/networks/ovn-k8s-cni-overlay
+      - name: env-overrides
+        configMap:
+          name: env-overrides
+          optional: true
       tolerations:
       - operator: "Exists"

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -14,6 +14,9 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/render"
 )
 
+const OVN_NB_PORT = "9641"
+const OVN_SB_PORT = "9642"
+
 // renderOVNKubernetes returns the manifests for the ovn-kubernetes.
 // This creates
 // - the ClusterNetwork object
@@ -31,10 +34,14 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.U
 	data := render.MakeRenderData()
 	data.Data["ReleaseVersion"] = os.Getenv("RELEASE_VERSION")
 	data.Data["OvnImage"] = os.Getenv("OVN_IMAGE")
+	data.Data["KUBERNETES_SERVICE_HOST"] = os.Getenv("KUBERNETES_SERVICE_HOST")
+	data.Data["KUBERNETES_SERVICE_PORT"] = os.Getenv("KUBERNETES_SERVICE_PORT")
 	data.Data["K8S_APISERVER"] = fmt.Sprintf("https://%s:%s", os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT"))
 	data.Data["MTU"] = c.MTU
 	data.Data["CNIConfDir"] = pluginCNIConfDir(conf)
 	data.Data["CNIBinDir"] = CNIBinDir
+	data.Data["OVN_NB_PORT"] = OVN_NB_PORT
+	data.Data["OVN_SB_PORT"] = OVN_SB_PORT
 
 	var ippools string
 	for _, net := range conf.ClusterNetwork {


### PR DESCRIPTION
While we're in the process of adding HA and TLS, let's just execute the binaries directly.