### PR TITLE
Bug 1778314:  False Alarm - SDN pod has gone too long without syncing iptables rule

### DIFF
--- a/bindata/network/openshift-sdn/alert-rules.yaml
+++ b/bindata/network/openshift-sdn/alert-rules.yaml
@@ -56,9 +56,11 @@ spec:
     - alert: NodeIPTablesStale
     # there is some scrape delay and some other offset 120 is not really 120s but it is still too long
       annotations:
-        message: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node {{"}}"}} has gone too long without syncing iptables rules. NOTE - There is some scrape delay and other offsets, 120s isn't exact but it is still too high.
+        message: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node {{"}}"}} has gone too long without syncing iptables rules.
       expr: |
-        (time() - kubeproxy_sync_proxy_rules_last_timestamp_seconds) * on(pod) group_right kube_pod_info{namespace="openshift-sdn",  pod=~"sdn-[^-]*"} > 120
+            (timestamp(kubeproxy_sync_proxy_rules_last_timestamp_seconds)
+            - on(pod) kubeproxy_sync_proxy_rules_last_timestamp_seconds)
+            * on(pod) group_right kube_pod_info{namespace="openshift-sdn",  pod=~"sdn-[^-]*"}> 120
       for: 20m
       labels:
         severity: warning


### PR DESCRIPTION
cherry pick of PR https://github.com/openshift/cluster-network-operator/pull/390 to 4.2

Fixes Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1778314