### PR TITLE
Bug 1808498: Ensure no API LB recreation happens upon Octavia upgrade

### DIFF
--- a/pkg/platform/openstack/loadbalancer.go
+++ b/pkg/platform/openstack/loadbalancer.go
@@ -142,6 +142,37 @@ func ensureOpenStackLb(client *gophercloud.ServiceClient, name, vipAddress, vipS
 	if err != nil {
 		return "", errors.Wrap(err, "failed to extract LB list")
 	}
+
+	if len(lbs) == 0 && octaviaTagSupport {
+		// Attempt to retrieve API load balancer with description tagging
+		// to avoid another load balancer creation upon Octavia upgrade.
+		opts := loadbalancers.ListOpts{
+			Name:        name,
+			VipAddress:  vipAddress,
+			VipSubnetID: vipSubnetId,
+			Description: tag,
+		}
+		page, err = loadbalancers.List(client, opts).AllPages()
+		if err != nil {
+			return "", errors.Wrap(err, "failed to get LB list")
+		}
+		lbs, err = loadbalancers.ExtractLoadBalancers(page)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to extract LB list")
+		}
+		if len(lbs) == 1 {
+			log.Printf("Tagging existing loadbalancer API %s", lbs[0].ID)
+			tags := []string{tag}
+			updateOpts := loadbalancers.UpdateOpts{
+				Tags: &tags,
+			}
+			_, err := loadbalancers.Update(client, lbs[0].ID, updateOpts).Extract()
+			if err != nil {
+				return "", errors.Wrap(err, "failed to update LB")
+			}
+		}
+	}
+
 	if len(lbs) > 1 {
 		return "", errors.Errorf("found multiple LB matching name %s, tag %s, cannot proceed", name, tag)
 	} else if len(lbs) == 1 {


### PR DESCRIPTION
When upgrading Octavia from OSP13 to OSP16 the CNO checks if
tagging is supported and look for an API load balancer with tag.
However, the existent LB was created with OSP13, which does not
support tagging and so the tagging was added on description.
The CNO then tries to create a new LB API and fails due to
address already in use.

This commit fixes the issue by ensuring no LB exists with tags
and description, when tagging is supported, prior to creating
a new one.