### PR TITLE
ovnkube: fix NoRunningOvnKubeMaster alert rule

### DIFF
--- a/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
@@ -15,9 +15,9 @@ spec:
     - alert: NoRunningOvnMaster
       annotations:
         message: |
-          there is no running ovn-kubernetes master
+          there is no running ovn-kubernetes master pod
       expr: |
-        absent(up{job="ovnkube-master",namespace="openshift-ovn-kubernetes"} ==1)
+        absent(up{job="ovnkube-db",namespace="openshift-ovn-kubernetes"} == 1)
       for: 10m
       labels:
         severity: warning


### PR DESCRIPTION
The "job" must be a Kubernetes Service object that selects all the
backend pods we care about. We have two options:

1) ovnkube-db service: selects all ovnkube master pods

2) ovn-kubernetes-master-metrics service: selects all master metrics
pods which are a separate daemonset for proxying metrics over TLS

Go with #1 since that accurately represents the thing we really care
about: the ovnkube master pods.

@trozet @abhat @knobunc @squeed 