### PR TITLE
Bug 1819571: NetworkAttachmentDefinitions should have output for "oc explain"

### DIFF
--- a/bindata/network/additional-networks/crd/001-crd.yaml
+++ b/bindata/network/additional-networks/crd/001-crd.yaml
@@ -16,7 +16,7 @@ spec:
   - name: v1
     served: true
     storage: true
-  preserveUnknownFields: true
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
       description: 'NetworkAttachmentDefinition is a CRD schema specified by the Network Plumbing


### PR DESCRIPTION
This fix changes CRD to show output for 'oc explain' correctly.