### PR TITLE
Bug 1837953: fixup server_id regex

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -123,8 +123,10 @@ spec:
                   return
             fi
             echo "Checking ${db} health"
-            serverid=$(ovsdb-tool show-log "${db}" | sed -ne '/server_id:/s/server_id: *\([[:xdigit:]]\+\)/\1/p')
-            match=$(ovsdb-tool show-log "${db}" | grep "prev_servers: *${serverid}(" || true)
+            serverid=$(ovsdb-tool show-log "${db}" | grep -m 1 -oP '(?<=server_id: )[[:xdigit:]]+')
+            # prev_servers is a list.  We are searching for " $server_id(" in the list
+            # prev_servers: 33b4("ssl:10.19.138.37:9643"), 720d("ssl:10.19.138.33:9643"), 7e4f("ssl:10.19.138.32:9643")
+            match=$(ovsdb-tool show-log "${db}" | grep "prev_servers:.* ${serverid}(" || true)
             if [[ -z ${match} ]]; then
                 echo "Current server_id $serverid not found in ${db}, cleaning up"
                 rm -- "${db}"
@@ -311,8 +313,10 @@ spec:
                   return
             fi
             echo "Checking ${db} health"
-            serverid=$(ovsdb-tool show-log "${db}" | sed -ne '/server_id:/s/server_id: *\([[:xdigit:]]\+\)/\1/p')
-            match=$(ovsdb-tool show-log "${db}" | grep "prev_servers: *${serverid}(" || true)
+            serverid=$(ovsdb-tool show-log "${db}" | grep -m 1 -oP '(?<=server_id: )[[:xdigit:]]+')
+            # prev_servers is a list.  We are searching for " $server_id(" in the list
+            # prev_servers: 33b4("ssl:10.19.138.37:9643"), 720d("ssl:10.19.138.33:9643"), 7e4f("ssl:10.19.138.32:9643")
+            match=$(ovsdb-tool show-log "${db}" | grep "prev_servers:.* ${serverid}(" || true)
             if [[ -z ${match} ]]; then
                 echo "Current server_id $serverid not found in ${db}, cleaning up"
                 rm -- "${db}"


### PR DESCRIPTION
We need to search the whole line for the server_id.

Current regex is too aggressive.

The original example indicates that the prev_server line is a list of servers

```bash
$ ovsdb-tool show-log /etc/ovn/ovnnb_db.db | grep "server_id\|prev_servers"
 server_id: d5db
  prev_servers: 33b4("ssl:10.19.138.37:9643"), 720d("ssl:10.19.138.33:9643"), 7e4f("ssl:10.19.138.32:9643"
```
  The above DB is inconsistent because d5db is not part of prev_servers.

A consistent DB looks like this:
```bash
$ ovsdb-tool show-log /etc/ovn/ovnnb_db.db | grep "server_id\|prev_servers"
 server_id: 33b4
  prev_servers: 33b4("ssl:10.19.138.37:9643"), 720d("ssl:10.19.138.33:9643")
```