### PR TITLE
Bug 1791277: Stop deploying kuryr-admission-controller if double listeners supported

### DIFF
--- a/bindata/network/kuryr/006-service.yaml
+++ b/bindata/network/kuryr/006-service.yaml
@@ -1,4 +1,4 @@
----
+{{if .AdmissionController}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,3 +12,4 @@ spec:
     targetPort: 6443
   selector:
     app: kuryr-dns-admission-controller
+{{- end}}

--- a/bindata/network/kuryr/007-admission.secret.yaml
+++ b/bindata/network/kuryr/007-admission.secret.yaml
@@ -1,4 +1,4 @@
----
+{{if .AdmissionController}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +7,4 @@ metadata:
 data:
   ca.crt: {{ .WebhookCA }}
   ca.key: {{ .WebhookCAKey }}
+{{- end}}

--- a/bindata/network/kuryr/008-webhook.secret.yaml
+++ b/bindata/network/kuryr/008-webhook.secret.yaml
@@ -1,4 +1,4 @@
----
+{{if .AdmissionController}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +7,4 @@ metadata:
 data:
   tls.crt: {{ .WebhookCert }}
   tls.key: {{ .WebhookKey }}
+{{- end}}

--- a/bindata/network/kuryr/009-admission-controller.yaml
+++ b/bindata/network/kuryr/009-admission-controller.yaml
@@ -1,4 +1,4 @@
----
+{{if .AdmissionController}}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -60,3 +60,4 @@ spec:
       - key: "node.kubernetes.io/not-ready"
         operator: Exists
         effect: NoSchedule
+{{- end}}

--- a/bindata/network/kuryr/010-webhook.yaml
+++ b/bindata/network/kuryr/010-webhook.yaml
@@ -1,4 +1,4 @@
----
+{{if .AdmissionController}}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -18,3 +18,4 @@ webhooks:
         apiGroups: [""]
         apiVersions: ["*"]
         resources: ["pods"]
+{{- end}}

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -5,19 +5,20 @@ import (
 )
 
 type KuryrBootstrapResult struct {
-	ServiceSubnet     string
-	PodSubnetpool     string
-	WorkerNodesRouter string
-	WorkerNodesSubnet string
-	PodSecurityGroups []string
-	ExternalNetwork   string
-	ClusterID         string
-	OctaviaProvider   string
-	OpenStackCloud    clientconfig.Cloud
-	WebhookCA         string
-	WebhookCAKey      string
-	WebhookCert       string
-	WebhookKey        string
+	ServiceSubnet            string
+	PodSubnetpool            string
+	WorkerNodesRouter        string
+	WorkerNodesSubnet        string
+	PodSecurityGroups        []string
+	ExternalNetwork          string
+	ClusterID                string
+	OctaviaProvider          string
+	OctaviaMultipleListeners bool
+	OpenStackCloud           clientconfig.Cloud
+	WebhookCA                string
+	WebhookCAKey             string
+	WebhookCert              string
+	WebhookKey               string
 }
 
 type OVNBootstrapResult struct {

--- a/pkg/network/kuryr.go
+++ b/pkg/network/kuryr.go
@@ -58,6 +58,9 @@ func renderKuryr(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapR
 	data.Data["PoolMinPorts"] = c.PoolMinPorts
 	data.Data["PoolBatchPorts"] = c.PoolBatchPorts
 
+	// deploy or not kuryr-admission-controller depending on double listeners support
+	data.Data["AdmissionController"] = !b.OctaviaMultipleListeners
+
 	// Octavia config data
 	data.Data["OctaviaProvider"] = b.OctaviaProvider
 	if b.OctaviaProvider == OVNProvider {


### PR DESCRIPTION
If octavia amphora provider supports double listeners, i.e.,
exposing the same port but on different protocol (e.g., udp and tcp)
then there is no need for deploying the kuryr-admission-controller
to enforce dns resolution over TCP, as we can create both udp and
tcp listeners on port 53 for the DNS service