### PR TITLE
OVN: Ensure ovn-monitor-all=true before ovn-controller starts.

### DIFF
--- a/bindata/network/ovn-kubernetes/006-ovs-node.yaml
+++ b/bindata/network/ovn-kubernetes/006-ovs-node.yaml
@@ -56,6 +56,30 @@ spec:
               exit 0
           }
           trap quit SIGTERM
+
+          # Start the ovsdb so that we can prep it before ovn-controller
+          # connects to it. To achieve that we use a temporary private socket,
+          # db-private.sock.
+          # https://bugzilla.redhat.com/show_bug.cgi?id=1808125
+          priv_db_sock=/var/run/openvswitch/db-private.sock
+          /usr/share/openvswitch/scripts/ovs-ctl start \
+            --ovs-user=openvswitch:openvswitch --db-sock=${priv_db_sock} \
+            --no-ovs-vswitchd
+
+          # The OVS DB should also be properly initialized before
+          # ovn-controller connects to it.
+          ovs-vsctl --db=unix:${priv_db_sock} -- init
+
+          # Ensure that ovn-controller will never read a value of
+          # ovn-monitor-all=false followed by an update with
+          # ovn-monitor-all=true.
+          # https://bugzilla.redhat.com/show_bug.cgi?id=1808125
+          ovs-vsctl --no-wait --db=unix:${priv_db_sock} \
+            set Open_vSwitch . external_ids:ovn-monitor-all=true
+          /usr/share/openvswitch/scripts/ovs-ctl stop
+
+          # Start ovsdb-server and ovs-vswitchd such that ovn-controller can
+          # connect to the database and br-int.
           /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --system-id=random
           ovs-appctl vlog/set "file:${OVS_LOG_LEVEL}"
           /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol


### PR DESCRIPTION
There is a race condition in ovn-controller when the
Open_vSwitch external_ids:ovn-monitor-all key is set to "true" after
ovn-controller starts.

Until the bug is fixed in OVS/OVN code, this is a workaround delaying
start up of ovn-controller until OVS is up and ovn-monitor-all is set to
"true".

This commit also ensures that upon an OVS pod reboot that would recreate
the OVS database ovn-controller would not connect to an uninitialized
database (i.e., "ovs-vsctl init" has been called first).

Reported-at: https://bugzilla.redhat.com/1808125
Signed-off-by: Dumitru Ceara <dceara@redhat.com>