### PR TITLE
Bug 1775838: Back-port, OVNKubernetes: introduce OVS anti-selector

### DIFF
--- a/bindata/network/ovn-kubernetes/006-ovs-node.yaml
+++ b/bindata/network/ovn-kubernetes/006-ovs-node.yaml
@@ -1,0 +1,148 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: ovs-node
+  namespace: openshift-ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This daemonset launches  Open vSwitch per-node networking components.
+    release.openshift.io/version: "{{.ReleaseVersion}}"
+spec:
+  selector:
+    matchLabels:
+      app: ovs-node
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: ovs-node
+        component: network
+        type: infra
+        openshift.io/component: network
+        kubernetes.io/os: "linux"
+    spec:
+      serviceAccountName: ovn-kubernetes-node
+      hostNetwork: true
+      hostPID: true
+      priorityClassName: "system-node-critical"
+      # volumes in all containers:
+      # (container) -> (host)
+      # /etc/openvswitch -> /var/lib/openvswitch/etc - ovsdb system id
+      # /var/lib/openvswitch -> /var/lib/openvswitch/data - ovsdb data
+      # /run/openvswitch -> tmpfs - ovsdb sockets
+      # /env -> configmap env-overrides - debug overrides
+      containers:
+      # ovsdb and ovs-vswitchd
+      - name: ovs-daemons
+        image: "{{.OvnImage}}"
+        command:
+        - /bin/bash
+        - -c
+        - |
+          #!/bin/bash
+          set -e
+          if [[ -f "/env/${K8S_NODE}" ]]; then
+            set -o allexport
+            source "/env/${K8S_NODE}"
+            set +o allexport
+          fi
+          if [[ -f "/old/openvswitch/conf.db" && ! -f "/etc/openvswitch/conf.db" ]]; then
+            mv /old/openvswitch/conf.db /etc/openvswitch/conf.db
+          fi
+          chown -R openvswitch:openvswitch /run/openvswitch
+          chown -R openvswitch:openvswitch /etc/openvswitch
+          function quit {
+              # Don't allow ovs-vswitchd to clear datapath flows on exit
+              kill -9 $(cat /var/run/openvswitch/ovs-vswitchd.pid 2>/dev/null) 2>/dev/null || true
+              kill $(cat /var/run/openvswitch/ovsdb-server.pid 2>/dev/null) 2>/dev/null || true
+              exit 0
+          }
+          trap quit SIGTERM
+          /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --system-id=random
+          ovs-appctl vlog/set "file:${OVS_LOG_LEVEL}"
+          /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol
+          tail -F --pid=$(cat /var/run/openvswitch/ovs-vswitchd.pid) /var/log/openvswitch/ovs-vswitchd.log &
+          tail -F --pid=$(cat /var/run/openvswitch/ovsdb-server.pid) /var/log/openvswitch/ovsdb-server.log &
+          wait
+        env:
+        - name: OVS_LOG_LEVEL
+          value: info
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: host-modules
+          readOnly: true
+        - mountPath: /sys
+          name: host-sys
+          readOnly: true
+        - mountPath: /run/openvswitch
+          name: run-openvswitch
+        - mountPath: /etc/openvswitch
+          name: etc-openvswitch
+        - mountPath: /old/openvswitch
+          name: old-openvswitch-database
+        - mountPath: /var/lib/openvswitch
+          name: var-lib-openvswitch
+        - mountPath: /env
+          name: env-overrides
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        livenessProbe:
+          exec:
+            command:
+            - /usr/share/openvswitch/scripts/ovs-ctl
+            - status
+          initialDelaySeconds: 15
+          periodSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - /usr/share/openvswitch/scripts/ovs-ctl
+            - status
+          initialDelaySeconds: 15
+          periodSeconds: 5
+        terminationGracePeriodSeconds: 10
+
+      nodeSelector:
+        beta.kubernetes.io/os: "linux"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: network.operator.openshift.io/external-openvswitch
+                operator: DoesNotExist        
+      volumes:
+      - name: host-modules
+        hostPath:
+          path: /lib/modules
+      - name: var-lib-openvswitch
+        hostPath:
+          path: /var/lib/openvswitch/data
+      # commit 0ac2cd changed the location of the ovs database, mount and check if a database already exists
+      - name: old-openvswitch-database
+        path: /etc/origin/openvswitch
+      - name: etc-openvswitch
+        hostPath:
+          path: /var/lib/openvswitch/etc
+      - name: run-openvswitch
+        hostPath:
+          path: /run/openvswitch
+      - name: host-sys
+        hostPath:
+          path: /sys
+      - name: env-overrides
+        configMap:
+          name: env-overrides
+          optional: true
+      tolerations:
+      - operator: "Exists"

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -33,86 +33,6 @@ spec:
       # /run/openvswitch -> tmpfs - ovsdb sockets
       # /env -> configmap env-overrides - debug overrides
       containers:
