### PR TITLE
OVN: Fix control plane metrics alert job name

### DIFF
--- a/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
@@ -15,9 +15,9 @@ spec:
     - alert: NoRunningOvnMaster
       annotations:
         message: |
-          there is no running ovn-kubernetes master
+          There is no running ovn-kubernetes master
       expr: |
-        absent(up{job="ovnkube-master",namespace="openshift-ovn-kubernetes"} ==1)
+        absent(up{job="ovnkube-master-metrics", namespace="openshift-ovn-kubernetes"} == 1)
       for: 10m
       labels:
         severity: warning


### PR DESCRIPTION
Following the change in PR #581 the job name should be renamed to
"ovnkube-master-metrics"

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>