### PR TITLE
Add capabilities in simpleMacvlan's staticIPAM config

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ spec:
 Users can configure static IPAM with following parameters:
 
 * `addresses`:
-  * `address`: Address is the IP address in CIDR format, optional
+  * `address`: Address is the IP address in CIDR format, optional (if no address, assume address will be supplied as pod annotation, k8s.v1.cni.cncf.io/networks)
   * `gateway`: Gateway is IP inside of subnet to designate as the gateway, optional
 * `routes`: optional
   * `destination`: Destination points the IP route destination

--- a/pkg/network/additional_networks.go
+++ b/pkg/network/additional_networks.go
@@ -65,10 +65,11 @@ func validateRaw(conf *operv1.AdditionalNetworkDefinition) []error {
 
 // staticIPAMConfig for json generation for static IPAM
 type staticIPAMConfig struct {
-	Type      string              `json:"type"`
-	Routes    []*cnitypes.Route   `json:"routes"`
-	Addresses []staticIPAMAddress `json:"addresses,omitempty"`
-	DNS       cnitypes.DNS        `json:"dns"`
+	Type         string              `json:"type"`
+	Routes       []*cnitypes.Route   `json:"routes,omitempty"`
+	Addresses    []staticIPAMAddress `json:"addresses,omitempty"`
+	DNS          *cnitypes.DNS       `json:"dns,omitempty"`
+	Capabilities []string            `json:"capabilities,omitempty"`
 }
 
 // staticIPAMAddress for json generation for static IPAM
@@ -81,21 +82,33 @@ type staticIPAMAddress struct {
 func getStaticIPAMConfigJSON(conf *operv1.StaticIPAMConfig) (string, error) {
 	staticIPAMConfig := staticIPAMConfig{}
 	staticIPAMConfig.Type = "static"
-	for _, address := range conf.Addresses {
-		staticIPAMConfig.Addresses = append(staticIPAMConfig.Addresses, staticIPAMAddress{AddressStr: address.Address, Gateway: net.ParseIP(address.Gateway)})
-	}
-	for _, route := range conf.Routes {
-		_, dest, err := net.ParseCIDR(route.Destination)
-		if err != nil {
-			return "", errors.Wrap(err, "failed to parse macvlan route")
+	if conf == nil {
+		// ip address will be supplied as runtimeConfig in nil StaticIPAMConfig case
+		staticIPAMConfig.Capabilities = []string{"ips"}
+	} else {
+		if conf.Addresses != nil {
+			for _, address := range conf.Addresses {
+				staticIPAMConfig.Addresses = append(staticIPAMConfig.Addresses, staticIPAMAddress{AddressStr: address.Address, Gateway: net.ParseIP(address.Gateway)})
+			}
 		}
-		staticIPAMConfig.Routes = append(staticIPAMConfig.Routes, &cnitypes.Route{Dst: *dest, GW: net.ParseIP(route.Gateway)})
-	}
+		// add capability in case of no address configured
+		if len(conf.Addresses) == 0 {
+			staticIPAMConfig.Capabilities = []string{"ips"}
+		}
+		for _, route := range conf.Routes {
+			_, dest, err := net.ParseCIDR(route.Destination)
+			if err != nil {
+				return "", errors.Wrap(err, "failed to parse macvlan route")
+			}
+			staticIPAMConfig.Routes = append(staticIPAMConfig.Routes, &cnitypes.Route{Dst: *dest, GW: net.ParseIP(route.Gateway)})
+		}
 
-	if conf.DNS != nil {
-		staticIPAMConfig.DNS.Nameservers = append(staticIPAMConfig.DNS.Nameservers, conf.DNS.Nameservers...)
-		staticIPAMConfig.DNS.Domain = conf.DNS.Domain
-		staticIPAMConfig.DNS.Search = append(staticIPAMConfig.DNS.Search, conf.DNS.Search...)
+		if conf.DNS != nil {
+			staticIPAMConfig.DNS = &cnitypes.DNS{}
+			staticIPAMConfig.DNS.Nameservers = append(staticIPAMConfig.DNS.Nameservers, conf.DNS.Nameservers...)
+			staticIPAMConfig.DNS.Domain = conf.DNS.Domain
+			staticIPAMConfig.DNS.Search = append(staticIPAMConfig.DNS.Search, conf.DNS.Search...)
+		}
 	}
 
 	jsonByte, err := json.Marshal(staticIPAMConfig)
@@ -189,8 +202,10 @@ func validateIPAMConfig(conf *operv1.IPAMConfig) []error {
 
 	switch conf.Type {
 	case operv1.IPAMTypeStatic:
-		outStatic := validateStaticIPAMConfig(conf.StaticIPAMConfig)
-		out = append(out, outStatic...)
+		if conf.StaticIPAMConfig != nil {
+			outStatic := validateStaticIPAMConfig(conf.StaticIPAMConfig)
+			out = append(out, outStatic...)
+		}
 	case operv1.IPAMTypeDHCP:
 	default:
 		out = append(out, errors.Errorf("invalid IPAM type: %s", conf.Type))

--- a/pkg/network/additional_networks_test.go
+++ b/pkg/network/additional_networks_test.go
@@ -67,6 +67,10 @@ var StaticIPAMConfig = operv1.IPAMConfig{
 	},
 }
 
+var NilStaticIPAMConfig = operv1.IPAMConfig{
+	Type: operv1.IPAMTypeStatic,
+}
+
 func TestRenderAdditionalNetworksCRD(t *testing.T) {
 	g := NewGomegaWithT(t)
 
@@ -189,6 +193,20 @@ func TestGetStaticIPAMConfigJSON(t *testing.T) {
 	g.Expect(obj.DNS.Search).To(HaveLen(2))
 	g.Expect(obj.DNS.Search[0]).To(Equal("testdomain1.example"))
 	g.Expect(obj.DNS.Search[1]).To(Equal("testdomain2.example"))
+}
+
+func TestGetNilStaticIPAMConfigJSON(t *testing.T) {
+	g := NewGomegaWithT(t)
+	cfg, err := getIPAMConfigJSON(&NilStaticIPAMConfig)
+	g.Expect(err).NotTo(HaveOccurred())
+	obj := staticIPAMConfig{}
+	err = json.Unmarshal([]byte(cfg), &obj)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(obj.Addresses).To(BeNil())
+	g.Expect(obj.Routes).To(BeNil())
+	g.Expect(obj.DNS).To(BeNil())
+	g.Expect(obj.Capabilities).To(HaveLen(1))
+	g.Expect(obj.Capabilities[0]).To(Equal("ips"))
 }
 
 func TestGetDHCPIPAMConfigJSON(t *testing.T) {


### PR DESCRIPTION
This change sets 'ips' in 'capabilities' in static IPAM CNI
config if no ip address in staticIPAM config because user will
supply ip address through pod annotation.