### PR TITLE
Add test to assert we fail if conntrack-max kubeproxy config option is passed

### DIFF
--- a/pkg/util/k8s/kubeproxy_test.go
+++ b/pkg/util/k8s/kubeproxy_test.go
@@ -329,6 +329,13 @@ winkernel:
 			},
 			err: "unused arguments: blah-blah-blah",
 		},
+		{
+			description: "deprecated args",
+			overrides: map[string]operv1.ProxyArgumentList{
+				"conntrack-max": {"100"},
+			},
+			err: "unused arguments: conntrack-max",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Since rebase to 1.16, conntrack-max is no longer a valid option
of KubeProxyConfig, thus degrade the operator if used.