### PR TITLE
Allow to only enable hybrid overlay and not handle Windows networks

### DIFF
--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -85,7 +85,11 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["OVN_service_cidr"] = svcpools
 
 	if c.HybridOverlayConfig != nil {
-		data.Data["OVNHybridOverlayNetCIDR"] = c.HybridOverlayConfig.HybridClusterNetwork[0].CIDR
+		if c.HybridOverlayConfig.HybridClusterNetwork != nil {
+			data.Data["OVNHybridOverlayNetCIDR"] = c.HybridOverlayConfig.HybridClusterNetwork[0].CIDR
+		} else {
+			data.Data["OVNHybridOverlayNetCIDR"] = ""
+		}
 		data.Data["OVNHybridOverlayEnable"] = "true"
 	} else {
 		data.Data["OVNHybridOverlayNetCIDR"] = ""


### PR DESCRIPTION
This allows to enable the hybrid overlay without the need to specify
hybridClusterNetwork which is only needed for clusters that connect
to Windows nodes