### PR TITLE
Bug 1834247: Don't override containernetworking binaries in SDN and Kuryr

### DIFF
--- a/bindata/network/kuryr/005-daemon.yaml
+++ b/bindata/network/kuryr/005-daemon.yaml
@@ -23,21 +23,6 @@ spec:
       hostNetwork: true
       serviceAccountName: kuryr
       priorityClassName: system-node-critical
-      initContainers:
-      - name: install-cni-plugins
-        image: {{ .CNIPluginsImage }}
-        command:
-        - /bin/bash
-        - -c
-        - |
-          #!/bin/bash
-          set -ex
-          cp -f /usr/src/plugins/bin/loopback /host-cni-bin/
-        volumeMounts:
-        - name: bin
-          mountPath: /host-cni-bin
-        securityContext:
-          privileged: true
       containers:
       - name: kuryr-cni
         image: {{ .DaemonImage }}

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -76,11 +76,12 @@ data:
     fi
 
     cp -rf ${sourcedir}* $DESTINATION_DIRECTORY
+
     if [ $? -eq 0 ]; then
-        echo "Successfully copied files in ${sourcedir} to $DESTINATION_DIRECTORY"
+      echo "Successfully copied files in ${sourcedir} to $DESTINATION_DIRECTORY"
     else
-        echo "Failed to copy files in ${sourcedir} to $DESTINATION_DIRECTORY"
-        exit 1
+      echo "Failed to copy files in ${sourcedir} to $DESTINATION_DIRECTORY"
+      exit 1
     fi
 ---
 kind: DaemonSet
@@ -350,7 +351,7 @@ spec:
             path: {{ .MultusCNIConfDir }}
         - name: cnibin
           hostPath:
-            path: /var/lib/cni/bin
+            path: {{ .CNIBinDir }}
         - name: os-release
           hostPath:
             path: /etc/os-release

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -37,21 +37,6 @@ spec:
       hostNetwork: true
       hostPID: true
       priorityClassName: system-node-critical
-      initContainers:
-      - name: install-cni-plugins
-        image: {{ .CNIPluginsImage }}
-        command:
-        - /bin/bash
-        - -c
-        - |
-          #!/bin/bash
-          set -ex
-          cp -f /usr/src/plugins/bin/{loopback,host-local} /host/opt/cni/bin
-        volumeMounts:
-        - mountPath: /host/opt/cni/bin
-          name: host-cni-bin
-        securityContext:
-          privileged: true
       containers:
       - name: sdn
         image: {{.SDNImage}}

--- a/pkg/network/multus.go
+++ b/pkg/network/multus.go
@@ -59,6 +59,7 @@ func renderMultusConfig(manifestDir, defaultNetworkType string, useDHCP bool) ([
 	data.Data["MultusCNIConfDir"] = MultusCNIConfDir
 	data.Data["SystemCNIConfDir"] = SystemCNIConfDir
 	data.Data["DefaultNetworkType"] = defaultNetworkType
+	data.Data["CNIBinDir"] = CNIBinDir
 
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/multus"), &data)
 	if err != nil {


### PR DESCRIPTION
Release 4.3 Back-port for https://github.com/openshift/cluster-network-operator/pull/602

/hold 

Until MCO PR is in: https://github.com/openshift/machine-config-operator/pull/1722

And since he's been in the loop of this since the very beginning: 

/assign @danwinship 

And just so that I don't forgot:

/cherry-pick release-4.2