### PR TITLE
Update NodeWithoutOVNKubeNodePodRunning alert to ignore Windows Nodes

### DIFF
--- a/bindata/network/ovn-kubernetes/alert-rules.yaml
+++ b/bindata/network/ovn-kubernetes/alert-rules.yaml
@@ -15,9 +15,10 @@ spec:
     - alert: NodeWithoutOVNKubeNodePodRunning
       annotations:
         message: |
-          All nodes should be running an ovnkube-node pod, {{"{{"}} $labels.node {{"}}"}} is not.
+          All Linux nodes should be running an ovnkube-node pod, {{"{{"}} $labels.node {{"}}"}} is not.
       expr: |
-        (kube_node_info unless on(node) kube_pod_info{namespace="openshift-ovn-kubernetes",  pod=~"ovnkube-node.*"}) > 0
+        (kube_node_info unless on(node) (kube_pod_info{namespace="openshift-ovn-kubernetes",pod=~"ovnkube-node.*"}
+        or kube_node_labels{label_kubernetes_io_os="windows"})) > 0
       for: 20m
       labels:
         severity: warning


### PR DESCRIPTION
This PR ensures that console dashboard do not fire`NodeWithoutOVNKubeNodePodRunning` alert for Windows
worker nodes, as we would not be running OVN pods on Windows.
