### PR TITLE
Ensure admission controller ignores failure

### DIFF
--- a/bindata/network/kuryr/011-webhook.yaml
+++ b/bindata/network/kuryr/011-webhook.yaml
@@ -7,6 +7,7 @@ metadata:
     app: kuryr-dns-admission-controller
 webhooks:
   - name: kuryr-dns-admission-controller.openshift.io
+    failurePolicy: Ignore
     sideEffects: None
     admissionReviewVersions: ['v1', 'v1beta1']
     clientConfig:


### PR DESCRIPTION
The v1beta1 MutatingWebhook version ensured by default
that if an error happened on admission controller endpoint
the failure would be ignored. However, with the new v1 version
the default is to Fail, which can block the installation
to proceed as the API requests would be rejected.

This commit ensures we still default to ignore the error.