### PR TITLE
Bug 1847675: [4.4] mount /var/run/netns rslave in ovnkube

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -171,6 +171,7 @@ spec:
         - mountPath: /run/netns
           name: host-run-netns
           readOnly: true
+          mountPropagation: HostToContainer
         # for installing the CNI plugin binary
         - mountPath: /cni-bin-dir
           name: host-cni-bin


### PR DESCRIPTION
When trying to transfer cri-o to manage its network namespaces in openshift, we have run into problems with multus. Specifically we see the error:
2020-04-07T17:46:52Z [error] delegateAdd: error invoking DelegateAdd - "ovn-k8s-cni-overlay": error in getting result from AddNetwork: CNI request failed with status 400: '[openshift-dns/dns-default-98tll] failed to configure pod interface: failed to open netns "/var/run/netns/76716600-f7fd-462f-b7df-ae054dbd144e": unknown FS magic on "/var/run/netns/76716600-f7fd-462f-b7df-ae054dbd144e": 1021994
'

through testing, I've found the netns is definitely mounted as an nsfs and not tmpfs, so I suspect we are seeing https://github.com/containernetworking/plugins/issues/69

to fix this, attempt mounting /var/run/netns as HostToContainer in ovnkube container

This is part 1 of 2 fixes for https://bugzilla.redhat.com/show_bug.cgi?id=1825339
the second will be a change in MCO

backport of https://github.com/openshift/cluster-network-operator/pull/579

Signed-off-by: Peter Hunt <pehunt@redhat.com>