### PR TITLE
SDN-394: Making the sdn controller a deployment

### DIFF
--- a/bindata/network/openshift-sdn/controller.yaml
+++ b/bindata/network/openshift-sdn/controller.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   name: sdn-controller
   namespace: openshift-sdn
@@ -10,6 +10,7 @@ metadata:
   labels:
     app: sdn-controller
 spec:
+  replicas: 2
   selector:
     matchLabels:
       app: sdn-controller
@@ -18,6 +19,16 @@ spec:
       labels:
         app: sdn-controller
     spec:
+      affinity:
+        podAntiAffinity:
+           requiredDuringSchedulingIgnoredDuringExecution:
+           - labelSelector:
+               matchExpressions:
+               - key: app
+                 operator: In
+                 values:
+                 - sdn-controller
+             topologyKey: kubernetes.io/hostname
       containers:
       - name: sdn-controller
         image: {{.SDNControllerImage}}
@@ -35,8 +46,6 @@ spec:
           value: "{{.KUBERNETES_SERVICE_HOST}}"
         terminationMessagePolicy: FallbackToLogsOnError
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: "system-cluster-critical"
       restartPolicy: Always
       serviceAccountName: sdn-controller

--- a/pkg/network/openshift_sdn_test.go
+++ b/pkg/network/openshift_sdn_test.go
@@ -70,14 +70,14 @@ func TestRenderOpenShiftSDN(t *testing.T) {
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ServiceAccount", "openshift-sdn", "sdn-controller")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRoleBinding", "", "openshift-sdn")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-sdn", "sdn")))
-	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-sdn", "sdn-controller")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("Deployment", "openshift-sdn", "sdn-controller")))
 
 	// No netnamespaces by default
 	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("NetNamespace", "", "openshift-ingress")))
 
-	// make sure all deployments are in the master
+	// make sure all deployments, except the sdn-controller, are on the master,
 	for _, obj := range objs {
-		if obj.GetKind() != "Deployment" {
+		if obj.GetKind() != "Deployment" || obj.GetName() == "sdn-controller" {
 			continue
 		}
 


### PR DESCRIPTION
This PR makes the SDN controller a deployment. 

* We will not use a `nodeSelector: master` anymore as that is not required (and should not be) for running the SDN controller. 
* We will run two replicas, as to mimic an active-active recovery.
* We will however introduce `antiAffinity` with itself, as to make sure that the leader election is done properly (today it's done by using to the `hostName` as key, as seen [here](https://github.com/openshift/sdn/blob/master/pkg/openshift-network-controller/network_controller.go#L68). This is required as the `hostName` equals the node's name for the SDN components (`hostNetwork: true`).

/assign @squeed 