### PR TITLE
Bug 1856289: Block MCS and metadata for host-networking pods

### DIFF
--- a/bindata/network/kuryr/005-daemon.yaml
+++ b/bindata/network/kuryr/005-daemon.yaml
@@ -24,6 +24,30 @@ spec:
       hostNetwork: true
       serviceAccountName: kuryr
       priorityClassName: system-node-critical
+      initContainers:
+        - name: block-mcs
+          image: {{ .CNIPluginsImage }}
+          securityContext:
+            privileged: true
+          command:
+          - /bin/sh
+          - -c
+          - |
+            #!/bin/sh
+
+            set -x -e
+
+            # Block MCS
+            iptables -A OUTPUT -p tcp -m tcp --dport 22623 -j REJECT
+            iptables -A OUTPUT -p tcp -m tcp --dport 22624 -j REJECT
+            iptables -A FORWARD -p tcp -m tcp --dport 22623 -j REJECT
+            iptables -A FORWARD -p tcp -m tcp --dport 22624 -j REJECT
+
+            # Block MCS on IPv6, ignore errors in case IPv6 iface is not there
+            ip6tables -A OUTPUT -p tcp -m tcp --dport 22623 -j REJECT || true
+            ip6tables -A OUTPUT -p tcp -m tcp --dport 22624 -j REJECT || true
+            ip6tables -A FORWARD -p tcp -m tcp --dport 22623 -j REJECT || true
+            ip6tables -A FORWARD -p tcp -m tcp --dport 22624 -j REJECT || true
       containers:
       - name: kuryr-cni
         image: {{ .DaemonImage }}


### PR DESCRIPTION
This commit adds an init container to kuryr-daemon pods that will
execute iptables commands to block access to machine-config-server and
metadata server for pods that run on host networking. Both should not be
required after ignition.