### PR TITLE
Bug 1781707: openshift-sdn, CNO: handle new kubeconfig path

### DIFF
--- a/bindata/network/openshift-sdn/controller.yaml
+++ b/bindata/network/openshift-sdn/controller.yaml
@@ -27,11 +27,10 @@ spec:
             cpu: 10m
             memory: 50Mi
         env:
-        # TODO: bind-mount the kubelet's kubeconfig like the openshift-sdn process
-        # need to get the `oc` binary in to the hypershift image first
-        - name: KUBERNETES_SERVICE_PORT # allows the controller to communicate with apiserver directly on same host.
+        # point sdn-controller to the internal apiserver load balancer
+        - name: KUBERNETES_SERVICE_PORT
           value: "{{.KUBERNETES_SERVICE_PORT}}"
-        - name: KUBERNETES_SERVICE_HOST # allows the controller to communicate with apiserver directly on same host.
+        - name: KUBERNETES_SERVICE_HOST
           value: "{{.KUBERNETES_SERVICE_HOST}}"
         terminationMessagePolicy: FallbackToLogsOnError
       hostNetwork: true

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -96,15 +96,12 @@ spec:
           cp -f /opt/cni/bin/openshift-sdn /host/opt/cni/bin/
 
           # Launch the network process
-          exec /usr/bin/openshift-sdn-node --proxy-config=/config/kube-proxy-config.yaml --url-only-kubeconfig=/etc/kubernetes/kubeconfig --v=${DEBUG_LOGLEVEL:-2}
+          exec /usr/bin/openshift-sdn-node --proxy-config=/config/kube-proxy-config.yaml --v=${DEBUG_LOGLEVEL:-2}
         securityContext:
           privileged: true
         volumeMounts:
         - mountPath: /config
           name: config
-          readOnly: true
-        - mountPath: /etc/kubernetes/kubeconfig
-          name: host-kubeconfig
           readOnly: true
         # Mount the entire run directory for socket access for Docker or CRI-o
         # TODO: remove
@@ -145,6 +142,11 @@ spec:
             cpu: 100m
             memory: 200Mi
         env:
+        # point openshift-sdn to the internal apiserver load balancer
+        - name: KUBERNETES_SERVICE_PORT
+          value: "{{.KUBERNETES_SERVICE_PORT}}"
+        - name: KUBERNETES_SERVICE_HOST
+          value: "{{.KUBERNETES_SERVICE_HOST}}"
         - name: OPENSHIFT_DNS_DOMAIN
           value: cluster.local
         - name: K8S_NODE_NAME
@@ -171,9 +173,6 @@ spec:
       - name: config
         configMap:
           name: sdn-config
-      - name: host-kubeconfig
-        hostPath:
-          path: /etc/kubernetes/kubeconfig
       - name: etc-sysconfig
         hostPath:
           path: /etc/sysconfig


### PR DESCRIPTION
We pull the apiserver url from the kubelet's kubeconfig. This has changed, and can be found in one of two places. Check them both.

Ultimately we need to generate this in a more sustainable way, but this is a good workaround (and easily backportable).