### PR TITLE
Multus whereabouts IPAM CNI should support overlapping ranges

### DIFF
--- a/bindata/network/additional-networks/crd/001-crd.yaml
+++ b/bindata/network/additional-networks/crd/001-crd.yaml
@@ -97,3 +97,49 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: overlappingrangeipreservations.whereabouts.cni.cncf.io
+spec:
+  group: whereabouts.cni.cncf.io
+  names:
+    kind: OverlappingRangeIPReservation
+    plural: overlappingrangeipreservations
+  scope: ""
+  validation:
+    openAPIV3Schema:
+      description: OverlappingRangeIPReservation is the Schema for the OverlappingRangeIPReservations
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: OverlappingRangeIPReservationSpec defines the desired state
+            of OverlappingRangeIPReservation
+          properties:
+            containerid:
+              type: string
+          required:
+          - containerid
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/bindata/network/multus/002-rbac.yaml
+++ b/bindata/network/multus/002-rbac.yaml
@@ -88,6 +88,7 @@ rules:
   - whereabouts.cni.cncf.io
   resources:
   - ippools
+  - overlappingrangeipreservations
   verbs:
   - get
   - list

--- a/pkg/network/additional_networks_test.go
+++ b/pkg/network/additional_networks_test.go
@@ -72,7 +72,7 @@ func TestRenderAdditionalNetworksCRD(t *testing.T) {
 
 	objs, err := renderAdditionalNetworksCRD(manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(objs).To(HaveLen(2))
+	g.Expect(objs).To(HaveLen(3))
 }
 
 func TestRenderRawCNIConfig(t *testing.T) {

--- a/pkg/network/multus_test.go
+++ b/pkg/network/multus_test.go
@@ -50,7 +50,7 @@ func TestRenderMultus(t *testing.T) {
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "multus")))
 
 	// It's important that the namespace is first
-	g.Expect(len(objs)).To(Equal(18))
+	g.Expect(len(objs)).To(Equal(19))
 	g.Expect(objs[0]).To(HaveKubernetesID("CustomResourceDefinition", "", "network-attachment-definitions.k8s.cni.cncf.io"))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("Namespace", "", "openshift-multus")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "multus")))

--- a/pkg/network/network_metrics_test.go
+++ b/pkg/network/network_metrics_test.go
@@ -50,7 +50,7 @@ func TestRenderNetworkMetricsDaemon(t *testing.T) {
 
 	// Check rendered object
 
-	g.Expect(len(objs)).To(Equal(18))
+	g.Expect(len(objs)).To(Equal(19))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "network-metrics-daemon")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("Service", "openshift-multus", "network-metrics-service")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "metrics-daemon-role")))


### PR DESCRIPTION
This change applies a new CRD and the appropriate RBAC permission to enable
functionality in Whereabouts IPAM CNI which enables the use of overlapping
ranges without re-assigning IP addresses across ranges.