### PR TITLE
bug 1831680: Want to be able to enable hybrid networking only if HybridOverlayConfig is nil

### DIFF
--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -142,7 +142,10 @@ func isOVNKubernetesChangeSafe(prev, next *operv1.NetworkSpec) []error {
 		errs = append(errs, errors.Errorf("cannot change ovn-kubernetes genevePort"))
 	}
 	if pn.HybridOverlayConfig == nil && nn.HybridOverlayConfig != nil {
-		errs = append(errs, errors.Errorf("cannot start a hybrid overlay network after install time"))
+		// only restrict from enabeling a hybrid overlay with a cluster network after install
+		if nn.HybridOverlayConfig.HybridClusterNetwork != nil {
+			errs = append(errs, errors.Errorf("cannot start a hybrid overlay network after install time"))
+		}
 	}
 	if pn.HybridOverlayConfig != nil {
 		if !reflect.DeepEqual(pn.HybridOverlayConfig, nn.HybridOverlayConfig) {

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -262,8 +262,15 @@ func TestOVNKubernetesIsSafe(t *testing.T) {
 	errs := isOVNKubernetesChangeSafe(prev, next)
 	g.Expect(errs).To(BeEmpty())
 
+	// try to enable hybrid overlay with an empty HybridClusterNetwork
+	hybridOverlayConfigNext := operv1.HybridOverlayConfig{}
+	next.DefaultNetwork.OVNKubernetesConfig.HybridOverlayConfig = &hybridOverlayConfigNext
+
+	errs = isOVNKubernetesChangeSafe(prev, next)
+	g.Expect(errs).To(BeEmpty())
+
 	// try to add a new hybrid overlay config
-	hybridOverlayConfigNext :=
+	hybridOverlayConfigNext =
 		operv1.HybridOverlayConfig{
 			HybridClusterNetwork: []operv1.ClusterNetworkEntry{
 				{CIDR: "10.132.0.0/14", HostPrefix: 23},


### PR DESCRIPTION

after install time it should be possible to enable hybrid networking but only if
a hybridcluster network is empty