### PR TITLE
Bug 1769015: Add preserveUnknownFields to CRDs

### DIFF
--- a/bindata/network/openshift-sdn/001-crd.yaml
+++ b/bindata/network/openshift-sdn/001-crd.yaml
@@ -12,6 +12,7 @@ spec:
     plural: clusternetworks
     singular: clusternetwork
   scope: Cluster
+  preserveUnknownFields: false
   validation:
     # As compared to ValidateClusterNetwork, this does not validate that:
     #   - the hostSubnetLengths are valid for their CIDRs
@@ -147,6 +148,7 @@ spec:
     plural: hostsubnets
     singular: hostsubnet
   scope: Cluster
+  preserveUnknownFields: false
   validation:
     # As compared to ValidateHostSubnet, this does not validate that:
     #   - .host == .name
@@ -252,6 +254,7 @@ spec:
     plural: netnamespaces
     singular: netnamespace
   scope: Cluster
+  preserveUnknownFields: false
   validation:
     # As compared to ValidateNetNamespace, this does not validate that:
     #   - .netname == .name
@@ -333,6 +336,7 @@ spec:
     plural: egressnetworkpolicies
     singular: egressnetworkpolicy
   scope: Namespaced
+  preserveUnknownFields: false
   validation:
     # This should be mostly equivalent to ValidateEgressNetworkPolicy
     openAPIV3Schema:


### PR DESCRIPTION
It turns out the bug was failing validation because the implementation of `explain` barfs if the crd schema doesn't have the `preserveUnknownFields` in the spec.

PR https://github.com/openshift/origin/pull/24477 may need some rework after this merges.