### PR TITLE
Kuryr: Preserve unknown in remote_ip_prefixes in NP CRD

### DIFF
--- a/bindata/network/kuryr/002-crds.yaml
+++ b/bindata/network/kuryr/002-crds.yaml
@@ -91,6 +91,7 @@ spec:
                   properties:
                     remote_ip_prefixes:
                       type: object
+                      x-kubernetes-preserve-unknown-fields: true
                     namespace:
                       type: string
                     security_group_rule:
@@ -125,6 +126,7 @@ spec:
                   properties:
                     remote_ip_prefixes:
                       type: object
+                      x-kubernetes-preserve-unknown-fields: true
                     namespace:
                       type: string
                     security_group_rule:


### PR DESCRIPTION
The remote_ip_prefixes field in KuryrNetPolicy CRD is an object. As it's
not defined with correct schema, it needs
x-kubernetes-preserve-unknown-fields property. This commit fixes that.

I'm not defining the field correctly as we're moving to new CRD anyway.