### PR TITLE
Bug 1831112: Kuryr: Mount /run/netns to ensure netns access

### DIFF
--- a/bindata/network/kuryr/005-daemon.yaml
+++ b/bindata/network/kuryr/005-daemon.yaml
@@ -56,6 +56,9 @@ spec:
           mountPath: /host_proc
         - name: openvswitch
           mountPath: /var/run/openvswitch
+        - name: netns
+          mountPath: /run/netns
+          mountPropagation: HostToContainer
 {{ if (default true .DaemonEnableProbes) eq "true" }}
         readinessProbe:
           failureThreshold: 10
@@ -85,6 +88,9 @@ spec:
       - name: proc
         hostPath:
           path: /proc
+      - name: netns
+        hostPath:
+          path: /run/netns
       - name: openvswitch
         hostPath:
           path: /var/run/openvswitch


### PR DESCRIPTION
openshift/machine-config-operator#1568 moved pod namespaces from
/proc into /var/run/crio. As Kuryr needs access to them in order to
manipulate interfaces, we need to mount the new directory and this
commit does that.

Most likely the same change needs to be done for ovn-kubernetes, but
it's a bit out of my expertise.