### PR TITLE
Bug 1810137: Delete admission controller if double listeners is supported

### DIFF
--- a/pkg/platform/openstack/loadbalancer.go
+++ b/pkg/platform/openstack/loadbalancer.go
@@ -15,8 +15,6 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools"
 )
 
-var maxOctaviaVersion *semver.Version = nil
-
 func getMaxOctaviaAPIVersion(client *gophercloud.ServiceClient) (*semver.Version, error) {
 	allPages, err := apiversions.List(client).AllPages()
 	if err != nil {
@@ -55,12 +53,9 @@ func getMaxOctaviaAPIVersion(client *gophercloud.ServiceClient) (*semver.Version
 }
 
 func IsOctaviaVersionSupported(client *gophercloud.ServiceClient, constraint string) (bool, error) {
-	if maxOctaviaVersion == nil {
-		var err error
-		maxOctaviaVersion, err = getMaxOctaviaAPIVersion(client)
-		if err != nil {
-			return false, errors.Wrap(err, "cannot get Octavia API versions")
-		}
+	maxOctaviaVersion, err := getMaxOctaviaAPIVersion(client)
+	if err != nil {
+		return false, errors.Wrap(err, "cannot get Octavia API versions")
 	}
 
 	constraintVer := semver.MustParse(constraint)


### PR DESCRIPTION
In case Octavia is upgraded while the CNO is already running, the admission
controller resources are not deleted due to checking the previous Octavia
API version, as the version is only retrieved once when the CNO is starting.
This commit fixes the issue by ensuring the current API version is always
fetched.