### PR TITLE
[WIP] Bug 1687750 - oc get clusternetwork should show all the ranges(CIDRs)

### DIFF
--- a/bindata/network/openshift-sdn/001-crd.yaml
+++ b/bindata/network/openshift-sdn/001-crd.yaml
@@ -19,7 +19,7 @@ spec:
     #   - the cluster/service networks do not overlap
     #   - .network and .hostsubnetlength are set if name == 'default'
     #   - .network and .hostsubnetlength are either unset, or equal to
-    #     .clusterNetworks[0].CIDR and .clusterNetworks[0].hostSubnetLength
+    #     .clusterNetworks[*].CIDR and .clusterNetworks[0].hostSubnetLength
     openAPIV3Schema:
       description: ClusterNetwork describes the cluster network. There is normally
         only one object of this type, named "default", which is created by the SDN
@@ -83,10 +83,9 @@ spec:
           minimum: 576
           maximum: 65536
         network:
-          description: Network is a CIDR string specifying the global overlay network's
+          description: Network is CIDR range string specifying the global overlay network's
             L3 space
           type: string
-          pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$'
         pluginName:
           description: PluginName is the name of the network plugin being used
           type: string
@@ -113,7 +112,7 @@ spec:
   additionalPrinterColumns:
   - name: Cluster Network
     type: string
-    description: The primary cluster network CIDR
+    description: The primary cluster network CIDR(s)
     JSONPath: .network
   - name: Service Network
     type: string


### PR DESCRIPTION
If there is more than one ClusterNetworkEntry for a ClusterNetwork, only
the first CIDR range is shown in the display while doing an oc get. It
should infact display all the CIDR ranges so that it doesn't confuse the
user similar to what oc describe clusternetwork does.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>