### PR TITLE
Support using common name as hostname for TLS server cert verification

### DIFF
--- a/bindata/network/ovn-kubernetes/006-pki.yaml
+++ b/bindata/network/ovn-kubernetes/006-pki.yaml
@@ -7,4 +7,4 @@ metadata:
   namespace: openshift-ovn-kubernetes
 spec:
   targetCert:
-    commonName: ovn
+    commonName: {{.OVN_CERT_CN}}

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -480,11 +480,13 @@ spec:
             --sb-client-privkey /ovn-cert/tls.key \
             --sb-client-cert /ovn-cert/tls.crt \
             --sb-client-cacert /ovn-ca/ca-bundle.crt \
+            --sb-cert-common-name "{{.OVN_CERT_CN}}" \
             --nb-address "{{.OVN_NB_DB_LIST}}" \
             --nb-client-privkey /ovn-cert/tls.key \
             --nb-client-cert /ovn-cert/tls.crt \
             --nb-client-cacert /ovn-ca/ca-bundle.crt \
             --nbctl-daemon-mode \
+            --nb-cert-common-name "{{.OVN_CERT_CN}}" \
             --enable-multicast
         lifecycle:
           preStop:

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -132,9 +132,11 @@ spec:
             --nb-client-privkey /ovn-cert/tls.key \
             --nb-client-cert /ovn-cert/tls.crt \
             --nb-client-cacert /ovn-ca/ca-bundle.crt \
+            --nb-cert-common-name "{{.OVN_CERT_CN}}" \
             --sb-client-privkey /ovn-cert/tls.key \
             --sb-client-cert /ovn-cert/tls.crt \
             --sb-client-cacert /ovn-ca/ca-bundle.crt \
+            --sb-cert-common-name "{{.OVN_CERT_CN}}" \
             --config-file=/run/ovnkube-config/ovnkube.conf \
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
             --inactivity-probe="${OVN_CONTROLLER_INACTIVITY_PROBE}" \

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -31,6 +31,7 @@ const OVN_NB_RAFT_PORT = "9643"
 const OVN_SB_RAFT_PORT = "9644"
 const CLUSTER_CONFIG_NAME = "cluster-config-v1"
 const CLUSTER_CONFIG_NAMESPACE = "kube-system"
+const OVN_CERT_CN = "ovn"
 
 // renderOVNKubernetes returns the manifests for the ovn-kubernetes.
 // This creates
@@ -67,6 +68,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["OVN_MASTER_IP"] = bootstrapResult.OVN.MasterIPs[0]
 	data.Data["OVN_MIN_AVAILABLE"] = len(bootstrapResult.OVN.MasterIPs)/2 + 1
 	data.Data["LISTEN_DUAL_STACK"] = listenDualStack(bootstrapResult.OVN.MasterIPs[0])
+	data.Data["OVN_CERT_CN"] = OVN_CERT_CN
 
 	var ippools string
 	for _, net := range conf.ClusterNetwork {


### PR DESCRIPTION
This change renders the daemonsets for ovnkube-master and ovnkube-node
using the same parameter that is used for the hostname parameter of
the PKI cert generated.