### PR TITLE
Bug 1824983: explicitly delete pidfiles when exiting

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -67,6 +67,12 @@ spec:
           }
           trap quit SIGTERM
 
+          function deletePid {
+              rm /var/run/openvswitch/ovs-vswitchd.pid
+              rm /var/run/openvswitch/ovsdb-server.pid
+          }
+          trap deletePid EXIT
+
           # launch OVS
           # Start the ovsdb so that we can prep it before we start the ovs-vswitchd
           /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --no-ovs-vswitchd --system-id=random --no-monitor


### PR DESCRIPTION
saw this error message in the logs

Terminated:&ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:ovsdb-server: /var/run/openvswitch/ovsdb-server.pid: pidfile check failed (No such process)

when it looked like ovs was restarting causing the sdn pods to spin. explicitly delete

/var/run/openvswitch/ovs-vswitchd.pid and
/var/run/openvswitch/ovsdb-server.pid:

on ovs pod exit