### PR TITLE
Set timeoutSeconds to reflect expected timeout for OVS commands

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -161,6 +161,7 @@ spec:
               /usr/bin/ovs-vsctl -t 5 show > /dev/null
           initialDelaySeconds: 15
           periodSeconds: 5
+          timeoutSeconds: 6
         terminationGracePeriodSeconds: 45
       nodeSelector:
         kubernetes.io/os: linux

--- a/bindata/network/ovn-kubernetes/006-ovs-node.yaml
+++ b/bindata/network/ovn-kubernetes/006-ovs-node.yaml
@@ -123,6 +123,7 @@ spec:
               /usr/bin/ovs-vsctl -t 5 show > /dev/null
           initialDelaySeconds: 15
           periodSeconds: 5
+          timeoutSeconds: 6
         terminationGracePeriodSeconds: 10
       nodeSelector:
         beta.kubernetes.io/os: "linux"


### PR DESCRIPTION
Seen on a distant and heavily loaded CI cluster: if the cluster is heavily loaded we can expect `ovs-vsctl` to be slow. The commands executed by our `livenessProbe`/`readinessProbe` already take this into account, however the probes themselves do not. We thus restart OVS many more times than what we should, as those probes default to 1 second. This is not a real problem, but an optimization. The real problem is that we flush our DB when restarting, which is something which will need to be fixed later on.  

PS: I decided to set `timeoutSeconds` to whatever timeout the command has + a 1 second buffer

I will file a separate PR for release-4.5....but I will wait with filing that until tomorrow, once we, possibly, find and define a fix for the DB flush. As such there are less back-ports, CI runs etc.

/assign @dcbw @juanluisvaladas  