### PR TITLE
Bug 1841507: Allow connection between authentication net namespaces

### DIFF
--- a/bindata/network/openshift-sdn/004-multitenant.yaml
+++ b/bindata/network/openshift-sdn/004-multitenant.yaml
@@ -126,4 +126,19 @@ metadata:
 netid: 1
 netname: openshift-service-catalog-controller-manager
 
+---
+apiVersion: network.openshift.io/v1
+kind: NetNamespace
+metadata:
+  name: openshift-authentication
+netid: 1
+netname: openshift-authentication
+
+---
+apiVersion: network.openshift.io/v1
+kind: NetNamespace
+metadata:
+  name: openshift-authentication-operator
+netid: 1
+netname: openshift-authentication-operator
 {{- end}}


### PR DESCRIPTION
This is a backport from 4.5 