### PR TITLE
Bug 1800633: Ensure etcd and authentication operator resolves dns over TCP

### DIFF
--- a/bindata/network/kuryr/010-admission-controller.yaml
+++ b/bindata/network/kuryr/010-admission-controller.yaml
@@ -37,6 +37,8 @@ spec:
         - --tls-private-key-file=/etc/webhook/tls.key
         - --tls-cert-file=/etc/webhook/tls.crt
         - --ns=openshift-insights
+        - --ns=openshift-etcd-operator
+        - --ns=openshift-authentication-operator
         volumeMounts:
         - name: webhook-certs
           mountPath: /etc/webhook


### PR DESCRIPTION
The etcd and authentication operators pods might start before the Kuryr admission
controller is running, resulting in no dnsConfig option injected
on the pod spec to allow DNS resolution over TCP, and consequently
failure on DNS resolution.
This commit ensures the pods will have the option in place.