### PR TITLE
Bug 1827009: correctly tell ovnkube-node containers the label that hybrid overlay nodes have

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -114,7 +114,7 @@ spec:
 
           hybrid_overlay_flags=
           if [[ -n "{{.OVNHybridOverlayEnable}}" ]]; then
-            hybrid_overlay_flags="--enable-hybrid-overlay"
+            hybrid_overlay_flags="--enable-hybrid-overlay --no-hostsubnet-nodes=kubernetes.io/os=windows"
             if [[ -n "{{.OVNHybridOverlayNetCIDR}}" ]]; then
               hybrid_overlay_flags="${hybrid_overlay_flags} --hybrid-overlay-cluster-subnets={{.OVNHybridOverlayNetCIDR}}"
             fi


### PR DESCRIPTION


when starting ovnkube-node in a cluster with hybrid overlay networking it
needs to be started with --no-hostsubnet-nodes=<label> so that it knows
what nodes that use the hybrid overlay network are labeled with.