### PR TITLE
Adding bond-cni binary installation

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -150,6 +150,24 @@ spec:
           value: "/usr/src/plugins/rhel8/bin/"
         - name: DEFAULT_SOURCE_DIRECTORY
           value: "/usr/src/plugins/bin/"
+      - name: bond-cni-plugin
+        image: {{.BondCNIPluginImage}}
+        command: ["/entrypoint/cnibincopy.sh"]
+        volumeMounts:
+        - mountPath: /entrypoint
+          name: cni-binary-copy
+        - mountPath: /host/opt/cni/bin
+          name: cnibin
+        - mountPath: /host/etc/os-release
+          name: os-release
+          readOnly: true
+        env:
+        - name: RHEL7_SOURCE_DIRECTORY
+          value: "/bondcni/rhel7/bin"
+        - name: RHEL8_SOURCE_DIRECTORY
+          value: "/bondcni/rhel8/bin"
+        - name: DEFAULT_SOURCE_DIRECTORY
+          value: "/bondcni/bin"
       - name: routeoverride-cni
         image: {{.RouteOverrideImage}}
         command: ["/entrypoint/cnibincopy.sh"]

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -37,6 +37,8 @@ spec:
           value: "quay.io/openshift/origin-multus-admission-controller:4.3"
         - name: CNI_PLUGINS_IMAGE
           value: "quay.io/openshift/origin-container-networking-plugins:4.3"
+        - name: BOND_CNI_PLUGIN_IMAGE
+          value: "quay.io/openshift/origin-network-interface-bond-cni:4.5"
         - name: WHEREABOUTS_CNI_IMAGE
           value: "quay.io/openshift/origin-multus-whereabouts-ipam-cni:4.4"
         - name: ROUTE_OVERRRIDE_CNI_IMAGE

--- a/pkg/network/multus.go
+++ b/pkg/network/multus.go
@@ -51,6 +51,7 @@ func renderMultusConfig(manifestDir, defaultNetworkType string, useDHCP bool) ([
 	data.Data["ReleaseVersion"] = os.Getenv("RELEASE_VERSION")
 	data.Data["MultusImage"] = os.Getenv("MULTUS_IMAGE")
 	data.Data["CNIPluginsImage"] = os.Getenv("CNI_PLUGINS_IMAGE")
+	data.Data["BondCNIPluginImage"] = os.Getenv("BOND_CNI_PLUGIN_IMAGE")
 	data.Data["WhereaboutsImage"] = os.Getenv("WHEREABOUTS_CNI_IMAGE")
 	data.Data["RouteOverrideImage"] = os.Getenv("ROUTE_OVERRRIDE_CNI_IMAGE")
 	data.Data["KUBERNETES_SERVICE_HOST"] = os.Getenv("KUBERNETES_SERVICE_HOST")


### PR DESCRIPTION
I want to add the bond-cni [1] to openshift. We want to use it mainly with sriov. 
It might however be useful not just with sriov, but also on with some cni's available by default with the cluster-network-operator (host-device, macvlan, ...), so it makes sense to ship it in the cluster-network-operator.

[1] https://github.com/intel/bond-cni,  https://github.com/openshift/bond-cni
