### PR TITLE
Bug 1807638: Fixes to reliably save/restore flows.

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -73,7 +73,7 @@ spec:
 
           # launch OVS
           # Start the ovsdb so that we can prep it before we start the ovs-vswitchd
-          /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --no-ovs-vswitchd --system-id=random
+          /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --no-ovs-vswitchd --system-id=random --no-monitor
 
           # Set the flow-restore-wait to true so ovs-vswitchd will wait till flows are restored
           ovs-vsctl --no-wait set Open_vSwitch . other_config:flow-restore-wait=true
@@ -88,7 +88,7 @@ spec:
           fi
 
           # And finally start the ovs-vswitchd now the DB is prepped
-          /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --no-ovsdb-server --system-id=random
+          /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --no-ovsdb-server --system-id=random --no-monitor
 
           /usr/share/openvswitch/scripts/ovs-ctl status > /dev/null &&
           /usr/bin/ovs-appctl -T 5 ofproto/list > /dev/null &&

--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -24,7 +24,6 @@ spec:
     spec:
       serviceAccountName: sdn #needed to run privileged pods; not used for api access
       hostNetwork: true
-      hostPID: true
       priorityClassName: system-node-critical
       containers:
       - name: openvswitch
@@ -35,7 +34,6 @@ spec:
         - |
           #!/bin/bash
           set -euo pipefail
-          TIMESTAMP=`date -u "+%Y-%m-%d %H:%M:%S"`
           chown -R openvswitch:openvswitch /var/run/openvswitch
           chown -R openvswitch:openvswitch /etc/openvswitch
 
@@ -57,16 +55,14 @@ spec:
 
           function quit {
               # Save the flows
-              echo "$TIMESTAMP info: Saving flows ..." 2>&1
+              echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Saving flows ..." 2>&1
               bridges=$(ovs-vsctl -- --real list-br)
               TMPDIR=/var/run/openvswitch /usr/share/openvswitch/scripts/ovs-save save-flows $bridges > /var/run/openvswitch/flows.sh
-              END_TS=`date -u "+%Y-%m-%d %H:%M:%S"`
-              echo "$END_TS info: Saved flows" 2>&1
+              echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Saved flows" 2>&1
 
               # Don't allow ovs-vswitchd to clear datapath flows on exit
               kill -9 $(cat /var/run/openvswitch/ovs-vswitchd.pid 2>/dev/null) 2>/dev/null || true
               kill $(cat /var/run/openvswitch/ovsdb-server.pid 2>/dev/null) 2>/dev/null || true
-              #kill $(jobs -p)
               exit 0
           }
           trap quit SIGTERM
@@ -77,7 +73,7 @@ spec:
 
           # Set the flow-restore-wait to true so ovs-vswitchd will wait till flows are restored
           ovs-vsctl --no-wait set Open_vSwitch . other_config:flow-restore-wait=true
-           
+          
           # Restrict the number of pthreads ovs-vswitchd creates to reduce the
           # amount of RSS it uses on hosts with many cores
           # https://bugzilla.redhat.com/show_bug.cgi?id=1571379
@@ -90,21 +86,19 @@ spec:
           # And finally start the ovs-vswitchd now the DB is prepped
           /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --no-ovsdb-server --system-id=random --no-monitor
 
-          /usr/share/openvswitch/scripts/ovs-ctl status > /dev/null &&
-          /usr/bin/ovs-appctl -T 5 ofproto/list > /dev/null &&
-          /usr/bin/ovs-vsctl -t 5 --retry show > /dev/null &&
-          /usr/bin/ovs-vsctl -t 5 --retry br-exists br0
-          
           # Load any flows that we saved
-          echo "$TIMESTAMP info: Loading previous flows ..." 2>&1
+          echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Loading previous flows ..." 2>&1
           if [[ -f /var/run/openvswitch/flows.sh ]]; then
-             echo "$TIMESTAMP info: Execute flow script ..." 2>&1
+             echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Adding br0 if it doesn't exist ..." 2>&1
+             /usr/bin/ovs-vsctl --may-exist add-br br0 -- set Bridge br0 fail_mode=secure protocols=OpenFlow13
+             echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Created br0, now adding flows ..." 2>&1
              sh -x /var/run/openvswitch/flows.sh
+             echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Done restoring the existing flows ..." 2>&1
           fi
           
-          echo "$TIMESTAMP info: Remove other config ..." 2>&1
+          echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Remove other config ..." 2>&1
           ovs-vsctl --no-wait --if-exists remove Open_vSwitch . other_config flow-restore-wait=true
