### PR TITLE
Bug 1852593: Add netns mount

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -114,6 +114,11 @@ spec:
         - mountPath: /var/run/kubernetes/
           name: host-var-run-kubernetes
           readOnly: true
+        # accessing bind-mounted net namespaces
+        - mountPath: /run/netns
+          name: host-run-netns
+          readOnly: true
+          mountPropagation: HostToContainer
         # We mount our socket here
         - mountPath: /var/run/openshift-sdn
           name: host-var-run-openshift-sdn
@@ -188,6 +193,9 @@ spec:
       - name: host-var-run
         hostPath:
           path: /var/run
+      - name: host-run-netns
+        hostPath:
+          path: /run/netns
       - name: host-var-run-dbus
         hostPath:
           path: /var/run/dbus


### PR DESCRIPTION
1852593 - EgressRouter: error in getting result from AddNetwork: CNI request failed with status 400
https://bugzilla.redhat.com/show_bug.cgi?id=1852593

Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create pod network sandbox k8s_egress-redirect-pod_test_d22d4544-18ec-43bf-95c4-70f21e5246fe_0(4d0cbd2631875f117df10c0a8501b385919b1162f40382e75b8c87b8bb3cf7ca): Multus: [test/egress-redirect-pod]: error adding container to network "openshift-sdn": delegateAdd: error invoking confAdd - "openshift-sdn": error in getting result from AddNetwork: CNI request failed with status 400: 'could not open netns "/var/run/netns/11cb808b-c141-40e9-86fe-c74643b481aa": unknown FS magic on "/var/run/netns/11cb808b-c141-40e9-86fe-c74643b481aa": 1021994

Fix by mounting /run/netns in container as HostToContainer

Signed-off-by: Phil Cameron <pcameron@redhat.com>