### PR TITLE
Bug 1820472: Not delete namespace object when cleanup not rended objects

### DIFF
--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -85,6 +85,12 @@ func (status *StatusManager) deleteRelatedObjectsNotRendered(co *configv1.Cluste
 				status.relatedObjects = append(status.relatedObjects, currentObj)
 				continue
 			}
+			if gvk.Kind == "Namespace" && gvk.Group == "" {
+				// BZ 1820472: During SDN migration, deleting a namespace object may get stuck in 'Terminating' forever if the cluster network doesn't working as expected.
+				// We choose to not delete the namespace here but to ask user do it manually after the cluster is back to normal state.
+				log.Printf("Object Kind is Namespace, skip")
+				continue
+			}
 			log.Printf("Detected related object with GVK %+v, namespace %v and name %v not rendered by manifests, deleting...", gvk, currentObj.Namespace, currentObj.Name)
 			objToDelete := &uns.Unstructured{}
 			objToDelete.SetName(currentObj.Name)


### PR DESCRIPTION
Namespace deletion cannot be done while openshift-apiserver is down. It will be stuck in 'Terminating' state forever, and that can block the sdn restore. So we choose not to delete the namespace by the cleanup function but leave it to the user to manually remove the namespace after the cluster is back to a normal state.