### PR TITLE
Bug 1870711: Move metrics to SDN DS

### DIFF
--- a/bindata/network/openshift-sdn/002-rbac.yaml
+++ b/bindata/network/openshift-sdn/002-rbac.yaml
@@ -53,51 +53,6 @@ rules:
   - create
   - patch
   - update
-
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: sdn
-  namespace: openshift-sdn
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: openshift-sdn
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: openshift-sdn
-subjects:
-- kind: ServiceAccount
-  name: sdn
-  namespace: openshift-sdn
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: openshift-sdn-metrics
-rules:
-- apiGroups: [""]
-  resources:
-  - namespaces
-  - endpoints
-  - services
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups: [""]
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-  - update
 - apiGroups: ['authentication.k8s.io']
   resources: ['tokenreviews']
   verbs: ['create']
@@ -109,19 +64,19 @@ rules:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: sdn-metrics
+  name: sdn
   namespace: openshift-sdn
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: openshift-sdn-metrics
+  name: openshift-sdn
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: openshift-sdn-metrics
+  name: openshift-sdn
 subjects:
 - kind: ServiceAccount
-  name: sdn-metrics
+  name: sdn
   namespace: openshift-sdn

--- a/bindata/network/openshift-sdn/monitor.yaml
+++ b/bindata/network/openshift-sdn/monitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app: sdn-metrics
+    app: sdn
   annotations:
     networkoperator.openshift.io/ignore-errors: ""
   name: monitor-sdn
@@ -16,14 +16,14 @@ spec:
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: sdn-metrics.openshift-sdn.svc
+      serverName: sdn.openshift-sdn.svc
   jobLabel: app
   namespaceSelector:
     matchNames:
     - openshift-sdn
   selector:
     matchLabels:
-      app: sdn-metrics
+      app: sdn
 ---
 apiVersion: v1
 kind: Service
@@ -31,12 +31,12 @@ metadata:
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: sdn-metrics-certs
   labels:
-    app: sdn-metrics
-  name: sdn-metrics
+    app: sdn
+  name: sdn
   namespace: openshift-sdn
 spec:
   selector:
-    app: sdn-metrics
+    app: sdn
   clusterIP: None
   publishNotReadyAddresses: true
   ports:

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -174,6 +174,65 @@ spec:
             command: ["test", "-f", "/etc/cni/net.d/80-openshift-network.conf"]
           initialDelaySeconds: 5
           periodSeconds: 5
+      - name: kube-rbac-proxy
+        image: {{.KubeRBACProxyImage}}
+        command:
+        - /bin/bash
+        - -c
+        - |
+          #!/bin/bash
+          set -euo pipefail
+          TLS_PK=/etc/pki/tls/metrics-certs/tls.key
+          TLS_CERT=/etc/pki/tls/metrics-certs/tls.crt
+
+          # As the secret mount is optional we must wait for the files to be present.
+          # The service is created in monitor.yaml and this is created in sdn.yaml.
+          # If it isn't created there is probably an issue so we want to crashloop.
+          TS=$(curl \
+            --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+            -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+            "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/openshift-sdn/services/sdn" |
+              python -c 'import json,sys; print(json.load(sys.stdin)["metadata"]["creationTimestamp"])'
+          )
+
+          TS=$(date -d "${TS}" +%s)
+          WARN_TS=$(( ${TS} + $(( 20 * 60)) ))
+          HAS_LOGGED_INFO=0
+          
+          log_missing_certs(){
+              CUR_TS=$(date +%s)
+              if [[ "${CUR_TS}" -gt "WARN_TS"  ]]; then
+                echo $(date -Iseconds) WARN: sdn-metrics-certs not mounted after 20 minutes.
+              elif [[ "${HAS_LOGGED_INFO}" -eq 0 ]] ; then
+                echo $(date -Iseconds) INFO: sdn-metrics-certs not mounted. Waiting one hour.
+                HAS_LOGGED_INFO=1
+              fi
+          }
+
+          while [[ ! -f "${TLS_PK}" ||  ! -f "${TLS_CERT}" ]] ; do
+            log_missing_certs
+            sleep 5
+          done
+          
+          exec /usr/bin/kube-rbac-proxy \
+            --logtostderr \
+            --secure-listen-address=:9101 \
+            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 \
+            --upstream=http://127.0.0.1:29101/ \
+            --tls-private-key-file=${TLS_PK} \
+            --tls-cert-file=${TLS_CERT}
+        ports:
+        - containerPort: 9101
+          name: https
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: sdn-metrics-certs
+          mountPath: /etc/pki/tls/metrics-certs
+          readOnly: True
       nodeSelector:
         kubernetes.io/os: linux
       volumes:
@@ -221,64 +280,11 @@ spec:
       - name: host-var-lib-cni-networks-openshift-sdn
         hostPath:
           path: /var/lib/cni/networks/openshift-sdn
-      tolerations:
-      - operator: Exists
----
-kind: DaemonSet
-apiVersion: apps/v1
-metadata:
-  name: sdn-metrics
-  namespace: openshift-sdn
-  annotations:
-    kubernetes.io/description: |
-      This daemon set launches the OpenShift networking components (kube-proxy and openshift-sdn).
-      It expects that OVS is running on the node.
-    release.openshift.io/version: "{{.ReleaseVersion}}"
-spec:
-  selector:
-    matchLabels:
-      app: sdn-metrics
-  updateStrategy:
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        app: sdn-metrics
-        component: network
-        type: infra
-        openshift.io/component: network
-      annotations:
-        networkoperator.openshift.io/non-critical: ""
-    spec:
-      # Requires fairly broad permissions - ability to read all services and network functions as well
-      # as all pods.
-      serviceAccountName: sdn-metrics
-      hostNetwork: true
-      containers:
-      - name: kube-rbac-proxy
-        image: {{.KubeRBACProxyImage}}
-        args:
-        - --logtostderr
-        - --secure-listen-address=:9101
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-        - --upstream=http://127.0.0.1:29101/
-        - --tls-private-key-file=/etc/pki/tls/metrics-certs/tls.key
-        - --tls-cert-file=/etc/pki/tls/metrics-certs/tls.crt
-        ports:
-        - containerPort: 9101
-          name: https
-        resources:
-          requests:
-            cpu: 10m
-            memory: 20Mi
-        terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts:
-        - name: sdn-metrics-certs
-          mountPath: /etc/pki/tls/metrics-certs
-          readOnly: True
-      nodeSelector:
-        kubernetes.io/os: linux
-      volumes:
+      # Must be optional because the sdn-metrics-certs is a service serving
+      # certificate and those cannot be generated without the SDN running
       - name: sdn-metrics-certs
         secret:
           secretName: sdn-metrics-certs
+          optional: true
+      tolerations:
+      - operator: Exists


### PR DESCRIPTION
The SDN metrics pod needs a service serving certificate which depends on
the SDN. However during the upgrade we've seen that sometimes during the
upgrade tis causes problems because the metrics daemonset is deployed
before rolling out the old daemonset.