### PR TITLE
Make ovn-kubernetes work with IPv6

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -156,9 +156,14 @@ spec:
               - -c
               - |
                 OVN_NODES_ARRAY=({{.OVN_NODES}})
+                OVN_NODE_IPS_ARRAY=({{.OVN_NODE_IPS}})
                 if [[ "$K8S_NODE" == "${OVN_NODES_ARRAY[0]}" ]]; then
+                  USEIPV6=
+                  if [[ ${OVN_NODE_IPS_ARRAY[0]} == *":"* ]]; then
+                    USEIPV6=":[::]"
+                  fi
                   retries=0
-                  while ! ovn-nbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_NB_PORT}}:[::] -- set connection . inactivity_probe=0; do
+                  while ! ovn-nbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_NB_PORT}}${USEIPV6} -- set connection . inactivity_probe=0; do
                     (( retries += 1 ))
                   if [[ "${retries}" -gt 40 ]]; then
                     echo "too many failed ovn-nbctl attempts, giving up"
@@ -258,9 +263,14 @@ spec:
               - -c
               - |
                 OVN_NODES_ARRAY=({{.OVN_NODES}})
+                OVN_NODE_IPS_ARRAY=({{.OVN_NODE_IPS}})
                 if [[ "$K8S_NODE" == "${OVN_NODES_ARRAY[0]}" ]]; then
+                  USEIPV6=
+                  if [[ ${OVN_NODE_IPS_ARRAY[0]} == *":"* ]]; then
+                    USEIPV6=":[::]"
+                  fi
                   retries=0
-                  while ! ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}}:[::] -- set connection . inactivity_probe=0; do
+                  while ! ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}}${USEIPV6} -- set connection . inactivity_probe=0; do
                     (( retries += 1 ))
                   if [[ "${retries}" -gt 40 ]]; then
                     echo "too many failed ovn-sbctl attempts, giving up"

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -150,7 +150,7 @@ spec:
                 OVN_NODES_ARRAY=({{.OVN_NODES}})
                 if [[ "$K8S_NODE" == "${OVN_NODES_ARRAY[0]}" ]]; then
                   retries=0
-                  while ! ovn-nbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_NB_PORT}} -- set connection . inactivity_probe=0; do
+                  while ! ovn-nbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_NB_PORT}}:[::] -- set connection . inactivity_probe=0; do
                     (( retries += 1 ))
                   if [[ "${retries}" -gt 40 ]]; then
                     echo "too many failed ovn-nbctl attempts, giving up"
@@ -244,7 +244,7 @@ spec:
                 OVN_NODES_ARRAY=({{.OVN_NODES}})
                 if [[ "$K8S_NODE" == "${OVN_NODES_ARRAY[0]}" ]]; then
                   retries=0
-                  while ! ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}} -- set connection . inactivity_probe=0; do
+                  while ! ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}}[::] -- set connection . inactivity_probe=0; do
                     (( retries += 1 ))
                   if [[ "${retries}" -gt 40 ]]; then
                     echo "too many failed ovn-sbctl attempts, giving up"

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -52,21 +52,21 @@ spec:
             set +o allexport
           fi
 
-          OVN_NODES_ARRAY=({{.OVN_NODES}})
-          
+          OVN_NODE_IPS_ARRAY=({{.OVN_NODE_IPS}})
+
           nb_addr_list=""
           sb_addr_list=""
-          
-          for i in "${!OVN_NODES_ARRAY[@]}"; do
+
+          for i in "${!OVN_NODE_IPS_ARRAY[@]}"; do
             if [[ $i != 0 ]]; then
               nb_addr_list="${nb_addr_list},"
               sb_addr_list="${sb_addr_list},"
             fi
-            host=$(getent ahostsv4 "${OVN_NODES_ARRAY[$i]}" | grep RAW | awk '{print $1}')
+            host="${OVN_NODE_IPS_ARRAY[$i]}"
             nb_addr_list="${nb_addr_list}ssl:${host}:{{.OVN_NB_PORT}}"
             sb_addr_list="${sb_addr_list}ssl:${host}:{{.OVN_SB_PORT}}"
           done
-          
+
           exec ovn-northd \
             --no-chdir "-vconsole:${OVN_LOG_LEVEL}" -vfile:off \
             --pidfile=/var/run/openvswitch/ovn-northd.pid \
@@ -109,15 +109,23 @@ spec:
             source /env/_master
             set +o allexport
           fi
-          
-          OVN_NODES_ARRAY=({{.OVN_NODES}})
-          MASTER_NODE=$(getent ahostsv4 "${OVN_NODES_ARRAY[0]}" | grep RAW | awk '{print $1}')
-          LOCALHOST=$(getent ahostsv4 "${K8S_NODE}" | grep RAW | awk '{print $1}')
 
