### PR TITLE
Adds missing OVN NB SSL args to ovnkube master

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -331,10 +331,13 @@ spec:
           fi
 
           # start nbctl daemon for caching
-          export OVN_NB_DAEMON=$(ovn-nbctl --pidfile=/tmp/ovnk-nbctl.pid \
+          export OVN_NB_DAEMON=$(ovn-nbctl --pidfile=/var/run/ovn/ovn-nbctl.pid \
             --detach \
             -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt \
             --db "{{.OVN_NB_DB_LIST}}")
+
+           # REMOVEME once OVN path for control socket is fixed (right now uses /var/run/openvswitch)
+          ln -sf $OVN_NB_DAEMON /var/run/ovn/
 
           exec /usr/bin/ovnkube \
             --init-master "${K8S_NODE}" \
@@ -346,11 +349,16 @@ spec:
             --sb-address "{{.OVN_SB_ADDR_LIST}}" \
             --sb-client-privkey /ovn-cert/tls.key \
             --sb-client-cert /ovn-cert/tls.crt \
-            --sb-client-cacert /ovn-ca/ca-bundle.crt
+            --sb-client-cacert /ovn-ca/ca-bundle.crt \
+            --nb-address "{{.OVN_NB_ADDR_LIST}}" \
+            --nb-client-privkey /ovn-cert/tls.key \
+            --nb-client-cert /ovn-cert/tls.crt \
+            --nb-client-cacert /ovn-ca/ca-bundle.crt \
+            --nbctl-daemon-mode true
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/bash", "-c", "kill $(cat /tmp/ovnk-nbctl.pid) && unset OVN_NB_DAEMON"]
+              command: ["/bin/bash", "-c", "kill $(cat /var/run/ovn/ovn-nbctl.pid) && unset OVN_NB_DAEMON"]
         volumeMounts:
         - mountPath: /etc/openvswitch/
           name: etc-openvswitch


### PR DESCRIPTION
For OVN NB DB interaction with the ovn-nbctl command, we use ovn-nbctl
daemon mode, where we do not need to use SSL arguments to directly
interact with the nbctl socket in the pod. However, SSL arguments are
needed for non-nbctl commands like ovsdb client. This patch adds those
arguments.

In addition, the nbctl-daemon-mode argument was missing as well. This
argument indicates to ovn-kubernetes that it needs to use nbctl daemon
mode. Even though we were previously not setting this, we were exporting
the proper bash env var to allow the process to automatically use daemon
mode. However, we should pass the correct arguments to be consistent.
Due to an OVN bug, we need to temporarily symlink the ovn-nbctl control
socket to /var/run/ovn as it is accidentally placed in
/var/run/openvswitch today.

Signed-off-by: Tim Rozet <trozet@redhat.com>