### PR TITLE
Bug 1802481: Don't override containernetworking binaries in SDN and Kuryr

### DIFF
--- a/bindata/network/kuryr/005-daemon.yaml
+++ b/bindata/network/kuryr/005-daemon.yaml
@@ -24,21 +24,6 @@ spec:
       hostNetwork: true
       serviceAccountName: kuryr
       priorityClassName: system-node-critical
-      initContainers:
-      - name: install-cni-plugins
-        image: {{ .CNIPluginsImage }}
-        command:
-        - /bin/bash
-        - -c
-        - |
-          #!/bin/bash
-          set -ex
-          cp -f /usr/src/plugins/bin/loopback /host-cni-bin/
-        volumeMounts:
-        - name: bin
-          mountPath: /host-cni-bin
-        securityContext:
-          privileged: true
       containers:
       - name: kuryr-cni
         image: {{ .DaemonImage }}

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -76,11 +76,12 @@ data:
     fi
 
     cp -rf ${sourcedir}* $DESTINATION_DIRECTORY
+
     if [ $? -eq 0 ]; then
-        echo "Successfully copied files in ${sourcedir} to $DESTINATION_DIRECTORY"
+      echo "Successfully copied files in ${sourcedir} to $DESTINATION_DIRECTORY"
     else
-        echo "Failed to copy files in ${sourcedir} to $DESTINATION_DIRECTORY"
-        exit 1
+      echo "Failed to copy files in ${sourcedir} to $DESTINATION_DIRECTORY"
+      exit 1
     fi
 ---
 kind: DaemonSet
@@ -350,7 +351,7 @@ spec:
             path: {{ .MultusCNIConfDir }}
         - name: cnibin
           hostPath:
-            path: /var/lib/cni/bin
+            path: {{ .CNIBinDir }}
         - name: os-release
           hostPath:
             path: /etc/os-release

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -37,21 +37,6 @@ spec:
       hostNetwork: true
       hostPID: true
       priorityClassName: system-node-critical
-      initContainers:
-      - name: install-cni-plugins
-        image: {{ .CNIPluginsImage }}
-        command:
-        - /bin/bash
-        - -c
-        - |
-          #!/bin/bash
-          set -ex
-          cp -f /usr/src/plugins/bin/{loopback,host-local} /host/opt/cni/bin
-        volumeMounts:
-        - mountPath: /host/opt/cni/bin
-          name: host-cni-bin
-        securityContext:
-          privileged: true
       containers:
       - name: sdn
         image: {{.SDNImage}}

--- a/pkg/network/multus.go
+++ b/pkg/network/multus.go
@@ -59,6 +59,7 @@ func renderMultusConfig(manifestDir, defaultNetworkType string, useDHCP bool) ([
 	data.Data["MultusCNIConfDir"] = MultusCNIConfDir
 	data.Data["SystemCNIConfDir"] = SystemCNIConfDir
 	data.Data["DefaultNetworkType"] = defaultNetworkType
+	data.Data["CNIBinDir"] = CNIBinDir
 
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/multus"), &data)
 	if err != nil {


### PR DESCRIPTION
Containernetworking binaries are compiled for RHEL7 and RHEL8 [here](https://github.com/openshift/containernetworking-plugins/blob/master/Dockerfile). This was done during the effort last year when fixing this bug: https://bugzilla.redhat.com/show_bug.cgi?id=1725832

That solution was applied to multus only and overlooked the fact that we have initcontainers in SDN and Kuryr that still copy the binaries blindly to the host without checking which OS version we're running on. This means that when we start the network plugin we can still end up in a situation where the binary cannot be executed without SIGSEGV-ing directly. 

Seeing as how Multus always runs, no matter the networking plugin used: just don't do anything and let Multus be the sole responsible, as such we should avoid stepping on each other toes. 

Assigning someone from SDN, Multus and Kuryr to review this PR. 

This will need back-ports to 4.2 (possibly even 4.1? @knobunc) 

/assign @vrutkovs @dougbtv @dcbw 