### PR TITLE
Update Progressing message for non-critical components

### DIFF
--- a/pkg/controller/statusmanager/pod_status.go
+++ b/pkg/controller/statusmanager/pod_status.go
@@ -82,15 +82,14 @@ func (status *StatusManager) SetFromPods() {
 
 		dsProgressing := false
 
-		if ds.Status.UpdatedNumberScheduled < ds.Status.DesiredNumberScheduled {
+		if isNonCritical(ds) && ds.Status.DesiredNumberScheduled == 0 {
+			progressing = append(progressing, fmt.Sprintf("DaemonSet %q is waiting for other operators to become ready", dsName.String()))
+			dsProgressing = true
+		} else if ds.Status.UpdatedNumberScheduled < ds.Status.DesiredNumberScheduled {
 			progressing = append(progressing, fmt.Sprintf("DaemonSet %q update is rolling out (%d out of %d updated)", dsName.String(), ds.Status.UpdatedNumberScheduled, ds.Status.DesiredNumberScheduled))
 			dsProgressing = true
 		} else if ds.Status.NumberUnavailable > 0 {
-			if isNonCritical(ds) {
-				progressing = append(progressing, fmt.Sprintf("DaemonSet %q is waiting for other operators to become ready", dsName.String()))
-			} else {
-				progressing = append(progressing, fmt.Sprintf("DaemonSet %q is not available (awaiting %d nodes)", dsName.String(), ds.Status.NumberUnavailable))
-			}
+			progressing = append(progressing, fmt.Sprintf("DaemonSet %q is not available (awaiting %d nodes)", dsName.String(), ds.Status.NumberUnavailable))
 			dsProgressing = true
 		} else if ds.Status.NumberAvailable == 0 { // NOTE: update this if we ever expect empty (unscheduled) daemonsets ~cdc
 			progressing = append(progressing, fmt.Sprintf("DaemonSet %q is not yet scheduled on any nodes", dsName.String()))

--- a/pkg/controller/statusmanager/status_manager_test.go
+++ b/pkg/controller/statusmanager/status_manager_test.go
@@ -850,6 +850,8 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 	// Now update
 	dsNC.Status.NumberAvailable = 1
 	dsNC.Status.NumberUnavailable = 0
+	dsNC.Status.DesiredNumberScheduled = 1
+	dsNC.Status.UpdatedNumberScheduled = 1
 	err = client.Update(context.TODO(), dsNC)
 	if err != nil {
 		t.Fatalf("error updating DaemonSet: %v", err)


### PR DESCRIPTION
I was backporting #474 and realized that it solves `DaemonSet "openshift-multus/multus-admission-controller" is not available ...` (ie, "your install failed after the worker nodes were created but before multus-admission-controller could be deployed") but not `DaemonSet "openshift-multus/multus-admission-controller" is not yet scheduled on any nodes` (ie, "your install failed before the worker nodes were created").

(WIP until I see it doing the right thing in a test run)