### PR TITLE
Bug 1769412: pkg/controller/operconfig/operconfig_controller: Add operator namespace to relatedObjects

### DIFF
--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -233,6 +233,11 @@ func (r *ReconcileOperConfig) Reconcile(request reconcile.Request) (reconcile.Re
 		})
 	}
 
+	relatedObjects = append(relatedObjects, configv1.ObjectReference{
+		Resource: "namespaces",
+		Name:     names.APPLIED_NAMESPACE,
+	})
+
 	r.status.SetDaemonSets(daemonSets)
 	r.status.SetDeployments(deployments)
 	r.status.SetRelatedObjects(relatedObjects)


### PR DESCRIPTION
For example, from a recent CI run [1], compare:

```console
$ curl -s https://storage.googleapis.com/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.3/1372/artifacts/e2e-aws/must-gather/registry-svc-ci-openshift-org-ocp-4-3-2019-10-30-020950-sha256-dae1257b516a5c177237cfef5a6a3e241962b0d20cf54bcb2b66dc1671c5035e/cluster-scoped-resources/config.openshift.io/clusteroperators/ingress.yaml | yaml2json | jq -cS '.status.relatedObjects[]'
{"group":"","name":"openshift-ingress-operator","resource":"namespaces"}
{"group":"operator.openshift.io","name":"","namespace":"openshift-ingress-operator","resource":"IngressController"}
{"group":"ingress.operator.openshift.io","name":"","namespace":"openshift-ingress-operator","resource":"DNSRecord"}
{"group":"","name":"openshift-ingress","resource":"namespaces"}
```

with:

```console
$ curl -s https://storage.googleapis.com/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.3/1372/artifacts/e2e-aws/must-gather/registry-svc-ci-openshift-org-ocp-4-3-2019-10-30-020950-sha256-dae1257b516a5c177237cfef5a6a3e241962b0d20cf54bcb2b66dc1671c5035e/cluster-scoped-resources/config.openshift.io/clusteroperators/network.yaml | yaml2json | jq -cS '.status.relatedObjects[] | select(.namespace == "cluster-network-operator")'
...no entries...
```

Which leads to [this rich ingress-operator must-gather][2] and [this very sparse network-operator must-gather][3] with just two ConfigMaps.  With this addition, we should get important things like network-operator logs in the must-gather output.

[1]: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.3/1372
[2]: https://gcsweb-ci.svc.ci.openshift.org/gcs/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.3/1372/artifacts/e2e-aws/must-gather/registry-svc-ci-openshift-org-ocp-4-3-2019-10-30-020950-sha256-dae1257b516a5c177237cfef5a6a3e241962b0d20cf54bcb2b66dc1671c5035e/namespaces/openshift-ingress-operator/
[3]: https://gcsweb-ci.svc.ci.openshift.org/gcs/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.3/1372/artifacts/e2e-aws/must-gather/registry-svc-ci-openshift-org-ocp-4-3-2019-10-30-020950-sha256-dae1257b516a5c177237cfef5a6a3e241962b0d20cf54bcb2b66dc1671c5035e/namespaces/openshift-network-operator/