-      # ovsdb and ovs-vswitchd
-      - name: ovs-daemons
-        image: "{{.OvnImage}}"
-        command:
-        - /bin/bash
-        - -c
-        - |
-          #!/bin/bash
-          set -e
-          if [[ -f "/env/${K8S_NODE}" ]]; then
-            set -o allexport
-            source "/env/${K8S_NODE}"
-            set +o allexport
-          fi
-          if [[ -f "/old/openvswitch/conf.db" && ! -f "/etc/openvswitch/conf.db" ]]; then
-            mv /old/openvswitch/conf.db /etc/openvswitch/conf.db
-          fi
-          chown -R openvswitch:openvswitch /run/openvswitch
-          chown -R openvswitch:openvswitch /etc/openvswitch
-          function quit {
-              # Don't allow ovs-vswitchd to clear datapath flows on exit
-              kill -9 $(cat /var/run/openvswitch/ovs-vswitchd.pid 2>/dev/null) 2>/dev/null || true
-              kill $(cat /var/run/openvswitch/ovsdb-server.pid 2>/dev/null) 2>/dev/null || true
-              exit 0
-          }
-          trap quit SIGTERM
-          /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --system-id=random
-          ovs-appctl vlog/set "file:${OVS_LOG_LEVEL}"
-          /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol
-
-          tail -F --pid=$(cat /var/run/openvswitch/ovs-vswitchd.pid) /var/log/openvswitch/ovs-vswitchd.log &
-          tail -F --pid=$(cat /var/run/openvswitch/ovsdb-server.pid) /var/log/openvswitch/ovsdb-server.log &
-          wait
-        env:
-        - name: OVS_LOG_LEVEL
-          value: info
-        - name: K8S_NODE
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: host-modules
-          readOnly: true
-        - mountPath: /sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /run/openvswitch
-          name: run-openvswitch
-        - mountPath: /etc/openvswitch
-          name: etc-openvswitch
-        - mountPath: /old/openvswitch
-          name: old-openvswitch-database
-        - mountPath: /var/lib/openvswitch
-          name: var-lib-openvswitch
-        - mountPath: /env
-          name: env-overrides
-        resources:
-          requests:
-            cpu: 100m
-            memory: 300Mi
-        terminationMessagePolicy: FallbackToLogsOnError
-        livenessProbe:
-          exec:
-            command:
-            - /usr/share/openvswitch/scripts/ovs-ctl
-            - status
-          initialDelaySeconds: 15
-          periodSeconds: 5
-        readinessProbe:
-          exec:
-            command:
-            - /usr/share/openvswitch/scripts/ovs-ctl
-            - status
-          initialDelaySeconds: 15
-          periodSeconds: 5
-        terminationGracePeriodSeconds: 10
-
       # ovn-controller: programs the vswitch with flows from the sbdb
       - name: ovn-controller
         image: "{{.OvnImage}}"
@@ -199,7 +119,6 @@ spec:
             echo "waiting for db endpoint"
             sleep 5
           done
-
           hybrid_overlay_flags=
           if [[ -n "{{.OVNHybridOverlayEnable}}" ]]; then
             hybrid_overlay_flags="--enable-hybrid-overlay"
@@ -222,8 +141,6 @@ spec:
             ${hybrid_overlay_flags} \
             --metrics-bind-address "0.0.0.0:9101"
         env:
-        - name: OVN_KUBE_LOG_LEVEL
-          value: "4"
         # for kubectl
         - name: KUBERNETES_SERVICE_PORT
           value: "{{.KUBERNETES_SERVICE_PORT}}"
@@ -300,9 +217,6 @@ spec:
       - name: host-slash
         hostPath:
           path: /
-      - name: host-modules
-        hostPath:
-          path: /lib/modules
       - name: host-run-netns
         hostPath:
           path: /run/netns
@@ -318,16 +232,10 @@ spec:
       - name: run-ovn
         hostPath:
           path: /var/run/ovn
-      # commit 0ac2cd changed the location of the ovs database, mount and check if a database already exists
-      - name: old-openvswitch-database
-        path: /etc/origin/openvswitch
       # For CNI server
       - name: host-run-ovn-kubernetes
         hostPath:
           path: /run/ovn-kubernetes
-      - name: host-sys
-        hostPath:
-          path: /sys
       - name: host-cni-bin
         hostPath:
           path: "{{.CNIBinDir}}"


### PR DESCRIPTION
/hold

While waiting for PR:  https://github.com/openshift/cluster-network-operator/pull/483 to get in 

OVNKubernetes is shipped with its own openvswitch service running
as a separate daemonset. However, in some cases we may want to use
an external openvswitch running on the host (e.g. to use it for
host networking). In order to support a mixed environment where some
hosts have this external service and some don't, we introduce an
openvswitch anti-selector:

network.operator.openshift.io/external-openvswitch

Note that this selector has to be set before the operator is started.
Otherwise, the label would not take effect on already scheduled
pods.