### PR TITLE
Bug 1812583: Normalize CPU requests on nodes

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -119,7 +119,7 @@ spec:
           name: host-config-openvswitch
         resources:
           requests:
-            cpu: 200m
+            cpu: 100m
             memory: 400Mi
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:


### PR DESCRIPTION
The ovs container uses approximately 100m of node CPU in a reasonable
medium sized workload. Tune the default to be more realistic for medium
clusters. For large clusters, a dynamic scaling policy would be
necessary.

4.4 bug is 1812709