### PR TITLE
Add the env-overrides debugging hack to openshift-sdn

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ spec:
       genevePort: 6081
 ```
 
-Additionally, you can configure per-node verbosity for ovn-kubernetes. This is useful
+Additionally, you can configure per-node verbosity for openshift-sdn and ovn-kubernetes. This is useful
 if you want to debug an issue, and can reproduce it on a single node. To do this,
 create a special ConfigMap with keys based on the Node's name:
 
@@ -214,6 +214,8 @@ data:
     OVN_KUBE_LOG_LEVEL=5
     OVN_LOG_LEVEL=dbg
 ```
+
+(For openshift-sdn, use `namespace: openshift-sdn` and, eg, `OPENSHIFT_SDN_LOG_LEVEL=5`.)
 
 ### Configuring OVNKubernetes On a Hybrid Cluster
 OVNKubernetes supports a hybrid cluster of both Linux and Windows nodes on x86_64 hosts. The ovn configuration is done as described above. In addition the `hybridOverlayConfig` can be included as follows:

--- a/bindata/network/openshift-sdn/controller.yaml
+++ b/bindata/network/openshift-sdn/controller.yaml
@@ -21,7 +21,17 @@ spec:
       containers:
       - name: sdn-controller
         image: {{.SDNImage}}
-        command: ["openshift-sdn-controller"]
+        command:
+        - /bin/bash
+        - -c
+        - |
+          if [[ -f /env/_master ]]; then
+            set -o allexport
+            source /env/_master
+            set +o allexport
+          fi
+
+          exec openshift-sdn-controller --v=${OPENSHIFT_SDN_LOG_LEVEL:-2}
         resources:
           requests:
             cpu: 10m
@@ -33,6 +43,9 @@ spec:
         - name: KUBERNETES_SERVICE_HOST
           value: "{{.KUBERNETES_SERVICE_HOST}}"
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /env
+          name: env-overrides
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
@@ -49,3 +62,8 @@ spec:
       - key: "node.kubernetes.io/not-ready"
         operator: "Exists"
         effect: "NoSchedule"
+      volumes:
+      - name: env-overrides
+        configMap:
+          name: env-overrides
+          optional: true

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -91,18 +91,27 @@ spec:
             rmdir /etc/sysconfig/openshift-sdn || true
           fi
 
+          # configmap-based overrides
+          if [[ -f /env/${K8S_NODE_NAME} ]]; then
+            set -o allexport
+            source /env/${K8S_NODE_NAME}
+            set +o allexport
+          fi
+
           # Take over network functions on the node
           rm -f /etc/cni/net.d/80-openshift-network.conf
           cp -f /opt/cni/bin/openshift-sdn /host/opt/cni/bin/
 
           # Launch the network process
-          exec /usr/bin/openshift-sdn-node --proxy-config=/config/kube-proxy-config.yaml --v=${DEBUG_LOGLEVEL:-2}
+          exec /usr/bin/openshift-sdn-node --proxy-config=/config/kube-proxy-config.yaml --v=${OPENSHIFT_SDN_LOG_LEVEL:-2}
         securityContext:
           privileged: true
         volumeMounts:
         - mountPath: /config
           name: config
           readOnly: true
+        - mountPath: /env
+          name: env-overrides
         # Mount the entire run directory for socket access for Docker or CRI-o
         # TODO: remove
         - mountPath: /var/run
@@ -173,6 +182,10 @@ spec:
       - name: config
         configMap:
           name: sdn-config
+      - name: env-overrides
+        configMap:
+          name: env-overrides
+          optional: true
       - name: etc-sysconfig
         hostPath:
           path: /etc/sysconfig


### PR DESCRIPTION
Casey had added a nice hack to CNO's deployment of ovn-kubernetes to make it easier to enable debugging, but we never did the same thing for openshift-sdn.
