### PR TITLE
verify if an older version of the ovs database exists

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -47,6 +47,9 @@ spec:
             source "/env/${K8S_NODE}"
             set +o allexport
           fi
+          if [[ -f "/old/openvswitch/conf.db" && ! -f "/etc/openvswitch/conf.db" ]]; then
+            mv /old/openvswitch/conf.db /etc/openvswitch/conf.db
+          fi
           chown -R openvswitch:openvswitch /run/openvswitch
           chown -R openvswitch:openvswitch /etc/openvswitch
           function quit {
@@ -81,6 +84,8 @@ spec:
           name: run-openvswitch
         - mountPath: /etc/openvswitch
           name: etc-openvswitch
+        - mountPath: /old/openvswitch
+          name: old-openvswitch-database
         - mountPath: /var/lib/openvswitch
           name: var-lib-openvswitch
         - mountPath: /env
@@ -276,6 +281,9 @@ spec:
           path: /var/lib/openvswitch/etc
       - name: run-openvswitch
         emptyDir: {}
+      # commit 0ac2cd changed the location of the ovs database, mount and check if a database already exists
+      - name: old-openvswitch-database
+        path: /etc/origin/openvswitch
       # For CNI server
       - name: host-run-ovn-kubernetes
         hostPath:


### PR DESCRIPTION
commit 0ac2cdf1... changes the location of the ovs database. The database was originally in
/etc/origin/openvswitch on the host and after Casey's change got moved to /var/lib/openvswitch. In the upgrade case where a database exists in the old location move the database to the new location so the cluster's networking remains stable.