### PR TITLE
Bug 1856271: Make sure the network metrics pod runs only on linux nodes.

### DIFF
--- a/bindata/network/network-metrics/001-daemonset.yaml
+++ b/bindata/network/network-metrics/001-daemonset.yaml
@@ -25,6 +25,7 @@ spec:
     spec:
       nodeSelector:
         node-role.kubernetes.io/worker: ""
+        kubernetes.io/os: linux
       tolerations:
         - operator: Exists
       containers:


### PR DESCRIPTION
The network metrics daemon is not supposed to run on windows nodes.


