### PR TITLE
The NetworkAttachmentDefinition CRD should have description fields

### DIFF
--- a/bindata/network/additional-networks/crd/001-crd.yaml
+++ b/bindata/network/additional-networks/crd/001-crd.yaml
@@ -19,12 +19,17 @@ spec:
   preserveUnknownFields: true
   validation:
     openAPIV3Schema:
+      description: 'NetworkAttachmentDefinition is a CRD schema specified by the Network Plumbing
+        Working Group to express the intent for attaching pods to one or more logical or physical
+        networks. More information available at: https://github.com/k8snetworkplumbingwg/multi-net-spec'
       type: object
       properties:
         spec:
+          description: 'NetworkAttachmentDefinition spec defines the desired state of a network attachment'
           type: object
           properties:
             config:
+              description: 'NetworkAttachmentDefinition config is a JSON-formatted CNI configuration'
               type: string
 ---
 apiVersion: apiextensions.k8s.io/v1beta1


### PR DESCRIPTION
This enables one to use the 'oc describe' command for the net-attach-def.