### PR TITLE
Bug 1838251: mount /var/run/netns rslave in DHCP daemonset

### DIFF
--- a/bindata/network/multus/003-dhcp-daemon.yaml
+++ b/bindata/network/multus/003-dhcp-daemon.yaml
@@ -52,6 +52,10 @@ spec:
           mountPath: /host/run/cni
         - name: procpath
           mountPath: /host/proc
+        - name: var-run-netnspath
+          mountPath: /host/var/run/netns
+          mountPropagation: HostToContainer
+          readOnly: true
       volumes:
         - name: socketpath
           hostPath:
@@ -59,4 +63,7 @@ spec:
         - name: procpath
           hostPath:
             path: /proc
+        - name: var-run-netnspath
+          hostPath:
+            path: /var/run/netns
 {{- end}}


### PR DESCRIPTION
To fix that DHCP pod cannot get netns info due to #579, need to change the mount option for DHCP CNI server. This fix changes it.