### PR TITLE
Fix dhcp daemon api version

### DIFF
--- a/bindata/network/multus/003-dhcp-daemon.yaml
+++ b/bindata/network/multus/003-dhcp-daemon.yaml
@@ -1,5 +1,5 @@
 {{if .RenderDHCP}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: dhcp-daemon


### PR DESCRIPTION
Error in logs:
```
could not apply (extensions/v1beta1, Kind=DaemonSet) openshift-multus/dhcp-daemon: could not retrieve existing (extensions/v1beta1, Kind=DaemonSet) openshift-multus/dhcp-daemon: no matches for kind "DaemonSet" in version "extensions/v1beta1"
```

Signed-off-by: Sebastian Sch <sebassch@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openshift/cluster-network-operator/442)
<!-- Reviewable:end -->
