### PR TITLE
Bug 1855121: mount host-slash HostToContainer

### DIFF
--- a/bindata/kube-proxy/kube-proxy.yaml
+++ b/bindata/kube-proxy/kube-proxy.yaml
@@ -58,6 +58,7 @@ spec:
         - mountPath: /host
           name: host-slash
           readOnly: true
+          mountPropagation: HostToContainer
         - mountPath: /config
           name: config
           readOnly: true

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -120,6 +120,7 @@ spec:
         - mountPath: /host
           name: host-slash
           readOnly: true
+          mountPropagation: HostToContainer
         # CNI related mounts which we take over
         - mountPath: /host/opt/cni/bin
           name: host-cni-bin

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -159,6 +159,7 @@ spec:
         - mountPath: /host
           name: host-slash
           readOnly: true
+          mountPropagation: HostToContainer
         # for the CNI server socket
         - mountPath: /run/ovn-kubernetes/
           name: host-run-ovn-kubernetes


### PR DESCRIPTION
which allows umount events that happen on the host to be propegated to the container.
This prevents situations where the networking pods hold onto a mount that was umounted on the host,
which causes attempts to remove the mountpoint to fail

Signed-off-by: Peter Hunt <pehunt@redhat.com>