### PR TITLE
Changes to get hostnames passed in via the common name in the CR

### DIFF
--- a/bindata/network/ovn-kubernetes/006-pki.yaml
+++ b/bindata/network/ovn-kubernetes/006-pki.yaml
@@ -7,4 +7,4 @@ metadata:
   namespace: openshift-ovn-kubernetes
 spec:
   targetCert:
-    commonName: ovn
+    commonName: {{.OVN_MASTER_ADDR_LIST}}

--- a/pkg/controller/pki/pki_controller.go
+++ b/pkg/controller/pki/pki_controller.go
@@ -211,7 +211,7 @@ func newPKI(config *netopv1.OperatorPKI, clientset *kubernetes.Clientset, mgr ma
 			Validity:  OneYear / 2,
 			Refresh:   OneYear / 4,
 			CertCreator: &certrotation.ServingRotation{
-				Hostnames: func() []string { return []string{spec.TargetCert.CommonName} },
+				Hostnames: func() []string { return strings.Split(spec.TargetCert.CommonName, " ") },
 
 				// Force the certificate to also be client
 				CertificateExtensionFn: []crypto.CertificateExtensionFunc{

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -65,6 +65,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["OVN_MASTER_IP"] = bootstrapResult.OVN.MasterIPs[0]
 	data.Data["OVN_MIN_AVAILABLE"] = len(bootstrapResult.OVN.MasterIPs)/2 + 1
 	data.Data["LISTEN_DUAL_STACK"] = listenDualStack(bootstrapResult.OVN.MasterIPs[0])
+	data.Data["OVN_MASTER_ADDR_LIST"] = strings.Join(bootstrapResult.OVN.MasterIPs, " ")
 
 	var ippools string
 	for _, net := range conf.ClusterNetwork {


### PR DESCRIPTION
The certificates generated by the rotation controller today don't work with the go-ovn client bindings because they are generated without any SANs. The hostname that we pass in to the certs is a dummy common name "ovn". When the certificates are being verified by the crypto/tls library, the VerifyHostname() API will look for the hostname of the server to be present in the SANs as either an IP address/DNS name.

This change is to enable hostnames to be passed in via the pki CR template parameter for common name. The hostnames passed to the CertRotationController get eventually included as IPAddresses in the certificate template and allow us to create a valid certificate that doesn't fail the IP SAN check.