### PR TITLE
pkg/names: Rename TRUSTED_CA_BUNDLE_CONFIGMAP_KEY -> CA_BUNDLE_CONFIGMAP_KEY

### DIFF
--- a/pkg/controller/configmap_ca_injector/controller.go
+++ b/pkg/controller/configmap_ca_injector/controller.go
@@ -170,9 +170,9 @@ func (r *ReconcileConfigMapInjector) Reconcile(request reconcile.Request) (recon
 			}
 			configMapToUpdate := retrievedConfigMap.DeepCopy()
 			if configMapToUpdate.Data == nil {
-				configMapToUpdate.Data = map[string]string{names.TRUSTED_CA_BUNDLE_CONFIGMAP_KEY: string(trustedCAbundleData)}
+				configMapToUpdate.Data = map[string]string{names.CA_BUNDLE_CONFIGMAP_KEY: string(trustedCAbundleData)}
 			} else {
-				configMapToUpdate.Data[names.TRUSTED_CA_BUNDLE_CONFIGMAP_KEY] = string(trustedCAbundleData)
+				configMapToUpdate.Data[names.CA_BUNDLE_CONFIGMAP_KEY] = string(trustedCAbundleData)
 			}
 			if equality.Semantic.DeepEqual(configMapToUpdate, retrievedConfigMap) {
 				// Nothing to update the new and old configmap object would be the same.

--- a/pkg/controller/proxyconfig/controller.go
+++ b/pkg/controller/proxyconfig/controller.go
@@ -386,7 +386,7 @@ func (r *ReconcileProxyConfig) mergeTrustBundlesToConfigMap(additionalData, syst
 			Namespace: names.TRUSTED_CA_BUNDLE_CONFIGMAP_NS,
 		},
 		Data: map[string]string{
-			names.TRUSTED_CA_BUNDLE_CONFIGMAP_KEY: string(combinedTrustData),
+			names.CA_BUNDLE_CONFIGMAP_KEY: string(combinedTrustData),
 		},
 	}
 	if _, _, err := r.validateTrustBundle(mergedCfgMap); err != nil {
@@ -414,7 +414,7 @@ func (r *ReconcileProxyConfig) syncTrustedCABundle(trustedCABundle *corev1.Confi
 		}
 	}
 
-	if !configMapsEqual(names.TRUSTED_CA_BUNDLE_CONFIGMAP_KEY, currentCfgMap, trustedCABundle) {
+	if !configMapsEqual(names.CA_BUNDLE_CONFIGMAP_KEY, currentCfgMap, trustedCABundle) {
 		if err := r.client.Update(context.TODO(), trustedCABundle); err != nil {
 			return fmt.Errorf("failed to update trusted CA bundle configmap '%s/%s': %v",
 				trustedCABundle.Namespace, trustedCABundle.Name, err)
@@ -447,7 +447,7 @@ func (r *ReconcileProxyConfig) generateSystemTrustBundle() (*corev1.ConfigMap, e
 			Namespace: names.TRUSTED_CA_BUNDLE_CONFIGMAP_NS,
 		},
 		Data: map[string]string{
-			names.TRUSTED_CA_BUNDLE_CONFIGMAP_KEY: string(bundleData),
+			names.CA_BUNDLE_CONFIGMAP_KEY: string(bundleData),
 		},
 	}
 

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -41,9 +41,9 @@ const MULTUS_VALIDATING_WEBHOOK = "multus.openshift.io"
 // ConfigMaps that contain user provided trusted CA bundles.
 const ADDL_TRUST_BUNDLE_CONFIGMAP_NS = "openshift-config"
 
-// TRUSTED_CA_BUNDLE_CONFIGMAP_KEY is the name of the data key containing
+// CA_BUNDLE_CONFIGMAP_KEY is the name of the data key containing
 // the PEM encoded trust bundle.
-const TRUSTED_CA_BUNDLE_CONFIGMAP_KEY = "ca-bundle.crt"
+const CA_BUNDLE_CONFIGMAP_KEY = "ca-bundle.crt"
 
 // TRUSTED_CA_BUNDLE_CONFIGMAP is the name of the ConfigMap
 // containing the combined user/system trust bundle.


### PR DESCRIPTION
From [the trustedCA docs][1]:

> The validator is responsible for reading the certificate bundle from required key "ca-bundle.crt" and...

so this key is used for all CA-bundle ConfigMaps, not just `openshift-config-managed/trusted-ca-bundle`.  Make the variable name suitably generic with:

```console
$ sed -i 's/TRUSTED_CA_BUNDLE_CONFIGMAP_KEY/CA_BUNDLE_CONFIGMAP_KEY/g' $(git grep -l TRUSTED_CA_BUNDLE_CONFIGMAP_KEY)
```

[1]: https://github.com/openshift/api/blob/86def77f6f909e31ffacf73fe63bf5ca830ede83/config/v1/types_proxy.go#L48