### PR TITLE
Bug 1837953: Check if the db file has been correctly initialized with raft.

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -115,6 +115,25 @@ spec:
 
           bracketify() { case "$1" in *:*) echo "[$1]" ;; *) echo "$1" ;; esac }
 
+          check_db_health() {
+            db="${1}"
+            if [[ ! -f "${db}" ]]; then
+                  echo "${db} does not exist, skipping health check"
+                  return
+            fi
+            echo "Checking ${db} health"
+            serverid=$(ovsdb-tool show-log "${db}" | sed -ne '/server_id:/s/server_id: *\([[:xdigit:]]\+\)/\1/p')
+            match=$(ovsdb-tool show-log "${db}" | grep "prev_servers: *${serverid}(" || true)
+            if [[ -z ${match} ]]; then
+                echo "Current server_id $serverid not found in ${db}, cleaning up"
+                rm -- "${db}"
+            else
+                  echo "${db} is healthy"
+            fi
+          }
+
+          check_db_health "/etc/ovn/ovnnb_db.db"
+
           MASTER_IP="{{.OVN_MASTER_IP}}"
           if [[ "${K8S_NODE_IP}" == "${MASTER_IP}" ]]; then
             exec /usr/share/ovn/scripts/ovn-ctl \
@@ -220,6 +239,25 @@ spec:
           fi
 
           bracketify() { case "$1" in *:*) echo "[$1]" ;; *) echo "$1" ;; esac }
+
+          check_db_health() {
+            db="${1}"
+            if [[ ! -f "${db}" ]]; then
+                  echo "${db} does not exist, skipping health check"
+                  return
+            fi
+            echo "Checking ${db} health"
+            serverid=$(ovsdb-tool show-log "${db}" | sed -ne '/server_id:/s/server_id: *\([[:xdigit:]]\+\)/\1/p')
+            match=$(ovsdb-tool show-log "${db}" | grep "prev_servers: *${serverid}(" || true)
+            if [[ -z ${match} ]]; then
+                echo "Current server_id $serverid not found in ${db}, cleaning up"
+                rm -- "${db}"
+            else
+                  echo "${db} is healthy"
+            fi
+          }
+
+          check_db_health "/etc/ovn/ovnsb_db.db"
 
           MASTER_IP="{{.OVN_MASTER_IP}}"
           if [[ "${K8S_NODE_IP}" == "${MASTER_IP}" ]]; then


### PR DESCRIPTION
If this does not happen, the master pod might fail with `ovsdb-server: ovsdb error: server does not belong to cluster`
and never recover. We make sure the current serverid is in the file by checking its presence in the prev_servers set.

As discussed in https://bugzilla.redhat.com/show_bug.cgi?id=1837953, this is a workaround to recover from inconsistent local db state that may cause the master pod to CrashLoopBackOff.