### PR TITLE
Bug 1852112: Ignore hostPrefix validation for non-(sdn/ovn) plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,12 +112,12 @@ Users must supply at least two address pools - ClusterNetwork for pods, and Serv
 
 For future expansion, multiple `serviceNetwork` entries are allowed by the configuration but not actually supported by any network plugins. Supplying multiple addresses is invalid.
 
-Each `clusterNetwork` entry has an additional required parameter, `hostPrefix`, that specifies the address size to assign to each individual node.  For example,
+Each `clusterNetwork` entry has an additional parameter, `hostPrefix`, that specifies the address size to assign to each individual node.  For example,
 ```yaml
 cidr: 10.128.0.0/14
 hostPrefix: 23
 ```
-means 512 nodes would get blocks of size `/23`, or 512 addresses.
+means 512 nodes would get blocks of size `/23`, or 512 addresses. If the hostPrefix field is not used by the plugin, it can be left unset.
 
 IP address pools are always read from the Cluster configuration and propagated "downwards" into the Operator configuration. Any changes to the Operator configuration are ignored.
 

--- a/manifests/0000_70_cluster-network-operator_01_crd.yaml
+++ b/manifests/0000_70_cluster-network-operator_01_crd.yaml
@@ -165,10 +165,10 @@ spec:
               items:
                 description: ClusterNetworkEntry is a subnet from which to allocate
                   PodIPs. A network of size HostPrefix (in CIDR notation) will be
-                  allocated when nodes join the cluster. Not all network providers
-                  support multiple ClusterNetworks
+                  allocated when nodes join the cluster. If HostPrefix is not used by the plugin,
+                  it can be left unset. Not all network providers support multiple ClusterNetworks
                 type: object
-                required: ["cidr", "hostPrefix"]
+                required: ["cidr"]
                 properties:
                   cidr:
                     type: string

--- a/pkg/network/cluster_config_test.go
+++ b/pkg/network/cluster_config_test.go
@@ -59,8 +59,19 @@ func TestValidateClusterConfig(t *testing.T) {
 	haveError(cc, "CIDRs 192.168.0.0/20 and 192.168.2.0/23 overlap")
 
 	cc = *ClusterConfig.DeepCopy()
+	cc.ClusterNetwork[1].HostPrefix = 0
+	res := ValidateClusterConfig(cc)
+	// Since the NetworkType is None, and the hostprefix is unset we don't validate it
+	g.Expect(res).Should(BeNil())
+
+	cc = *ClusterConfig.DeepCopy()
 	cc.ClusterNetwork[1].HostPrefix = 21
 	haveError(cc, "hostPrefix 21 is larger than its cidr 10.2.0.0/22")
+
+	cc = *ClusterConfig.DeepCopy()
+	cc.NetworkType = "OpenShiftSDN"
+	cc.ClusterNetwork[1].HostPrefix = 0
+	haveError(cc, "hostPrefix 0 is larger than its cidr 10.2.0.0/22")
 
 	// network type
 	cc = *ClusterConfig.DeepCopy()


### PR DESCRIPTION
For plugins like Calico which don't use the hostPrefix for anything,
it does not make sense to validate this field and force customers
to set specific values just to pass validation considering the
field is not even used in these plugins. This patch ensures that
we perform the validation only for OpenShiftSDN and OVNKubernetes.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>