### PR TITLE
ovn-kubernetes: fix endpoint namespace

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -181,6 +181,7 @@ spec:
             --cluster-subnets "${OVN_NET_CIDR}" \
             --k8s-service-cidr "${OVN_SVC_CIDR}" \
             --k8s-apiserver "{{.K8S_APISERVER}}" \
+            --ovn-config-namespace openshift-ovn-kubernetes \
             --nodeport \
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
             --logfile /dev/stdout

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -163,9 +163,10 @@ spec:
             set +o allexport
           fi
           cp -f /usr/libexec/cni/ovn-k8s-cni-overlay /cni-bin-dir/
+          ovn_config_namespace=openshift-ovn-kubernetes
           retries=0
           while true; do
-            db_ip=$(kubectl get ep ovnkube-db -o jsonpath='{.subsets[0].addresses[0].ip}')
+            db_ip=$(kubectl get ep -n ${ovn_config_namespace} ovnkube-db -o jsonpath='{.subsets[0].addresses[0].ip}')
             if [[ -n "${db_ip}" ]]; then
               break
             fi
@@ -181,6 +182,7 @@ spec:
             --cluster-subnets "${OVN_NET_CIDR}" \
             --k8s-service-cidr "${OVN_SVC_CIDR}" \
             --k8s-apiserver "{{.K8S_APISERVER}}" \
+            --ovn-config-namespace ${ovn_config_namespace} \
             --nb-address "tcp://${db_ip}:{{.OVN_NB_PORT}}" \
             --sb-address "tcp://${db_ip}:{{.OVN_SB_PORT}}" \
             --nodeport --gateway-mode local \


### PR DESCRIPTION
Upstream defaults to just 'ovn-kubernetes' but we need to use
openshift-ovn-kubernetes.

Fixes: 0ac2cdf16adffca72e385337df95d54d9e97e249

@squeed @JacobTanenbaum @danwinship 