### PR TITLE
Read install-config and wait for the requested amount of control plane nodes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1224,6 +1224,7 @@
     "k8s.io/apimachinery/pkg/util/runtime",
     "k8s.io/apimachinery/pkg/util/sets",
     "k8s.io/apimachinery/pkg/util/validation",
+    "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/apimachinery/pkg/util/yaml",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/informers",

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -7,22 +7,28 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
-	"github.com/pkg/errors"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
+	yaml "github.com/ghodss/yaml"
 	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
 	"github.com/openshift/cluster-network-operator/pkg/render"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const OVN_NB_PORT = "9641"
 const OVN_SB_PORT = "9642"
 const OVN_NB_RAFT_PORT = "9643"
 const OVN_SB_RAFT_PORT = "9644"
+const CLUSTER_CONFIG_NAME = "cluster-config-v1"
+const CLUSTER_CONFIG_NAMESPACE = "kube-system"
 
 // renderOVNKubernetes returns the manifests for the ovn-kubernetes.
 // This creates
@@ -130,6 +136,7 @@ func isOVNKubernetesChangeSafe(prev, next *operv1.NetworkSpec) []error {
 }
 
 func fillOVNKubernetesDefaults(conf, previous *operv1.NetworkSpec, hostMTU int) {
+
 	if conf.DefaultNetwork.OVNKubernetesConfig == nil {
 		conf.DefaultNetwork.OVNKubernetesConfig = &operv1.OVNKubernetesConfig{}
 	}
@@ -151,15 +158,37 @@ func networkPluginName() string {
 	return "ovn-kubernetes"
 }
 
+type replicaCountDecoder struct {
+	ControlPlane struct {
+		Replicas string `json:"replicas"`
+	} `json:"controlPlane"`
+}
+
 func boostrapOVN(kubeClient client.Client) (*bootstrap.BootstrapResult, error) {
+	clusterConfig := &corev1.ConfigMap{}
+	clusterConfigLookup := types.NamespacedName{Name: CLUSTER_CONFIG_NAME, Namespace: CLUSTER_CONFIG_NAMESPACE}
 	masterNodeList := &corev1.NodeList{}
-	matchingLabels := &client.MatchingLabels{"node-role.kubernetes.io/master": ""}
-	if err := kubeClient.List(context.TODO(), masterNodeList, matchingLabels); err != nil {
-		return nil, err
+
+	if err := kubeClient.Get(context.TODO(), clusterConfigLookup, clusterConfig); err != nil {
+		return nil, fmt.Errorf("Unable to bootstrap OVN, unable to retrieve cluster config: %s", err)
 	}
 
-	if len(masterNodeList.Items) == 0 {
-		return nil, fmt.Errorf("unable to bootstrap OVN, no master nodes found")
+	rcD := replicaCountDecoder{}
+	if err := yaml.Unmarshal([]byte(clusterConfig.Data["install-config"]), &rcD); err != nil {
+		return nil, fmt.Errorf("Unable to bootstrap OVN, unable to unmarshal install-config: %s", err)
+	}
+
+	controlPlaneReplicaCount, _ := strconv.Atoi(rcD.ControlPlane.Replicas)
+
+	err := wait.PollImmediate(2*time.Second, 60*time.Second, func() (bool, error) {
+		matchingLabels := &client.MatchingLabels{"node-role.kubernetes.io/master": ""}
+		if err := kubeClient.List(context.TODO(), masterNodeList, matchingLabels); err != nil {
+			return false, err
+		}
+		return len(masterNodeList.Items) != 0 && controlPlaneReplicaCount == len(masterNodeList.Items), nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("Unable to bootstrap OVN, expected amount of control plane nodes (%v) do not match found (%v): %s", controlPlaneReplicaCount, len(masterNodeList.Items), err)
 	}
 
 	ovnMasterNodes := []string{}


### PR DESCRIPTION
As seen by @pecameron, the CNO might proceed to bootstrapping OVN whilst some control plane nodes are unknown to him/her. 

This PR while make sure we wait until all control plane nodes that should exist, do exist. It does so by reading the `install-config.yaml` which is written as the `cluster-config-v1` configmap in `kube-system`, and proceeds to decoding the user defined amount of control plane nodes. It only proceeds with the OVN bootstrap once the kubeclient return the expected amount of nodes.  

I didn't have any better way of ascertaining this information then doing this, so if anyone has a better idea / knows how to retrieve this information more easily, please raise a hand. 

/assign @pecameron @danwinship 