### PR TITLE
ovn: use app label instead of name for master metrics and quorum guard

### DIFF
--- a/bindata/network/ovn-kubernetes/monitor.yaml
+++ b/bindata/network/ovn-kubernetes/monitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    name: ovnkube-master
+    app: ovnkube-master
   annotations:
     networkoperator.openshift.io/ignore-errors: ""
   name: monitor-ovn-master
@@ -24,7 +24,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: ovnkube-master
+    app: ovnkube-master
   name: ovn-kubernetes-master
   namespace: openshift-ovn-kubernetes
 spec:

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -10,7 +10,7 @@ spec:
   minAvailable: {{.OVN_MIN_AVAILABLE}}
   selector:
     matchLabels:
-      name: ovnkube-master
+      app: ovnkube-master
 
 ---
 


### PR DESCRIPTION
Finish what https://github.com/openshift/cluster-network-operator/pull/419 was trying to do. We need all the master things to use 'app' not 'name' for metrics scraping to work correctly.

@JacobTanenbaum @danwinship @juanluisvaladas @alexanderConstantinescu @rcarrillocruz @pecameron 