### PR TITLE
Bug 1796562: sdn/ovn: don't allow ovs-vswitchd to clean up datapath flows on exit

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -55,12 +55,15 @@ spec:
             fi
           done
 
-          # launch OVS
           function quit {
-              /usr/share/openvswitch/scripts/ovs-ctl stop
+              # Don't allow ovs-vswitchd to clear datapath flows on exit
+              kill -9 $(cat /var/run/openvswitch/ovs-vswitchd.pid 2>/dev/null) 2>/dev/null || true
+              kill $(cat /var/run/openvswitch/ovsdb-server.pid 2>/dev/null) 2>/dev/null || true
               exit 0
           }
           trap quit SIGTERM
+
+          # launch OVS
           /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --no-ovs-vswitchd --system-id=random
 
           # Restrict the number of pthreads ovs-vswitchd creates to reduce the
@@ -129,10 +132,6 @@ spec:
               /usr/bin/ovs-vsctl -t 5 show > /dev/null
           initialDelaySeconds: 15
           periodSeconds: 5
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/usr/share/openvswitch/scripts/ovs-ctl", "stop"]
         terminationGracePeriodSeconds: 10
       nodeSelector:
         kubernetes.io/os: linux

--- a/bindata/network/ovn-kubernetes/006-ovs-node.yaml
+++ b/bindata/network/ovn-kubernetes/006-ovs-node.yaml
@@ -50,7 +50,9 @@ spec:
           chown -R openvswitch:openvswitch /run/openvswitch
           chown -R openvswitch:openvswitch /etc/openvswitch
           function quit {
-              /usr/share/openvswitch/scripts/ovs-ctl stop
+              # Don't allow ovs-vswitchd to clear datapath flows on exit
+              kill -9 $(cat /var/run/openvswitch/ovs-vswitchd.pid 2>/dev/null) 2>/dev/null || true
+              kill $(cat /var/run/openvswitch/ovsdb-server.pid 2>/dev/null) 2>/dev/null || true
               exit 0
           }
           trap quit SIGTERM
@@ -104,10 +106,6 @@ spec:
             - status
           initialDelaySeconds: 15
           periodSeconds: 5
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/usr/share/openvswitch/scripts/ovs-ctl", "stop"]
         terminationGracePeriodSeconds: 10
 
       nodeSelector:


### PR DESCRIPTION
When terminated gracefully, either via 'ovs-ctl stop' or TERM,
ovs-vswitchd cleans up datapath flows. This prevents any existing
flows from continuing to work, which kinda defeats the purpose of
a seamless upgrade.

@orgcandman @knobunc @danwinship @rcarrillocruz @smarterclayton 