### PR TITLE
Bug 1754046: Modif kuryr-admission-controller pod definition

### DIFF
--- a/bindata/network/kuryr/001-rbac.yaml
+++ b/bindata/network/kuryr/001-rbac.yaml
@@ -18,6 +18,7 @@ rules:
   - list
   - update
   - patch
+  - delete
 - apiGroups: ["extensions"]
   resources:
   - networkpolicies

--- a/bindata/network/kuryr/009-admission-controller.yaml
+++ b/bindata/network/kuryr/009-admission-controller.yaml
@@ -25,6 +25,7 @@ spec:
         type: infra
         openshift.io/component: network
     spec:
+      serviceAccountName: kuryr
       containers:
       - name: kuryr-dns-admission-controller
         image: {{ .ControllerImage }}
@@ -35,6 +36,7 @@ spec:
         - --port=6443
         - --tls-private-key-file=/etc/webhook/tls.key
         - --tls-cert-file=/etc/webhook/tls.crt
+        - --ns=openshift-insights
         volumeMounts:
         - name: webhook-certs
           mountPath: /etc/webhook


### PR DESCRIPTION
Pass extra information to the kuryr-admission-controller so that it is able to identify the operators that must be restarted in case they don't have the proper dns configuration. The other side of this is handle in kuryr-kubernetes PR: https://github.com/openshift/kuryr-kubernetes/pull/108