### PR TITLE
Bug 1803697: Changing OVN DB readinessProbe to check membership status instead of DB status

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -187,7 +187,7 @@ spec:
                   DB_SOCK_PATH=/var/run/openvswitch/ovnnb_db.ctl
                   APPCTL_PATH=/usr/bin/ovs-appctl
               fi
-              exec ${APPCTL_PATH} -t ${DB_SOCK_PATH} ovsdb-server/sync-status
+              exec ${APPCTL_PATH} -t ${DB_SOCK_PATH} cluster/status OVN_Northbound  2>/dev/null | grep ${K8S_NODE_IP} | grep -v Address -q
         env:
         - name: OVN_LOG_LEVEL
           value: info 
@@ -311,7 +311,7 @@ spec:
                   DB_SOCK_PATH=/var/run/openvswitch/ovnsb_db.ctl
                   APPCTL_PATH=/usr/bin/ovs-appctl
               fi
-              exec ${APPCTL_PATH} -t ${DB_SOCK_PATH} ovsdb-server/sync-status
+              exec ${APPCTL_PATH} -t ${DB_SOCK_PATH} cluster/status OVN_Southbound  2>/dev/null | grep ${K8S_NODE_IP} | grep -v Address -q
         env:
         - name: OVN_LOG_LEVEL
           value: info 


### PR DESCRIPTION
This PR fixes the recently changed `readinessProbe` for `nbdb` and `sbdb` to check each pod's membership status instead of the general cluster status. 

Some background concerning this change (as to understand the implemented check better): 

We should check raft cluster status using `ovs-appctl -t /var/run/openvswitch/ovnnb_db.ctl  cluster/status OVN_Northbound`, which outputs 

```
sh-4.2#  ovs-appctl -t /var/run/openvswitch/ovnnb_db.ctl  cluster/status OVN_Northbound       
f782
Name: OVN_Northbound
Cluster ID: f72d (f72d04b2-f90e-4ce0-98a4-3636e668d1e7)
Server ID: f782 (f7826705-a5a9-4e4c-b2a0-935da3d72743)
Address: ssl:10.0.146.224:9643
Status: cluster member
Role: follower
Term: 3
Leader: 1b1b
Vote: 1b1b

Election timer: 1000
Log: [2, 1699]
Entries not yet committed: 0
Entries not yet applied: 0
Connections: ->0368 ->1b1b <-1b1b <-0368
Servers:
    0368 (0368 at ssl:10.0.137.205:9643)
    f782 (f782 at ssl:10.0.146.224:9643) (self)
    1b1b (1b1b at ssl:10.0.134.97:9643)
```

The following will be returned in the case that the pod is not a member of the cluster (has left or otherwise):

```
sh-4.2#  ovs-appctl -t /var/run/openvswitch/ovnnb_db.ctl  cluster/status OVN_Northbound
unknown cluster
ovs-appctl: /var/run/openvswitch/ovnnb_db.ctl: server returned an error
```

/assign @dcbw 