### PR TITLE
ovn: container env variables need quotes

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -383,7 +383,7 @@ spec:
             memory: 300Mi
         env:
         - name: OVN_KUBE_LOG_LEVEL
-          value: 4
+          value: "4"
         - name: K8S_NODE
           valueFrom:
             fieldRef:

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -240,7 +240,7 @@ spec:
         - name: KUBERNETES_SERVICE_HOST
           value: "{{.KUBERNETES_SERVICE_HOST}}"
         - name: OVN_KUBE_LOG_LEVEL
-          value: 4
+          value: "4"
         - name: K8S_NODE
           valueFrom:
             fieldRef:


### PR DESCRIPTION
@danwinship 

Otherwise:
`2020/01/08 03:54:48 could not apply (apps/v1, Kind=DaemonSet) openshift-ovn-kubernetes/ovnkube-master: could not create (apps/v1, Kind=DaemonSet) openshift-ovn-kubernetes/ovnkube-master: DaemonSet in version "v1" cannot be handled as a DaemonSet: v1.DaemonSet.Spec: v1.DaemonSetSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.Containers: []v1.Container: v1.Container.Env: []v1.EnvVar: v1.EnvVar.v1.EnvVar.Value: ReadString: expects " or n, but found 4, error found in #10 byte of ...|,"value":4},{"name":|..., bigger context ...|\n"],"env":[{"name":"OVN_KUBE_LOG_LEVEL","value":4},{"name":"K8S_NODE","valueFrom":{"fieldRef":{"fie|...`

Fixes: a5209000b556287a15cef2d6bc1dc78be85e0d17