### PR TITLE
Bug 1823709: [backport 4.4] NetworkAttachmentDefinitions should have output for "oc explain"

### DIFF
--- a/bindata/network/additional-networks/crd/001-crd.yaml
+++ b/bindata/network/additional-networks/crd/001-crd.yaml
@@ -21,6 +21,19 @@ spec:
     openAPIV3Schema:
       type: object
       properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this represen
+            tation of an object. Servers should convert recognized schemas to the
+            latest internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
         spec:
           type: object
           properties:

--- a/bindata/network/additional-networks/crd/001-crd.yaml
+++ b/bindata/network/additional-networks/crd/001-crd.yaml
@@ -16,7 +16,7 @@ spec:
   - name: v1
     served: true
     storage: true
-  preserveUnknownFields: true
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
       type: object

--- a/bindata/network/additional-networks/crd/001-crd.yaml
+++ b/bindata/network/additional-networks/crd/001-crd.yaml
@@ -19,6 +19,9 @@ spec:
   preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      description: 'NetworkAttachmentDefinition is a CRD schema specified by the Network Plumbing
+        Working Group to express the intent for attaching pods to one or more logical or physical
+        networks. More information available at: https://github.com/k8snetworkplumbingwg/multi-net-spec'
       type: object
       properties:
         apiVersion:
@@ -35,9 +38,11 @@ spec:
         metadata:
           type: object
         spec:
+          description: 'NetworkAttachmentDefinition spec defines the desired state of a network attachment'
           type: object
           properties:
             config:
+              description: 'NetworkAttachmentDefinition config is a JSON-formatted CNI configuration'
               type: string
 ---
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/bindata/network/additional-networks/crd/001-crd.yaml
+++ b/bindata/network/additional-networks/crd/001-crd.yaml
@@ -98,7 +98,7 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
-  preserveUnknownFields: true
+  preserveUnknownFields: false
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
This adds the apiversion, kind and metadata fields for explain to properly function.

Backport of #729