### PR TITLE
Increase termination grace period to 45s to allow for flows to get saved

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -155,7 +155,7 @@ spec:
               /usr/bin/ovs-vsctl -t 5 show > /dev/null
           initialDelaySeconds: 15
           periodSeconds: 5
-        terminationGracePeriodSeconds: 10
+        terminationGracePeriodSeconds: 45
       nodeSelector:
         kubernetes.io/os: linux
       affinity:


### PR DESCRIPTION
This pull request changes the termination grace period to 45s from 10s to allow for saving off flows prior to the pod getting a SIGKILL.