### PR TITLE
controller/status: set Degraded if rollout is hung.

### DIFF
--- a/pkg/controller/statusmanager/pod_status.go
+++ b/pkg/controller/statusmanager/pod_status.go
@@ -1,0 +1,278 @@
+package statusmanager
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"reflect"
+	"strings"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// if a rollout has not made any progress by this time,
+	// mark ourselves as Degraded
+	ProgressTimeout = 10 * time.Minute
+
+	// lastSeenAnnotation - the annotation where we stash our state
+	lastSeenAnnotation = "network.operator.openshift.io/last-seen-state"
+)
+
+// podState is a snapshot of the last-seen-state and last-changed-times
+// for pod-creating entities, as marshalled to json in an annotation
+type podState struct {
+	// "public" for marshalling to json, since we can't have complex keys
+	DaemonsetStates  []daemonsetState
+	DeploymentStates []deploymentState
+}
+
+// daemonsetState is the internal state we use to check if a rollout has
+// stalled.
+type daemonsetState struct {
+	types.NamespacedName
+
+	LastSeenStatus appsv1.DaemonSetStatus
+	LastChangeTime time.Time
+}
+
+// deploymentState is the same as daemonsetState.. but for deployments!
+type deploymentState struct {
+	types.NamespacedName
+
+	LastSeenStatus appsv1.DeploymentStatus
+	LastChangeTime time.Time
+}
+
+// SetFromPods sets the operator Degraded/Progressing/Available status, based on
+// the current status of the manager's DaemonSets and Deployments.
+func (status *StatusManager) SetFromPods() {
+	status.Lock()
+	defer status.Unlock()
+
+	targetLevel := os.Getenv("RELEASE_VERSION")
+	reachedAvailableLevel := (len(status.daemonSets) + len(status.deployments)) > 0
+
+	progressing := []string{}
+	hung := []string{}
+
+	daemonsetStates, deploymentStates := status.getLastPodState()
+
+	for _, dsName := range status.daemonSets {
+		ds := &appsv1.DaemonSet{}
+		if err := status.client.Get(context.TODO(), dsName, ds); err != nil {
+			log.Printf("Error getting DaemonSet %q: %v", dsName.String(), err)
+			progressing = append(progressing, fmt.Sprintf("Waiting for DaemonSet %q to be created", dsName.String()))
+			// Assume the OperConfig Controller is in the process of reconciling
+			// things; it will set a Degraded status if it fails.
+			continue
+		}
+
+		dsProgressing := false
+
+		if ds.Status.UpdatedNumberScheduled < ds.Status.DesiredNumberScheduled {
+			progressing = append(progressing, fmt.Sprintf("DaemonSet %q update is rolling out (%d out of %d updated)", dsName.String(), ds.Status.UpdatedNumberScheduled, ds.Status.DesiredNumberScheduled))
+			dsProgressing = true
+		} else if ds.Status.NumberUnavailable > 0 {
+			progressing = append(progressing, fmt.Sprintf("DaemonSet %q is not available (awaiting %d nodes)", dsName.String(), ds.Status.NumberUnavailable))
+			dsProgressing = true
+		} else if ds.Status.NumberAvailable == 0 { // NOTE: update this if we ever expect empty (unscheduled) daemonsets ~cdc
+			progressing = append(progressing, fmt.Sprintf("DaemonSet %q is not yet scheduled on any nodes", dsName.String()))
+			dsProgressing = true
+		} else if ds.Generation > ds.Status.ObservedGeneration {
+			progressing = append(progressing, fmt.Sprintf("DaemonSet %q update is being processed (generation %d, observed generation %d)", dsName.String(), ds.Generation, ds.Status.ObservedGeneration))
+			dsProgressing = true
+		}
+
+		if dsProgressing || ds.Annotations["release.openshift.io/version"] != targetLevel {
+			reachedAvailableLevel = false
+		}
+
+		if dsProgressing {
+			dsState, exists := daemonsetStates[dsName]
+			if !exists || !reflect.DeepEqual(dsState.LastSeenStatus, ds.Status) {
+				dsState.LastChangeTime = time.Now()
+				ds.Status.DeepCopyInto(&dsState.LastSeenStatus)
+				daemonsetStates[dsName] = dsState
+			}
+
+			// Catch hung rollouts
+			if exists && (time.Since(dsState.LastChangeTime)) > ProgressTimeout {
+				hung = append(hung, fmt.Sprintf("DaemonSet %q rollout is not making progress - last change %s", dsName.String(), dsState.LastChangeTime.Format(time.RFC3339)))
+			}
+		} else {
+			delete(daemonsetStates, dsName)
+		}
+	}
+
+	for _, depName := range status.deployments {
+		dep := &appsv1.Deployment{}
+		if err := status.client.Get(context.TODO(), depName, dep); err != nil {
+			log.Printf("Error getting Deployment %q: %v", depName.String(), err)
+			progressing = append(progressing, fmt.Sprintf("Waiting for Deployment %q to be created", depName.String()))
+			// Assume the OperConfig Controller is in the process of reconciling
+			// things; it will set a Degraded status if it fails.
+			continue
+		}
+
+		depProgressing := false
+
+		if dep.Status.UnavailableReplicas > 0 {
+			progressing = append(progressing, fmt.Sprintf("Deployment %q is not available (awaiting %d nodes)", depName.String(), dep.Status.UnavailableReplicas))
+			depProgressing = true
+		} else if dep.Status.AvailableReplicas == 0 {
+			progressing = append(progressing, fmt.Sprintf("Deployment %q is not yet scheduled on any nodes", depName.String()))
+			depProgressing = true
+		} else if dep.Status.ObservedGeneration < dep.Generation {
+			progressing = append(progressing, fmt.Sprintf("Deployment %q update is being processed (generation %d, observed generation %d)", depName.String(), dep.Generation, dep.Status.ObservedGeneration))
+			depProgressing = true
+		}
+
+		if depProgressing || dep.Annotations["release.openshift.io/version"] != targetLevel {
+			reachedAvailableLevel = false
+		}
+
+		if depProgressing {
+			depState, exists := deploymentStates[depName]
+			if !exists || !reflect.DeepEqual(depState.LastSeenStatus, dep.Status) {
+				depState.LastChangeTime = time.Now()
+				dep.Status.DeepCopyInto(&depState.LastSeenStatus)
+				deploymentStates[depName] = depState
+			}
+
+			// Catch hung rollouts
+			if exists && (time.Since(depState.LastChangeTime)) > ProgressTimeout {
+				hung = append(hung, fmt.Sprintf("Deployment %q rollout is not making progress - last change %s", depName.String(), depState.LastChangeTime.Format(time.RFC3339)))
+			}
+		} else {
+			delete(deploymentStates, depName)
+		}
+	}
+
+	status.setNotDegraded(PodDeployment)
+	if err := status.setLastPodState(daemonsetStates, deploymentStates); err != nil {
+		log.Printf("Failed to set pod state (continuing): %+v\n", err)
+	}
+
+	if len(progressing) > 0 {
+		status.set(
+			reachedAvailableLevel,
+			configv1.ClusterOperatorStatusCondition{
+				Type:    configv1.OperatorProgressing,
+				Status:  configv1.ConditionTrue,
+				Reason:  "Deploying",
+				Message: strings.Join(progressing, "\n"),
+			},
+		)
+
+		if len(hung) > 0 {
+			status.setDegraded(RolloutHung, "RolloutHung", strings.Join(hung, "\n"))
+		} else {
+			status.setNotDegraded(RolloutHung)
+		}
+	} else {
+		status.set(
+			reachedAvailableLevel,
+			configv1.ClusterOperatorStatusCondition{
+				Type:   configv1.OperatorProgressing,
+				Status: configv1.ConditionFalse,
+			},
+			configv1.ClusterOperatorStatusCondition{
+				Type:   configv1.OperatorAvailable,
+				Status: configv1.ConditionTrue,
+			},
+		)
+		status.setNotDegraded(RolloutHung)
+	}
+}
+
+// getLastPodState reads the last-seen daemonset + deployment state
+// from the clusteroperator annotation and parses it. On error, it returns
+// an empty state, since this should not block updating operator status.
+func (status *StatusManager) getLastPodState() (map[types.NamespacedName]daemonsetState, map[types.NamespacedName]deploymentState) {
+	// with maps allocated
+	daemonsetStates := map[types.NamespacedName]daemonsetState{}
+	deploymentStates := map[types.NamespacedName]deploymentState{}
+
+	// Load the last-seen snapshot from our annotation
+	co := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: status.name}}
+	err := status.client.Get(context.TODO(), types.NamespacedName{Name: status.name}, co)
+	if err != nil {
+		log.Printf("Failed to get ClusterOperator: %v", err)
+		return daemonsetStates, deploymentStates
+	}
+
+	lsbytes := co.Annotations[lastSeenAnnotation]
+	if lsbytes == "" {
+		return daemonsetStates, deploymentStates
+	}
+
+	out := podState{}
+	err = json.Unmarshal([]byte(lsbytes), &out)
+	if err != nil {
+		// No need to return error; just move on
+		log.Printf("failed to unmashal last-seen-status: %v", err)
+		return daemonsetStates, deploymentStates
+	}
+
+	for _, ds := range out.DaemonsetStates {
+		daemonsetStates[ds.NamespacedName] = ds
+	}
+
+	for _, ds := range out.DeploymentStates {
+		deploymentStates[ds.NamespacedName] = ds
+	}
+
+	return daemonsetStates, deploymentStates
+}
+
+func (status *StatusManager) setLastPodState(
+	dss map[types.NamespacedName]daemonsetState,
+	deps map[types.NamespacedName]deploymentState) error {
+
+	ps := podState{
+		DaemonsetStates:  make([]daemonsetState, 0, len(dss)),
+		DeploymentStates: make([]deploymentState, 0, len(deps)),
+	}
+
+	for nsn, ds := range dss {
+		ds.NamespacedName = nsn
+		ps.DaemonsetStates = append(ps.DaemonsetStates, ds)
+	}
+
+	for nsn, ds := range deps {
+		ds.NamespacedName = nsn
+		ps.DeploymentStates = append(ps.DeploymentStates, ds)
+	}
+
+	lsbytes, err := json.Marshal(ps)
+	if err != nil {
+		return err
+	}
+
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		oldStatus := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: status.name}}
+		err := status.client.Get(context.TODO(), types.NamespacedName{Name: status.name}, oldStatus)
+		isNotFound := errors.IsNotFound(err)
+		if err != nil && !isNotFound {
+			return err
+		}
+
+		newStatus := oldStatus.DeepCopy()
+		if newStatus.Annotations == nil {
+			newStatus.Annotations = map[string]string{}
+		}
+		newStatus.Annotations[lastSeenAnnotation] = string(lsbytes)
+		return status.client.Patch(context.TODO(), newStatus, client.MergeFrom(oldStatus))
+	})
+}

