### PR TITLE
Enabling pprof for ovnkubernetes by default

### DIFF
--- a/bindata/network/ovn-kubernetes/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/004-config.yaml
@@ -16,6 +16,7 @@ data:
     service-cidr="{{.OVN_service_cidr}}"
     ovn-config-namespace="openshift-ovn-kubernetes"
     apiserver="{{.K8S_APISERVER}}"
+    metrics-enable-pprof=true
 
     [gateway]
     mode=local


### PR DESCRIPTION
This will help us get pprof data for ovnkube-master by default for debugging.