### PR TITLE
Bug 1807611: Set network config status even with unknown network plugin

### DIFF
--- a/pkg/controller/operconfig/cluster.go
+++ b/pkg/controller/operconfig/cluster.go
@@ -81,7 +81,7 @@ func (r *ReconcileOperConfig) ClusterNetworkStatus(ctx context.Context, operConf
 	}
 
 	// Update the cluster config status
-	status := network.StatusFromOperatorConfig(&operConfig.Spec)
+	status := network.StatusFromOperatorConfig(&operConfig.Spec, &clusterConfig.Status)
 	if status == nil || reflect.DeepEqual(*status, clusterConfig.Status) {
 		return nil, nil
 	}


### PR DESCRIPTION
Some components depend on some fields of `configv1.NetworkStatus`. Eg, cluster-kubernetes-apiserver-operator needs to know the `ServiceNetwork`.

Previously we weren't setting the status when the default network type was unknown, because we didn't know that the external network plugin would consider them valid. (eg, there might be multiple `ClusterNetwork` values but the plugin only supports one.) But this breaks components that assume they can get their config from there.

Fix this by setting the status fields but allowing them to be overridden by another operator if the network type is unknown.

/assign @dcbw @rcarrillocruz 
/cc @deads2k 