### PR TITLE
clarify and tweek the threshold for NetworkPodsCrashlooping

### DIFF
--- a/bindata/network/openshift-sdn/alert-rules.yaml
+++ b/bindata/network/openshift-sdn/alert-rules.yaml
@@ -33,9 +33,9 @@ spec:
     - alert: NetworkPodsCrashLooping
       annotations:
         message: Pod {{"{{"}} $labels.namespace{{"}}"}}/{{"{{"}} $labels.pod{{"}}"}} ({{"{{"}} $labels.container
-          {{"}}"}}) is restarting {{"{{"}} printf "%.2f" $value {{"}}"}} times / 5 minutes.
+          {{"}}"}}) is restarting an average of {{"{{"}} printf "%.2f" $value {{"}}"}} times every 5 minutes.
       expr: |
-        rate(kube_pod_container_status_restarts_total{namespace="openshift-sdn"}[15m]) * 60 * 5 > 0
+        rate(kube_pod_container_status_restarts_total{namespace="openshift-sdn"}[15m]) * 60 * 5 >= 1
       for: 1h
       labels:
         severity: warning


### PR DESCRIPTION
clarify the error message and increase the threshold so that the
alert will not fire during upgrade