### PR TITLE
Bug 1831680: Prevent patching the HybridOverlayConfig after install time

### DIFF
--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -141,9 +141,12 @@ func isOVNKubernetesChangeSafe(prev, next *operv1.NetworkSpec) []error {
 	if !reflect.DeepEqual(pn.GenevePort, nn.GenevePort) {
 		errs = append(errs, errors.Errorf("cannot change ovn-kubernetes genevePort"))
 	}
+	if pn.HybridOverlayConfig == nil && nn.HybridOverlayConfig != nil {
+		errs = append(errs, errors.Errorf("cannot start a hybrid overlay network after install time"))
+	}
 	if pn.HybridOverlayConfig != nil {
 		if !reflect.DeepEqual(pn.HybridOverlayConfig, nn.HybridOverlayConfig) {
-			errs = append(errs, errors.Errorf("once set cannot change ovn-kubernetes Hybrid Overlay Config"))
+			errs = append(errs, errors.Errorf("cannot edit a running hybrid overlay network"))
 		}
 	}
 


### PR DESCRIPTION
Since adding a hybrid network after install time is not a supported
operation throw an error when processesing the config.