### PR TITLE
ovn-kubernetes: enable TLS

### DIFF
--- a/bindata/network/ovn-kubernetes/006-pki.yaml
+++ b/bindata/network/ovn-kubernetes/006-pki.yaml
@@ -1,0 +1,10 @@
+# Request that the cluster network operator PKI controller
+# creates a certificate and key for us.
+apiVersion: network.operator.openshift.io/v1
+kind: OperatorPKI
+metadata:
+  name: ovn
+  namespace: openshift-ovn-kubernetes
+spec:
+  targetCert:
+    commonName: ovn

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -133,7 +133,7 @@ spec:
           fi
           exec /usr/share/openvswitch/scripts/ovn-ctl run_sb_ovsdb \
             --no-monitor \
-            --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off"
+            --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off"
         env:
         - name: OVN_LOG_LEVEL
           value: info

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -64,6 +64,10 @@ spec:
           name: run-openvswitch
         - mountPath: /env
           name: env-overrides
+        - mountPath: /ovn-cert # not needed, but useful when exec'ing in to pod.
+          name: ovn-cert
+        - mountPath: /ovn-ca
+          name: ovn-ca
         resources:
           requests:
             cpu: 100m
@@ -84,6 +88,9 @@ spec:
           fi
           exec /usr/share/openvswitch/scripts/ovn-ctl run_nb_ovsdb \
             --no-monitor \
+            --ovn-nb-db-ssl-key=/ovn-cert/tls.key \
+            --ovn-nb-db-ssl-cert=/ovn-cert/tls.crt \
+            --ovn-nb-db-ssl-ca-cert=/ovn-ca/ca-bundle.crt \
             --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off"
         lifecycle:
           postStart:
@@ -93,7 +100,7 @@ spec:
               - -c
               - |
                 retries=0
-                while ! ovn-nbctl -t 5 set-connection ptcp:{{.OVN_NB_PORT}} -- set connection . inactivity_probe=0; do
+                while ! ovn-nbctl -t 5 set-connection pssl:{{.OVN_NB_PORT}} -- set connection . inactivity_probe=0; do
                   (( retries += 1 ))
                   if [[ "${retries}" -gt 40 ]]; then
                     echo "too many failed ovn-nbctl attempts, giving up"
@@ -113,6 +120,10 @@ spec:
           name: run-openvswitch
         - mountPath: /env
           name: env-overrides
+        - mountPath: /ovn-cert
+          name: ovn-cert
+        - mountPath: /ovn-ca
+          name: ovn-ca
         resources:
           requests:
             cpu: 100m
@@ -133,6 +144,9 @@ spec:
           fi
           exec /usr/share/openvswitch/scripts/ovn-ctl run_sb_ovsdb \
             --no-monitor \
+            --ovn-sb-db-ssl-key=/ovn-cert/tls.key \
+            --ovn-sb-db-ssl-cert=/ovn-cert/tls.crt \
+            --ovn-sb-db-ssl-ca-cert=/ovn-ca/ca-bundle.crt \
             --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off"
         env:
         - name: OVN_LOG_LEVEL
@@ -145,7 +159,7 @@ spec:
               - -c
               - |
                 retries=0
-                while ! ovn-sbctl -t 5 set-connection ptcp:{{.OVN_SB_PORT}} -- set connection . inactivity_probe=0; do
+                while ! ovn-sbctl -t 5 set-connection pssl:{{.OVN_SB_PORT}} -- set connection . inactivity_probe=0; do
                   (( retries += 1 ))
                   if [[ "${retries}" -gt 40 ]]; then
                     echo "too many failed ovn-sbctl attempts, giving up"
@@ -162,6 +176,10 @@ spec:
           name: run-openvswitch
         - mountPath: /env
           name: env-overrides
+        - mountPath: /ovn-cert
+          name: ovn-cert
+        - mountPath: /ovn-ca
+          name: ovn-ca
 
       # ovnkube master: convert kubernetes objects in to nbdb logical network components
       - name: ovnkube-master
@@ -245,6 +263,12 @@ spec:
         configMap:
           name: env-overrides
           optional: true
+      - name: ovn-ca
+        configMap:
+          name: ovn-ca
+      - name: ovn-cert
+        secret:
+          secretName: ovn-cert
       tolerations:
       - key: "node-role.kubernetes.io/master"
         operator: "Exists"

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -130,6 +130,7 @@ spec:
           fi
           exec ovn-controller unix:/var/run/openvswitch/db.sock -vfile:off \
             --no-chdir --pidfile=/var/run/openvswitch/ovn-controller.pid \
+            -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt \
             -vconsole:"${OVN_LOG_LEVEL}"
         securityContext:
           privileged: true
@@ -149,6 +150,10 @@ spec:
           name: var-lib-openvswitch
         - mountPath: /env
           name: env-overrides
+        - mountPath: /ovn-cert
+          name: ovn-cert
+        - mountPath: /ovn-ca
+          name: ovn-ca
         terminationMessagePolicy: FallbackToLogsOnError
         resources:
           requests:
@@ -198,8 +203,14 @@ spec:
             --k8s-service-cidr "${OVN_SVC_CIDR}" \
             --k8s-apiserver "{{.K8S_APISERVER}}" \
             --ovn-config-namespace ${ovn_config_namespace} \
-            --nb-address "tcp://${db_ip}:{{.OVN_NB_PORT}}" \
-            --sb-address "tcp://${db_ip}:{{.OVN_SB_PORT}}" \
+            --nb-address "ssl://${db_ip}:{{.OVN_NB_PORT}}" \
+            --nb-client-privkey /ovn-cert/tls.key \
+            --nb-client-cert /ovn-cert/tls.crt \
+            --nb-client-cacert /ovn-ca/ca-bundle.crt \
+            --sb-address "ssl://${db_ip}:{{.OVN_SB_PORT}}" \
+            --sb-client-privkey /ovn-cert/tls.key \
+            --sb-client-cert /ovn-cert/tls.crt \
+            --sb-client-cacert /ovn-ca/ca-bundle.crt \
             --nodeport --gateway-mode local \
             ${hybrid_overlay_flags} \
             --pidfile /var/run/openvswitch/ovnkube-node.pid \
@@ -261,6 +272,10 @@ spec:
           name: var-lib-openvswitch
         - mountPath: /env
           name: env-overrides
+        - mountPath: /ovn-cert
+          name: ovn-cert
+        - mountPath: /ovn-ca
+          name: ovn-ca
         resources:
           requests:
             cpu: 100m
@@ -318,5 +333,11 @@ spec:
         configMap:
           name: env-overrides
           optional: true
+      - name: ovn-ca
+        configMap:
+          name: ovn-ca
+      - name: ovn-cert
+        secret:
+          secretName: ovn-cert
       tolerations:
       - operator: "Exists"


### PR DESCRIPTION
This creates a certificate authority and a single certificate. It configures all the OVN processes to use that certificate:
- nbdb and sbdb serve behind that certificate
- nbdb and sbdb authenticate clients against the CA
- ovn-controller and ovnkube-node use the certificate to authenticate