### PR TITLE
osdn, ovnk: add publishNotReadyAddresses to metrics services

### DIFF
--- a/bindata/network/openshift-sdn/monitor.yaml
+++ b/bindata/network/openshift-sdn/monitor.yaml
@@ -30,6 +30,7 @@ spec:
   selector:
     app: sdn
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
   - name: metrics
     port: 9101

--- a/bindata/network/ovn-kubernetes/monitor.yaml
+++ b/bindata/network/ovn-kubernetes/monitor.yaml
@@ -31,6 +31,7 @@ spec:
   selector:
     app: ovnkube-master
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
   - name: metrics
     port: 9102
@@ -72,6 +73,7 @@ spec:
   selector:
     app: ovnkube-node
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
   - name: metrics
     port: 9101


### PR DESCRIPTION
Since these services are just used to configure Prometheus scrape targets, rather than load-balance traffic, we should not remove not-ready addresses from them.