### PR TITLE
Add Prometheus capability to a multus admission controller

### DIFF
--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -37,6 +37,7 @@ spec:
         - -tls-private-key-file=/etc/webhook/tls.key
         - -tls-cert-file=/etc/webhook/tls.crt
         - -alsologtostderr=true
+        - -metrics-listen-address=0.0.0.0:9091
         volumeMounts:
         - name: webhook-certs
           mountPath: /etc/webhook
@@ -45,6 +46,9 @@ spec:
         resources:
           requests:
             cpu: 10m
+        ports:
+        - name: metrics-port
+          containerPort: 9091
       serviceAccountName: multus
       priorityClassName: "system-cluster-critical"
       restartPolicy: Always

--- a/bindata/network/multus-admission-controller/monitor.yaml
+++ b/bindata/network/multus-admission-controller/monitor.yaml
@@ -1,0 +1,71 @@
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    name: monitor-multus-admission-controller
+  annotations:
+    networkoperator.openshift.io/ignore-errors: ""
+  name: monitor-multus-admission-controller
+  namespace: openshift-multus
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+  jobLabel: app
+  namespaceSelector:
+    matchNames:
+    - openshift-multus
+  selector:
+    matchLabels:
+      name: multus-admission-controller-monitor-service
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: multus-admission-controller-monitor-service
+  name:  multus-admission-controller-monitor-service
+  namespace: openshift-multus
+spec:
+  selector:
+    app: multus-admission-controller
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: 9091
+    protocol: TCP
+    targetPort: 9091
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-multus
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-multus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/bindata/network/multus-admission-controller/rules.yaml
+++ b/bindata/network/multus-admission-controller/rules.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  annotations:
+    networkoperator.openshift.io/ignore-errors: ""
+  name: prometheus-k8s-rules
+  namespace: openshift-multus
+spec:
+  groups:
+  - name: multus-admission-controller-monitor-service.rules
+    rules:
+    - expr: |
+        max  (network_attachment_definition_enabled_instance_up) by (networks)
+      record: cluster:network_attachment_definition_enabled_instance_up:max
+    - expr: |
+       max  (network_attachment_definition_instances) by (networks)
+      record: cluster:network_attachment_definition_instances:max
+  

--- a/bindata/network/multus/000-ns.yaml
+++ b/bindata/network/multus/000-ns.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     name: openshift-multus
     openshift.io/run-level: "0"
+    openshift.io/cluster-monitoring: "true"
   annotations:
     openshift.io/node-selector: "" #override default node selector
     openshift.io/description: "Multus network plugin components"

--- a/pkg/network/multus_admission_controller_test.go
+++ b/pkg/network/multus_admission_controller_test.go
@@ -1,11 +1,12 @@
 package network
 
 import (
+	"testing"
+
 	. "github.com/onsi/gomega"
 	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/apply"
 	"github.com/openshift/cluster-network-operator/pkg/names"
-	"testing"
 )
 
 var MultusAdmissionControllerConfig = operv1.Network{
@@ -49,7 +50,7 @@ func TestRenderMultusAdmissionController(t *testing.T) {
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "multus-admission-controller")))
 
 	// Check rendered object
-	g.Expect(len(objs)).To(Equal(6))
+	g.Expect(len(objs)).To(Equal(11))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("Service", "openshift-multus", "multus-admission-controller")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "multus-admission-controller-webhook")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRoleBinding", "", "multus-admission-controller-webhook")))


### PR DESCRIPTION
Add Prometheus capability to a multus admission controller.
This PR does not add any metrics but does allow the metrics to be exposed from within a multus-admission-controller to an in cluster Prometheus server.

Along with multus-admission-controller PR which exposes metrics: openshift/multus-admission-controller#11