### PR TITLE
adding initial alert rules to ovnkubernetes

### DIFF
--- a/bindata/network/ovn-kubernetes/alert-rules.yaml
+++ b/bindata/network/ovn-kubernetes/alert-rules.yaml
@@ -1,0 +1,32 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  annotations:
+    networkoperator.openshift.io/ignore-errors: ""
+  name: networking-rules
+  namespace: openshift-ovn-kubernetes
+spec:
+  groups:
+  - name: general.rules
+    rules:
+    - alert: NodeWithoutOVNKubeNodePodRunning
+      annotations:
+        message: |
+          All nodes should be running an ovnkube-node pod, {{"{{"}} $labels.node {{"}}"}} is not.
+      expr: |
+        (kube_node_info unless on(node) kube_pod_info{namespace="openshift-ovn-kubernetes",  pod=~"ovnkube-node.*"}) > 0
+      for: 20m
+      labels:
+        severity: warning
+    - alert: NetworkPodsCrashLooping
+      annotations:
+        message: Pod {{"{{"}} $labels.namespace{{"}}"}}/{{"{{"}} $labels.pod{{"}}"}} ({{"{{"}} $labels.container
+          {{"}}"}}) is restarting {{"{{"}} printf "%.2f" $value {{"}}"}} times / 5 minutes.
+      expr: |
+        rate(kube_pod_container_status_restarts_total{namespace="openshift-ovn-kubernetes"}[15m]) * 60 * 5 > 0
+      for: 1h
+      labels:
+        severity: warning


### PR DESCRIPTION
 - check that every node has a running ovnkube-node pod
 - check that none of the pods in openshift-ovn-kubernetes namespace are in CrashLoopBackoff