--- a/pkg/controller/statusmanager/status_manager_test.go
+++ b/pkg/controller/statusmanager/status_manager_test.go
@@ -2,6 +2,8 @@ package statusmanager
 
 import (
 	"context"
+	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 
@@ -334,12 +336,12 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 	}
 
 	// Create minimal DaemonSets
-	dsA := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: "one", Name: "alpha"}}
+	dsA := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: "one", Name: "alpha", Generation: 1}}
 	err = client.Create(context.TODO(), dsA)
 	if err != nil {
 		t.Fatalf("error creating DaemonSet: %v", err)
 	}
-	dsB := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: "two", Name: "beta"}}
+	dsB := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: "two", Name: "beta", Generation: 1}}
 	err = client.Create(context.TODO(), dsB)
 	if err != nil {
 		t.Fatalf("error creating DaemonSet: %v", err)
@@ -389,7 +391,9 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 	dsANodes := int32(1)
 	dsBNodes := int32(3)
 	dsA.Status.NumberUnavailable = dsANodes
+	dsA.Status.ObservedGeneration = 1
 	dsB.Status.NumberUnavailable = dsBNodes
+	dsB.Status.ObservedGeneration = 1
 
 	// Now start "deploying"
 	for dsA.Status.NumberUnavailable > 0 || dsB.Status.NumberUnavailable > 0 {
@@ -494,9 +498,269 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 		// unreachable
 		t.Fatalf("Progressing condition unexpectedly missing")
 	}
+
+	// Now, bump the generation of one of the daemonsets, and verify
+	// that we enter Progressing state but otherwise stay Available
+	dsA.Generation = 2
+	err = client.Update(context.TODO(), dsA)
+	if err != nil {
+		t.Fatalf("error updating DaemonSet: %v", err)
+	}
+	status.SetFromPods()
+
+	co, err = getCO(client, "testing")
+	if err != nil {
+		t.Fatalf("error getting ClusterOperator: %v", err)
+	}
+	if !conditionsInclude(co.Status.Conditions, []configv1.ClusterOperatorStatusCondition{
+		{
+			Type:   configv1.OperatorDegraded,
+			Status: configv1.ConditionFalse,
+		},
+		{
+			Type:   configv1.OperatorProgressing,
+			Status: configv1.ConditionTrue,
+		},
+		{
+			Type:   configv1.OperatorUpgradeable,
+			Status: configv1.ConditionTrue,
+		},
+		{
+			Type:   configv1.OperatorAvailable,
+			Status: configv1.ConditionTrue,
+		},
+	}) {
+		t.Fatalf("unexpected Status.Conditions: %#v", co.Status.Conditions)
+	}
+
+	// update the daemonset status to mimic a kubernetes rollout
+	// Taken from a live v1.16 apiserver
+	// Transition: observedGeneration -> 2, UpdatedNumberScheduled -> 0
+	dsA.Status = appsv1.DaemonSetStatus{
+		CurrentNumberScheduled: 1,
+		DesiredNumberScheduled: 1,
+		NumberMisscheduled:     0,
+		NumberReady:            1,
+		ObservedGeneration:     2,
+	}
+	err = client.Update(context.TODO(), dsA)
+	if err != nil {
+		t.Fatalf("error updating DaemonSet: %v", err)
+	}
+	status.SetFromPods()
+
+	co, err = getCO(client, "testing")
+	if err != nil {
+		t.Fatalf("error getting ClusterOperator: %v", err)
+	}
+	if !conditionsInclude(co.Status.Conditions, []configv1.ClusterOperatorStatusCondition{
+		{
+			Type:   configv1.OperatorDegraded,
+			Status: configv1.ConditionFalse,
+		},
+		{
+			Type:   configv1.OperatorProgressing,
+			Status: configv1.ConditionTrue,
+		},
+		{
+			Type:   configv1.OperatorUpgradeable,
+			Status: configv1.ConditionTrue,
+		},
+		{
+			Type:   configv1.OperatorAvailable,
+			Status: configv1.ConditionTrue,
+		},
+	}) {
+		t.Fatalf("unexpected Status.Conditions: %#v", co.Status.Conditions)
+	}
+
+	// Next update: Ready -> 0 Unavailable -> 1
+	dsA.Status = appsv1.DaemonSetStatus{
+		CurrentNumberScheduled: 1,
+		DesiredNumberScheduled: 1,
+		NumberMisscheduled:     0,
+		NumberReady:            0,
+		NumberUnavailable:      1,
+		ObservedGeneration:     2,
+	}
+	err = client.Update(context.TODO(), dsA)
+	if err != nil {
+		t.Fatalf("error updating DaemonSet: %v", err)
+	}
+	status.SetFromPods()
+
+	co, err = getCO(client, "testing")
+	if err != nil {
+		t.Fatalf("error getting ClusterOperator: %v", err)
+	}
+	if !conditionsInclude(co.Status.Conditions, []configv1.ClusterOperatorStatusCondition{
+		{
+			Type:   configv1.OperatorDegraded,
+			Status: configv1.ConditionFalse,
+		},
+		{
+			Type:   configv1.OperatorProgressing,
+			Status: configv1.ConditionTrue,
+		},
+		{
+			Type:   configv1.OperatorUpgradeable,
+			Status: configv1.ConditionTrue,
+		},
+		{
+			Type:   configv1.OperatorAvailable,
+			Status: configv1.ConditionTrue,
+		},
+	}) {
+		t.Fatalf("unexpected Status.Conditions: %#v", co.Status.Conditions)
+	}
+
+	// Next update: updatedNumberScheduled -> 1
+	dsA.Status = appsv1.DaemonSetStatus{
+		CurrentNumberScheduled: 1,
+		DesiredNumberScheduled: 1,
+		NumberMisscheduled:     0,
+		NumberReady:            0,
+		NumberUnavailable:      1,
+		ObservedGeneration:     2,
+		UpdatedNumberScheduled: 1,
+	}
+	err = client.Update(context.TODO(), dsA)
+	if err != nil {
+		t.Fatalf("error updating DaemonSet: %v", err)
+	}
+
+	t0 := time.Now()
+	time.Sleep(time.Second / 10)
+	status.SetFromPods()
+
+	co, err = getCO(client, "testing")
+	if err != nil {
+		t.Fatalf("error getting ClusterOperator: %v", err)
+	}
+	if !conditionsInclude(co.Status.Conditions, []configv1.ClusterOperatorStatusCondition{
+		{
+			Type:   configv1.OperatorDegraded,
+			Status: configv1.ConditionFalse,
+		},
+		{
+			Type:   configv1.OperatorProgressing,
+			Status: configv1.ConditionTrue,
+		},
+		{
+			Type:   configv1.OperatorUpgradeable,
+			Status: configv1.ConditionTrue,
+		},
+		{
+			Type:   configv1.OperatorAvailable,
+			Status: configv1.ConditionTrue,
+		},
+	}) {
+		t.Fatalf("unexpected Status.Conditions: %#v", co.Status.Conditions)
+	}
+
+	// See that the last pod state is reasonable
+	ps := getLastPodState(t, client, "testing")
+	nsn := types.NamespacedName{Namespace: "one", Name: "alpha"}
+	found := false
+	for _, ds := range ps.DaemonsetStates {
+		if ds.NamespacedName == nsn {
+			found = true
+			if !ds.LastChangeTime.After(t0) {
+				t.Fatalf("Expected %s to be after %s", ds.LastChangeTime, t0)
+			}
+			if !reflect.DeepEqual(dsA.Status, ds.LastSeenStatus) {
+				t.Fatal("expected cached status to equal last seen status")
+			}
+
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("Didn't find %s in pod state", nsn)
+	}
+
+	// intermission: set the last-update-time to an hour ago, make sure we
+	// set degraded (because the rollout is hung)
+	ps = getLastPodState(t, client, "testing")
+	for idx, ds := range ps.DaemonsetStates {
+		if ds.NamespacedName == nsn {
+			ps.DaemonsetStates[idx].LastChangeTime = time.Now().Add(-time.Hour)
+			break
+		}
+	}
+	setLastPodState(t, client, "testing", ps)
+	status.SetFromPods()
+
+	co, err = getCO(client, "testing")
+	if err != nil {
+		t.Fatalf("error getting ClusterOperator: %v", err)
+	}
+	if !conditionsInclude(co.Status.Conditions, []configv1.ClusterOperatorStatusCondition{
+		{
+			Type:   configv1.OperatorDegraded,
+			Status: configv1.ConditionTrue,
+		},
+		{
+			Type:   configv1.OperatorProgressing,
+			Status: configv1.ConditionTrue,
+		},
+		{
+			Type:   configv1.OperatorUpgradeable,
+			Status: configv1.ConditionTrue,
+		},
+		{
+			Type:   configv1.OperatorAvailable,
+			Status: configv1.ConditionTrue,
+		},
+	}) {
+		t.Fatalf("unexpected Status.Conditions: %#v", co.Status.Conditions)
+	}
+
+	// done: numberReady -> 1, numberUnavailable -> 0
+	dsA.Status = appsv1.DaemonSetStatus{
+		CurrentNumberScheduled: 1,
+		DesiredNumberScheduled: 1,
+		NumberAvailable:        1,
+		NumberMisscheduled:     0,
+		NumberReady:            1,
+		ObservedGeneration:     2,
+		UpdatedNumberScheduled: 1,
+	}
+	err = client.Update(context.TODO(), dsA)
+	if err != nil {
+		t.Fatalf("error updating DaemonSet: %v", err)
+	}
+	status.SetFromPods()
+
+	co, err = getCO(client, "testing")
+	if err != nil {
+		t.Fatalf("error getting ClusterOperator: %v", err)
+	}
+	if !conditionsInclude(co.Status.Conditions, []configv1.ClusterOperatorStatusCondition{
+		{
+			Type:   configv1.OperatorDegraded,
+			Status: configv1.ConditionFalse,
+		},
+		{
+			Type:   configv1.OperatorProgressing,
+			Status: configv1.ConditionFalse,
+		},
+		{
+			Type:   configv1.OperatorUpgradeable,
+			Status: configv1.ConditionTrue,
+		},
+		{
+			Type:   configv1.OperatorAvailable,
+			Status: configv1.ConditionTrue,
+		},
+	}) {
+		t.Fatalf("unexpected Status.Conditions: %#v", co.Status.Conditions)
+	}
+
+	// see that the pod state is sensible
 }
 
-func TestStatusManagerSetFromPods(t *testing.T) {
+func TestStatusManagerSetFromDeployments(t *testing.T) {
 	client := fake.NewFakeClient()
 	mapper := &fakeRESTMapper{}
 	status := New(client, mapper, "testing", "1.2.3")
@@ -637,6 +901,9 @@ func TestStatusManagerSetFromPods(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating DaemonSet: %v", err)
 	}
+
+	t0 := time.Now()
+	time.Sleep(time.Second / 10)
 	status.SetFromPods()
 
 	co, err = getCO(client, "testing")
@@ -667,12 +934,73 @@ func TestStatusManagerSetFromPods(t *testing.T) {
 		t.Fatalf("unexpected Status.Conditions: %#v", co.Status.Conditions)
 	}
 
+	ps := getLastPodState(t, client, "testing")
+	// see that the pod state is sensible
+	nsn := types.NamespacedName{Namespace: "one", Name: "beta"}
+	found := false
+	for _, ds := range ps.DeploymentStates {
+		if ds.NamespacedName == nsn {
+			found = true
+			if !ds.LastChangeTime.After(t0) {
+				t.Fatalf("Expected %s to be after %s", ds.LastChangeTime, t0)
+			}
+			if !reflect.DeepEqual(depB.Status, ds.LastSeenStatus) {
+				t.Fatal("expected cached status to equal last seen status")
+			}
+
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("Didn't find %s in pod state", nsn)
+	}
+
+	// intermission: set back last-seen times by an hour, see that we mark
+	// as hung
+	ps = getLastPodState(t, client, "testing")
+	for idx, ds := range ps.DeploymentStates {
+		if ds.NamespacedName == nsn {
+			ps.DeploymentStates[idx].LastChangeTime = time.Now().Add(-time.Hour)
+			break
+		}
+	}
+	setLastPodState(t, client, "testing", ps)
+	status.SetFromPods()
+
+	co, err = getCO(client, "testing")
+	if err != nil {
+		t.Fatalf("error getting ClusterOperator: %v", err)
+	}
+	// We should still be Progressing, since nothing else has changed, but
+	// now we're also Degraded, since rollout has not made any progress
+	if !conditionsInclude(co.Status.Conditions, []configv1.ClusterOperatorStatusCondition{
+		{
+			Type:   configv1.OperatorDegraded,
+			Status: configv1.ConditionTrue,
+		},
+		{
+			Type:   configv1.OperatorProgressing,
+			Status: configv1.ConditionTrue,
+		},
+		{
+			Type:   configv1.OperatorUpgradeable,
+			Status: configv1.ConditionTrue,
+		},
+		{
+			Type:   configv1.OperatorAvailable,
+			Status: configv1.ConditionTrue,
+		},
+	}) {
+		t.Fatalf("unexpected Status.Conditions: %#v", co.Status.Conditions)
+	}
+
 	depB.Status.UnavailableReplicas = 0
 	depB.Status.AvailableReplicas = 1
 	err = client.Update(context.TODO(), depB)
 	if err != nil {
 		t.Fatalf("error updating Deployment: %v", err)
 	}
+
 	status.SetFromPods()
 
 	co, err = getCO(client, "testing")
@@ -698,5 +1026,41 @@ func TestStatusManagerSetFromPods(t *testing.T) {
 		},
 	}) {
 		t.Fatalf("unexpected Status.Conditions: %#v", co.Status.Conditions)
+	}
+
+}
+
+func getLastPodState(t *testing.T, client client.Client, name string) podState {
+	t.Helper()
+	co, err := getCO(client, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(co.Annotations)
+
+	ps := podState{}
+	if err := json.Unmarshal([]byte(co.Annotations[lastSeenAnnotation]), &ps); err != nil {
+		t.Fatal(err)
+	}
+
+	return ps
+}
+
+// sets *all* last-seen-times back an hour
+func setLastPodState(t *testing.T, client client.Client, name string, ps podState) {
+	t.Helper()
+	co, err := getCO(client, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lsBytes, err := json.Marshal(ps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	co.Annotations[lastSeenAnnotation] = string(lsBytes)
+	err = client.Update(context.Background(), co)
+	if err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
If we find ourselves with a DaemonSet or Deployment that hasn't made any progress for the past 10 minutes, then highlight this to the operator as a Degraded state.

This doesn't affect any of the other states (Progressing, Available, etc.).

/cc @danwinship @rcarrillocruz 