### PR TITLE
Bug 1829824: Remove dead member from LB pool.

### DIFF
--- a/pkg/platform/openstack/kuryr_bootstrap.go
+++ b/pkg/platform/openstack/kuryr_bootstrap.go
@@ -457,9 +457,11 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient client.Client) (*bootst
 	log.Print("Creating OpenShift API loadbalancer pool members")
 	r, _ := regexp.Compile(fmt.Sprintf("^%s-(master-port-[0-9]+|bootstrap-port)$", clusterID))
 	portList, err := listOpenStackPortsMatchingPattern(client, tag, r)
+	addresses := make([]string, 0)
 	for _, port := range portList {
 		if len(port.FixedIPs) > 0 {
 			portIp := port.FixedIPs[0].IPAddress
+			addresses = append(addresses, portIp)
 			log.Printf("Found port %s with IP %s", port.ID, portIp)
 
 			// We want bootstrap to stop being used as soon as possible, as it will serve
@@ -479,6 +481,11 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient client.Client) (*bootst
 		} else {
 			log.Printf("Matching port %s has no IP", port.ID)
 		}
+	}
+
+	err = purgeOpenStackLbPoolMember(client, poolId, addresses)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed on purging invalid LB members from LB pool")
 	}
 
 	log.Print("Ensuring certificates")

--- a/pkg/platform/openstack/loadbalancer.go
+++ b/pkg/platform/openstack/loadbalancer.go
@@ -411,3 +411,35 @@ func listOpenStackOctaviaProviders(client *gophercloud.ServiceClient) ([]provide
 		return providersList, nil
 	}
 }
+
+// Iterate on pool members and check their address against provided list
+// addresses of current master/bootstrap nodes. Remove all surplus members,
+// which address doesn't exists on that list.
+func purgeOpenStackLbPoolMember(client *gophercloud.ServiceClient, poolId string, addresses []string) error {
+	page, err := pools.ListMembers(client, poolId, nil).AllPages()
+	if err != nil {
+		return errors.Wrap(err, "failed to get LB member list")
+	}
+
+	members, err := pools.ExtractMembers(page)
+	if err != nil {
+		return errors.Wrap(err, "failed to extract LB members list")
+	}
+
+	for _, member := range members {
+		found := false
+		for _, address := range addresses {
+			if address == member.Address {
+				found = true
+				break
+			}
+		}
+		if !found {
+			err = pools.DeleteMember(client, poolId, member.ID).ExtractErr()
+			if err != nil {
+				return errors.Wrap(err, "failed to delete LB member")
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
During installation a bootstrap node is used as an API node at first,
but then gets removed. In Kuryr's bootstrap we never remove it from API
loadbalancer pool which leads to Octavia stating that LB is in degraded
state.

With those changes we prevent it by making sure on reconciliation we
remove loadbalancer members that we don't need there anymore. This
should help with scaledown of masters too.