### PR TITLE
Dynamic HA 

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -31,8 +31,6 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      # by default, Deployments spin up the new pod before terminating the old one
-      # but we don't want that - because ovsdb holds the lock.
       maxSurge: 0
       maxUnavailable: 1
   template:
@@ -47,6 +45,12 @@ spec:
       serviceAccountName: ovn-kubernetes-controller
       hostNetwork: true
       priorityClassName: "system-cluster-critical"
+      hostAliases:
+      {{range .OVN_INITIAL_CONTROL_PLANE_IPS}}
+      - ip: "{{ . }}"
+        hostnames:
+        - "{{$.OVN_DB_SVC}}"
+      {{end}}
       # volumes in all containers:
       # (container) -> (host)
       # /etc/openvswitch -> /var/lib/ovn/etc - ovsdb data
@@ -62,11 +66,16 @@ spec:
         - -c
         - |
           set -xe
+
+          source /root/ovnkube-helper.sh
+
           if [[ -f /env/_master ]]; then
             set -o allexport
             source /env/_master
             set +o allexport
           fi
+
+          watch_core_dns_ep &
 
           exec ovn-northd \
             --no-chdir "-vconsole:${OVN_LOG_LEVEL}" -vfile:off \
@@ -75,8 +84,12 @@ spec:
             --ovnsb-db "{{.OVN_SB_DB_LIST}}" \
             -p /ovn-cert/tls.key \
             -c /ovn-cert/tls.crt \
-            -C /ovn-ca/ca-bundle.crt 
+            -C /ovn-ca/ca-bundle.crt
         env:
+        - name: KUBERNETES_SERVICE_PORT
+          value: "{{.KUBERNETES_SERVICE_PORT}}"
+        - name: KUBERNETES_SERVICE_HOST
+          value: "{{.KUBERNETES_SERVICE_HOST}}"
         - name: OVN_LOG_LEVEL
           value: info 
         volumeMounts:
@@ -97,8 +110,6 @@ spec:
             cpu: 100m
             memory: 300Mi
         terminationMessagePolicy: FallbackToLogsOnError
-
-      # nbdb: the northbound, or logical network object DB. In raft mode 
       - name: nbdb
         image: "{{.OvnImage}}"
         command:
@@ -315,6 +326,9 @@ spec:
         - -c
         - |
           set -xe
+          
+          source /root/ovnkube-helper.sh
+          
           if [[ -f "/env/_master" ]]; then
             set -o allexport
             source "/env/_master"
@@ -329,10 +343,13 @@ spec:
             fi
           fi
 
+          watch_core_dns_ep &
+
           # start nbctl daemon for caching
           export OVN_NB_DAEMON=$(ovn-nbctl --pidfile=/run/openvswitch/ovnk-nbctl.pid \
             --detach \
             -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt \
+            --no-leader-only \
             --db "{{.OVN_NB_DB_LIST}}")
 
           exec /usr/bin/ovnkube \
@@ -345,7 +362,7 @@ spec:
             --sb-address "{{.OVN_SB_ADDR_LIST}}" \
             --sb-client-privkey /ovn-cert/tls.key \
             --sb-client-cert /ovn-cert/tls.crt \
-            --sb-client-cacert /ovn-ca/ca-bundle.crt
+            --sb-client-cacert /ovn-ca/ca-bundle.crt 
         lifecycle:
           preStop:
             exec:
@@ -378,6 +395,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: KUBERNETES_SERVICE_PORT
+          value: "{{.KUBERNETES_SERVICE_PORT}}"
+        - name: KUBERNETES_SERVICE_HOST
+          value: "{{.KUBERNETES_SERVICE_HOST}}"
         ports:
         - name: metrics-port
           containerPort: 9102

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -26,6 +26,12 @@ spec:
       hostNetwork: true
       hostPID: true
       priorityClassName: "system-node-critical"