-          echo "$TIMESTAMP info: Removed other config ..." 2>&1
+          echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Removed other config ..." 2>&1
 
           tail -F --pid=$(cat /var/run/openvswitch/ovs-vswitchd.pid) /var/log/openvswitch/ovs-vswitchd.log &
           tail -F --pid=$(cat /var/run/openvswitch/ovsdb-server.pid) /var/log/openvswitch/ovsdb-server.log &

--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -35,11 +35,11 @@ spec:
         - |
           #!/bin/bash
           set -euo pipefail
+          TIMESTAMP=`date -u "+%Y-%m-%d %H:%M:%S"`
           chown -R openvswitch:openvswitch /var/run/openvswitch
           chown -R openvswitch:openvswitch /etc/openvswitch
 
           # if another process is listening on the cni-server socket, wait until it exits
-          trap 'kill $(jobs -p); exit 0' TERM
           retries=0
           while true; do
             if /usr/share/openvswitch/scripts/ovs-ctl status &>/dev/null; then
@@ -57,14 +57,16 @@ spec:
 
           function quit {
               # Save the flows
-              echo "info: Saving flows ..." 2>&1
+              echo "$TIMESTAMP info: Saving flows ..." 2>&1
               bridges=$(ovs-vsctl -- --real list-br)
               TMPDIR=/var/run/openvswitch /usr/share/openvswitch/scripts/ovs-save save-flows $bridges > /var/run/openvswitch/flows.sh
-              echo "info: Saved flows" 2>&1
+              END_TS=`date -u "+%Y-%m-%d %H:%M:%S"`
+              echo "$END_TS info: Saved flows" 2>&1
 
               # Don't allow ovs-vswitchd to clear datapath flows on exit
               kill -9 $(cat /var/run/openvswitch/ovs-vswitchd.pid 2>/dev/null) 2>/dev/null || true
               kill $(cat /var/run/openvswitch/ovsdb-server.pid 2>/dev/null) 2>/dev/null || true
+              #kill $(jobs -p)
               exit 0
           }
           trap quit SIGTERM
@@ -75,7 +77,7 @@ spec:
 
           # Set the flow-restore-wait to true so ovs-vswitchd will wait till flows are restored
           ovs-vsctl --no-wait set Open_vSwitch . other_config:flow-restore-wait=true
-          
+           
           # Restrict the number of pthreads ovs-vswitchd creates to reduce the
           # amount of RSS it uses on hosts with many cores
           # https://bugzilla.redhat.com/show_bug.cgi?id=1571379
@@ -88,16 +90,21 @@ spec:
           # And finally start the ovs-vswitchd now the DB is prepped
           /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --no-ovsdb-server --system-id=random
 
+          /usr/share/openvswitch/scripts/ovs-ctl status > /dev/null &&
+          /usr/bin/ovs-appctl -T 5 ofproto/list > /dev/null &&
+          /usr/bin/ovs-vsctl -t 5 --retry show > /dev/null &&
+          /usr/bin/ovs-vsctl -t 5 --retry br-exists br0
+          
           # Load any flows that we saved
-          echo "info: Loading previous flows ..." 2>&1
+          echo "$TIMESTAMP info: Loading previous flows ..." 2>&1
           if [[ -f /var/run/openvswitch/flows.sh ]]; then
-             echo "info: Execute flow script ..." 2>&1
+             echo "$TIMESTAMP info: Execute flow script ..." 2>&1
              sh -x /var/run/openvswitch/flows.sh
           fi
           
-          echo "info: Remove other config ..." 2>&1
+          echo "$TIMESTAMP info: Remove other config ..." 2>&1
           ovs-vsctl --no-wait --if-exists remove Open_vSwitch . other_config flow-restore-wait=true
-          echo "info: Removed other config ..." 2>&1
+          echo "$TIMESTAMP info: Removed other config ..." 2>&1
 
           tail -F --pid=$(cat /var/run/openvswitch/ovs-vswitchd.pid) /var/log/openvswitch/ovs-vswitchd.log &
           tail -F --pid=$(cat /var/run/openvswitch/ovsdb-server.pid) /var/log/openvswitch/ovsdb-server.log &


### PR DESCRIPTION
This PR adds:
a) a timestamp when adding logs for save/restore so they can be correlated with other logs.
b) removes the `hostPID` setting on the daemonset pods
c) removes the `--monitor` option when starting the `ovs-vswitchd` and `ovsdb-server` processes
