### PR TITLE
Bug 1796114: Kuryr: Do not reconfigure if LB providers change

### DIFF
--- a/bindata/network/kuryr/003-config.yaml
+++ b/bindata/network/kuryr/003-config.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: kuryr-config
   namespace: openshift-kuryr
+  annotations:
+    networkoperator.openshift.io/kuryr-octavia-provider: {{ .OctaviaProvider }}
 data:
   kuryr.conf: |+
     [DEFAULT]

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -37,6 +37,10 @@ const NonCriticalAnnotation = "networkoperator.openshift.io/non-critical"
 // that executing network migration (switching the default network type of the cluster) is allowed.
 const NetworkMigrationAnnotation = "networkoperator.openshift.io/network-migration"
 
+// KuryrOctaviaProviderAnnotation is used to save latest Octavia provider that was configured in order to
+// prevent from reconfiguring it automatically when underlying Octavia changes.
+const KuryrOctaviaProviderAnnotation = "networkoperator.openshift.io/kuryr-octavia-provider"
+
 // SERVICE_CA_CONFIGMAP is the name of the ConfigMap that contains service CA bundle
 // that is used in multus admission controller deployment
 const SERVICE_CA_CONFIGMAP = "openshift-service-ca"


### PR DESCRIPTION
When bootstrapping OpenStack resources CNO does autodetection of
available Octavia providers and if OVN provider is at hand Kuryr will
get configured to use it.

In order to make sure Kuryr won't get reconfigured when underlying
OpenStack cluster changes, an annotation marking the initial choice will
be saved to the kuryr-config ConfigMap created by CNO and if present CNO
will always choose that Octavia provider.

In order to force CNO to reconfigure Kuryr the annotation needs to be
manually removed by the user to indicate that this is intended and user
had followed upgrade documentation.