### PR TITLE
Bug 1761344: Tweaking kuryr-controller configuration to avoid restarts

### DIFF
--- a/bindata/network/kuryr/003-config.yaml
+++ b/bindata/network/kuryr/003-config.yaml
@@ -16,7 +16,7 @@ data:
     daemon_enabled = true
     docker_mode = true
     netns_proc_dir = /host_proc
-    vif_annotation_timeout = 120
+    vif_annotation_timeout = 500
 
     [ingress]
     #l7_router_uuid = <None>
@@ -33,7 +33,7 @@ data:
     vif_pool_driver = nested
     multi_vif_drivers = noop
 
-    enabled_handlers = vif,lb,lbaasspec,policy,pod_label,namespace,kuryrnetpolicy,kuryrnet
+    enabled_handlers = vif,lb,lbaasspec,policy,pod_label,namespace,kuryrnetpolicy
     pod_security_groups_driver = policy
     service_security_groups_driver = policy
     pod_subnets_driver = namespace

--- a/bindata/network/kuryr/005-controller.yaml
+++ b/bindata/network/kuryr/005-controller.yaml
@@ -28,12 +28,13 @@ spec:
         name: controller
 {{ if (default true .ControllerEnableProbes) eq "true" }}
         readinessProbe:
+          failureThreshold: 10
           httpGet:
             path: /ready
             port: {{ default 8091 .ControllerProbesPort }}
             scheme: HTTP
-          timeoutSeconds: 15
-          periodSeconds: 20
+          timeoutSeconds: 20
+          periodSeconds: 30
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/platform/openstack/kuryr_bootstrap.go
+++ b/pkg/platform/openstack/kuryr_bootstrap.go
@@ -724,13 +724,13 @@ func ensureOpenStackLbListener(client *gophercloud.ServiceClient, name, lbId, po
 			LoadbalancerID: lbId,
 		}
 
-		// NOTE(dulek): If Octavia supports setting data timeouts in listeners (Rocky+) we set them to 1 hour as this
+		// NOTE(dulek): If Octavia supports setting data timeouts in listeners (Rocky+) we set them to 10 mins hour as this
 		//              LB will be used for watching the Kubernetes API, that shouldn't time out after the default 50 seconds.
 		timeoutSupport, err := IsOctaviaVersionSupported(client, MinOctaviaVersionWithTimeouts)
 		if err != nil {
 			return "", errors.Wrap(err, "failed to determine if Octavia supports listener timeouts API")
 		}
-		timeout := 3600000
+		timeout := 600000
 		if timeoutSupport {
 			opts.TimeoutClientData = &timeout
 			opts.TimeoutMemberData = &timeout


### PR DESCRIPTION
Kuryr-controller restarts may lead to OpenStack resource leaks.
This PR makes a few adjustments to avoid unneeded restarts by:
- Disable pools pre-population: this has extra stress on neutron
as more ports need to be created for each namespace. Until all the
leaks are fixed, it is better to disable it. The pros is that
namespace creation/deletion will be faster and neutron load will
be lower. The cons is that first allocated pod on a not for a given
namespace will take longer to get to running, as the ports needs to
be created.
- Increase the threshold for considering the kuryr-controller unhealty
- Increase the timeout to wait for OpenStack resources to be ready
(e.g., ports to become active, networks to be created, namespaces to
be annnotated, ...). This, in case of resource creation spikes or
Neutron/Octavia slowness, avoids unneeded kuryr-controller restarts
when only needs to wait for resources to become ready.