### PR TITLE
Remove logfile from ovnkube configmap as to avoid log rotation

### DIFF
--- a/bindata/network/ovn-kubernetes/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/004-config.yaml
@@ -17,9 +17,6 @@ data:
     ovn-config-namespace="openshift-ovn-kubernetes"
     apiserver="{{.K8S_APISERVER}}"
 
-    [logging]
-    logfile="/dev/stdout"
-
     [gateway]
     mode=local
     nodeport=true


### PR DESCRIPTION
For ovnkube logging we can chose to specify a logfile explicitly by passing the `logfile` parameter in the ovnkube configmap. However, /dev is constrained to 64MB in openshift pods, which means that for long running pods: when logging exceeds that limit we get broken pipes for logging.    

Part of the solution (the one fixed by this patch) is to change the `logfile` location to a unconstrained file system location. 

The other part is to switch from logrus to klog completely as logrus does not provide a feature of logging to a file and to stdout simultaneously, as klog does. This part means that we should back-port the "switch to klog" patch to 4.3. 