### PR TITLE
Bug 1779183: Don't mark the operator un-Available or Degraded because of multus-admission-controller

### DIFF
--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -10,6 +10,7 @@ metadata:
     kubernetes.io/description: |
       This daemon set launches the Multus admisson controller component on each node.
     release.openshift.io/version: "{{.ReleaseVersion}}"
+    networkoperator.openshift.io/non-critical: ""
 spec:
   selector:
     matchLabels:

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -29,6 +29,10 @@ const APPLIED_NAMESPACE = "openshift-network-operator"
 // or update. Useful when we want to make a CR for which the CRD may not exist yet.
 const IgnoreObjectErrorAnnotation = "networkoperator.openshift.io/ignore-errors"
 
+// NonCriticalAnnotation is an annotation on Deployments/DaemonSets to indicate
+// that they are not critical to the functioning of the pod network
+const NonCriticalAnnotation = "networkoperator.openshift.io/non-critical"
+
 // SERVICE_CA_CONFIGMAP is the name of the ConfigMap that contains service CA bundle
 // that is used in multus admission controller deployment
 const SERVICE_CA_CONFIGMAP = "openshift-service-ca"


### PR DESCRIPTION
Changes the status reporting so that `multus-admission-controller` is treated as "non-critical", meaning that we will transition to `Available` if everything else has deployed even if `multus-admission-controller` hasn't (though in that case we'd be both `Available` and `Progressing`) and we will never go to `Degraded` just because `multus-admission-controller` took too long to deploy.

You could argue that we should *eventually* mark the operator `Degraded` if `multus-admission-controller` doesn't deploy, but if so, then we should improve the status tracking to only degrade if `multus-admission-controller` fails to deploy *after* the credentials operator is `Available`, since it is not expected to deploy before that.

@squeed I know we were talking about this somewhere so if there's a related issue/bugzilla bug/jira card, can you link it?