### PR TITLE
Bug 1866792: Fix oc explain ippools

### DIFF
--- a/bindata/network/additional-networks/crd/001-crd.yaml
+++ b/bindata/network/additional-networks/crd/001-crd.yaml
@@ -103,7 +103,7 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
-  preserveUnknownFields: true
+  preserveUnknownFields: false
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
Similar to https://github.com/openshift/cluster-network-operator/pull/745

After the change
```
$ oc explain ippools
KIND:     IPPool
VERSION:  whereabouts.cni.cncf.io/v1alpha1

DESCRIPTION:
     IPPool is the Schema for Whereabouts for IP address allocation

FIELDS:
   apiVersion	<string>
     APIVersion defines the versioned schema of this representation of an
     object. Servers should convert recognized schemas to the latest internal
     value, and may reject unrecognized values. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources

   kind	<string>
     Kind is a string value representing the REST resource this object
     represents. Servers may infer this from the endpoint the client submits
     requests to. Cannot be updated. In CamelCase. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds

   metadata	<Object>
     Standard object's metadata. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

   spec	<Object>
     IPPoolSpec defines the desired state of IPPool
```

Before the change:
```
$ oc explain ippools
KIND:     IPPool
VERSION:  whereabouts.cni.cncf.io/v1alpha1

DESCRIPTION:
     <empty>
```

/assign @dougbtv 