### PR TITLE
Remove some unwanted logging. Fix an error message

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -383,7 +383,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_KUBE_LOG_LEVEL
-          value: "{{.OvnkubeLogLevel}}"
+          value: 4
         - name: K8S_NODE
           valueFrom:
             fieldRef:

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -82,12 +82,6 @@ spec:
             nb_addr_list="${nb_addr_list}ssl:${host}:{{.OVN_NB_PORT}}"
             sb_addr_list="${sb_addr_list}ssl:${host}:{{.OVN_SB_PORT}}"
           done
-          echo /ovn-cert/tls.key
-          cat /ovn-cert/tls.key
-          echo /ovn-cert/tls.crt
-          cat /ovn-cert/tls.crt
-          echo /ovn-ca/ca-bundle.crt
-          cat /ovn-ca/ca-bundle.crt
           
           exec ovn-northd \
             --no-chdir "-vconsole:${OVN_LOG_LEVEL}" -vfile:off \
@@ -136,12 +130,6 @@ spec:
           OVN_NODES_ARRAY=({{.OVN_NODES}})
           MASTER_NODE=$(getent ahostsv4 "${OVN_NODES_ARRAY[0]}" | grep RAW | awk '{print $1}')
           LOCALHOST=$(getent ahostsv4 "${K8S_NODE}" | grep RAW | awk '{print $1}')
-          echo /ovn-cert/tls.key
-          cat /ovn-cert/tls.key
-          echo /ovn-cert/tls.crt
-          cat /ovn-cert/tls.crt
-          echo /ovn-ca/ca-bundle.crt
-          cat /ovn-ca/ca-bundle.crt
 
           if [[ "$LOCALHOST" == "$MASTER_NODE" ]]; then
             exec /usr/share/openvswitch/scripts/ovn-ctl \
@@ -240,12 +228,6 @@ spec:
           OVN_NODES_ARRAY=({{.OVN_NODES}})
           MASTER_NODE=$(getent ahostsv4 "${OVN_NODES_ARRAY[0]}" | grep RAW | awk '{print $1}')
           LOCALHOST=$(getent ahostsv4 "${K8S_NODE}" | grep RAW | awk '{print $1}')
-          echo /ovn-cert/tls.key
-          cat /ovn-cert/tls.key
-          echo /ovn-cert/tls.crt
-          cat /ovn-cert/tls.crt
-          echo /ovn-ca/ca-bundle.crt
-          cat /ovn-ca/ca-bundle.crt
 
           if [[ "$LOCALHOST" == "$MASTER_NODE" ]]; then
             exec /usr/share/openvswitch/scripts/ovn-ctl \
@@ -358,12 +340,6 @@ spec:
             nb_addr_list="${nb_addr_list}ssl:${host}:{{.OVN_NB_PORT}}"
             sb_addr_list="${sb_addr_list}ssl://${host}:{{.OVN_SB_PORT}}"
           done
-          echo /ovn-cert/tls.key
-          cat /ovn-cert/tls.key
-          echo /ovn-cert/tls.crt
-          cat /ovn-cert/tls.crt
-          echo /ovn-ca/ca-bundle.crt
-          cat /ovn-ca/ca-bundle.crt
           
           # start nbctl daemon for caching
           export OVN_NB_DAEMON=$(ovn-nbctl --pidfile=/run/openvswitch/ovnk-nbctl.pid \

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -128,12 +128,6 @@ spec:
             source "/env/${K8S_NODE}"
             set +o allexport
           fi
-          echo /ovn-cert/tls.key
-          cat /ovn-cert/tls.key
-          echo /ovn-cert/tls.crt
-          cat /ovn-cert/tls.crt
-          echo /ovn-ca/ca-bundle.crt
-          cat /ovn-ca/ca-bundle.crt
           exec ovn-controller unix:/var/run/openvswitch/db.sock -vfile:off \
             --no-chdir --pidfile=/var/run/openvswitch/ovn-controller.pid \
             -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt \
@@ -216,12 +210,6 @@ spec:
             nb_addr_list="${nb_addr_list}ssl://${host}:{{.OVN_NB_PORT}}"
             sb_addr_list="${sb_addr_list}ssl://${host}:{{.OVN_SB_PORT}}"
           done
-          echo /ovn-cert/tls.key
-          cat /ovn-cert/tls.key
-          echo /ovn-cert/tls.crt
-          cat /ovn-cert/tls.crt
-          echo /ovn-ca/ca-bundle.crt
-          cat /ovn-ca/ca-bundle.crt
 
           exec /usr/bin/ovnkube --init-node "${K8S_NODE}" \
             --cluster-subnets "${OVN_NET_CIDR}" \

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -240,7 +240,7 @@ spec:
         - name: KUBERNETES_SERVICE_HOST
           value: "{{.KUBERNETES_SERVICE_HOST}}"
         - name: OVN_KUBE_LOG_LEVEL
-          value: "{{.OvnkubeLogLevel}}"
+          value: 4
         - name: K8S_NODE
           valueFrom:
             fieldRef:

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -178,10 +178,6 @@ func boostrapOVN(kubeClient client.Client) (*bootstrap.BootstrapResult, error) {
 		return nil, fmt.Errorf("unable to bootstrap OVN, no master nodes found")
 	}
 
-	if len(masterNodeList.Items) < 3 {
-		return nil, fmt.Errorf("PHIL Need at least 3 nodes, have %d", len(masterNodeList.Items))
-	}
-
 	ovnMasterNodes := []string{}
 	for _, masterNode := range masterNodeList.Items {
 		ovnMasterNodes = append(ovnMasterNodes, masterNode.Name)

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -72,9 +72,6 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	}
 	data.Data["OVN_service_cidr"] = svcpools
 
-	// ovnkube config file
-	data.Data["OvnkubeLogLevel"] = 4
-
 	if c.HybridOverlayConfig != nil {
 		data.Data["OVNHybridOverlayNetCIDR"] = c.HybridOverlayConfig.HybridClusterNetwork[0].CIDR
 		data.Data["OVNHybridOverlayEnable"] = "true"


### PR DESCRIPTION
#333 added logging of the ovn-kube TLS keys to the startup of all of the daemons. I assume @pecameron did this for debugging reasons at one point and then forgot to remove it? If the admin wants to see the key they can just look at the Secret directly... we should not be logging private keys to pod logs.

I'm assuming that for the other fix here (removing "PHIL" from an error message) we actually do want to keep that check.