+      hostAliases:
+      {{range .OVN_INITIAL_CONTROL_PLANE_IPS}}
+      - ip: "{{ . }}"
+        hostnames:
+        - "{{$.OVN_DB_SVC}}"
+      {{end}}
       # volumes in all containers:
       # (container) -> (host)
       # /etc/openvswitch -> /var/lib/openvswitch/etc - ovsdb system id
@@ -88,16 +94,20 @@ spec:
         - -c
         - |
           set -xe
+
+          source /root/ovnkube-helper.sh
+
           if [[ -f "/env/${K8S_NODE}" ]]; then
             set -o allexport
             source "/env/${K8S_NODE}"
             set +o allexport
           fi
+          
           cp -f /usr/libexec/cni/ovn-k8s-cni-overlay /cni-bin-dir/
-          ovn_config_namespace=openshift-ovn-kubernetes
+
           retries=0
           while true; do
-            db_ip=$(kubectl get ep -n ${ovn_config_namespace} ovnkube-db -o jsonpath='{.subsets[0].addresses[0].ip}')
+            db_ip=$(kubectl get ep -n ${OVN_NAMESPACE} ${OVN_DB_SVC_NAME} -o jsonpath='{.subsets[0].addresses[0].ip}')
             if [[ -n "${db_ip}" ]]; then
               break
             fi
@@ -109,6 +119,8 @@ spec:
             echo "waiting for db endpoint"
             sleep 5
           done
+
+          watch_core_dns_ep &
 
           hybrid_overlay_flags=
           if [[ -n "{{.OVNHybridOverlayEnable}}" ]]; then
@@ -122,7 +134,7 @@ spec:
             --cluster-subnets "${OVN_NET_CIDR}" \
             --k8s-service-cidr "${OVN_SVC_CIDR}" \
             --k8s-apiserver "{{.K8S_APISERVER}}" \
-            --ovn-config-namespace ${ovn_config_namespace} \
+            --ovn-config-namespace ${OVN_NAMESPACE} \
             --nb-address "{{.OVN_NB_ADDR_LIST}}" \
             --sb-address "{{.OVN_SB_ADDR_LIST}}" \
             --nb-client-privkey /ovn-cert/tls.key \
@@ -148,6 +160,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: OVN_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OVN_DB_SVC_NAME
+          value: "ovnkube-db"
         ports:
         - name: metrics-port
           containerPort: 9103


### PR DESCRIPTION
This PR introduces the notion of "dynamic HA" (concretely meaning: the control plane nodes that ovnkube is deployed on, can both appear and disappear without affecting the deployment). 

**Today**: we have a deployment of ovnkube which - once the amount of control plane nodes change -  re-deploys ovnkube from scratch across all nodes. Issues have been seen by @pecameron related to this which caused the filing of https://github.com/openshift/cluster-network-operator/pull/421. That PR waits for the amount of control plane nodes to match the amount of nodes specified by the user during the cluster creation. If that condition does not apply we do not proceed with the deployment however, which is not optimal. 

This PR introduces a utilization of the `ovnkube-db` service DNS to generically target all ovnkube pods through CoreDNS. The benefit of this is will be: no new re-deployment of ovnkube when a new node pops up or disappears. The daemonset will deploy ovnkube-master on the new node and all pods in the cluster will continue to function as nothing happened since they're communicating with the svc DNS and not a specific list of IPs.

This is the chain of execution to make this work:

1) cluster boots and the CNO populates the `OVN_CONTROL_PLANE_IPS` in the ovnkube-master/node templates as to populate /etc/hosts with the initial cluster members and allow for initial communication to happen
2) pods boot and we change the `nsswitch.conf` to specify that we first want to perform DNS resolution on dns first and files (/etc/hosts) second.
3) we launch a daemon process which will watch when CoreDNS is up, and once it is, change /etc/resolv.conf to point to that instead of the host's nameserver. 

This PR needs a corresponding PR in ovn-kubernetes downstreams, that one adds `--no-leader-only` to "non-daemon-mode" triggered `ovn-nbctl` and `ovn-sbctl` commands. 

https://github.com/openshift/ovn-kubernetes/pull/78

/assign @danwinship @dcbw 
  