### PR TITLE
Bug 1805987: Uses the readiness indicator file option for Multus

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -132,7 +132,11 @@ spec:
         - "--multus-conf-file=auto"
         - "--multus-autoconfig-dir=/host/var/run/multus/cni/net.d"
         - "--multus-kubeconfig-file-host=/etc/kubernetes/cni/net.d/multus.d/multus.kubeconfig"
+{{- if eq .DefaultNetworkType "OpenShiftSDN"}}
         - "--readiness-indicator-file=/var/run/multus/cni/net.d/80-openshift-network.conf"
+{{- else if eq .DefaultNetworkType "OVNKubernetes"}}
+        - "--readiness-indicator-file=/var/run/multus/cni/net.d/10-ovn-kubernetes.conf"
+{{- end}}
         - "--cleanup-config-on-exit=true"
         - "--namespace-isolation=true"
         - "--multus-log-level=verbose"

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -132,6 +132,7 @@ spec:
         - "--multus-conf-file=auto"
         - "--multus-autoconfig-dir=/host/var/run/multus/cni/net.d"
         - "--multus-kubeconfig-file-host=/etc/kubernetes/cni/net.d/multus.d/multus.kubeconfig"
+        - "--readiness-indicator-file=/var/run/multus/cni/net.d/80-openshift-network.conf"
         - "--cleanup-config-on-exit=true"
         - "--namespace-isolation=true"
         - "--multus-log-level=verbose"

--- a/pkg/network/multus.go
+++ b/pkg/network/multus.go
@@ -34,7 +34,7 @@ func RenderMultus(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Unstruct
 	out = append(out, objs...)
 
 	usedhcp := UseDHCP(conf)
-	objs, err = renderMultusConfig(manifestDir, usedhcp)
+	objs, err = renderMultusConfig(manifestDir, string(conf.DefaultNetwork.Type), usedhcp)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func RenderMultus(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Unstruct
 }
 
 // renderMultusConfig returns the manifests of Multus
-func renderMultusConfig(manifestDir string, useDHCP bool) ([]*uns.Unstructured, error) {
+func renderMultusConfig(manifestDir, defaultNetworkType string, useDHCP bool) ([]*uns.Unstructured, error) {
 	objs := []*uns.Unstructured{}
 
 	// render the manifests on disk
@@ -56,6 +56,7 @@ func renderMultusConfig(manifestDir string, useDHCP bool) ([]*uns.Unstructured, 
 	data.Data["RenderDHCP"] = useDHCP
 	data.Data["MultusCNIConfDir"] = MultusCNIConfDir
 	data.Data["SystemCNIConfDir"] = SystemCNIConfDir
+	data.Data["DefaultNetworkType"] = defaultNetworkType
 
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/multus"), &data)
 	if err != nil {


### PR DESCRIPTION
This helps to smooth out inconsistencies during an upgrade and helps Multus know openshift-sdn is ready.

This depends on https://github.com/openshift/multus-cni/pull/47 and likely will not pass CI until that is merged.