### PR TITLE
Bug 1832872: Remove dead member from LB pool.

### DIFF
--- a/pkg/platform/openstack/kuryr_bootstrap.go
+++ b/pkg/platform/openstack/kuryr_bootstrap.go
@@ -1187,7 +1187,7 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient client.Client) (*bootst
 		}
 	}
 
-	err = purgeOpenStackLbPoolMember(client, poolId, addresses)
+	err = purgeOpenStackLbPoolMember(lbClient, poolId, addresses)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed on purging invalid LB members from LB pool")
 	}

--- a/pkg/platform/openstack/kuryr_bootstrap.go
+++ b/pkg/platform/openstack/kuryr_bootstrap.go
@@ -1161,9 +1161,11 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient client.Client) (*bootst
 	log.Print("Creating OpenShift API loadbalancer pool members")
 	r, _ := regexp.Compile(fmt.Sprintf("^%s-(master-port-[0-9]+|bootstrap-port)$", clusterID))
 	portList, err := listOpenStackPortsMatchingPattern(client, tag, r)
+	addresses := make([]string, 0)
 	for _, port := range portList {
 		if len(port.FixedIPs) > 0 {
 			portIp := port.FixedIPs[0].IPAddress
+			addresses = append(addresses, portIp)
 			log.Printf("Found port %s with IP %s", port.ID, portIp)
 
 			// We want bootstrap to stop being used as soon as possible, as it will serve
@@ -1183,6 +1185,11 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient client.Client) (*bootst
 		} else {
 			log.Printf("Matching port %s has no IP", port.ID)
 		}
+	}
+
+	err = purgeOpenStackLbPoolMember(client, poolId, addresses)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed on purging invalid LB members from LB pool")
 	}
 
 	log.Print("Ensuring certificates")

--- a/pkg/platform/openstack/loadbalancer.go
+++ b/pkg/platform/openstack/loadbalancer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/apiversions"
+	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools"
 )
 
 func getMaxOctaviaAPIVersion(client *gophercloud.ServiceClient) (*semver.Version, error) {


### PR DESCRIPTION

During installation a bootstrap node is used as an API node at first,
but then gets removed. In Kuryr's bootstrap we never remove it from API
loadbalancer pool which leads to Octavia stating that LB is in degraded
state.

With those changes we prevent it by making sure on reconciliation we
remove loadbalancer members that we don't need there anymore. This
should help with scaledown of masters too.

(cherry picked from commit 0ccf62b3f058ebc1e9d8ddfa7a661098b37b1a21)
