### PR TITLE
ovn-kube: add pod disruption budget, readiness check

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -1,3 +1,19 @@
+# The ovnkube control-plane components
+
+# The pod disruption budget ensures that we keep a raft quorum
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: ovn-raft-quorum-guard
+  namespace: openshift-ovn-kubernetes
+spec:
+  minAvailable: {{.OVN_MIN_AVAILABLE}}
+  selector:
+    matchLabels:
+      name: ovnkube-master
+
+---
+
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -95,6 +111,7 @@ spec:
           requests:
             cpu: 100m
             memory: 300Mi
+        terminationMessagePolicy: FallbackToLogsOnError
 
       # nbdb: the northbound, or logical network object DB. In raft mode 
       - name: nbdb
@@ -159,6 +176,10 @@ spec:
                   sleep 2
                   done
                 fi
+        readinessProbe:
+          initialDelaySeconds: 30
+          tcpSocket:
+            port: {{.OVN_NB_PORT}}
         env:
         - name: OVN_LOG_LEVEL
           value: info 
@@ -188,6 +209,7 @@ spec:
           containerPort: {{.OVN_NB_PORT}}
         - name: nb-db-raft-port
           containerPort: {{.OVN_NB_RAFT_PORT}}
+        terminationMessagePolicy: FallbackToLogsOnError
       
       # sbdb: The southbound, or flow DB. In raft mode 
       - name: sbdb
@@ -253,6 +275,10 @@ spec:
                   sleep 2
                   done
                 fi
+        readinessProbe:
+          initialDelaySeconds: 30
+          tcpSocket:
+            port: {{.OVN_SB_PORT}}
         env:
         - name: OVN_LOG_LEVEL
           value: info 
@@ -278,6 +304,7 @@ spec:
           containerPort: {{.OVN_SB_PORT}}
         - name: sb-db-raft-port
           containerPort: {{.OVN_SB_RAFT_PORT}}
+        terminationMessagePolicy: FallbackToLogsOnError
 
       # ovnkube master: convert kubernetes objects in to nbdb logical network components
       - name: ovnkube-master
@@ -381,6 +408,7 @@ spec:
         ports:
         - name: metrics-port
           containerPort: 9102
+        terminationMessagePolicy: FallbackToLogsOnError
 
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -260,6 +260,7 @@ spec:
           containerPort: 9101
         securityContext:
           privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         # for the iptables wrapper
         - mountPath: /host

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -52,6 +52,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["OVN_NB_RAFT_PORT"] = OVN_NB_RAFT_PORT
 	data.Data["OVN_SB_RAFT_PORT"] = OVN_SB_RAFT_PORT
 	data.Data["OVN_NODES"] = strings.Join(bootstrapResult.OVN.OVNMasterNodes, " ")
+	data.Data["OVN_MIN_AVAILABLE"] = len(bootstrapResult.OVN.OVNMasterNodes)/2 + 1
 
 	var ippools string
 	for _, net := range conf.ClusterNetwork {


### PR DESCRIPTION
Add a PodDisruptionBudget to protect the raft quorum.

Configure a readines probe for the DBs: ovsdb raft only opens its port once it has a raft consensus. Utilize that.

Also, add a TerminationMessagePolicy.

(Closes SDN-662)

/cc @alexanderConstantinescu 