### PR TITLE
Bug 1848374: Delete flows.sh after restore.

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -116,8 +116,10 @@ spec:
               echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Adding br0 if it doesn't exist ..." 2>&1
               /usr/bin/ovs-vsctl --may-exist add-br br0 -- set Bridge br0 fail_mode=secure protocols=OpenFlow13
               echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Created br0, now adding flows ..." 2>&1
-              sh -x /var/run/openvswitch/flows.sh
+              mv /var/run/openvswitch/flows.sh /var/run/openvswitch/flows-old.sh
+              sh -x /var/run/openvswitch/flows-old.sh
               echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Done restoring the existing flows ..." 2>&1
+              rm /var/run/openvswitch/flows-old.sh
             fi
 
             echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Remove other config ..." 2>&1


### PR DESCRIPTION
This commit deletes /var/run/openvswitch/flows.sh after being done with
restoring. This avoids appending old flows to such file and
misconfiguring OVSDB.

Closes-Bug 1848374: Killing ovs-vswitchd cause some ovs openflows lost