### PR TITLE
Bug 1789881: Start ovn correctly with hybrid networking

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -362,7 +362,7 @@ spec:
 
           hybrid_overlay_flags=
           if [[ -n "{{.OVNHybridOverlayEnable }}" ]]; then
-            hybrid_overlay_flags="--enable-hybrid-overlay"
+            hybrid_overlay_flags="--enable-hybrid-overlay --no-hostsubnet-nodes=\"kubernetes.io/os=windows\""
             if [[ -n "{{.OVNHybridOverlayNetCIDR}}" ]]; then
               hybrid_overlay_flags="${hybrid_overlay_flags} --hybrid-overlay-cluster-subnets={{.OVNHybridOverlayNetCIDR}}"
             fi


### PR DESCRIPTION
Tell ovn to not assign hostsubnets to nodes labeled

kubernetes.io/os=windows

when enabeling hybrid networking. This ensures correct operation as the
node deals with it's own hostsubnet

fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1789881