### PR TITLE
Bug 1857222: Run the network metrics daemon on masters too.

### DIFF
--- a/bindata/network/network-metrics/001-daemonset.yaml
+++ b/bindata/network/network-metrics/001-daemonset.yaml
@@ -24,7 +24,6 @@ spec:
         openshift.io/component: network
     spec:
       nodeSelector:
-        node-role.kubernetes.io/worker: ""
         kubernetes.io/os: linux
       tolerations:
         - operator: Exists


### PR DESCRIPTION
It makes sense to have the daemon running on masters too, because users may end up using the composed metric to monitor the networks.

The query we are going to document looks like:
(container_network_receive_bytes_total) + on(namespace,pod,interface) group_left(network_name) ( pod_network_name_info )

Which results in the same metric exposed by cAdvisor, but with the network name added to it.
If the daemon does not run on masters, the composed metric won't be available for pods running on masters.
