### PR TITLE
Bug 1857387: Do not reset the election-timer value

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -218,7 +218,7 @@ spec:
                   fi
                 done
 
-                if [[ ${election_timer} -ne ${current_election_timer} ]]; then
+                if [[ ${election_timer} -lt ${current_election_timer} ]]; then
                   retries=0
                   while is_candidate=$(ovs-appctl -t /var/run/ovn/ovnnb_db.ctl cluster/status OVN_Northbound 2>/dev/null \
                     | grep "Role: candidate" ); do
@@ -390,7 +390,7 @@ spec:
                   fi
                 done
 
-                if [[ ${election_timer} -ne ${current_election_timer} ]]; then
+                if [[ ${election_timer} -lt ${current_election_timer} ]]; then
                   retries=0
                   while is_candidate=$(ovs-appctl -t /var/run/ovn/ovnsb_db.ctl cluster/status OVN_Southbound 2>/dev/null \
                     | grep "Role: candidate" ); do


### PR DESCRIPTION
If user manually configure the election-timer, restarting the pods
can reset the value to default value (5 second). This can be an issue
if pods are restarted at large scale -- resetting to 5 second might
disrupt the cluster at that scale and it might not converge.

Signed-off-by: Anil Vishnoi <avishnoi@redhat.com>