### PR TITLE
Bug 1802606: pkg/util: Fix URI validation to modern standards

### DIFF
--- a/pkg/util/validation/network.go
+++ b/pkg/util/validation/network.go
@@ -57,18 +57,14 @@ func Port(port int) error {
 	return nil
 }
 
-// URI validates uri as being a valid url and returns the url scheme.
+// URI validates uri as being a http(s) valid url and returns the url scheme.
 func URI(uri string) (string, error) {
-	parsed, err := url.Parse(uri)
+	parsed, err := url.ParseRequestURI(uri)
 	if err != nil {
 		return "", err
 	}
 	if !parsed.IsAbs() {
 		return "", fmt.Errorf("failed validating URI, no scheme for URI %q", uri)
-	}
-	host := parsed.Hostname()
-	if err := Host(host); err != nil {
-		return "", fmt.Errorf("failed validating URI %q: %v", uri, err)
 	}
 	if port := parsed.Port(); len(port) != 0 {
 		intPort, err := strconv.Atoi(port)

--- a/pkg/util/validation/network_test.go
+++ b/pkg/util/validation/network_test.go
@@ -1,0 +1,49 @@
+package validation
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+// URI validates uri as being a valid http(s) url and returns the url scheme.
+func TestURI(t *testing.T) {
+	g := NewGomegaWithT(t)
+	validHTTPURIs := []string{
+		"http://1.2.3.4",
+		"http://1.2.3.4/",
+		"http://1.2.3.4:80",
+		"http://1.2.3.4:80/",
+		"http://redhat",
+		"http://red_hat.com",
+		"http://redhat.com",
+		"http://REDHAT.COM",
+		"http://RedHat.com",
+		"http://redhat.com/",
+		"http://redhat.com:80",
+		"http://redhat.com:80/",
+		"http://-8080:8080/",
+		"http://日©ñعசிש.com",
+	}
+	validHTTPSURIs := []string{
+		"https://1.2.3.4",
+		"https://EXAMPLe.com:8080/",
+	}
+	invalidURIs := []string{
+		"http://1.2.3.4:8080808080",
+		"redhat.com",
+	}
+	for _, uri := range validHTTPURIs {
+		_, err := URI(uri)
+		g.Expect(err).NotTo(HaveOccurred())
+	}
+	for _, uri := range validHTTPSURIs {
+		_, err := URI(uri)
+		g.Expect(err).NotTo(HaveOccurred())
+	}
+	for _, uri := range invalidURIs {
+		_, err := URI(uri)
+		g.Expect(err).To(HaveOccurred())
+	}
+
+}


### PR DESCRIPTION
We were validating agains a subset of RFC-1123, which is invalid.
DNS allows much fancier stuff, this delegates validation to golang and
gets some stuff for free, such as IDNs.

