### PR TITLE
Enable shared gateway mode for OVN

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -475,6 +475,8 @@ spec:
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
             ${hybrid_overlay_flags} \
             --metrics-bind-address "127.0.0.1:29102" \
+            --gateway-mode shared \
+            --gateway-interface br-ex \
             --sb-address "{{.OVN_SB_DB_LIST}}" \
             --sb-client-privkey /ovn-cert/tls.key \
             --sb-client-cert /ovn-cert/tls.crt \
@@ -537,7 +539,8 @@ spec:
         hostPath:
           path: /var/lib/ovn/data
       - name: run-openvswitch
-        emptyDir: {}
+        hostPath:
+          path: /var/run/openvswitch
       - name: run-ovn
         hostPath:
           path: /var/run/ovn

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -142,6 +142,8 @@ spec:
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
             --inactivity-probe="${OVN_CONTROLLER_INACTIVITY_PROBE}" \
             ${hybrid_overlay_flags} \
+            --gateway-mode shared \
+            --gateway-interface br-ex \
             --metrics-bind-address "127.0.0.1:29103"
         env:
         # for kubectl


### PR DESCRIPTION
This patch migrates from using Local gateway mode to Shared gateway mode
with ovn-kubernetes. With shared gateway mode, the external network NIC
is now directly configured as part of an OVS bridge, which has a Layer 2
connection to OVN, effectively allowing OVN to share the NIC with the
host as a Layer 2 network.

Unlike Local gateway mode, this eliminates the need to route through the
kernel for certain OVN traffic to egress the host.

Signed-off-by: Tim Rozet <trozet@redhat.com>