### PR TITLE
enforce a single egressNetworkPolicy object per project

### DIFF
--- a/bindata/network/openshift-sdn/001-crd.yaml
+++ b/bindata/network/openshift-sdn/001-crd.yaml
@@ -359,6 +359,10 @@ spec:
           type: string
         metadata:
           type: object
+          properties:
+            name:
+              type: string
+              pattern: ^default$
         spec:
           description: spec is the specification of the current egress network policy
           properties:


### PR DESCRIPTION
by changing the egressNetworkPolicy CRD to enforce the only valid name
for egressNetworkPolicy is "default" guarantees that there will only
be one egressNetworkPoliy object per project.