### PR TITLE
ovnkube: add perms for ovnkube-node to patch node resources

### DIFF
--- a/bindata/network/ovn-kubernetes/002-rbac.yaml
+++ b/bindata/network/ovn-kubernetes/002-rbac.yaml
@@ -15,7 +15,6 @@ rules:
   resources:
   - endpoints
   - namespaces
-  - nodes
   - pods
   - services
   verbs:
@@ -34,6 +33,15 @@ rules:
   - events
   verbs:
   - create
+  - patch
+  - update
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
   - patch
   - update
 


### PR DESCRIPTION
In commit aa36fc12 of ovn-kubernetes (ovn-org/ovn-kubernetes#767), the ovnkube-node started patching the node resource with an annotation. Currently this is failing with:

```
  Failed to set node [...] mgmt port macAddress annotation: map[k8s.ovn.org/node-mgmt-port-mac-address:...]
  nodes \"...\" is forbidden: User \"system:serviceaccount:openshift-ovn-kubernetes:ovn-kubernetes-node\" cannot patch resource \"nodes\" in API group \"\" at the cluster scope
```

Add permission to the openshift-ovn-kubernetes-node cluster role to allow this patching.