### PR TITLE
Bug 1762867: [backport 4.2] The Multus admission controller should validate & gate on UPDATE events

### DIFF
--- a/bindata/network/multus-admission-controller/003-webhook.yaml
+++ b/bindata/network/multus-admission-controller/003-webhook.yaml
@@ -13,7 +13,7 @@ webhooks:
         namespace: openshift-multus
         path: "/validate"
     rules:
-      - operations: [ "CREATE" ]
+      - operations: [ "CREATE", "UPDATE" ]
         apiGroups: ["k8s.cni.cncf.io"]
         apiVersions: ["v1"]
         resources: ["network-attachment-definitions"]


### PR DESCRIPTION
(missed the 4.2 backport for this change)

This adds the UPDATE operation to the list of operations on which to perform validation