### PR TITLE
Change the metrics port for OVN-Kubernetes

### DIFF
--- a/bindata/network/ovn-kubernetes/monitor.yaml
+++ b/bindata/network/ovn-kubernetes/monitor.yaml
@@ -76,9 +76,9 @@ spec:
   publishNotReadyAddresses: true
   ports:
   - name: metrics
-    port: 9101
+    port: 9103
     protocol: TCP
-    targetPort: 9101
+    targetPort: 9103
   sessionAffinity: None
   type: ClusterIP
 ---

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -148,7 +148,7 @@ spec:
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
             ${hybrid_overlay_flags} \
             --pidfile /var/run/openvswitch/ovnkube-node.pid \
-            --metrics-bind-address "0.0.0.0:9101"
+            --metrics-bind-address "0.0.0.0:9103"
         env:
         - name: OVN_HYBRID_OVERLAY_ENABLE
           value: "{{ .OVNHybridOverlayEnable }}"
@@ -167,7 +167,7 @@ spec:
               fieldPath: spec.nodeName
         ports:
         - name: metrics-port
-          containerPort: 9101
+          containerPort: 9103
         securityContext:
           privileged: true
         terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
Change the port number from 9101 to 9103 to avoid the port conflict during SDN migration.

Per https://github.com/openshift/cluster-network-operator/pull/438#discussion_r364287748