### PR TITLE
Kuryr: Add new Custom Resource Definitions

### DIFF
--- a/bindata/network/kuryr/001-rbac.yaml
+++ b/bindata/network/kuryr/001-rbac.yaml
@@ -45,6 +45,9 @@ rules:
   - kuryrnets
   - kuryrnetworks
   - kuryrnetpolicies
+  - kuryrnetworkpolicies
+  - kuryrports
+  - kuryrloadbalancers
   verbs: ["*"]
 - apiGroups: ["route.openshift.io"]
   resources:

--- a/bindata/network/kuryr/002-crds.yaml
+++ b/bindata/network/kuryr/002-crds.yaml
@@ -115,8 +115,7 @@ spec:
     plural: kuryrnetpolicies
     singular: kuryrnetpolicy
     kind: KuryrNetPolicy
-    shortNames:
-    - knp
+    shortNames: []
   versions:
   - name: v1
     served: true
@@ -239,3 +238,438 @@ spec:
                 type: string
               securityGroupName:
                 type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuryrports.openstack.org
+spec:
+  group: openstack.org
+  scope: Namespaced
+  names:
+    plural: kuryrports
+    singular: kuryrport
+    kind: KuryrPort
+    shortNames:
+    - kp
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            required:
+            - podUid
+            - podNodeName
+            - vifs
+            properties:
+              podUid:
+                type: string
+              podNodeName:
+                type: string
+              vifs:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: PodUID
+      type: string
+      description: Pod UID
+      jsonPath: .spec.podUid
+    - name: Nodename
+      type: string
+      description: Name of the node corresponding pod lives in
+      jsonPath: .spec.podNodeName
+    - name: labels
+      type: string
+      description: Labels for the CRD
+      jsonPath: .metadata.labels
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuryrnetworkpolicies.openstack.org
+spec:
+  group: openstack.org
+  scope: Namespaced
+  names:
+    plural: kuryrnetworkpolicies
+    singular: kuryrnetworkpolicy
+    kind: KuryrNetworkPolicy
+    shortNames:
+    - knp
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: SG-ID
+      type: string
+      description: The ID of the SG associated to the policy
+      jsonPath: .status.securityGroupId
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    schema:
+      openAPIV3Schema:
+        type: object
+        required:
+        - status
+        - spec
+        properties:
+          spec:
+            type: object
+            required:
+            - egressSgRules
+            - ingressSgRules
+            - podSelector
+            - policyTypes
+            properties:
+              egressSgRules:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - sgRule
+                  properties:
+                    affectedPods:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          podIP:
+                            type: string
+                          podNamespace:
+                            type: string
+                        required:
+                        - podIP
+                        - podNamespace
+                    namespace:
+                      type: string
+                    sgRule:
+                      type: object
+                      properties:
+                        description:
+                          type: string
+                        direction:
+                          type: string
+                        ethertype:
+                          type: string
+                        port_range_max:
+                          type: integer
+                        port_range_min:
+                          type: integer
+                        protocol:
+                          type: string
+                        remote_ip_prefix:
+                          type: string
+              ingressSgRules:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - sgRule
+                  properties:
+                    affectedPods:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          podIP:
+                            type: string
+                          podNamespace:
+                            type: string
+                        required:
+                        - podIP
+                        - podNamespace
+                    namespace:
+                      type: string
+                    sgRule:
+                      type: object
+                      properties:
+                        description:
+                          type: string
+                        direction:
+                          type: string
+                        ethertype:
+                          type: string
+                        port_range_max:
+                          type: integer
+                        port_range_min:
+                          type: integer
+                        protocol:
+                          type: string
+                        remote_ip_prefix:
+                          type: string
+              podSelector:
+                x-kubernetes-preserve-unknown-fields: true
+                type: object
+              policyTypes:
+                type: array
+                items:
+                  type: string
+          status:
+            type: object
+            required:
+            - securityGroupRules
+            properties:
+              securityGroupId:
+                type: string
+              securityGroupRules:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - id
+                  properties:
+                    id:
+                      type: string
+                    description:
+                      type: string
+                    direction:
+                      type: string
+                    ethertype:
+                      type: string
+                    port_range_max:
+                      type: integer
+                    port_range_min:
+                      type: integer
+                    protocol:
+                      type: string
+                    remote_ip_prefix:
+                      type: string
+                    security_group_id:
+                      type: string
+              podSelector:
+                x-kubernetes-preserve-unknown-fields: true
+                type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuryrloadbalancers.openstack.org
+spec:
+  group: openstack.org
+  scope: Namespaced
+  names:
+    plural: kuryrloadbalancers
+    singular: kuryrloadbalancer
+    kind: KuryrLoadBalancer
+    shortNames:
+    - klb
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: PROJECT-ID
+      type: string
+      description: The ID of the PROJECT associated to the loadbalancer
+      jsonPath: .spec.project_id
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              ip:
+                type: string
+              lb_ip:
+                type: string
+              ports:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - port
+                  - protocol
+                  - targetPort
+                  properties:
+                    name:
+                      type: string
+                    port:
+                      type: integer
+                    protocol:
+                      type: string
+                    targetPort:
+                      type: string
+              project_id:
+                type: string
+              security_groups_ids:
+                type: array
+                items:
+                  type: string
+              subnet_id:
+                type: string
+              type:
+                type: string
+              subsets:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    addresses:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          hostname:
+                            type: string
+                          ip:
+                            type: string
+                          nodeName:
+                            type: string
+                          targetRef:
+                            type: object
+                            properties:
+                              apiVersion:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              resourceVersion:
+                                type: string
+                              uid:
+                                type: string
+                    ports:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          port:
+                            type: integer
+                          protocol:
+                            type: string
+          status:
+            type: object
+            properties:
+              listeners:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - id
+                  - loadbalancer_id
+                  - name
+                  - port
+                  - project_id
+                  - protocol
+                  properties:
+                    id:
+                      type: string
+                    loadbalancer_id:
+                      type: string
+                    name:
+                      type: string
+                    port:
+                      type: integer
+                    project_id:
+                      type: string
+                    protocol:
+                      type: string
+              loadbalancer:
+                type: object
+                required:
+                - id
+                - ip
+                - name
+                - port_id
+                - project_id
+                - provider
+                - security_groups
+                - subnet_id
+                properties:
+                  id:
+                    type: string
+                  ip:
+                    type: string
+                  name:
+                    type: string
+                  port_id:
+                    type: string
+                  project_id:
+                    type: string
+                  provider:
+                    type: string
+                  security_groups:
+                    type: array
+                    items:
+                      type: string
+                  subnet_id:
+                    type: string
+              members:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - id
+                  - ip
+                  - name
+                  - pool_id
+                  - port
+                  - project_id
+                  - subnet_id
+                  properties:
+                    id:
+                      type: string
+                    ip:
+                      type: string
+                    name:
+                      type: string
+                    pool_id:
+                      type: string
+                    port:
+                      type: integer
+                    project_id:
+                      type: string
+                    subnet_id:
+                      type: string
+              pools:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - id
+                  - listener_id
+                  - loadbalancer_id
+                  - name
+                  - project_id
+                  - protocol
+                  properties:
+                    id:
+                      type: string
+                    listener_id:
+                      type: string
+                    loadbalancer_id:
+                      type: string
+                    name:
+                      type: string
+                    project_id:
+                      type: string
+                    protocol:
+                      type: string
+              service_pub_ip_info:
+                type: object
+                required:
+                - ip_id
+                - ip_addr
+                - alloc_method
+                properties:
+                  ip_id:
+                    type: string
+                  ip_addr:
+                    type: string
+                  alloc_method:
+                    type: string

--- a/bindata/network/kuryr/003-config.yaml
+++ b/bindata/network/kuryr/003-config.yaml
@@ -36,7 +36,7 @@ data:
     vif_pool_driver = nested
     multi_vif_drivers = noop
 
-    enabled_handlers = vif,lb,lbaasspec,policy,pod_label,namespace,kuryrnetpolicy,kuryrnetwork{{ if .EnablePortPoolsPrepopulation }},kuryrnetwork_population{{ end }}
+    enabled_handlers = vif,kuryrport,service,endpoints,kuryrloadbalancer,policy,pod_label,namespace,kuryrnetworkpolicy,kuryrnetwork{{ if .EnablePortPoolsPrepopulation }},kuryrnetwork_population{{ end }}
     pod_security_groups_driver = policy
     service_security_groups_driver = policy
     pod_subnets_driver = namespace


### PR DESCRIPTION
With 4.6 Kuryr uses KuryrPort custom resources to save Neutron port
information instead of annotating them on the pod. Also the
KuryrNetPolicy is replaced by updated format of KuryrNetworkPolicy CR.
This commit makes sure new CRDs are added, RBAC extended and Kuryr
configuration updated to support this.