### PR TITLE
Change ovnkube-node.yaml to  getent ahostsv4

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -206,7 +206,7 @@ spec:
               nb_addr_list="${nb_addr_list},"
               sb_addr_list="${sb_addr_list},"
             fi
-            host=$(getent hosts "${OVN_NODES_ARRAY[$i]}" | awk '{print $1}')
+            host=$(getent ahostsv4 "${OVN_NODES_ARRAY[$i]}" | grep RAW | awk '{print $1}')
             nb_addr_list="${nb_addr_list}ssl://${host}:{{.OVN_NB_PORT}}"
             sb_addr_list="${sb_addr_list}ssl://${host}:{{.OVN_SB_PORT}}"
           done


### PR DESCRIPTION
getent hosts can return an ipv6 address.

Bug 1748162
[GCP]Failed to install cluster with OVN network type
https://bugzilla.redhat.com/show_bug.cgi?id=1748162

SDN-637 OVN doesn't work on GCP
https://jira.coreos.com/browse/SDN-637

Signed-off-by: Phil Cameron <pcameron@redhat.com>