### PR TITLE
OpenShiftSDN: introduce OVS anti-selector

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -136,6 +136,13 @@ spec:
         terminationGracePeriodSeconds: 10
       nodeSelector:
         kubernetes.io/os: linux
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: network.operator.openshift.io/external-openvswitch
+                operator: DoesNotExist
       volumes:
       - name: host-modules
         hostPath:


### PR DESCRIPTION
OpenShiftSDN is shipped with its own openvswitch service running
as a separate daemonset. However, in some cases we may want to use
an external openvswitch running on the host (e.g. to use it for
host networking). In order to support a mixed environment where some
hosts have this external service and some don't, we introduce
openvswitch anti-selector:

`network.operator.openshift.io/external-openvswitch`

Note that this selector has to be set **before** the operator is started.
Otherwise, the label would not take effect on already scheduled
pods.

TODO: documentation

Signed-off-by: Petr Horacek <phoracek@redhat.com>