### PR TITLE
[release-4.4] mount /var/run shared

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -107,6 +107,7 @@ spec:
         # TODO: remove
         - mountPath: /var/run
           name: host-var-run
+          mountPropagation: Bidirectional
         # Run directories where we need to be able to access sockets
         - mountPath: /var/run/dbus/
           name: host-var-run-dbus

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -170,7 +170,7 @@ spec:
         # accessing bind-mounted net namespaces
         - mountPath: /run/netns
           name: host-run-netns
-          readOnly: true
+          mountPropagation: Bidirectional
         # for installing the CNI plugin binary
         - mountPath: /cni-bin-dir
           name: host-cni-bin


### PR DESCRIPTION
When trying to transfer cri-o to manage its network namespaces in openshift, we have run into problems with multus. Specifically we see the error:
```
2020-04-07T17:46:52Z [error] delegateAdd: error invoking DelegateAdd - "ovn-k8s-cni-overlay": error in getting result from AddNetwork: CNI request failed with status 400: '[openshift-dns/dns-default-98tll] failed to configure pod interface: failed to open netns "/var/run/netns/76716600-f7fd-462f-b7df-ae054dbd144e": unknown FS magic on "/var/run/netns/76716600-f7fd-462f-b7df-ae054dbd144e": 1021994
```

through testing, I've found the netns is definitely mounted as an nsfs and not tmpfs, so I suspect we are seeing https://github.com/containernetworking/plugins/issues/69

to fix this, attempt mounting /var/run/{,netns} as Bidirectional

This PR is to aid in the kata effort. right now, it's only a WIP, and the release image created will be used to test if it actually works. It's targeted at 4.4 because that's what is being used for other kata related tests right now. If this actually works, I will first target a PR at master and then go through the backporting rigmarole. but feedback is definitely welcome here :smile: 