### PR TITLE
Bug 1857738: [release-4.5] Set timeoutSeconds to reflect expected timeout for OVS commands

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -141,6 +141,7 @@ spec:
               if /usr/bin/ovs-vsctl -t 5 br-exists br0; then /usr/bin/ovs-ofctl -t 5 -O OpenFlow13 probe br0; else true; fi
           initialDelaySeconds: 15
           periodSeconds: 5
+          timeoutSeconds: 21
         readinessProbe:
           exec:
             command:
@@ -156,6 +157,7 @@ spec:
               /usr/bin/ovs-vsctl -t 5 show > /dev/null
           initialDelaySeconds: 15
           periodSeconds: 5
+          timeoutSeconds: 11
         terminationGracePeriodSeconds: 45
       nodeSelector:
         kubernetes.io/os: linux


### PR DESCRIPTION
This is the release-4.5 back-port of https://github.com/openshift/cluster-network-operator/pull/701

Unlike https://github.com/openshift/cluster-network-operator/pull/701 we need to set the values in different places as the code varies a lot between these versions, so no cherry-pick involved here, however same logic applies to the value definition. 

