### PR TITLE
Adds failsafe for OVN nbctl daemon socket

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -337,7 +337,7 @@ spec:
             --db "{{.OVN_NB_DB_LIST}}")
 
            # REMOVEME once OVN path for control socket is fixed (right now uses /var/run/openvswitch)
-          ln -sf $OVN_NB_DAEMON /var/run/ovn/
+          ln -sf $OVN_NB_DAEMON /var/run/ovn/ || true
 
           exec /usr/bin/ovnkube \
             --init-master "${K8S_NODE}" \


### PR DESCRIPTION
If/When OVN gets a backport fix for the wrong nbctl socket location, our
CI will break because the symlink will fail. This adds a failsafe.

Signed-off-by: Tim Rozet <trozet@redhat.com>