### PR TITLE
Bug 1823399: Allow to only enable hybrid overlay and not handle Windows networks

### DIFF
--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -79,7 +79,11 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["OVN_service_cidr"] = svcpools
 
 	if c.HybridOverlayConfig != nil {
-		data.Data["OVNHybridOverlayNetCIDR"] = c.HybridOverlayConfig.HybridClusterNetwork[0].CIDR
+		if c.HybridOverlayConfig.HybridClusterNetwork != nil {
+			data.Data["OVNHybridOverlayNetCIDR"] = c.HybridOverlayConfig.HybridClusterNetwork[0].CIDR
+		} else {
+			data.Data["OVNHybridOverlayNetCIDR"] = ""
+		}
 		data.Data["OVNHybridOverlayEnable"] = "true"
 	} else {
 		data.Data["OVNHybridOverlayNetCIDR"] = ""


### PR DESCRIPTION
This allows to have a hybridOverlayConfig empty struct and that will just
enable hybrid overlay but not handle Windows networks.

(cherry picked from commit 4e13142579d27445b4d95dcbb51841a62285d3f7)