### PR TITLE
Bug 1796718: ovn: use ovs-appctl ovsdb-server/sync-status for NB/SB DB readiness

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -169,8 +169,23 @@ spec:
                 fi
         readinessProbe:
           initialDelaySeconds: 30
-          tcpSocket:
-            port: {{.OVN_NB_PORT}}
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - |
+              set -xe
+              # Determine the ovn rundir.
+              if [[ -f /usr/bin/ovn-appctl ]] ; then
+                  # ovn-appctl is present. Use new ovn run dir path.
+                  DB_SOCK_PATH=/var/run/ovn/ovnnb_db.ctl
+                  APPCTL_PATH=/usr/bin/ovn-appctl
+              else
+                  # ovn-appctl is not present. Use openvswitch run dir path.
+                  DB_SOCK_PATH=/var/run/openvswitch/ovnnb_db.ctl
+                  APPCTL_PATH=/usr/bin/ovs-appctl
+              fi
+              exec ${APPCTL_PATH} -t ${DB_SOCK_PATH} ovsdb-server/sync-status
         env:
         - name: OVN_LOG_LEVEL
           value: info 
@@ -276,8 +291,23 @@ spec:
                 fi
         readinessProbe:
           initialDelaySeconds: 30
-          tcpSocket:
-            port: {{.OVN_SB_PORT}}
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - |
+              set -xe
+              # Determine the ovn rundir.
+              if [[ -f /usr/bin/ovn-appctl ]] ; then
+                  # ovn-appctl is present. Use new ovn run dir path.
+                  DB_SOCK_PATH=/var/run/ovn/ovnsb_db.ctl
+                  APPCTL_PATH=/usr/bin/ovn-appctl
+              else
+                  # ovn-appctl is not present. Use openvswitch run dir path.
+                  DB_SOCK_PATH=/var/run/openvswitch/ovnsb_db.ctl
+                  APPCTL_PATH=/usr/bin/ovs-appctl
+              fi
+              exec ${APPCTL_PATH} -t ${DB_SOCK_PATH} ovsdb-server/sync-status
         env:
         - name: OVN_LOG_LEVEL
           value: info 


### PR DESCRIPTION
Rather than connecting to the database TCP socket which just spams the
database logs with failed SSL connection messages.

@danwinship @openshift/networking 