### PR TITLE
bug 1831006: For third party plugins enable testing of IPv6 single stack

### DIFF
--- a/pkg/network/kube_proxy.go
+++ b/pkg/network/kube_proxy.go
@@ -121,7 +121,18 @@ func FillKubeProxyDefaults(conf, previous *operv1.NetworkSpec) {
 	}
 
 	if conf.KubeProxyConfig.BindAddress == "" {
-		conf.KubeProxyConfig.BindAddress = "0.0.0.0"
+		// TODO: this will probably need to change for dual stack
+		ip, _, err := net.ParseCIDR(conf.ClusterNetwork[0].CIDR)
+		if err != nil {
+			// this should not happen
+			return
+		}
+		if ip.To4() != nil {
+			conf.KubeProxyConfig.BindAddress = "0.0.0.0"
+		} else {
+			conf.KubeProxyConfig.BindAddress = "::"
+		}
+
 	}
 }
 


### PR DESCRIPTION
since the clusterCIDR is user configurable determine if the
given cluster is IPv4 or IPv6 single stack based on that value
for network plugins. this will allow third party plugins that
do support single stack to function