### PR TITLE
Bug 1807638: Minimize disruption to pod network while OVS is being upgraded

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -73,16 +73,8 @@ spec:
           # Start the ovsdb so that we can prep it before we start the ovs-vswitchd
           /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --no-ovs-vswitchd --system-id=random
 
-          # Load any flows that we saved
-          echo "info: Loading previous flows ..." 2>&1
+          # Set the flow-restore-wait to true so ovs-vswitchd will wait till flows are restored
           ovs-vsctl --no-wait set Open_vSwitch . other_config:flow-restore-wait=true
-          if [[ -f /var/run/openvswitch/flows.sh ]]; then
-             echo "info: Execute flow script ..." 2>&1
-             sh -x /var/run/openvswitch/flows.sh
-          fi
-          echo "info: Remove other config ..." 2>&1
-          ovs-vsctl --no-wait --if-exists remove Open_vSwitch . other_config flow-restore-wait=true
-          echo "info: Removed other config ..." 2>&1
           
           # Restrict the number of pthreads ovs-vswitchd creates to reduce the
           # amount of RSS it uses on hosts with many cores
@@ -95,6 +87,17 @@ spec:
 
           # And finally start the ovs-vswitchd now the DB is prepped
           /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --no-ovsdb-server --system-id=random
+
+          # Load any flows that we saved
+          echo "info: Loading previous flows ..." 2>&1
+          if [[ -f /var/run/openvswitch/flows.sh ]]; then
+             echo "info: Execute flow script ..." 2>&1
+             sh -x /var/run/openvswitch/flows.sh
+          fi
+          
+          echo "info: Remove other config ..." 2>&1
+          ovs-vsctl --no-wait --if-exists remove Open_vSwitch . other_config flow-restore-wait=true
+          echo "info: Removed other config ..." 2>&1
 
           tail -F --pid=$(cat /var/run/openvswitch/ovs-vswitchd.pid) /var/log/openvswitch/ovs-vswitchd.log &
           tail -F --pid=$(cat /var/run/openvswitch/ovsdb-server.pid) /var/log/openvswitch/ovsdb-server.log &

--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -56,6 +56,12 @@ spec:
           done
 
           function quit {
+              # Save the flows
+              echo "info: Saving flows ..." 2>&1
+              bridges=$(ovs-vsctl -- --real list-br)
+              /usr/share/openvswitch/scripts/ovs-save save-flows $bridges > /var/run/openvswitch/flows.sh
+              echo "info: Saved flows" 2>&1
+
               # Don't allow ovs-vswitchd to clear datapath flows on exit
               kill -9 $(cat /var/run/openvswitch/ovs-vswitchd.pid 2>/dev/null) 2>/dev/null || true
               kill $(cat /var/run/openvswitch/ovsdb-server.pid 2>/dev/null) 2>/dev/null || true
@@ -64,8 +70,20 @@ spec:
           trap quit SIGTERM
 
           # launch OVS
+          # Start the ovsdb so that we can prep it before we start the ovs-vswitchd
           /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --no-ovs-vswitchd --system-id=random
 
+          # Load any flows that we saved
+          echo "info: Loading previous flows ..." 2>&1
+          ovs-vsctl --no-wait set Open_vSwitch . other_config:flow-restore-wait=true
+          if [[ -f /var/run/openvswitch/flows.sh ]]; then
+             echo "info: Execute flow script ..." 2>&1
+             sh -x /var/run/openvswitch/flows.sh
+          fi
+          echo "info: Remove other config ..." 2>&1
+          ovs-vsctl --no-wait --if-exists remove Open_vSwitch . other_config flow-restore-wait=true
+          echo "info: Removed other config ..." 2>&1
+          
           # Restrict the number of pthreads ovs-vswitchd creates to reduce the
           # amount of RSS it uses on hosts with many cores
           # https://bugzilla.redhat.com/show_bug.cgi?id=1571379
@@ -74,6 +92,8 @@ spec:
               ovs-vsctl --no-wait set Open_vSwitch . other_config:n-revalidator-threads=4
               ovs-vsctl --no-wait set Open_vSwitch . other_config:n-handler-threads=10
           fi
+
+          # And finally start the ovs-vswitchd now the DB is prepped
           /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --no-ovsdb-server --system-id=random
 
           tail -F --pid=$(cat /var/run/openvswitch/ovs-vswitchd.pid) /var/log/openvswitch/ovs-vswitchd.log &

--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -59,7 +59,7 @@ spec:
               # Save the flows
               echo "info: Saving flows ..." 2>&1
               bridges=$(ovs-vsctl -- --real list-br)
-              /usr/share/openvswitch/scripts/ovs-save save-flows $bridges > /var/run/openvswitch/flows.sh
+              TMPDIR=/var/run/openvswitch /usr/share/openvswitch/scripts/ovs-save save-flows $bridges > /var/run/openvswitch/flows.sh
               echo "info: Saved flows" 2>&1
 
               # Don't allow ovs-vswitchd to clear datapath flows on exit


### PR DESCRIPTION
During OVS shutdown and startup, attempt to preserve all existing flows in the kernel while the OVS daemon is offline, and during startup avoid clearing those flows.

While this does not completely mitigate dropped / failed connections while OVS is upgrading, it dramatically reduces the amount of time user applications are impacted both by upgrades or by unexpected disruption (an OOM kill or OVS crash).  Future changes will build on this to try to make OVS upgrade completely transparent to end user applications.

Known gaps:

* ARP flows are potentially still being lost for new connections (workarounds being investigated with OVS team).