### PR TITLE
Bug 1833372: Drop 'dep verify' from verify-style

### DIFF
--- a/hack/verify-style.sh
+++ b/hack/verify-style.sh
@@ -16,11 +16,6 @@ if [[ ! $(which golint) ]]; then
   echo "go get -u github.com/golang/lint/golint"
   exit 1
 fi
-if [[ ! $(which dep) ]]; then
-  echo "dep not found on PATH. To install:"
-  echo "curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh"
-  exit 1
-fi
 
 rc=0
 trap 'rc=$?' ERR
@@ -41,9 +36,6 @@ fi
 
 echo "Running go vet..."
 go vet $GOPKGS
-
-echo "Running dep check..."
-dep check
 
 echo "Done!"
 exit ${rc}


### PR DESCRIPTION
ci/prow/verify is failing in #616 because of weird interactions between "go get" and "migrating to go modules", but we can't fix either side without breaking the other unless we do this first

@squeed @dcbw @rcarrillocruz 
(cc @vishnoianil )