### PR TITLE
Logging: add time stamp to echo in cno yaml

### DIFF
--- a/bindata/network/ovn-kubernetes/006-ovs-node.yaml
+++ b/bindata/network/ovn-kubernetes/006-ovs-node.yaml
@@ -47,6 +47,7 @@ spec:
             source "/env/${K8S_NODE}"
             set +o allexport
           fi
+          echo "$(date -Iseconds) - starting ovs-daemons"
           chown -R openvswitch:openvswitch /run/openvswitch
           chown -R openvswitch:openvswitch /etc/openvswitch
           function quit {
@@ -59,6 +60,7 @@ spec:
           /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --system-id=random
           ovs-appctl vlog/set "file:${OVS_LOG_LEVEL}"
           /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol
+          echo "$(date -Iseconds) - ovs-daemons running"
 
           tail -F --pid=$(cat /var/run/openvswitch/ovs-vswitchd.pid) /var/log/openvswitch/ovs-vswitchd.log &
           tail -F --pid=$(cat /var/run/openvswitch/ovsdb-server.pid) /var/log/openvswitch/ovsdb-server.log &

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -68,6 +68,7 @@ spec:
             set +o allexport
           fi
 
+          echo "$(date -Iseconds) - starting ovn-northd"
           exec ovn-northd \
             --no-chdir "-vconsole:${OVN_LOG_LEVEL}" -vfile:off \
             --ovnnb-db "{{.OVN_NB_DB_LIST}}" \
@@ -116,6 +117,7 @@ spec:
           bracketify() { case "$1" in *:*) echo "[$1]" ;; *) echo "$1" ;; esac }
 
           MASTER_IP="{{.OVN_MASTER_IP}}"
+          echo "$(date -Iseconds) - starting nbdb  MASTER_IP=${MASTER_IP}"
           if [[ "${K8S_NODE_IP}" == "${MASTER_IP}" ]]; then
             exec /usr/share/ovn/scripts/ovn-ctl \
             --db-nb-cluster-local-port={{.OVN_NB_RAFT_PORT}} \
@@ -151,11 +153,12 @@ spec:
               - |
                 MASTER_IP="{{.OVN_MASTER_IP}}"
                 if [[ "${K8S_NODE_IP}" == "${MASTER_IP}" ]]; then
+                  echo "$(date -Iseconds) - nbdb - postStart - waiting for master to be selected"
                   retries=0
                   while ! ovn-nbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_NB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe=60000; do
                     (( retries += 1 ))
                   if [[ "${retries}" -gt 40 ]]; then
-                    echo "too many failed ovn-nbctl attempts, giving up"
+                    echo "$(date -Iseconds) - ERROR RESTARTING - nbdb - too many failed ovn-nbctl attempts, giving up"
                       exit 1
                   fi
                   sleep 2
@@ -222,6 +225,7 @@ spec:
           bracketify() { case "$1" in *:*) echo "[$1]" ;; *) echo "$1" ;; esac }
 
           MASTER_IP="{{.OVN_MASTER_IP}}"
+          echo "$(date -Iseconds) - starting sbdb  MASTER_IP=${MASTER_IP}"
           if [[ "${K8S_NODE_IP}" == "${MASTER_IP}" ]]; then
             exec /usr/share/ovn/scripts/ovn-ctl \
             --db-sb-cluster-local-port={{.OVN_SB_RAFT_PORT}} \
@@ -234,7 +238,7 @@ spec:
             --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
             run_sb_ovsdb
           else
-            echo "joining cluster at ${MASTER_IP}"
+            echo "$(date -Iseconds) - joining cluster at ${MASTER_IP}"
             exec /usr/share/ovn/scripts/ovn-ctl \
             --db-sb-cluster-local-port={{.OVN_SB_RAFT_PORT}} \
             --db-sb-cluster-remote-port={{.OVN_SB_RAFT_PORT}} \
@@ -258,11 +262,12 @@ spec:
               - |
                 MASTER_IP="{{.OVN_MASTER_IP}}"
                 if [[ "${K8S_NODE_IP}" == "${MASTER_IP}" ]]; then
+                  echo "$(date -Iseconds) - sdb - postStart - waiting for master to be selected"
                   retries=0
                   while ! ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe=60000; do
                     (( retries += 1 ))
                   if [[ "${retries}" -gt 40 ]]; then
-                    echo "too many failed ovn-sbctl attempts, giving up"
+                    echo "$(date -Iseconds) - ERROR RESTARTING - sbdb - too many failed ovn-sbctl attempts, giving up"
                       exit 1
                   fi
                   sleep 2
@@ -331,6 +336,7 @@ spec:
           fi
 
           # start nbctl daemon for caching
+          echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-master - start nbctl daemon for caching"
           export OVN_NB_DAEMON=$(ovn-nbctl --pidfile=/var/run/ovn/ovn-nbctl.pid \
             --detach \
             -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt \
@@ -339,6 +345,7 @@ spec:
            # REMOVEME once OVN path for control socket is fixed (right now uses /var/run/openvswitch)
           ln -sf $OVN_NB_DAEMON /var/run/ovn/ || true
 
+          echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-master - start ovnkube --init-master ${K8S_NODE}"
           exec /usr/bin/ovnkube \
             --init-master "${K8S_NODE}" \
             --config-file=/run/ovnkube-config/ovnkube.conf \

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -46,6 +46,7 @@ spec:
             source "/env/${K8S_NODE}"
             set +o allexport
           fi
+          echo "$(date -Iseconds) - starting ovn-controller"
           exec ovn-controller unix:/var/run/openvswitch/db.sock -vfile:off \
             --no-chdir --pidfile=/var/run/ovn/ovn-controller.pid \
             -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt \
@@ -95,6 +96,7 @@ spec:
             source "/env/${K8S_NODE}"
             set +o allexport
           fi
+          echo "I$(date "+%m%d %H:%M:%S.%N") - waiting for db_ip addresses"
           cp -f /usr/libexec/cni/ovn-k8s-cni-overlay /cni-bin-dir/
           ovn_config_namespace=openshift-ovn-kubernetes
           retries=0
@@ -105,13 +107,14 @@ spec:
             fi
             (( retries += 1 ))
             if [[ "${retries}" -gt 40 ]]; then
-              echo "db endpoint never came up"
+              echo "E$(date "+%m%d %H:%M:%S.%N") - db endpoint never came up"
               exit 1
             fi
-            echo "waiting for db endpoint"
+            echo "I$(date "+%m%d %H:%M:%S.%N") - waiting for db endpoint"
             sleep 5
           done
 
+          echo "I$(date "+%m%d %H:%M:%S.%N") - starting ovnkube-node db_ip ${db_ip}"
           hybrid_overlay_flags=
           if [[ -n "{{.OVNHybridOverlayEnable}}" ]]; then
             hybrid_overlay_flags="--enable-hybrid-overlay --no-hostsubnet-nodes=kubernetes.io/os=windows"


### PR DESCRIPTION
This modifies the CNO daemonse yaml to add a timestamp in the same format
as the logfile generated by the container. This permits including them in
trace output

SDN-971 - Logging: Modify CNO .yaml files to prefix logged lines with the std prefix
https://issues.redhat.com/browse/SDN-971

Signed-off-by: Phil Cameron <pcameron@redhat.com>