### PR TITLE
Allow changing LogLevel online in Kuryr

### DIFF
--- a/bindata/network/kuryr/004-daemon.yaml
+++ b/bindata/network/kuryr/004-daemon.yaml
@@ -19,6 +19,7 @@ spec:
         component: network
         type: infra
         openshift.io/component: network
+        configuration-hash: {{ .ConfigMapHash }}
     spec:
       hostNetwork: true
       serviceAccountName: kuryr

--- a/bindata/network/kuryr/005-controller.yaml
+++ b/bindata/network/kuryr/005-controller.yaml
@@ -11,6 +11,9 @@ spec:
   selector:
     matchLabels:
       app: kuryr-controller
+  # There can be only one kuryr-controller without HA enabled
+  strategy:
+    type: Recreate
   template:
     metadata:
       name: kuryr-controller
@@ -19,6 +22,7 @@ spec:
         component: network
         type: infra
         openshift.io/component: network
+        configuration-hash: {{ .ConfigMapHash }}
     spec:
       serviceAccountName: kuryr
       hostNetwork: true

--- a/pkg/util/k8s/unstructured.go
+++ b/pkg/util/k8s/unstructured.go
@@ -1,7 +1,9 @@
 package k8s
 
 import (
+	"crypto/md5"
 	"encoding/json"
+	"fmt"
 
 	"github.com/pkg/errors"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -19,4 +21,14 @@ func ToUnstructured(obj interface{}) (*uns.Unstructured, error) {
 		return nil, errors.Wrapf(err, "failed to convert to unstructured (unmarshal)")
 	}
 	return u, nil
+}
+
+// CalculateHash computes MD5 sum of the JSONfied object passed as obj.
+func CalculateHash(obj interface{}) (string, error) {
+	configStr, err := json.Marshal(obj)
+	if err != nil {
+		return "", err
+	}
+	configSum := md5.Sum(configStr)
+	return fmt.Sprintf("%x", configSum), nil
 }


### PR DESCRIPTION
This commit makes sure that Kuryr pods are restarted when LogLevel
option is changed in NetworkSpec. This is possible by injecting each
Kuryr pod with a hash representing set of all the options passed to the
templates. If the options change, hash will change and
controller-manager will rollout new DaemonSet/Deployment.