### PR TITLE
OVN: Add the NoOvnMasterLeader alert-rule

### DIFF
--- a/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
@@ -21,6 +21,15 @@ spec:
       for: 10m
       labels:
         severity: warning
+    - alert: NoOvnMasterLeader
+      annotations:
+        message: |
+          There is no ovn-kubernetes master leader
+      expr: |
+        max(ovnkube_master_leader) == 0
+      for: 10m
+      labels:
+        severity: warning
     - alert: NorthboundStale
       annotations:
         message: |


### PR DESCRIPTION
Add a new rule that will alert when there is no OVN master
leader present for more than 10minutes.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>