### PR TITLE
Bug 1779863: backport ovn-controller rbac fix to 4.3  

### DIFF
--- a/bindata/network/ovn-kubernetes/003-rbac-controller.yaml
+++ b/bindata/network/ovn-kubernetes/003-rbac-controller.yaml
@@ -66,6 +66,12 @@ rules:
   - use
   resourceNames:
   - privileged
+- apiGroups: [""]
+  resources:
+  - "nodes/status"
+  verbs:
+  - patch
+  - update
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
All e2e-gcp-ovn jobs are failing (at least in part) due to RBAC problems: https://prow.svc.ci.openshift.org/job-history/origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-ovn-4.3

Back-port 1e843cb6ba3d524cb2c84d640206bc9f15788768 to 4.3 to fix this error.