### PR TITLE
Bug 1841029: Recreate DNS service upon Octavia upgrade

### DIFF
--- a/bindata/network/kuryr/003-config.yaml
+++ b/bindata/network/kuryr/003-config.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-kuryr
   annotations:
     networkoperator.openshift.io/kuryr-octavia-provider: {{ .OctaviaProvider }}
+    networkoperator.openshift.io/kuryr-octavia-version: {{ .OctaviaVersion }}
 data:
   kuryr.conf: |+
     [DEFAULT]

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -14,6 +14,7 @@ type KuryrBootstrapResult struct {
 	ClusterID                string
 	OctaviaProvider          string
 	OctaviaMultipleListeners bool
+	OctaviaVersion           string
 	OpenStackCloud           clientconfig.Cloud
 	WebhookCA                string
 	WebhookCAKey             string

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -41,6 +41,9 @@ const NetworkMigrationAnnotation = "networkoperator.openshift.io/network-migrati
 // prevent from reconfiguring it automatically when underlying Octavia changes.
 const KuryrOctaviaProviderAnnotation = "networkoperator.openshift.io/kuryr-octavia-provider"
 
+// KuryrOctaviaVersionAnnotation is used to save latest Octavia version detected
+const KuryrOctaviaVersionAnnotation = "networkoperator.openshift.io/kuryr-octavia-version"
+
 // SERVICE_CA_CONFIGMAP is the name of the ConfigMap that contains service CA bundle
 // that is used in multus admission controller deployment
 const SERVICE_CA_CONFIGMAP = "openshift-service-ca"

--- a/pkg/network/kuryr.go
+++ b/pkg/network/kuryr.go
@@ -78,6 +78,7 @@ func renderKuryr(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapR
 		data.Data["OctaviaSGEnforce"] = "true"
 		data.Data["OctaviaLBAlgorithm"] = "ROUND_ROBIN"
 	}
+	data.Data["OctaviaVersion"] = b.OctaviaVersion
 
 	// kuryr-daemon DaemonSet data
 	data.Data["DaemonEnableProbes"] = true

--- a/pkg/platform/openstack/kuryr_bootstrap.go
+++ b/pkg/platform/openstack/kuryr_bootstrap.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
 
+	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
@@ -38,6 +39,7 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/names"
 	"github.com/openshift/cluster-network-operator/pkg/platform/openstack/util/cert"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	confv1 "github.com/openshift/api/config/v1"
@@ -61,6 +63,8 @@ const (
 	MinOctaviaVersionWithTimeouts          = "v2.1"
 	KuryrNamespace                         = "openshift-kuryr"
 	KuryrConfigMapName                     = "kuryr-config"
+	DNSNamespace                           = "openshift-dns"
+	DNSServiceName                         = "dns-default"
 	// NOTE(ltomasbo): Only OVN octavia driver supported on kuryr
 	OVNProvider              = "ovn"
 	etcdPort                 = 2379
@@ -907,12 +911,12 @@ func getUserCACert(kubeClient client.Client) (string, error) {
 	return cm.Data["ca-bundle.pem"], nil
 }
 
-func getSavedOctaviaProvider(kubeClient client.Client) (string, error) {
+func getSavedAnnotation(kubeClient client.Client, annotation string) (string, error) {
 	cm, err := getConfigMap(kubeClient, KuryrNamespace, KuryrConfigMapName)
 	if err != nil {
 		return "", err
 	}
-	return cm.Annotations[names.KuryrOctaviaProviderAnnotation], nil
+	return cm.Annotations[annotation], nil
 }
 
 // Logs into OpenStack and creates all the resources that are required to run
@@ -1276,7 +1280,7 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient client.Client) (*bootst
 	//    b. List providers and look for OVN one.
 	//    c. If it's present configure Kuryr to use it.
 	//    d. In case of any issues just use whatever the default is.
-	octaviaProvider, err := getSavedOctaviaProvider(kubeClient) // Ignore error, just do the normal discovery then.
+	octaviaProvider, err := getSavedAnnotation(kubeClient, names.KuryrOctaviaProviderAnnotation)
 	if octaviaProvider != "" {
 		log.Printf("Detected that Kuryr was already configured to use %s LB provider. Making sure to keep it that way.",
 			octaviaProvider)
@@ -1307,6 +1311,39 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient client.Client) (*bootst
 		}
 	}
 
+	octaviaVersion, err := getSavedAnnotation(kubeClient, names.KuryrOctaviaVersionAnnotation)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, errors.Wrap(err, "failed to get kuryr-config ConfigMap")
+	}
+
+	maxOctaviaVersion, err := getMaxOctaviaAPIVersion(lbClient)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get max octavia api version")
+	}
+
+	// In case the Kuryr config-map is annotated with an Octavia version different
+	// than the current Octavia version, and older than the version that multiple
+	// listeners becomes available and the Octavia provider is amphora, an Octavia
+	// upgrade happened and UDP listeners are now allowed to be created.
+	// By recreating the OpenShift DNS service a new load balancer amphora is in
+	// place with all required listeners.
+	log.Print("Checking Octavia upgrade happened")
+	if octaviaVersion != "" && octaviaProvider == "default" {
+		savedOctaviaVersion := semver.MustParse(octaviaVersion)
+		multipleListenersVersion := semver.MustParse(MinOctaviaVersionWithMultipleListeners)
+		if !savedOctaviaVersion.Equal(maxOctaviaVersion) && savedOctaviaVersion.LessThan(multipleListenersVersion) && octaviaMultipleListenersSupport {
+			dnsService := &v1.Service{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
+				ObjectMeta: metav1.ObjectMeta{Name: DNSServiceName, Namespace: DNSNamespace},
+			}
+			err := kubeClient.Delete(context.TODO(), dnsService)
+			if err != nil {
+				return nil, errors.Wrapf(err, "Failed to delete %s Service", DNSServiceName)
+			}
+		}
+	}
+	octaviaVersion = maxOctaviaVersion.Original()
+
 	log.Print("Kuryr bootstrap finished")
 
 	res := bootstrap.BootstrapResult{
@@ -1320,6 +1357,7 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient client.Client) (*bootst
 			ClusterID:                clusterID,
 			OctaviaProvider:          octaviaProvider,
 			OctaviaMultipleListeners: octaviaMultipleListenersSupport,
+			OctaviaVersion:           octaviaVersion,
 			OpenStackCloud:           cloud,
 			WebhookCA:                b64.StdEncoding.EncodeToString(ca),
 			WebhookCAKey:             b64.StdEncoding.EncodeToString(key),


### PR DESCRIPTION
When Octavia is upgraded from OSP13 to OSP16 double listeners becomes
supported and the load balancers that requires TCP and UDP on same
port should be recreated.

This commit ensure the DNS service is recreated upon Octavia upgrade.