### PR TITLE
fix up dual-stack Service reconciling

### DIFF
--- a/pkg/apply/merge.go
+++ b/pkg/apply/merge.go
@@ -76,7 +76,7 @@ func MergeDeploymentForUpdate(current, updated *uns.Unstructured) error {
 	return nil
 }
 
-// MergeServiceForUpdate ensures the clusterip is never written to
+// MergeServiceForUpdate ensures the ClusterIP/IPFamily is never modified
 func MergeServiceForUpdate(current, updated *uns.Unstructured) error {
 	gvk := updated.GroupVersionKind()
 	if gvk.Group == "" && gvk.Kind == "Service" {
@@ -84,9 +84,22 @@ func MergeServiceForUpdate(current, updated *uns.Unstructured) error {
 		if err != nil {
 			return err
 		}
-
 		if found {
-			return uns.SetNestedField(updated.Object, clusterIP, "spec", "clusterIP")
+			err = uns.SetNestedField(updated.Object, clusterIP, "spec", "clusterIP")
+			if err != nil {
+				return err
+			}
+		}
+
+		ipFamily, found, err := uns.NestedString(current.Object, "spec", "ipFamily")
+		if err != nil {
+			return err
+		}
+		if found {
+			err = uns.SetNestedField(updated.Object, ipFamily, "spec", "ipFamily")
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/apply/merge_test.go
+++ b/pkg/apply/merge_test.go
@@ -210,7 +210,8 @@ kind: Service
 metadata:
   name: d1
 spec:
-  clusterIP: cur`)
+  clusterIP: cur
+  ipFamily: IPv4`)
 
 	upd := UnstructuredFromYaml(t, `
 apiVersion: v1
@@ -226,6 +227,10 @@ spec:
 	ip, _, err := uns.NestedString(upd.Object, "spec", "clusterIP")
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(ip).To(Equal("cur"))
+
+	ipFamily, _, err := uns.NestedString(upd.Object, "spec", "ipFamily")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ipFamily).To(Equal("IPv4"))
 }
 
 func TestMergeServiceAccount(t *testing.T) {


### PR DESCRIPTION
We should not attempt to overwrite Service.Spec.IPFamily, if it's set (in a dual-stack cluster)