-          if [[ "$LOCALHOST" == "$MASTER_NODE" ]]; then
+          OVN_NODES_ARRAY=({{.OVN_NODES}})
+          OVN_NODE_IPS_ARRAY=({{.OVN_NODE_IPS}})
+          MASTER_NODE_IP="${OVN_NODE_IPS_ARRAY[0]}"
+          NODE_INDEX=0
+          for i in "${!OVN_NODES_ARRAY[@]}"; do
+            if [[ "${OVN_NODES_ARRAY[i]}" == "${K8S_NODE}" ]]; then
+              NODE_INDEX=${i}
+              break
+            fi
+          done
+          THIS_NODE_IP="${OVN_NODE_IPS_ARRAY[${NODE_INDEX}]}"
+
+          if [[ "$THIS_NODE_IP" == "$MASTER_NODE_IP" ]]; then
             exec /usr/share/openvswitch/scripts/ovn-ctl \
             --db-nb-cluster-local-port={{.OVN_NB_RAFT_PORT}} \
-            --db-nb-cluster-local-addr=${LOCALHOST} \
+            --db-nb-cluster-local-addr=${THIS_NODE_IP} \
             --no-monitor \
             --db-nb-cluster-local-proto=ssl \
             --ovn-nb-db-ssl-key=/ovn-cert/tls.key \
@@ -129,8 +137,8 @@ spec:
             exec /usr/share/openvswitch/scripts/ovn-ctl \
             --db-nb-cluster-local-port={{.OVN_NB_RAFT_PORT}} \
             --db-nb-cluster-remote-port={{.OVN_NB_RAFT_PORT}} \
-            --db-nb-cluster-local-addr=${LOCALHOST} \
-            --db-nb-cluster-remote-addr=${MASTER_NODE} \
+            --db-nb-cluster-local-addr=${THIS_NODE_IP} \
+            --db-nb-cluster-remote-addr=${MASTER_NODE_IP} \
             --no-monitor \
             --db-nb-cluster-local-proto=ssl \
             --db-nb-cluster-remote-proto=ssl \
@@ -204,13 +212,21 @@ spec:
           fi
 
           OVN_NODES_ARRAY=({{.OVN_NODES}})
-          MASTER_NODE=$(getent ahostsv4 "${OVN_NODES_ARRAY[0]}" | grep RAW | awk '{print $1}')
-          LOCALHOST=$(getent ahostsv4 "${K8S_NODE}" | grep RAW | awk '{print $1}')
+          OVN_NODE_IPS_ARRAY=({{.OVN_NODE_IPS}})
+          MASTER_NODE_IP="${OVN_NODE_IPS_ARRAY[0]}"
+          NODE_INDEX=0
+          for i in "${!OVN_NODES_ARRAY[@]}"; do
+            if [[ "${OVN_NODES_ARRAY[i]}" == "${K8S_NODE}" ]]; then
+              NODE_INDEX=${i}
+              break
+            fi
+          done
+          THIS_NODE_IP="${OVN_NODE_IPS_ARRAY[${NODE_INDEX}]}"
 
-          if [[ "$LOCALHOST" == "$MASTER_NODE" ]]; then
+          if [[ "$THIS_NODE_IP" == "$MASTER_NODE_IP" ]]; then
             exec /usr/share/openvswitch/scripts/ovn-ctl \
             --db-sb-cluster-local-port={{.OVN_SB_RAFT_PORT}} \
-            --db-sb-cluster-local-addr=${LOCALHOST} \
+            --db-sb-cluster-local-addr=${THIS_NODE_IP} \
             --no-monitor \
             --db-sb-cluster-local-proto=ssl \
             --ovn-sb-db-ssl-key=/ovn-cert/tls.key \
@@ -223,8 +239,8 @@ spec:
             exec /usr/share/openvswitch/scripts/ovn-ctl \
             --db-sb-cluster-local-port={{.OVN_SB_RAFT_PORT}} \
             --db-sb-cluster-remote-port={{.OVN_SB_RAFT_PORT}} \
-            --db-sb-cluster-local-addr=${LOCALHOST} \
-            --db-sb-cluster-remote-addr=${MASTER_NODE} \
+            --db-sb-cluster-local-addr=${THIS_NODE_IP} \
+            --db-sb-cluster-remote-addr=${MASTER_NODE_IP} \
             --no-monitor \
             --db-sb-cluster-local-proto=ssl \
             --db-sb-cluster-remote-proto=ssl \
@@ -244,7 +260,7 @@ spec:
                 OVN_NODES_ARRAY=({{.OVN_NODES}})
                 if [[ "$K8S_NODE" == "${OVN_NODES_ARRAY[0]}" ]]; then
                   retries=0
