### PR TITLE
Bug 1838251: The DHCP CNI daemonset should mount the netns paths

### DIFF
--- a/bindata/network/multus/003-dhcp-daemon.yaml
+++ b/bindata/network/multus/003-dhcp-daemon.yaml
@@ -52,6 +52,9 @@ spec:
           mountPath: /host/run/cni
         - name: procpath
           mountPath: /host/proc
+        - name: netnspath
+          mountPath: /host/var/run/netns
+          mountPropagation: HostToContainer
       volumes:
         - name: socketpath
           hostPath:
@@ -59,4 +62,8 @@ spec:
         - name: procpath
           hostPath:
             path: /proc
+        - name: netnspath
+          hostPath:
+            path: /run/netns
+
 {{- end}}


### PR DESCRIPTION
Otherwise, it can fail with out being able to locate the netns paths under OCP 4.5