### PR TITLE
Bug 1823711: [backport 4.3] NetworkAttachmentDefinitions should have output for "oc explain"

### DIFF
--- a/bindata/network/additional-networks/crd/001-crd.yaml
+++ b/bindata/network/additional-networks/crd/001-crd.yaml
@@ -99,7 +99,7 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
-  preserveUnknownFields: true
+  preserveUnknownFields: false
 status:
   acceptedNames:
     kind: ""

--- a/bindata/network/additional-networks/crd/001-crd.yaml
+++ b/bindata/network/additional-networks/crd/001-crd.yaml
@@ -20,6 +20,9 @@ spec:
   preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      description: 'NetworkAttachmentDefinition is a CRD schema specified by the Network Plumbing
+        Working Group to express the intent for attaching pods to one or more logical or physical
+        networks. More information available at: https://github.com/k8snetworkplumbingwg/multi-net-spec'
       type: object
       properties:
         apiVersion:
@@ -36,9 +39,11 @@ spec:
         metadata:
           type: object
         spec:
+          description: 'NetworkAttachmentDefinition spec defines the desired state of a network attachment'
           type: object
           properties:
             config:
+              description: 'NetworkAttachmentDefinition config is a JSON-formatted CNI configuration'
               type: string
 ---
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/bindata/network/additional-networks/crd/001-crd.yaml
+++ b/bindata/network/additional-networks/crd/001-crd.yaml
@@ -22,6 +22,19 @@ spec:
     openAPIV3Schema:
       type: object
       properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this represen
+            tation of an object. Servers should convert recognized schemas to the
+            latest internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
         spec:
           type: object
           properties:

--- a/bindata/network/additional-networks/crd/001-crd.yaml
+++ b/bindata/network/additional-networks/crd/001-crd.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1
     served: true
     storage: true
-  preserveUnknownFields: true
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
       type: object


### PR DESCRIPTION
This adds the apiversion, kind and metadata fields for explain to properly function.

Backport of #729