### PR TITLE
Bug 1846459: Recreate DNS service upon Octavia upgrade

### DIFF
--- a/bindata/network/kuryr/003-config.yaml
+++ b/bindata/network/kuryr/003-config.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: kuryr-config
   namespace: openshift-kuryr
+  annotations:
+    networkoperator.openshift.io/kuryr-octavia-version: {{ .OctaviaVersion }}
 data:
   kuryr.conf: |+
     [DEFAULT]

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -14,6 +14,7 @@ type KuryrBootstrapResult struct {
 	ClusterID                string
 	OctaviaMultipleListeners bool
 	OpenStackCloud           clientconfig.Cloud
+	OctaviaVersion           string
 	WebhookCA                string
 	WebhookCAKey             string
 	WebhookCert              string

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -88,3 +88,6 @@ const KURYR_ADMISSION_CONTROLLER_SECRET = "kuryr-dns-admission-controller-secret
 
 // KURYR_WEB_HOOK_SECRET is the name of the secret used in the kuryr-dns-admission-controller DaemonSet
 const KURYR_WEBHOOK_SECRET = "kuryr-webhook-secret"
+
+// KuryrOctaviaVersionAnnotation is used to save latest Octavia version detected
+const KuryrOctaviaVersionAnnotation = "networkoperator.openshift.io/kuryr-octavia-version"

--- a/pkg/network/kuryr.go
+++ b/pkg/network/kuryr.go
@@ -60,6 +60,9 @@ func renderKuryr(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapR
 	// deploy or not kuryr-admission-controller depending on double listeners support
 	data.Data["AdmissionController"] = !b.OctaviaMultipleListeners
 
+	// Octavia config data
+	data.Data["OctaviaVersion"] = b.OctaviaVersion
+
 	// kuryr-daemon DaemonSet data
 	data.Data["DaemonEnableProbes"] = true
 	data.Data["DaemonProbesPort"] = c.DaemonProbesPort


### PR DESCRIPTION
When Octavia is upgraded from OSP13 to OSP16 double listeners becomes
supported and the load balancers that requires TCP and UDP on same
port should be recreated.

This commit ensure the DNS service is recreated upon Octavia upgrade.