### PR TITLE
Bug 1825019: Setting resource request for kube-proxy deployment

### DIFF
--- a/bindata/kube-proxy/kube-proxy.yaml
+++ b/bindata/kube-proxy/kube-proxy.yaml
@@ -77,6 +77,10 @@ spec:
             port: healthz
           initialDelaySeconds: 5
           periodSeconds: 5
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
       restartPolicy: Always
       tolerations:
       - operator: Exists


### PR DESCRIPTION
 This is done as to avoid `QoSClass: BestEffort` status which will fail certain e2e tests. I applied the same requests we have for openshift-sdn. But please advise if someone has an idea on a more scientifically correct way of setting these. 

/assign @danwinship 