### PR TITLE
Update Kuryr K8s resources to latest versions

### DIFF
--- a/bindata/network/kuryr/002-crds.yaml
+++ b/bindata/network/kuryr/002-crds.yaml
@@ -1,161 +1,179 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kuryrnets.openstack.org
 spec:
   group: openstack.org
-  version: v1
   scope: Cluster
   names:
     plural: kuryrnets
     singular: kuryrnet
     kind: KuryrNet
-  additionalPrinterColumns:
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
     - name: SUBNET-CIDR
       type: string
       description: The subnet CIDR allocated to the namespace
-      JSONPath: .spec.subnetCIDR
+      jsonPath: .spec.subnetCIDR
     - name: Age
       type: date
-      JSONPath: .metadata.creationTimestamp
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          required:
-          - netId
-          - routerId
-          - subnetCIDR
-          - subnetId
-          properties:
-            netId:
-              type: string
-            populated:
-              type: boolean
-            routerId:
-              type: string
-            sgId:
-              type: string
-            subnetCIDR:
-              type: string
-            subnetId:
-              type: string
+      jsonPath: .metadata.creationTimestamp
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            required:
+            - netId
+            - routerId
+            - subnetCIDR
+            - subnetId
+            properties:
+              netId:
+                type: string
+              populated:
+                type: boolean
+              routerId:
+                type: string
+              subnetCIDR:
+                type: string
+              subnetId:
+                type: string
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kuryrnetpolicies.openstack.org
 spec:
   group: openstack.org
-  version: v1
   scope: Namespaced
   names:
     plural: kuryrnetpolicies
     singular: kuryrnetpolicy
     kind: KuryrNetPolicy
     shortNames:
-      - knp
-  additionalPrinterColumns:
+    - knp
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
     - name: SG-ID
       type: string
       description: The ID of the SG associated to the policy
-      JSONPath: .spec.securityGroupId
+      jsonPath: .spec.securityGroupId
     - name: Age
       type: date
-      JSONPath: .metadata.creationTimestamp
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          required:
-          - egressSgRules
-          - ingressSgRules
-          - networkpolicy_spec
-          - podSelector
-          - securityGroupId
-          properties:
-            egressSgRules:
-              type: array
-              items:
-                type: object
-                required:
-                - security_group_rule
-                properties:
-                  remote_ip_prefixes:
-                    type: object
-                  namespace:
-                    type: string
-                  security_group_rule:
-                    type: object
-                    required:
-                    - id
-                    properties:
-                      description:
-                        type: string
-                      direction:
-                        type: string
-                      ethertype:
-                        type: string
-                      id:
-                        type: string
-                      port_range_max:
-                        type: integer
-                      port_range_min:
-                        type: integer
-                      protocol:
-                        type: string
-                      remote_ip_prefix:
-                        type: string
-                      security_group_id:
-                        type: string
-            ingressSgRules:
-              type: array
-              items:
-                type: object
-                required:
-                - security_group_rule
-                properties:
-                  remote_ip_prefixes:
-                    type: object
-                  namespace:
-                    type: string
-                  security_group_rule:
-                    type: object
-                    required:
-                    - id
-                    properties:
-                      description:
-                        type: string
-                      direction:
-                        type: string
-                      ethertype:
-                        type: string
-                      id:
-                        type: string
-                      port_range_max:
-                        type: integer
-                      port_range_min:
-                        type: integer
-                      protocol:
-                        type: string
-                      remote_ip_prefix:
-                        type: string
-                      security_group_id:
-                        type: string
-            networkpolicy_spec:
-              type: object
-              properties:
-                podSelector:
+      jsonPath: .metadata.creationTimestamp
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            required:
+            - egressSgRules
+            - ingressSgRules
+            - networkpolicy_spec
+            - podSelector
+            - securityGroupId
+            properties:
+              egressSgRules:
+                type: array
+                items:
                   type: object
-                policyTypes:
-                  type: array
-                ingress:
-                  type: array
-                egress:
-                  type: array
-            podSelector:
-              type: object
-            securityGroupId:
-              type: string
-            securityGroupName:
-              type: string
+                  required:
+                  - security_group_rule
+                  properties:
+                    remote_ip_prefixes:
+                      type: object
+                    namespace:
+                      type: string
+                    security_group_rule:
+                      type: object
+                      required:
+                      - id
+                      properties:
+                        description:
+                          type: string
+                        direction:
+                          type: string
+                        ethertype:
+                          type: string
+                        id:
+                          type: string
+                        port_range_max:
+                          type: integer
+                        port_range_min:
+                          type: integer
+                        protocol:
+                          type: string
+                        remote_ip_prefix:
+                          type: string
+                        security_group_id:
+                          type: string
+              ingressSgRules:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - security_group_rule
+                  properties:
+                    remote_ip_prefixes:
+                      type: object
+                    namespace:
+                      type: string
+                    security_group_rule:
+                      type: object
+                      required:
+                      - id
+                      properties:
+                        description:
+                          type: string
+                        direction:
+                          type: string
+                        ethertype:
+                          type: string
+                        id:
+                          type: string
+                        port_range_max:
+                          type: integer
+                        port_range_min:
+                          type: integer
+                        protocol:
+                          type: string
+                        remote_ip_prefix:
+                          type: string
+                        security_group_id:
+                          type: string
+              networkpolicy_spec:
+                type: object
+                properties:
+                  podSelector:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  policyTypes:
+                    type: array
+                    items:
+                      type: string
+                  ingress:
+                    type: array
+                    items:
+                      x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                  egress:
+                    type: array
+                    items:
+                      x-kubernetes-preserve-unknown-fields: true
+                      type: object
+              podSelector:
+                x-kubernetes-preserve-unknown-fields: true
+                type: object
+              securityGroupId:
+                type: string
+              securityGroupName:
+                type: string

--- a/bindata/network/kuryr/011-webhook.yaml
+++ b/bindata/network/kuryr/011-webhook.yaml
@@ -1,5 +1,5 @@
 {{if .AdmissionController}}
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: kuryr-dns-admission-controller
@@ -7,6 +7,8 @@ metadata:
     app: kuryr-dns-admission-controller
 webhooks:
   - name: kuryr-dns-admission-controller.openshift.io
+    sideEffects: None
+    admissionReviewVersions: ['v1', 'v1beta1']
     clientConfig:
       service:
         name: kuryr-dns-admission-controller


### PR DESCRIPTION
Webhooks and CRDs got out of beta with K8s 1.16. This commit updates
Kuryr resources to use the new v1 versions of them.