### PR TITLE
ovn: fix master control plane job name

### DIFF
--- a/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
@@ -17,7 +17,7 @@ spec:
         message: |
           there is no running ovn-kubernetes master
       expr: |
-        absent(up{job="ovn-kubernetes-master",namespace="openshift-ovn-kubernetes"} ==1)
+        absent(up{job="ovnkube-master",namespace="openshift-ovn-kubernetes"} ==1)
       for: 10m
       labels:
         severity: warning


### PR DESCRIPTION
It's ovnkube-master not ovn-kubernetes-master.

In conjunction with https://github.com/openshift/cluster-network-operator/pull/435 this should fix the prometheus NoRunningOvnMaster alert issue.