### PR TITLE
SDN-662: OVN raft followups

### DIFF
--- a/bindata/network/ovn-kubernetes/007-pdb.yaml
+++ b/bindata/network/ovn-kubernetes/007-pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: ovn-raft-quorum-guard
+  namespace: openshift-ovn-kubernetes
+spec:
+  minAvailable: {{.OVN_MIN_AVAILABLE}} 
+  selector:
+    matchLabels:
+      name: ovnkube-master

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -188,6 +188,25 @@ spec:
           containerPort: {{.OVN_NB_PORT}}
         - name: nb-db-raft-port
           containerPort: {{.OVN_NB_RAFT_PORT}}
+        readinessProbe:
+          initalDelaySeconds: 30
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - |
+              set -e
+              OVN_NODES_ARRAY=({{.OVN_NODES}})
+              AVAILABLE_NODES=0 
+              for node in "${OVN_NODES_ARRAY[@]}"; do
+                node_ip=$(getent ahostsv4 "${node}" | grep RAW | awk '{print $1}')
+                if ovs-appctl -t /var/run/openvswitch/ovnnb_db.ctl  cluster/status OVN_Northbound | grep -q $node_ip; then
+                  (( AVAILABLE_NODES += 1 ))
+                fi
+              done
+              if [[ "${AVAILABLE_NODES}" -lt {{.OVN_MIN_AVAILABLE}} ]]; then
+                exit 1
+              fi
       
       # sbdb: The southbound, or flow DB. In raft mode 
       - name: sbdb
@@ -278,6 +297,25 @@ spec:
           containerPort: {{.OVN_SB_PORT}}
         - name: sb-db-raft-port
           containerPort: {{.OVN_SB_RAFT_PORT}}
+        readinessProbe:
+          initalDelaySeconds: 30
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - |
+              set -xe
+              OVN_NODES_ARRAY=({{.OVN_NODES}})
+              AVAILABLE_NODES=0 
+              for node in "${OVN_NODES_ARRAY[@]}"; do
+                node_ip=$(getent ahostsv4 "${node}" | grep RAW | awk '{print $1}')
+                if ovs-appctl -t /var/run/openvswitch/ovnsb_db.ctl  cluster/status OVN_Southbound | grep -q $node_ip; then
+                  (( AVAILABLE_NODES += 1 ))
+                fi
+              done
+              if [[ "${AVAILABLE_NODES}" -lt {{.OVN_MIN_AVAILABLE}} ]]; then
+                exit 1
+              fi
 
       # ovnkube master: convert kubernetes objects in to nbdb logical network components
       - name: ovnkube-master

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -20,7 +20,8 @@ type KuryrBootstrapResult struct {
 }
 
 type OVNBootstrapResult struct {
-	OVNMasterNodes []string
+	OVNMasterNodes  []string
+	OVNMinAvailable int
 }
 
 type BootstrapResult struct {

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -52,6 +52,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["OVN_NB_RAFT_PORT"] = OVN_NB_RAFT_PORT
 	data.Data["OVN_SB_RAFT_PORT"] = OVN_SB_RAFT_PORT
 	data.Data["OVN_NODES"] = strings.Join(bootstrapResult.OVN.OVNMasterNodes, " ")
+	data.Data["OVN_MIN_AVAILABLE"] = bootstrapResult.OVN.OVNMinAvailable
 
 	var ippools string
 	for _, net := range conf.ClusterNetwork {
@@ -170,7 +171,8 @@ func boostrapOVN(kubeClient client.Client) (*bootstrap.BootstrapResult, error) {
 
 	res := bootstrap.BootstrapResult{
 		OVN: bootstrap.OVNBootstrapResult{
-			OVNMasterNodes: ovnMasterNodes,
+			OVNMasterNodes:  ovnMasterNodes,
+			OVNMinAvailable: len(ovnMasterNodes)/2 + 1,
 		},
 	}
 	return &res, nil


### PR DESCRIPTION
This PR adds a `PodDisruptionBudget` for maintaining concensus for the raft cluster + a `readinessProbe` for the `sbdb` and `nbdb` checking that all members have joined the cluster, and if they have: waits 30 seconds according to what has been mentioned here: https://jira.coreos.com/browse/SDN-662

/assign @squeed 