### PR TITLE
Bug 1851928: [metrics] TargetDown alert is always fired in ovnkube-node job

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -134,7 +134,7 @@ spec:
             --sb-client-cacert /ovn-ca/ca-bundle.crt \
             --config-file=/run/ovnkube-config/ovnkube.conf \
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
-            --inactivity-probe="${OVN_CONTROLLER_INACTIVITY_PROBE}"
+            --inactivity-probe="${OVN_CONTROLLER_INACTIVITY_PROBE}" \
             ${hybrid_overlay_flags} \
             --metrics-bind-address "0.0.0.0:9103"
         env:


### PR DESCRIPTION
The TargetDown alert was always getting fired for all the ovnkube-nodes
because the metrics-bind-address flag was not getting passed in the exec
command for the ovnkube-node container. This regression was introduced
in  PR #615. Promethues was hence not able to scrape the up metrics.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>