### PR TITLE
Bug 1811748: Ensure removal of not rendered resources upon CNO recreation

### DIFF
--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -114,7 +114,9 @@ func (status *StatusManager) set(reachedAvailableLevel bool, conditions ...confi
 
 		oldStatus := co.Status.DeepCopy()
 		status.deleteRelatedObjectsNotRendered(co)
-		co.Status.RelatedObjects = status.relatedObjects
+		if status.relatedObjects != nil {
+			co.Status.RelatedObjects = status.relatedObjects
+		}
 
 		if reachedAvailableLevel {
 			if releaseVersion := os.Getenv("RELEASE_VERSION"); len(releaseVersion) > 0 {


### PR DESCRIPTION
If the CNO pod is recreated, the resources that are not rendered
anymore are not deleted. Due to The related objects field of the
cluster operator status being wiped out upon cno recreation.

This commit fixes the issue by ensuring the objects on the status
manager are only updated when the current status is filled.