### PR TITLE
multus: copy RHEL8 binaries on FCOS

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -45,6 +45,14 @@ spec:
               ;;
               rhel) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .) 
               ;;
+              fedora)
+                if [ "${VARIANT_ID}" == "coreos" ]; then
+                  rhelmajor=8
+                else 
+                  echo "FATAL ERROR: Unsupported Fedora variant=${VARIANT_ID}"
+                  exit 1
+                fi
+              ;;
               *) echo "FATAL ERROR: Unsupported OS ID=${ID}"; exit 1
               ;;
             esac


### PR DESCRIPTION
This ensures OKD-on-FCOS doesn't crash when FCOS is used as a base. Currently RHEL8 binaries are used, proper Fedora support would be added later.

See https://github.com/openshift/installer/pull/2548#issuecomment-548474221