### PR TITLE
pkg/controller/configmap_ca_injector: "proxy not found" -> "ConfigMap ... not found"

### DIFF
--- a/pkg/controller/configmap_ca_injector/controller.go
+++ b/pkg/controller/configmap_ca_injector/controller.go
@@ -101,7 +101,7 @@ func (r *ReconcileConfigMapInjector) Reconcile(request reconcile.Request) (recon
 	err := r.client.Get(context.TODO(), trustedCAbundleConfigMapName, trustedCAbundleConfigMap)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			log.Println("proxy not found; reconciliation will be skipped", "request", request)
+			log.Printf("ConfigMap '%s/%s' not found; reconciliation will be skipped", trustedCAbundleConfigMapName.Namespace, trustedCAbundleConfigMapName.Name)
 			return reconcile.Result{}, nil
 		}
 		log.Println(err)


### PR DESCRIPTION
Adjusting one of the log lines from 482ce00a0c (#300) to match another log line from that same commit.  There's nothing inherently proxy-ish about the trusted CA bundle ConfigMap, so we don't need a proxy-specific log line.  And giving the namespace/name is a more actionable error message (admins will know which resource they need to chase down).