### PR TITLE
Fixes permissions for CRDs with OVN

### DIFF
--- a/bindata/network/ovn-kubernetes/002-rbac.yaml
+++ b/bindata/network/ovn-kubernetes/002-rbac.yaml
@@ -45,6 +45,12 @@ rules:
   - watch
   - patch
   - update
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["*"]
+  resources: ["egressfirewalls.k8s.ovn.org"]
+  verbs: ["get", "list", "watch", "patch", "update"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/bindata/network/ovn-kubernetes/003-rbac-controller.yaml
+++ b/bindata/network/ovn-kubernetes/003-rbac-controller.yaml
@@ -72,6 +72,12 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["*"]
+  resources: ["egressfirewalls.k8s.ovn.org"]
+  verbs: ["get", "list", "watch", "patch", "update"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
With addition of Egress Firewall CRD, we now need to be able to watch
for this custom resource.

Signed-off-by: Tim Rozet <trozet@redhat.com>