### PR TITLE
Bug 1846117: Bump ovn default MTU to 1442

### DIFF
--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -193,7 +193,14 @@ func fillOVNKubernetesDefaults(conf, previous *operv1.NetworkSpec, hostMTU int) 
 	// (which may not be a node in the cluster).
 	// However, this can never change, so we always prefer previous.
 	if sc.MTU == nil {
-		var mtu uint32 = uint32(hostMTU) - 100 // 100 byte geneve header
+		var mtu uint32 = uint32(hostMTU) - 58 // 58 bytes geneve header
+		// if it's an ipv6 cluster or dual stack, ip header would be an extra 20 bytes.
+		for _, cn := range conf.ClusterNetwork {
+			if utilnet.IsIPv6CIDRString(cn.CIDR) {
+				mtu = mtu - 20
+				break
+			}
+		}
 		if previous != nil && previous.DefaultNetwork.OVNKubernetesConfig != nil &&
 			previous.DefaultNetwork.OVNKubernetesConfig.MTU != nil {
 			mtu = *previous.DefaultNetwork.OVNKubernetesConfig.MTU

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -189,7 +189,7 @@ func TestFillOVNKubernetesDefaults(t *testing.T) {
 	conf.DefaultNetwork.OVNKubernetesConfig = nil
 
 	// vars
-	m := uint32(8900)
+	m := uint32(8942)
 	p := uint32(6081)
 
 	expected := operv1.NetworkSpec{
@@ -214,6 +214,40 @@ func TestFillOVNKubernetesDefaults(t *testing.T) {
 	}
 
 	fillOVNKubernetesDefaults(conf, nil, 9000)
+
+	g.Expect(conf).To(Equal(&expected))
+
+	conf.ServiceNetwork = []string{
+		"172.30.0.0/16",
+		"fd02::/112",
+	}
+	conf.ClusterNetwork = append(config.ClusterNetwork, operv1.ClusterNetworkEntry{
+		CIDR: "fd01::/48", HostPrefix: 64,
+	})
+	conf.DefaultNetwork.OVNKubernetesConfig = nil
+	m = uint32(1422)
+	expected = operv1.NetworkSpec{
+		ServiceNetwork: []string{"172.30.0.0/16", "fd02::/112"},
+		ClusterNetwork: []operv1.ClusterNetworkEntry{
+			{
+				CIDR:       "10.128.0.0/14",
+				HostPrefix: 23,
+			},
+			{
+				CIDR:       "fd01::/48",
+				HostPrefix: 64,
+			},
+		},
+		DefaultNetwork: operv1.DefaultNetworkDefinition{
+			Type: operv1.NetworkTypeOVNKubernetes,
+			OVNKubernetesConfig: &operv1.OVNKubernetesConfig{
+				MTU:        &m,
+				GenevePort: &p,
+			},
+		},
+	}
+
+	fillOVNKubernetesDefaults(conf, nil, 1500)
 
 	g.Expect(conf).To(Equal(&expected))
 


### PR DESCRIPTION
This patch changes the default ovn MTU value to 1442.