### PR TITLE
GCP add ClusterRoleBinding to permit changing node/status

### DIFF
--- a/bindata/network/ovn-kubernetes/003-rbac-controller.yaml
+++ b/bindata/network/ovn-kubernetes/003-rbac-controller.yaml
@@ -20,6 +20,7 @@ rules:
   - list
   - patch
   - watch
+  - update
 - apiGroups: [""]
   resources:
   - pods


### PR DESCRIPTION
Bug 1748162
[GCP]Failed to install cluster with OVN network type
https://bugzilla.redhat.com/show_bug.cgi?id=1748162

SDN-637 OVN doesn't work on GCP
https://jira.coreos.com/browse/SDN-637

Signed-off-by: Phil Cameron <pcameron@redhat.com>