### PR TITLE
Bug 1819571: NetworkAttachmentDefinitions should have output for "oc explain" 

### DIFF
--- a/bindata/network/additional-networks/crd/001-crd.yaml
+++ b/bindata/network/additional-networks/crd/001-crd.yaml
@@ -24,6 +24,19 @@ spec:
         networks. More information available at: https://github.com/k8snetworkplumbingwg/multi-net-spec'
       type: object
       properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this represen
+            tation of an object. Servers should convert recognized schemas to the
+            latest internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
         spec:
           description: 'NetworkAttachmentDefinition spec defines the desired state of a network attachment'
           type: object


### PR DESCRIPTION
This adds the apiversion, kind and metadata fields for explain to properly function.

@s1061123 can you check and see if this look OK? If it does, we can move forward with backports. Thanks!