### PR TITLE
WIP: Save the ovs flows before terminating the ovs pod

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -56,6 +56,10 @@ spec:
           done
 
           function quit {
+              # Save the flows
+              bridges=$(ovs-vsctl -- --real list-br)
+              /usr/share/openvswitch/scripts/ovs-save save-flows $bridges > /var/run/openvswitch/flows.sh
+
               # Don't allow ovs-vswitchd to clear datapath flows on exit
               kill -9 $(cat /var/run/openvswitch/ovs-vswitchd.pid 2>/dev/null) 2>/dev/null || true
               kill $(cat /var/run/openvswitch/ovsdb-server.pid 2>/dev/null) 2>/dev/null || true
@@ -64,7 +68,15 @@ spec:
           trap quit SIGTERM
 
           # launch OVS
+          # Start the ovsdb so that we can prep it before we start the ovs-vswitchd
           /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --no-ovs-vswitchd --system-id=random
+
+          # Load any flows that we saved
+          ovs-vsctl --no-wait set open_vswitch . other_config:flow-restore-wait=true
+          if [[ -f /var/run/openvswitch/flows.sh ]]; then
+             sh /var/run/openvswitch/flows.sh
+          fi
+          ovs-vsctl --if-exists remove open_vswitch . other_config flow-restore-wait=true
 
           # Restrict the number of pthreads ovs-vswitchd creates to reduce the
           # amount of RSS it uses on hosts with many cores
@@ -74,6 +86,8 @@ spec:
               ovs-vsctl --no-wait set Open_vSwitch . other_config:n-revalidator-threads=4
               ovs-vsctl --no-wait set Open_vSwitch . other_config:n-handler-threads=10
           fi
+
+          # And finally start the ovs-vswitchd now the DB is prepped
           /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --no-ovsdb-server --system-id=random
 
           tail -F --pid=$(cat /var/run/openvswitch/ovs-vswitchd.pid) /var/log/openvswitch/ovs-vswitchd.log &


### PR DESCRIPTION
This saves the ovs flows when a pod is shut down and restores them
when a pod is restarted.  This should make the ovs behavior better
match that of a system daemon and make it respond to packets more
rapidly, rather than being empty when the pod restarts and waiting for
the sdn container to reprogam all of the rules.