### PR TITLE
Bug 1797894: Don't add empty MachineCIDR to noProxy

### DIFF
--- a/pkg/util/proxyconfig/no_proxy.go
+++ b/pkg/util/proxyconfig/no_proxy.go
@@ -50,8 +50,13 @@ func MergeUserSystemNoProxy(proxy *configv1.Proxy, infra *configv1.Infrastructur
 		"localhost",
 		".svc",
 		".cluster.local",
-		ic.Networking.MachineCIDR,
 	)
+	if ic.Networking.MachineCIDR != "" {
+		if _, _, err := net.ParseCIDR(ic.Networking.MachineCIDR); err != nil {
+			return "", fmt.Errorf("MachineCIDR has an invalid CIDR: %s", ic.Networking.MachineCIDR)
+		}
+		set.Insert(ic.Networking.MachineCIDR)
+	}
 
 	for _, mc := range ic.Networking.MachineNetwork {
 		if _, _, err := net.ParseCIDR(mc.CIDR); err != nil {


### PR DESCRIPTION
https://github.com/openshift/cluster-network-operator/pull/490 didn't consider that MachineCIDR might be empty. I will add a test but as this is a regression I want to get this done quickly.