### PR TITLE
The Multus readinessindicator should match OVN-kubernetes .conflist

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -315,7 +315,7 @@ spec:
 {{- if eq .DefaultNetworkType "OpenShiftSDN"}}
         - "--readiness-indicator-file=/var/run/multus/cni/net.d/80-openshift-network.conf"
 {{- else if eq .DefaultNetworkType "OVNKubernetes"}}
-        - "--readiness-indicator-file=/var/run/multus/cni/net.d/10-ovn-kubernetes.conf"
+        - "--readiness-indicator-file=/var/run/multus/cni/net.d/10-ovn-kubernetes.conflist"
 {{- end}}
         - "--cleanup-config-on-exit=true"
         - "--namespace-isolation=true"


### PR DESCRIPTION
Apparently this was changed somewhere along the line, or was initially incorrect.