### PR TITLE
Revert "OVN: Ensure ovn-monitor-all=true before ovn-controller starts."

### DIFF
--- a/bindata/network/ovn-kubernetes/006-ovs-node.yaml
+++ b/bindata/network/ovn-kubernetes/006-ovs-node.yaml
@@ -56,33 +56,6 @@ spec:
               exit 0
           }
           trap quit SIGTERM
-
-          # Start the ovsdb so that we can prep it before ovn-controller
-          # connects to it. To achieve that we use a temporary private socket,
-          # db-private.sock.
-          # https://bugzilla.redhat.com/show_bug.cgi?id=1808125
-          # When called with '--db-sock', ovs-ctl doesn't point
-          # 'ovs-vsctl -- init' to the correct socket path so we have to
-          # ignore the error returned by ovs-ctl.
-          priv_db_sock=/var/run/openvswitch/db-private.sock
-          /usr/share/openvswitch/scripts/ovs-ctl start \
-            --ovs-user=openvswitch:openvswitch --db-sock=${priv_db_sock} \
-            --no-ovs-vswitchd || true
-
-          # The OVS DB should also be properly initialized before
-          # ovn-controller connects to it.
-          ovs-vsctl --db=unix:${priv_db_sock} -- init
-
-          # Ensure that ovn-controller will never read a value of
-          # ovn-monitor-all=false followed by an update with
-          # ovn-monitor-all=true.
-          # https://bugzilla.redhat.com/show_bug.cgi?id=1808125
-          ovs-vsctl --no-wait --db=unix:${priv_db_sock} \
-            set Open_vSwitch . external_ids:ovn-monitor-all=true
-          /usr/share/openvswitch/scripts/ovs-ctl stop
-
-          # Start ovsdb-server and ovs-vswitchd such that ovn-controller can
-          # connect to the database and br-int.
           /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --system-id=random
           ovs-appctl vlog/set "file:${OVS_LOG_LEVEL}"
           /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol


### PR DESCRIPTION
This reverts commit cae57b4a547d0241d6eef565dc5161f0dcdb7b81 and its
follow up 82d1913cf99564dcbe2a35880b77148f9b47678d. These commits tried
to work around a bug in OVSDB-IDL (https://bugzilla.redhat.com/1808125).

There is no clean and safe way to ensure that ovn-monitor-all=true in
the OVS database so it's better to wait until the proper fix is merged
in OVSDB-IDL instead.

Signed-off-by: Dumitru Ceara <dceara@redhat.com>