### PR TITLE
Bug 1826322: sdn: fix typo in openshift-sdn run script

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -105,7 +105,7 @@ spec:
           # Launch the network process
           exec /usr/bin/openshift-sdn-node \
             --node-name ${K8S_NODE_NAME} --node-ip ${K8S_NODE_IP} \
-            --proxy-config /config/kube-proxy-config.yaml
+            --proxy-config /config/kube-proxy-config.yaml \
             --v ${OPENSHIFT_SDN_LOG_LEVEL:-2}
         securityContext:
           privileged: true


### PR DESCRIPTION
Thanks to the magic of bash, this was never caught!

The only effect was that overriding verbosity is not possible.