### PR TITLE
DO NOT MERGE: Update OVS daemonset pods only on deletion

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -13,9 +13,12 @@ spec:
     matchLabels:
       app: ovs
   updateStrategy:
-    type: RollingUpdate
+    type: OnDelete
   template:
     metadata:
+      annotations:
+        # Indicates this daemonset must be purged during shutdown
+        upgrade.openshift.io/delete-on-node-shutdown: "true"
       labels:
         app: ovs
         component: network


### PR DESCRIPTION
Move the responsibility for updating the OVS daemonset to node
drain by indicating pods should remain until deleted, and annotating
the pod with `upgrade.openshift.io/delete-on-node-shutdown` to
instruct the MCD to purge the pod during shutdown.

The controller will report available once the DS is updated, but
go degraded if 2 hours pass without the DS reaching availability.