### PR TITLE
Bug 1806854: Populate cluster-wide config maps with content from user-ca-bundle

### DIFF
--- a/pkg/controller/configmap_ca_injector/controller.go
+++ b/pkg/controller/configmap_ca_injector/controller.go
@@ -95,8 +95,8 @@ func (r *ReconcileConfigMapInjector) Reconcile(request reconcile.Request) (recon
 
 	trustedCAbundleConfigMap := &corev1.ConfigMap{}
 	trustedCAbundleConfigMapName := types.NamespacedName{
-		Namespace: names.TRUSTED_CA_BUNDLE_CONFIGMAP_NS,
-		Name:      names.TRUSTED_CA_BUNDLE_CONFIGMAP,
+		Namespace: names.ADDL_TRUST_BUNDLE_CONFIGMAP_NS,
+		Name:      names.ADDL_TRUST_BUNDLE_CONFIGMAP,
 	}
 	err := r.client.Get(context.TODO(), trustedCAbundleConfigMapName, trustedCAbundleConfigMap)
 	if err != nil {
@@ -119,10 +119,10 @@ func (r *ReconcileConfigMapInjector) Reconcile(request reconcile.Request) (recon
 	configMapsToChange := []corev1.ConfigMap{}
 
 	// The trusted-ca-bundle changed.
-	if request.Name == names.TRUSTED_CA_BUNDLE_CONFIGMAP && request.Namespace == names.TRUSTED_CA_BUNDLE_CONFIGMAP_NS {
+	if request.Name == names.ADDL_TRUST_BUNDLE_CONFIGMAP && request.Namespace == names.ADDL_TRUST_BUNDLE_CONFIGMAP_NS {
 
 		configMapList := &corev1.ConfigMapList{}
-		matchingLabels := &client.MatchingLabels{names.TRUSTED_CA_BUNDLE_CONFIGMAP_LABEL: "true"}
+		matchingLabels := &client.MatchingLabels{names.ADDL_TRUST_CA_BUNDLE_CONFIGMAP_LABEL: "true"}
 		err = r.client.List(context.TODO(), configMapList, matchingLabels)
 		if err != nil {
 			log.Println(err)
@@ -131,7 +131,7 @@ func (r *ReconcileConfigMapInjector) Reconcile(request reconcile.Request) (recon
 			return reconcile.Result{}, err
 		}
 		configMapsToChange = configMapList.Items
-		log.Printf("%s changed, updating %d configMaps", names.TRUSTED_CA_BUNDLE_CONFIGMAP, len(configMapsToChange))
+		log.Printf("%s changed, updating %d configMaps", names.ADDL_TRUST_BUNDLE_CONFIGMAP, len(configMapsToChange))
 	} else {
 		// Changing a single labeled configmap.
 
@@ -204,6 +204,6 @@ func (r *ReconcileConfigMapInjector) Reconcile(request reconcile.Request) (recon
 }
 
 func shouldUpdateConfigMaps(meta metav1.Object) bool {
-	return meta.GetLabels()[names.TRUSTED_CA_BUNDLE_CONFIGMAP_LABEL] == "true" ||
-		(meta.GetName() == names.TRUSTED_CA_BUNDLE_CONFIGMAP && meta.GetNamespace() == names.TRUSTED_CA_BUNDLE_CONFIGMAP_NS)
+	return meta.GetLabels()[names.ADDL_TRUST_CA_BUNDLE_CONFIGMAP_LABEL] == "true" ||
+		(meta.GetName() == names.ADDL_TRUST_BUNDLE_CONFIGMAP && meta.GetNamespace() == names.ADDL_TRUST_BUNDLE_CONFIGMAP_NS)
 }

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -53,6 +53,13 @@ const MULTUS_VALIDATING_WEBHOOK = "multus.openshift.io"
 // ConfigMaps that contain user provided trusted CA bundles.
 const ADDL_TRUST_BUNDLE_CONFIGMAP_NS = "openshift-config"
 
+// ADDL_TRUST_BUNDLE_CONFIGMAP_NS is the configmap that contain user provided trusted CA bundles.
+const ADDL_TRUST_BUNDLE_CONFIGMAP = "user-ca-bundle"
+
+// ADDL_TRUST_CA_BUNDLE_CONFIGMAP_LABEL is the name of the label that
+// determines whether or not to inject the combined ca certificate
+const ADDL_TRUST_CA_BUNDLE_CONFIGMAP_LABEL = "config.openshift.io/inject-trusted-cabundle"
+
 // TRUSTED_CA_BUNDLE_CONFIGMAP_KEY is the name of the data key containing
 // the PEM encoded trust bundle.
 const TRUSTED_CA_BUNDLE_CONFIGMAP_KEY = "ca-bundle.crt"
@@ -65,10 +72,6 @@ const TRUSTED_CA_BUNDLE_CONFIGMAP = "trusted-ca-bundle"
 // ADDL_TRUST_BUNDLE_CONFIGMAP and TRUST_BUNDLE_CONFIGMAP
 // ConfigMaps.
 const TRUSTED_CA_BUNDLE_CONFIGMAP_NS = "openshift-config-managed"
-
-// TRUSTED_CA_BUNDLE_CONFIGMAP_LABEL is the name of the label that
-// determines whether or not to inject the combined ca certificate
-const TRUSTED_CA_BUNDLE_CONFIGMAP_LABEL = "config.openshift.io/inject-trusted-cabundle"
 
 // SYSTEM_TRUST_BUNDLE is the full path to the file containing
 // the system trust bundle.


### PR DESCRIPTION
Problem this solves: today the CNO reconciles configmaps with the label `config.openshift.io/inject-trusted-cabundle: true` by populating them with the content from `openshift-config-managed/trusted-ca-bundle`, whereas we are expected (apperently, I am not sure about this...) to populate them with the content from `openshift-config/user-ca-bundle`. Questions still exists in my mind as to what the expected behaviour should be w.r.t this, should all CMs be populated like this, or only some of them?

If someone can summon/tag a proxy/CA experienced engineer, then please feel free to do so. I have going through this article: https://github.com/openshift/enhancements/blob/master/enhancements/proxy/global-cluster-egress-proxy.md but it's still not clear which CA related configmap should be used to populate everything. 