### PR TITLE
ovn-kubernetes: allow dual-stack configs

### DIFF
--- a/bindata/network/ovn-kubernetes/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/004-config.yaml
@@ -13,7 +13,7 @@ data:
     encap-port="{{.GenevePort}}"
 
     [kubernetes]
-    service-cidr="{{.OVN_service_cidr}}"
+    service-cidrs="{{.OVN_service_cidr}}"
     ovn-config-namespace="openshift-ovn-kubernetes"
     apiserver="{{.K8S_APISERVER}}"
 

--- a/vendor/k8s.io/utils/net/ipnet.go
+++ b/vendor/k8s.io/utils/net/ipnet.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"net"
+	"strings"
+)
+
+// IPNetSet maps string to net.IPNet.
+type IPNetSet map[string]*net.IPNet
+
+// ParseIPNets parses string slice to IPNetSet.
+func ParseIPNets(specs ...string) (IPNetSet, error) {
+	ipnetset := make(IPNetSet)
+	for _, spec := range specs {
+		spec = strings.TrimSpace(spec)
+		_, ipnet, err := net.ParseCIDR(spec)
+		if err != nil {
+			return nil, err
+		}
+		k := ipnet.String() // In case of normalization
+		ipnetset[k] = ipnet
+	}
+	return ipnetset, nil
+}
+
+// Insert adds items to the set.
+func (s IPNetSet) Insert(items ...*net.IPNet) {
+	for _, item := range items {
+		s[item.String()] = item
+	}
+}
+
+// Delete removes all items from the set.
+func (s IPNetSet) Delete(items ...*net.IPNet) {
+	for _, item := range items {
+		delete(s, item.String())
+	}
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s IPNetSet) Has(item *net.IPNet) bool {
+	_, contained := s[item.String()]
+	return contained
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s IPNetSet) HasAll(items ...*net.IPNet) bool {
+	for _, item := range items {
+		if !s.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// Difference returns a set of objects that are not in s2
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s IPNetSet) Difference(s2 IPNetSet) IPNetSet {
+	result := make(IPNetSet)
+	for k, i := range s {
+		_, found := s2[k]
+		if found {
+			continue
+		}
+		result[k] = i
+	}
+	return result
+}
+
+// StringSlice returns a []string with the String representation of each element in the set.
+// Order is undefined.
+func (s IPNetSet) StringSlice() []string {
+	a := make([]string, 0, len(s))
+	for k := range s {
+		a = append(a, k)
+	}
+	return a
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s IPNetSet) IsSuperset(s2 IPNetSet) bool {
+	for k := range s2 {
+		_, found := s[k]
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s IPNetSet) Equal(s2 IPNetSet) bool {
+	return len(s) == len(s2) && s.IsSuperset(s2)
+}
+
+// Len returns the size of the set.
+func (s IPNetSet) Len() int {
+	return len(s)
+}

--- a/vendor/k8s.io/utils/net/net.go
+++ b/vendor/k8s.io/utils/net/net.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"net"
+	"strconv"
+)
+
+// ParseCIDRs parses a list of cidrs and return error if any is invalid.
+// order is maintained
+func ParseCIDRs(cidrsString []string) ([]*net.IPNet, error) {
+	cidrs := make([]*net.IPNet, 0, len(cidrsString))
+	for _, cidrString := range cidrsString {
+		_, cidr, err := net.ParseCIDR(cidrString)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse cidr value:%q with error:%v", cidrString, err)
+		}
+		cidrs = append(cidrs, cidr)
+	}
+	return cidrs, nil
+}
+
+// IsDualStackIPs returns if a slice of ips is:
+// - all are valid ips
+// - at least one ip from each family (v4 or v6)
+func IsDualStackIPs(ips []net.IP) (bool, error) {
+	v4Found := false
+	v6Found := false
+	for _, ip := range ips {
+		if ip == nil {
+			return false, fmt.Errorf("ip %v is invalid", ip)
+		}
+
+		if v4Found && v6Found {
+			continue
+		}
+
+		if IsIPv6(ip) {
+			v6Found = true
+			continue
+		}
+
+		v4Found = true
+	}
+
+	return (v4Found && v6Found), nil
+}
+
+// IsDualStackIPStrings returns if
+// - all are valid ips
+// - at least one ip from each family (v4 or v6)
+func IsDualStackIPStrings(ips []string) (bool, error) {
+	parsedIPs := make([]net.IP, 0, len(ips))
+	for _, ip := range ips {
+		parsedIP := net.ParseIP(ip)
+		parsedIPs = append(parsedIPs, parsedIP)
+	}
+	return IsDualStackIPs(parsedIPs)
+}
+
+// IsDualStackCIDRs returns if
+// - all are valid cidrs
+// - at least one cidr from each family (v4 or v6)
+func IsDualStackCIDRs(cidrs []*net.IPNet) (bool, error) {
+	v4Found := false
+	v6Found := false
+	for _, cidr := range cidrs {
+		if cidr == nil {
+			return false, fmt.Errorf("cidr %v is invalid", cidr)
+		}
+
+		if v4Found && v6Found {
+			continue
+		}
+
+		if IsIPv6(cidr.IP) {
+			v6Found = true
+			continue
+		}
+		v4Found = true
+	}
+
+	return v4Found && v6Found, nil
+}
+
+// IsDualStackCIDRStrings returns if
+// - all are valid cidrs
+// - at least one cidr from each family (v4 or v6)
+func IsDualStackCIDRStrings(cidrs []string) (bool, error) {
+	parsedCIDRs, err := ParseCIDRs(cidrs)
+	if err != nil {
+		return false, err
+	}
+	return IsDualStackCIDRs(parsedCIDRs)
+}
+
+// IsIPv6 returns if netIP is IPv6.
+func IsIPv6(netIP net.IP) bool {
+	return netIP != nil && netIP.To4() == nil
+}
+
+// IsIPv6String returns if ip is IPv6.
+func IsIPv6String(ip string) bool {
+	netIP := net.ParseIP(ip)
+	return IsIPv6(netIP)
+}
+
+// IsIPv6CIDRString returns if cidr is IPv6.
+// This assumes cidr is a valid CIDR.
+func IsIPv6CIDRString(cidr string) bool {
+	ip, _, _ := net.ParseCIDR(cidr)
+	return IsIPv6(ip)
+}
+
+// IsIPv6CIDR returns if a cidr is ipv6
+func IsIPv6CIDR(cidr *net.IPNet) bool {
+	ip := cidr.IP
+	return IsIPv6(ip)
+}
+
+// ParsePort parses a string representing an IP port.  If the string is not a
+// valid port number, this returns an error.
+func ParsePort(port string, allowZero bool) (int, error) {
+	portInt, err := strconv.ParseUint(port, 10, 16)
+	if err != nil {
+		return 0, err
+	}
+	if portInt == 0 && !allowZero {
+		return 0, errors.New("0 is not a valid port number")
+	}
+	return int(portInt), nil
+}
+
+// BigForIP creates a big.Int based on the provided net.IP
+func BigForIP(ip net.IP) *big.Int {
+	b := ip.To4()
+	if b == nil {
+		b = ip.To16()
+	}
+	return big.NewInt(0).SetBytes(b)
+}
+
+// AddIPOffset adds the provided integer offset to a base big.Int representing a
+// net.IP
+func AddIPOffset(base *big.Int, offset int) net.IP {
+	return net.IP(big.NewInt(0).Add(base, big.NewInt(int64(offset))).Bytes())
+}
+
+// RangeSize returns the size of a range in valid addresses.
+// returns the size of the subnet (or math.MaxInt64 if the range size would overflow int64)
+func RangeSize(subnet *net.IPNet) int64 {
+	ones, bits := subnet.Mask.Size()
+	if bits == 32 && (bits-ones) >= 31 || bits == 128 && (bits-ones) >= 127 {
+		return 0
+	}
+	// this checks that we are not overflowing an int64
+	if bits-ones >= 63 {
+		return math.MaxInt64
+	}
+	return int64(1) << uint(bits-ones)
+}
+
+// GetIndexedIP returns a net.IP that is subnet.IP + index in the contiguous IP space.
+func GetIndexedIP(subnet *net.IPNet, index int) (net.IP, error) {
+	ip := AddIPOffset(BigForIP(subnet.IP), index)
+	if !subnet.Contains(ip) {
+		return nil, fmt.Errorf("can't generate IP with index %d from subnet. subnet too small. subnet: %q", index, subnet)
+	}
+	return ip, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -542,6 +542,7 @@ k8s.io/kube-proxy/config/v1alpha1
 # k8s.io/utils v0.0.0-20191114200735-6ca3b61696b6
 k8s.io/utils/buffer
 k8s.io/utils/integer
+k8s.io/utils/net
 k8s.io/utils/pointer
 k8s.io/utils/trace
 # sigs.k8s.io/controller-runtime v0.5.2


### PR DESCRIPTION
CNO is enforcing that ovn-kubernetes only accepts a single service CIDR, which is no longer true
