### PR TITLE
Bug 1834858: Kuryr: Remove old SG rules on upgrade

### DIFF
--- a/pkg/platform/openstack/kuryr_bootstrap.go
+++ b/pkg/platform/openstack/kuryr_bootstrap.go
@@ -441,8 +441,8 @@ func ensureOpenStackSgRule(client *gophercloud.ServiceClient, sgId, remotePrefix
 		Direction:      rules.DirIngress,
 		RemoteIPPrefix: remotePrefix,
 	}
-	// Let's just assume that we're getting passed -1 when we aren't supposed to set those
-	if portMin >= 0 && portMax >= 0 {
+	// Let's just assume that we're getting passed 0 when we aren't supposed to set those
+	if portMin > 0 && portMax > 0 {
 		opts.PortRangeMin = portMin
 		opts.PortRangeMax = portMax
 		opts.Protocol = protocol
@@ -456,6 +456,29 @@ func ensureOpenStackSgRule(client *gophercloud.ServiceClient, sgId, remotePrefix
 		return errors.Wrap(err, "failed to create SG rule")
 	}
 	return nil
+}
+
+// Returns list of OpenStack ingress security group rules on SGs tagged with tag.
+func listOpenStackSgRules(client *gophercloud.ServiceClient, tag string) ([]rules.SecGroupRule, error) {
+	page, err := groups.List(client, groups.ListOpts{Tags: tag}).AllPages()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get security group list")
+	}
+	groupsList, err := groups.ExtractGroups(page)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to extract security group list")
+	}
+
+	var rulesList []rules.SecGroupRule
+	for _, group := range groupsList {
+		for _, rule := range group.Rules {
+			if rule.Direction == string(rules.DirIngress) {
+				rulesList = append(rulesList, rule)
+			}
+		}
+	}
+
+	return rulesList, nil
 }
 
 // Delete a LoadBalancer and all associated resources
@@ -1054,9 +1077,14 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient client.Client) (*bootst
 	}
 
 	var sgRules = []sgRule{
-		{podSgId, "0.0.0.0/0", -1, -1, rules.ProtocolTCP},
+		{podSgId, "0.0.0.0/0", 0, 0, rules.ProtocolTCP},
 		{masterSgId, openStackSvcCIDR, etcdPort, etcdPort, rules.ProtocolTCP},
 		{masterSgId, openStackSvcCIDR, apiPort, apiPort, rules.ProtocolTCP},
+	}
+
+	var decommissionedRules = []sgRule{
+		{podSgId, workerSubnet.CIDR, 0, 0, ""},
+		{masterSgId, openStackSvcCIDR, 2379, 2380, rules.ProtocolTCP},
 	}
 
 	for _, cidr := range podSubnetCidrs {
@@ -1079,6 +1107,11 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient client.Client) (*bootst
 			sgRule{workerSgId, cidr, 9000, 9999, rules.ProtocolTCP},
 			sgRule{workerSgId, cidr, 9000, 9999, rules.ProtocolUDP},
 		)
+
+		decommissionedRules = append(decommissionedRules,
+			sgRule{masterSgId, cidr, 0, 0, ""},
+			sgRule{workerSgId, cidr, 0, 0, ""},
+		)
 	}
 
 	log.Print("Allowing required traffic")
@@ -1090,6 +1123,33 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient client.Client) (*bootst
 		}
 	}
 	log.Print("All requried traffic allowed")
