### PR TITLE
Configure northd probe interval during startup

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -167,7 +167,40 @@ spec:
                   sleep 2
                   done
                 fi
+                #configure northd_probe_interval
+                OVN_NB_CTL="ovn-nbctl -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt \
+                --db "{{.OVN_NB_DB_LIST}}""
+                northd_probe_interval=${OVN_NORTHD_PROBE_INTERVAL:-5000}
+                echo "Setting northd probe interval to ${northd_probe_interval} ms"
+                retries=0
+                current_probe_interval=0
+                while [[ "${retries}" -lt 10 ]]; do
+                  current_probe_interval=$(${OVN_NB_CTL} --if-exists get NB_GLOBAL . options:northd_probe_interval)
+                  if [[ $? == 0 ]]; then
+                    current_probe_interval=$(echo ${current_probe_interval} | tr -d '\"')
+                    break
+                  else
+                    sleep 2
+                    (( retries += 1 ))
+                  fi
+                done
 
+                if [[ "${current_probe_interval}" != "${northd_probe_interval}" ]]; then
+                  retries=0
+                  while [[ "${retries}" -lt 10 ]]; do
+                    ${OVN_NB_CTL} set NB_GLOBAL . options:northd_probe_interval=${northd_probe_interval}
+                    if [[ $? != 0 ]]; then
+                      echo "Failed to set northd probe interval to ${northd_probe_interval}. retrying....."
+                      sleep 2
+                      (( retries += 1 ))
+                    else
+                      echo "Successfully set northd probe interval to ${northd_probe_interval} ms"
+                      break
+                    fi
+                  done
+                fi
+
+                #configure NB RAFT election timers
                 election_timer="${OVN_NB_RAFT_ELECTION_TIMER}"
                 echo "Setting nb-db raft election timer to ${election_timer} ms"
                 retries=0
@@ -237,6 +270,8 @@ spec:
           value: info 
         - name: OVN_NB_RAFT_ELECTION_TIMER
           value: "{{.OVN_NB_RAFT_ELECTION_TIMER}}"
+        - name: OVN_NORTHD_PROBE_INTERVAL
+          value: "{{.OVN_NORTHD_PROBE_INTERVAL}}"
         - name: K8S_NODE_IP
           valueFrom:
             fieldRef:

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -49,6 +49,8 @@ spec:
           value: "5000"
         - name: OVN_SB_RAFT_ELECTION_TIMER
           value: "5000"
+        - name: OVN_NORTHD_PROBE_INTERVAL
+          value: "5000"
         - name: OVN_CONTROLLER_INACTIVITY_PROBE
           value: "30000"
         - name: KURYR_DAEMON_IMAGE

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -70,6 +70,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["OVN_MIN_AVAILABLE"] = len(bootstrapResult.OVN.MasterIPs)/2 + 1
 	data.Data["LISTEN_DUAL_STACK"] = listenDualStack(bootstrapResult.OVN.MasterIPs[0])
 	data.Data["OVN_CERT_CN"] = OVN_CERT_CN
+	data.Data["OVN_NORTHD_PROBE_INTERVAL"] = os.Getenv("OVN_NORTHD_PROBE_INTERVAL")
 
 	var ippools string
 	for _, net := range conf.ClusterNetwork {


### PR DESCRIPTION
This commit adds support for configuring the ovn northd probe interval
in the start-up script for the nbdb container.