### PR TITLE
Allow to change the cluster default network type

### DIFF
--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -171,14 +171,17 @@ func (r *ReconcileOperConfig) Reconcile(request reconcile.Request) (reconcile.Re
 	// Compare against previous applied configuration to see if this change
 	// is safe.
 	if prev != nil {
-		// We may need to fill defaults here -- sort of as a poor-man's
-		// upconversion scheme -- if we add additional fields to the config.
-		err = network.IsChangeSafe(prev, &operConfig.Spec)
-		if err != nil {
-			log.Printf("Not applying unsafe change: %v", err)
-			r.status.SetDegraded(statusmanager.OperatorConfig, "InvalidOperatorConfig",
-				fmt.Sprintf("Not applying unsafe configuration change: %v. Use 'oc edit network.operator.openshift.io cluster' to undo the change.", err))
-			return reconcile.Result{}, err
+		// Check if the operator is put in the 'Network Migration' mode.
+		if _, ok := operConfig.GetAnnotations()[names.NetworkMigrationAnnotation]; !ok {
+			// We may need to fill defaults here -- sort of as a poor-man's
+			// upconversion scheme -- if we add additional fields to the config.
+			err = network.IsChangeSafe(prev, &operConfig.Spec)
+			if err != nil {
+				log.Printf("Not applying unsafe change: %v", err)
+				r.status.SetDegraded(statusmanager.OperatorConfig, "InvalidOperatorConfig",
+					fmt.Sprintf("Not applying unsafe configuration change: %v. Use 'oc edit network.operator.openshift.io cluster' to undo the change.", err))
+				return reconcile.Result{}, err
+			}
 		}
 	}
 

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -33,6 +33,10 @@ const IgnoreObjectErrorAnnotation = "networkoperator.openshift.io/ignore-errors"
 // that they are not critical to the functioning of the pod network
 const NonCriticalAnnotation = "networkoperator.openshift.io/non-critical"
 
+// NetworkMigrationAnnotation is an annotation on the networks.operator.openshift.io CR to indicate
+// that executing network migration (switching the default network type of the cluster) is allowed.
+const NetworkMigrationAnnotation = "networkoperator.openshift.io/network-migration"
+
 // SERVICE_CA_CONFIGMAP is the name of the ConfigMap that contains service CA bundle
 // that is used in multus admission controller deployment
 const SERVICE_CA_CONFIGMAP = "openshift-service-ca"


### PR DESCRIPTION
Allow users to change the cluster default network type by updating the 'networkType' field of the network.config.openshift.io CR. This not only support the use case of migrating the cluster network from Openshift SDN to OVN-Kubernetes, but also the use case vise Versa. 