+
+	// It may happen that we tightened some SG rules in an upgrade, we need to make sure to remove the ones that are
+	// not expected anymore.
+	log.Print("Removing old SG rules")
+	existingRules, err := listOpenStackSgRules(client, tag)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list SG rules")
+	}
+
+	for _, existingRule := range existingRules {
+		// Need to convert to "our" format for easy comparisons.
+		rule := sgRule{existingRule.SecGroupID, existingRule.RemoteIPPrefix, existingRule.PortRangeMin,
+			existingRule.PortRangeMax, rules.RuleProtocol(existingRule.Protocol)}
+		for _, decommissionedRule := range decommissionedRules {
+			if decommissionedRule == rule {
+				log.Printf("Removing decommisioned rule %s (%s, %d, %d, %s) from SG %s", existingRule.ID,
+					existingRule.RemoteIPPrefix, existingRule.PortRangeMin, existingRule.PortRangeMax,
+					existingRule.Protocol, existingRule.SecGroupID)
+				err = rules.Delete(client, existingRule.ID).ExtractErr()
+				if err != nil {
+					return nil, errors.Wrapf(err, "Could not delete SG rule %s", existingRule.ID)
+				}
+				break
+			}
+		}
+	}
+	log.Print("All old SG rules removed")
 
 	lbClient, err := openstack.NewLoadBalancerV2(provider, gophercloud.EndpointOpts{})
 	if err != nil {

--- a/pkg/platform/openstack/kuryr_bootstrap.go
+++ b/pkg/platform/openstack/kuryr_bootstrap.go
@@ -58,8 +58,13 @@ const (
 	MinOctaviaVersionWithTagSupport        = "v2.5"
 	MinOctaviaVersionWithTimeouts          = "v2.1"
 	KuryrNamespace                         = "openshift-kuryr"
-	EtcdPort                               = 2379
-	DNSPort                                = 53
+	etcdPort                               = 2379
+	dnsPort                                = 53
+	apiPort                                = 6443
+	routerMetricsPort                      = 1936
+	kubeCMMetricsPort                      = 10257
+	kubeSchedulerMetricsPort               = 10259
+	kubeletMetricsPort                     = 10250
 )
 
 func GetClusterID(kubeClient client.Client) (string, error) {
@@ -1040,41 +1045,49 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient client.Client) (*bootst
 	podSgId, err := ensureOpenStackSg(client, generateName("kuryr-pods-security-group", clusterID), tag)
 	log.Printf("Pods security group %s present", podSgId)
 
-	log.Print("Allowing traffic from pod to pod")
-	err = ensureOpenStackSgRule(client, podSgId, "0.0.0.0/0", -1, -1, rules.ProtocolTCP)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to add rule opening traffic pod to pod")
+	type sgRule struct {
+		sgId     string
+		cidr     string
+		minPort  int
+		maxPort  int
+		protocol rules.RuleProtocol
 	}
+
+	var sgRules = []sgRule{
+		{podSgId, "0.0.0.0/0", -1, -1, rules.ProtocolTCP},
+		{masterSgId, openStackSvcCIDR, etcdPort, etcdPort, rules.ProtocolTCP},
+		{masterSgId, openStackSvcCIDR, apiPort, apiPort, rules.ProtocolTCP},
+	}
+
 	for _, cidr := range podSubnetCidrs {
-		err = ensureOpenStackSgRule(client, masterSgId, cidr, EtcdPort, EtcdPort, rules.ProtocolTCP)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to add TCP rule opening traffic to masters from %s on %d", cidr, EtcdPort)
-		}
-		err = ensureOpenStackSgRule(client, masterSgId, cidr, DNSPort, DNSPort, rules.ProtocolTCP)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to add TCP rule opening traffic to masters from %s on %d", cidr, DNSPort)
-		}
-		err = ensureOpenStackSgRule(client, masterSgId, cidr, DNSPort, DNSPort, rules.ProtocolUDP)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to add UDP rule opening traffic to masters from %s on %d", cidr, DNSPort)
-		}
-		err = ensureOpenStackSgRule(client, workerSgId, cidr, DNSPort, DNSPort, rules.ProtocolTCP)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to add TCP rule opening traffic to workers from %s on %d", cidr, DNSPort)
-		}
-		err = ensureOpenStackSgRule(client, workerSgId, cidr, DNSPort, DNSPort, rules.ProtocolUDP)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to add UDP rule opening traffic to workers from %s on %d", cidr, DNSPort)
-		}
+		sgRules = append(sgRules,
+			sgRule{masterSgId, cidr, etcdPort, etcdPort, rules.ProtocolTCP},
+			sgRule{masterSgId, cidr, dnsPort, dnsPort, rules.ProtocolTCP},
+			sgRule{masterSgId, cidr, dnsPort, dnsPort, rules.ProtocolUDP},
+			sgRule{workerSgId, cidr, dnsPort, dnsPort, rules.ProtocolTCP},
+			sgRule{workerSgId, cidr, dnsPort, dnsPort, rules.ProtocolUDP},
+			sgRule{workerSgId, cidr, routerMetricsPort, routerMetricsPort, rules.ProtocolTCP},
+			sgRule{masterSgId, cidr, kubeCMMetricsPort, kubeCMMetricsPort, rules.ProtocolTCP},
+			sgRule{masterSgId, cidr, kubeSchedulerMetricsPort, kubeSchedulerMetricsPort, rules.ProtocolTCP},
+			sgRule{masterSgId, cidr, kubeletMetricsPort, kubeletMetricsPort, rules.ProtocolTCP},
+			sgRule{workerSgId, cidr, kubeletMetricsPort, kubeletMetricsPort, rules.ProtocolTCP},
+			// NOTE(dulek): I honestly don't know why this is so broad range, but I took it from SGs installer sets
+			//              for workers and masters. In general point was to open 9192 so that metrics of
+			//              cluster-autoscaler-operator were rechable.
+			sgRule{masterSgId, cidr, 9000, 9999, rules.ProtocolTCP},
+			sgRule{masterSgId, cidr, 9000, 9999, rules.ProtocolUDP},
+			sgRule{workerSgId, cidr, 9000, 9999, rules.ProtocolTCP},
+			sgRule{workerSgId, cidr, 9000, 9999, rules.ProtocolUDP},
+		)
 	}
-	err = ensureOpenStackSgRule(client, masterSgId, openStackSvcCIDR, EtcdPort, EtcdPort, rules.ProtocolTCP)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to add rule opening etcd traffic to masters from service subnet %s", conf.ServiceNetwork[0])
-	}
-	// We need to open traffic from service subnet to masters for API LB to work.
-	err = ensureOpenStackSgRule(client, masterSgId, openStackSvcCIDR, 6443, 6443, rules.ProtocolTCP)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to add rule opening traffic to masters from service subnet %s", conf.ServiceNetwork[0])
+
+	log.Print("Allowing required traffic")
+	for _, rule := range sgRules {
+		err = ensureOpenStackSgRule(client, rule.sgId, rule.cidr, rule.minPort, rule.maxPort, rule.protocol)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to add %s rule opening traffic from %s in security group %s on ports %d:%d",
+				rule.protocol, rule.cidr, rule.sgId, rule.minPort, rule.maxPort)
+		}
 	}
 	log.Print("All requried traffic allowed")
 


### PR DESCRIPTION
In order to support updates in the SG rules added on Kuryr bootstrap we
need to make sure the security groups that got replaced by others are
removed. This commit, by maintaing list of "decommissioned" SG rules,
will make sure we delete them on upgrade.