### PR TITLE
ovn: use normal OVN DB address syntax

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -346,11 +346,11 @@ spec:
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
             ${hybrid_overlay_flags} \
             --metrics-bind-address "0.0.0.0:9102" \
-            --sb-address "{{.OVN_SB_ADDR_LIST}}" \
+            --sb-address "{{.OVN_SB_DB_LIST}}" \
             --sb-client-privkey /ovn-cert/tls.key \
             --sb-client-cert /ovn-cert/tls.crt \
             --sb-client-cacert /ovn-ca/ca-bundle.crt \
-            --nb-address "{{.OVN_NB_ADDR_LIST}}" \
+            --nb-address "{{.OVN_NB_DB_LIST}}" \
             --nb-client-privkey /ovn-cert/tls.key \
             --nb-client-cert /ovn-cert/tls.crt \
             --nb-client-cacert /ovn-ca/ca-bundle.crt \

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -121,8 +121,8 @@ spec:
           fi
           
           exec /usr/bin/ovnkube --init-node "${K8S_NODE}" \
-            --nb-address "{{.OVN_NB_ADDR_LIST}}" \
-            --sb-address "{{.OVN_SB_ADDR_LIST}}" \
+            --nb-address "{{.OVN_NB_DB_LIST}}" \
+            --sb-address "{{.OVN_SB_DB_LIST}}" \
             --nb-client-privkey /ovn-cert/tls.key \
             --nb-client-cert /ovn-cert/tls.crt \
             --nb-client-cacert /ovn-ca/ca-bundle.crt \

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -60,8 +60,6 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["OVN_SB_RAFT_PORT"] = OVN_SB_RAFT_PORT
 	data.Data["OVN_NB_DB_LIST"] = dbList(bootstrapResult.OVN.MasterIPs, OVN_NB_PORT)
 	data.Data["OVN_SB_DB_LIST"] = dbList(bootstrapResult.OVN.MasterIPs, OVN_SB_PORT)
-	data.Data["OVN_NB_ADDR_LIST"] = addrList(bootstrapResult.OVN.MasterIPs, OVN_NB_PORT)
-	data.Data["OVN_SB_ADDR_LIST"] = addrList(bootstrapResult.OVN.MasterIPs, OVN_SB_PORT)
 	data.Data["OVN_MASTER_IP"] = bootstrapResult.OVN.MasterIPs[0]
 	data.Data["OVN_MIN_AVAILABLE"] = len(bootstrapResult.OVN.MasterIPs)/2 + 1
 	data.Data["LISTEN_DUAL_STACK"] = listenDualStack(bootstrapResult.OVN.MasterIPs[0])
@@ -243,14 +241,6 @@ func dbList(masterIPs []string, port string) string {
 	addrs := make([]string, len(masterIPs))
 	for i, ip := range masterIPs {
 		addrs[i] = "ssl:" + net.JoinHostPort(ip, port)
-	}
-	return strings.Join(addrs, ",")
-}
-
-func addrList(masterIPs []string, port string) string {
-	addrs := make([]string, len(masterIPs))
-	for i, ip := range masterIPs {
-		addrs[i] = "ssl://" + net.JoinHostPort(ip, port)
 	}
 	return strings.Join(addrs, ",")
 }


### PR DESCRIPTION
ovnkube has supported normal syntax for a while, let's use it and clean up some tech debt.