### PR TITLE
Bug 1835497 : Prevent sb/nb db readiness probe from being zombie

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -163,13 +163,14 @@ spec:
                 fi
         readinessProbe:
           initialDelaySeconds: 30
+          timeoutSeconds: 5
           exec:
             command:
             - /bin/bash
             - -c
             - |
               set -xe
-              exec /usr/bin/ovn-appctl -t /var/run/ovn/ovnnb_db.ctl cluster/status OVN_Northbound  2>/dev/null | grep ${K8S_NODE_IP} | grep -v Address -q
+              /usr/bin/ovn-appctl -t /var/run/ovn/ovnnb_db.ctl --timeout=3 cluster/status OVN_Northbound  2>/dev/null | grep ${K8S_NODE_IP} | grep -v Address -q
         env:
         - name: OVN_LOG_LEVEL
           value: info 
@@ -270,13 +271,14 @@ spec:
                 fi
         readinessProbe:
           initialDelaySeconds: 30
+          timeoutSeconds: 5
           exec:
             command:
             - /bin/bash
             - -c
             - |
               set -xe
-              exec /usr/bin/ovn-appctl -t /var/run/ovn/ovnsb_db.ctl cluster/status OVN_Southbound  2>/dev/null | grep ${K8S_NODE_IP} | grep -v Address -q
+              /usr/bin/ovn-appctl -t /var/run/ovn/ovnsb_db.ctl --timeout=3 cluster/status OVN_Southbound  2>/dev/null | grep ${K8S_NODE_IP} | grep -v Address -q
         env:
         - name: OVN_LOG_LEVEL
           value: info 


### PR DESCRIPTION
Current implementation of sb/nb db containers readiness probe uses
exec to call the ovn-appctl to check the status of the sb/nb db raft
cluster. This exec call will be executed by another exec call that is
used to execute the probe. If sb/nb db raft cluster is busy and readiness
probe is fired, it will be stuck till the raft cluster respond with
success or failure. It might take time in seconds (even more than
`periodSeconds` time). Next readiness probe executes and kills the parent
that makes the child processes zombie and they never reap. With single
readiness probe failure it creates 3 zombie threads.

With higher scale, raft cluster can be busy for long duration
(10 to 100s depending on the load) and readiness probe will fail
more frequently and that can increase the zombie threads and slowly
 eat up the pthread_thread quota and newly scheduled or rebooted pods
 on the nodes might not be able to create threads and fails.

In this reported bug, sb raft cluster was not in healthy state and
CNO endup rebooting the node, but it fails to boot because it was not
allowed to create anymore threads, and this raft cluster never recovered.

Signed-off-by: Anil Vishnoi <avishnoi@redhat.com>