### PR TITLE
Bug 1846396: Drop ovn-octavia provider limitation for multiprotocol listeners

### DIFF
--- a/pkg/platform/openstack/kuryr_bootstrap.go
+++ b/pkg/platform/openstack/kuryr_bootstrap.go
@@ -42,8 +42,9 @@ const (
 	OpenShiftConfigNamespace = "openshift-config"
 	UserCABundleConfigMap    = "cloud-provider-config"
 	// NOTE(dulek): This one is hardcoded in openshift/installer.
-	InfrastructureCRDName                  = "cluster"
-	MinOctaviaVersionWithMultipleListeners = "v2.11"
+	InfrastructureCRDName = "cluster"
+	// NOTE(ltomasbo): Amphora driver supports came on 2.11, but ovn-octavia only supports it after 2.13
+	MinOctaviaVersionWithMultipleListeners = "v2.13"
 	MinOctaviaVersionWithHTTPSMonitors     = "v2.10"
 	MinOctaviaVersionWithProviders         = "v2.6"
 	MinOctaviaVersionWithTagSupport        = "v2.5"
@@ -566,10 +567,6 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient client.Client) (*bootst
 	if octaviaProvider != "" {
 		log.Printf("Detected that Kuryr was already configured to use %s LB provider. Making sure to keep it that way.",
 			octaviaProvider)
-		if octaviaProvider == OVNProvider {
-			// OVN provider does not support multiple listeners, so in that case we always set false to that.
-			octaviaMultipleListenersSupport = false
-		}
 	} else {
 		octaviaProvider = "default"
 		if octaviaProviderSupport {
@@ -581,8 +578,6 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient client.Client) (*bootst
 					if provider.Name == OVNProvider {
 						log.Print("OVN Provider is enabled and Kuryr will use it")
 						octaviaProvider = OVNProvider
-						// OVN provider does not support multiple listeners, so in that case we always set false to that.
-						octaviaMultipleListenersSupport = false
 					}
 				}
 			}


### PR DESCRIPTION
The ovn-octavia limitation of having several listener protocols
on the same port has been fixed, so the exception made for it
is not needed anymore.