### PR TITLE
Bug 1762145: TLS handshake error breaking multus admission controller functionality

### DIFF
--- a/pkg/controller/operconfig/configmap_controller.go
+++ b/pkg/controller/operconfig/configmap_controller.go
@@ -55,7 +55,7 @@ func addConfigMapReconciler(mgr manager.Manager, r reconcile.Reconciler) error {
 }
 
 func (r *ReconcileConfigMaps) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	if request.Namespace == names.APPLIED_NAMESPACE && request.Name == names.OPERATOR_CONFIG {
+	if request.Namespace == "" && request.Name == names.OPERATOR_CONFIG {
 		return r.ReconcileMultusWebhook(request)
 	}
 	return reconcile.Result{}, nil


### PR DESCRIPTION
controller-runtime change[1] changes to set namespace hence
multus-admission-controller's caBundle is not supplied by CNO.
This change fixes the condition to invoke to reconcile it.

[1] https://github.com/kubernetes-sigs/controller-runtime/commit/6cfbed364aece9fa862ff37c382386630df70bca