### PR TITLE
OVN: Fix initial OVS DB preparation.

### DIFF
--- a/bindata/network/ovn-kubernetes/006-ovs-node.yaml
+++ b/bindata/network/ovn-kubernetes/006-ovs-node.yaml
@@ -61,10 +61,13 @@ spec:
           # connects to it. To achieve that we use a temporary private socket,
           # db-private.sock.
           # https://bugzilla.redhat.com/show_bug.cgi?id=1808125
+          # When called with '--db-sock', ovs-ctl doesn't point
+          # 'ovs-vsctl -- init' to the correct socket path so we have to
+          # ignore the error returned by ovs-ctl.
           priv_db_sock=/var/run/openvswitch/db-private.sock
           /usr/share/openvswitch/scripts/ovs-ctl start \
             --ovs-user=openvswitch:openvswitch --db-sock=${priv_db_sock} \
-            --no-ovs-vswitchd
+            --no-ovs-vswitchd || true
 
           # The OVS DB should also be properly initialized before
           # ovn-controller connects to it.


### PR DESCRIPTION
When 'ovs-ctl start' is called with --db-sock=<value>, ovs-ctl doesn't
properly point its invocation of 'ovs-vsctl' to use the non-default unix
socket passed as argument. The ovsdb-server instance is however started
properly and the error returned can be safely ignored.

Fixes: cae57b4a547d ("OVN: Ensure ovn-monitor-all=true before ovn-controller starts.")
Signed-off-by: Dumitru Ceara <dceara@redhat.com>