-                  while ! ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}}[::] -- set connection . inactivity_probe=0; do
+                  while ! ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}}:[::] -- set connection . inactivity_probe=0; do
                     (( retries += 1 ))
                   if [[ "${retries}" -gt 40 ]]; then
                     echo "too many failed ovn-sbctl attempts, giving up"
@@ -301,15 +317,15 @@ spec:
             fi
           fi
 
-          OVN_NODES_ARRAY=({{.OVN_NODES}})
+          OVN_NODE_IPS_ARRAY=({{.OVN_NODE_IPS}})
           nb_addr_list=""
           sb_addr_list=""
-          for i in "${!OVN_NODES_ARRAY[@]}"; do
+          for i in "${!OVN_NODE_IPS_ARRAY[@]}"; do
             if [[ $i != 0 ]]; then
               nb_addr_list="${nb_addr_list},"
               sb_addr_list="${sb_addr_list},"
             fi
-            host=$(getent ahostsv4 "${OVN_NODES_ARRAY[$i]}" | grep RAW | awk '{print $1}')
+            host="${OVN_NODE_IPS_ARRAY[$i]}"
             nb_addr_list="${nb_addr_list}ssl:${host}:{{.OVN_NB_PORT}}"
             sb_addr_list="${sb_addr_list}ssl://${host}:{{.OVN_SB_PORT}}"
           done

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -198,7 +198,7 @@ spec:
             fi
           fi
           
-          OVN_NODES_ARRAY=({{.OVN_NODES}})
+          OVN_NODES_ARRAY=({{.OVN_NODE_IPS}})
           nb_addr_list=""
           sb_addr_list=""
           for i in "${!OVN_NODES_ARRAY[@]}"; do
@@ -206,7 +206,7 @@ spec:
               nb_addr_list="${nb_addr_list},"
               sb_addr_list="${sb_addr_list},"
             fi
-            host=$(getent ahostsv4 "${OVN_NODES_ARRAY[$i]}" | grep RAW | awk '{print $1}')
+            host="${OVN_NODES_ARRAY[$i]}"
             nb_addr_list="${nb_addr_list}ssl://${host}:{{.OVN_NB_PORT}}"
             sb_addr_list="${sb_addr_list}ssl://${host}:{{.OVN_SB_PORT}}"
           done

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -20,7 +20,8 @@ type KuryrBootstrapResult struct {
 }
 
 type OVNBootstrapResult struct {
-	OVNMasterNodes []string
+	OVNMasterNodes   []string
+	OVNMasterNodeIPs []string
 }
 
 type BootstrapResult struct {

--- a/pkg/network/cluster_config.go
+++ b/pkg/network/cluster_config.go
@@ -39,15 +39,15 @@ func ValidateClusterConfig(clusterConfig configv1.NetworkSpec) error {
 		if err != nil {
 			return errors.Errorf("could not parse spec.clusterNetwork %s", cnet.CIDR)
 		}
-		size, _ := cidr.Mask.Size()
+		ones, bits := cidr.Mask.Size()
 		// The comparison is inverted; smaller number is larger block
-		if cnet.HostPrefix < uint32(size) {
+		if cnet.HostPrefix < uint32(ones) {
 			return errors.Errorf("hostPrefix %d is larger than its cidr %s",
 				cnet.HostPrefix, cnet.CIDR)
 		}
-		if cnet.HostPrefix > 30 {
-			return errors.Errorf("hostPrefix %d is too small, must be a /30 or larger",
-				cnet.HostPrefix)
+		if int(cnet.HostPrefix) > bits-2 {
+			return errors.Errorf("hostPrefix %d is too small, must be a /%d or larger",
+				cnet.HostPrefix, bits-2)
 		}
 		if err := pool.Add(*cidr); err != nil {
 			return err

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -26,9 +26,8 @@ const OVN_SB_RAFT_PORT = "9644"
 
 // renderOVNKubernetes returns the manifests for the ovn-kubernetes.
 // This creates
-// - the ClusterNetwork object
-// - the ovn-kubernetes namespace
-// - the ovn-kubeernetes setup
+// - the openshift-ovn-kubernetes namespace
+// - the ovn-config ConfigMap
 // - the ovnkube-node daemonset
 // - the ovnkube-master deployment
 // and some other small things.


### PR DESCRIPTION
These changes represent the cluster-network-operator portion of making ovn-kubernetes work with single-stack IPv6.

Some of the most invasive changes are with how IP addresses are handled for OVN databases.  Instead of using DNS, we only use IP addresses taken straight from Nodes.  In our AWS IPv6 environment, the node names only resolve to their IPv4 addresses.