### PR TITLE
Bug 1812037: Ensure correct Octavia API version is retrieved

### DIFF
--- a/pkg/platform/openstack/kuryr_bootstrap.go
+++ b/pkg/platform/openstack/kuryr_bootstrap.go
@@ -1118,7 +1118,7 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient client.Client) (*bootst
 	}
 
 	log.Print("Checking Double Listeners Octavia support")
-	octaviaMultipleListenersSupport, err := IsOctaviaVersionSupported(client, MinOctaviaVersionWithMultipleListeners)
+	octaviaMultipleListenersSupport, err := IsOctaviaVersionSupported(lbClient, MinOctaviaVersionWithMultipleListeners)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to determine if Octavia supports double listeners")
 	}


### PR DESCRIPTION
We are using a Network client to retrieve the octavia API version,
this results in a wrong api version.
This commit fixes the issue by using the Load Balancer client.