### PR TITLE
Revert "Secure metrics endpoint for multus"

### DIFF
--- a/bindata/network/multus-admission-controller/002-rbac.yaml
+++ b/bindata/network/multus-admission-controller/002-rbac.yaml
@@ -20,12 +20,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups: ['authentication.k8s.io']
-  resources: ['tokenreviews']
-  verbs: ['create']
-- apiGroups: ['authorization.k8s.io']
-  resources: ['subjectaccessreviews']
-  verbs: ['create']
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -50,27 +50,6 @@ spec:
         ports:
         - name: metrics-port
           containerPort: 9091
-      - name: kube-rbac-proxy
-        image: {{.KubeRBACProxyImage}}
-        args:
-        - --logtostderr
-        - --secure-listen-address=:8443
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-        - --upstream=http://127.0.0.1:9091/
-        - --tls-private-key-file=/etc/webhook/tls.key
-        - --tls-cert-file=/etc/webhook/tls.crt
-        ports:
-        - containerPort: 8443
-          name: https
-        resources:
-          requests:
-            cpu: 10m
-            memory: 20Mi
-        terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts:
-        - name: webhook-certs
-          mountPath: /etc/webhook
-          readOnly: True
       serviceAccountName: multus
       priorityClassName: "system-cluster-critical"
       restartPolicy: Always

--- a/bindata/network/multus-admission-controller/monitor.yaml
+++ b/bindata/network/multus-admission-controller/monitor.yaml
@@ -12,11 +12,6 @@ spec:
   endpoints:
   - interval: 30s
     port: metrics
-    bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token'
-    scheme: 'https'
-    tlsConfig:
-      caFile: '/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt'
-      serverName: 'multus-admission-controller.openshift-multus.svc'
   jobLabel: app
   namespaceSelector:
     matchNames:
@@ -32,8 +27,6 @@ metadata:
     name: multus-admission-controller-monitor-service
   name:  multus-admission-controller-monitor-service
   namespace: openshift-multus
-  annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: multus-admission-controller-secret
 spec:
   selector:
     app: multus-admission-controller
@@ -42,10 +35,7 @@ spec:
   - name: metrics
     port: 9091
     protocol: TCP
-    targetPort: https
-  - name: https
-    port: 8443
-    targetPort: https
+    targetPort: 9091
   sessionAffinity: None
   type: ClusterIP
 ---

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -31,8 +31,6 @@ spec:
           value: "quay.io/openshift/origin-sdn:4.3"
         - name: KUBE_PROXY_IMAGE
           value: "quay.io/openshift/origin-kube-proxy:4.3"
-        - name: KUBE_RBAC_PROXY_IMAGE
-          value: "quay.io/openshift/origin-kube-rbac-proxy:4.4"
         - name: MULTUS_IMAGE
           value: "quay.io/openshift/origin-multus-cni:4.3"
         - name: MULTUS_ADMISSION_CONTROLLER_IMAGE

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -46,8 +46,3 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-kuryr-controller:4.3
-  - name: kube-rbac-proxy
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-kube-rbac-proxy:4.4
-

--- a/pkg/network/multus_admission_controller.go
+++ b/pkg/network/multus_admission_controller.go
@@ -20,7 +20,6 @@ func renderMultusAdmissonControllerConfig(manifestDir string) ([]*uns.Unstructur
 	data.Data["MultusAdmissionControllerImage"] = os.Getenv("MULTUS_ADMISSION_CONTROLLER_IMAGE")
 	data.Data["MultusValidatingWebhookName"] = names.MULTUS_VALIDATING_WEBHOOK
 	data.Data["ServiceCAConfigMap"] = names.SERVICE_CA_CONFIGMAP
-	data.Data["KubeRBACProxyImage"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
 
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/multus-admission-controller"), &data)
 	if err != nil {


### PR DESCRIPTION
This reverts commit 76b1e1e4df3a6906d82e0f642a3f92296e11924e.

Apparently causing 80+% failures in OpenShift CI.