### PR TITLE
Bug 1858834: Revert ovn db consistency check.

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -117,27 +117,6 @@ spec:
 
           bracketify() { case "$1" in *:*) echo "[$1]" ;; *) echo "$1" ;; esac }
 
-          check_db_health() {
-            db="${1}"
-            if [[ ! -f "${db}" ]]; then
-                  echo "${db} does not exist, skipping health check"
-                  return
-            fi
-            echo "Checking ${db} health"
-            serverid=$(ovsdb-tool show-log "${db}" | grep -m 1 -oP '(?<=server_id: )[[:xdigit:]]+')
-            # prev_servers is a list.  We are searching for " $server_id(" in the list
-            # prev_servers: 33b4("ssl:10.19.138.37:9643"), 720d("ssl:10.19.138.33:9643"), 7e4f("ssl:10.19.138.32:9643")
-            match=$(ovsdb-tool show-log "${db}" | grep "prev_servers:.* ${serverid}(" || true)
-            if [[ -z ${match} ]]; then
-                echo "Current server_id $serverid not found in ${db}, cleaning up"
-                rm -- "${db}"
-            else
-                  echo "${db} is healthy"
-            fi
-          }
-
-          check_db_health "/etc/ovn/ovnnb_db.db"
-
           MASTER_IP="{{.OVN_MASTER_IP}}"
           echo "$(date -Iseconds) - starting nbdb  MASTER_IP=${MASTER_IP}"
           if [[ "${K8S_NODE_IP}" == "${MASTER_IP}" ]]; then
@@ -306,27 +285,6 @@ spec:
           fi
 
           bracketify() { case "$1" in *:*) echo "[$1]" ;; *) echo "$1" ;; esac }
-
-          check_db_health() {
-            db="${1}"
-            if [[ ! -f "${db}" ]]; then
-                  echo "${db} does not exist, skipping health check"
-                  return
-            fi
-            echo "Checking ${db} health"
-            serverid=$(ovsdb-tool show-log "${db}" | grep -m 1 -oP '(?<=server_id: )[[:xdigit:]]+')
-            # prev_servers is a list.  We are searching for " $server_id(" in the list
-            # prev_servers: 33b4("ssl:10.19.138.37:9643"), 720d("ssl:10.19.138.33:9643"), 7e4f("ssl:10.19.138.32:9643")
-            match=$(ovsdb-tool show-log "${db}" | grep "prev_servers:.* ${serverid}(" || true)
-            if [[ -z ${match} ]]; then
-                echo "Current server_id $serverid not found in ${db}, cleaning up"
-                rm -- "${db}"
-            else
-                  echo "${db} is healthy"
-            fi
-          }
-
-          check_db_health "/etc/ovn/ovnsb_db.db"
 
           MASTER_IP="{{.OVN_MASTER_IP}}"
           echo "$(date -Iseconds) - starting sbdb  MASTER_IP=${MASTER_IP}"


### PR DESCRIPTION
It turned out the prev_servers list contains only the leader, so it can't be used to understand if the db is consistent or not. This leads in always deleting the db file when restarting a ovn-master pod that is not the leader.

More details in https://bugzilla.redhat.com/show_bug.cgi?id=1837953#c36

Revert "Merge pull request #694 from rbbratta/fix-server_id_regex"

This reverts commit 3ff3b90bffdce72cdf3fe9c95115374f2242c54d, reversing
changes made to a8ababe5dd02dedfa0ed451504140b8d0f60aa15.

Revert "Merge pull request #688 from fedepaol/dbhealthy"

This reverts commit a0aaca735a240cc6cdf8cd3517fc71c2efc5e043, reversing
changes made to 2f04083382a5a824aeca0adfc2b5a58bd34cbb80.