### PR TITLE
Bug 1809205: Configure TLS for OpenShift SDN metrics endpoint

### DIFF
--- a/bindata/network/openshift-sdn/002-rbac.yaml
+++ b/bindata/network/openshift-sdn/002-rbac.yaml
@@ -74,3 +74,54 @@ subjects:
 - kind: ServiceAccount
   name: sdn
   namespace: openshift-sdn
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openshift-sdn-metrics
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - endpoints
+  - services
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: [""]
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups: ['authentication.k8s.io']
+  resources: ['tokenreviews']
+  verbs: ['create']
+- apiGroups: ['authorization.k8s.io']
+  resources: ['subjectaccessreviews']
+  verbs: ['create']
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sdn-metrics
+  namespace: openshift-sdn
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openshift-sdn-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-sdn-metrics
+subjects:
+- kind: ServiceAccount
+  name: sdn-metrics
+  namespace: openshift-sdn

--- a/bindata/network/openshift-sdn/monitor.yaml
+++ b/bindata/network/openshift-sdn/monitor.yaml
@@ -1,8 +1,9 @@
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app: sdn
+    app: sdn-metrics
   annotations:
     networkoperator.openshift.io/ignore-errors: ""
   name: monitor-sdn
@@ -11,24 +12,31 @@ spec:
   endpoints:
   - interval: 30s
     port: metrics
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: sdn-metrics.openshift-sdn.svc
   jobLabel: app
   namespaceSelector:
     matchNames:
     - openshift-sdn
   selector:
     matchLabels:
-      app: sdn
+      app: sdn-metrics
 ---
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: sdn-metrics-certs
   labels:
-    app: sdn
-  name: sdn
+    app: sdn-metrics
+  name: sdn-metrics
   namespace: openshift-sdn
 spec:
   selector:
-    app: sdn
+    app: sdn-metrics
   clusterIP: None
   publishNotReadyAddresses: true
   ports:

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -229,3 +229,62 @@ spec:
           path: /var/lib/cni/networks/openshift-sdn
       tolerations:
       - operator: Exists
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: sdn-metrics
+  namespace: openshift-sdn
+  annotations:
+    kubernetes.io/description: |
+      This daemon set launches the OpenShift networking components (kube-proxy and openshift-sdn).
+      It expects that OVS is running on the node.
+    release.openshift.io/version: "{{.ReleaseVersion}}"
+spec:
+  selector:
+    matchLabels:
+      app: sdn-metrics
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: sdn-metrics
+        component: network
+        type: infra
+        openshift.io/component: network
+      annotations:
+        networkoperator.openshift.io/non-critical: ""
+    spec:
+      # Requires fairly broad permissions - ability to read all services and network functions as well
+      # as all pods.
+      serviceAccountName: sdn-metrics
+      hostNetwork: true
+      containers:
+      - name: kube-rbac-proxy
+        image: {{.KubeRBACProxyImage}}
+        args:
+        - --logtostderr
+        - --secure-listen-address=:9101
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+        - --upstream=http://127.0.0.1:29101/
+        - --tls-private-key-file=/etc/pki/tls/metrics-certs/tls.key
+        - --tls-cert-file=/etc/pki/tls/metrics-certs/tls.crt
+        ports:
+        - containerPort: 9101
+          name: https
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: sdn-metrics-certs
+          mountPath: /etc/pki/tls/metrics-certs
+          readOnly: True
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+      - name: sdn-metrics-certs
+        secret:
+          secretName: sdn-metrics-certs

--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -34,6 +34,7 @@ func renderOpenShiftSDN(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Un
 	data.Data["InstallOVS"] = (c.UseExternalOpenvswitch == nil || *c.UseExternalOpenvswitch == false)
 	data.Data["SDNImage"] = os.Getenv("SDN_IMAGE")
 	data.Data["CNIPluginsImage"] = os.Getenv("CNI_PLUGINS_IMAGE")
+	data.Data["KubeRBACProxyImage"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
 	data.Data["KUBERNETES_SERVICE_HOST"] = os.Getenv("KUBERNETES_SERVICE_HOST")
 	data.Data["KUBERNETES_SERVICE_PORT"] = os.Getenv("KUBERNETES_SERVICE_PORT")
 	data.Data["Mode"] = c.Mode
@@ -48,7 +49,7 @@ func renderOpenShiftSDN(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Un
 
 	kpcDefaults := map[string]operv1.ProxyArgumentList{
 		"metrics-bind-address":    {"0.0.0.0"},
-		"metrics-port":            {"9101"},
+		"metrics-port":            {"29101"},
 		"healthz-port":            {"10256"},
 		"proxy-mode":              {"iptables"},
 		"iptables-masquerade-bit": {"0"},

--- a/pkg/network/openshift_sdn_test.go
+++ b/pkg/network/openshift_sdn_test.go
@@ -426,7 +426,7 @@ ipvs:
   strictARP: false
   syncPeriod: 0s
 kind: KubeProxyConfiguration
-metricsBindAddress: 0.0.0.0:9101
+metricsBindAddress: 0.0.0.0:29101
 mode: unidling+iptables
 nodePortAddresses: null
 oomScoreAdj: null
@@ -474,7 +474,7 @@ ipvs:
   strictARP: false
   syncPeriod: 0s
 kind: KubeProxyConfiguration
-metricsBindAddress: 0.0.0.0:9101
+metricsBindAddress: 0.0.0.0:29101
 mode: iptables
 nodePortAddresses: null
 oomScoreAdj: null


### PR DESCRIPTION
We use port 29101 for plain HTTP metrics which is firewalled and expose 29102 over HTTPS.

---
Uses RBAC proxy just like https://github.com/openshift/cluster-network-operator/pull/563
Because  the pod uses `hostNetwork: true` and I don't want to add additional ports, the regular http metrics endpoint is exposed in `127.0.01:9101` and the https one on `0.0.0.0:9101`