### PR TITLE
Bug 1866200: fix recording rules group name

### DIFF
--- a/bindata/network/kuryr/alert-rules.yaml
+++ b/bindata/network/kuryr/alert-rules.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: openshift-kuryr
 spec:
   groups:
-  - name: general.rules
+  - name: cluster-network-operator-kuryr.rules
     rules:
     - alert: NoRunningKuryrKubernetes
       annotations:

--- a/bindata/network/openshift-sdn/alert-rules.yaml
+++ b/bindata/network/openshift-sdn/alert-rules.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: openshift-sdn
 spec:
   groups:
-  - name: general.rules
+  - name: cluster-network-operator-sdn.rules
     rules:
     # note: all joins on kube_pod_* need a a "topk by (key) (1, <metric> )"
     # otherwise you will generate query errors when kube_state_metrics is being

--- a/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: openshift-ovn-kubernetes
 spec:
   groups:
-  - name: general.rules
+  - name: cluster-network-operator-master.rules
     rules:
     - alert: NoRunningOvnMaster
       annotations:

--- a/bindata/network/ovn-kubernetes/alert-rules.yaml
+++ b/bindata/network/ovn-kubernetes/alert-rules.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: openshift-ovn-kubernetes
 spec:
   groups:
-  - name: general.rules
+  - name: cluster-network-operator-ovn.rules
     rules:
     - alert: NodeWithoutOVNKubeNodePodRunning
       annotations:


### PR DESCRIPTION
The `general.rules` group name conflicts with others, causing them to be merged with other rules in OpenShift console via Thanos Querier.

This fixes it.

/cc @openshift/openshift-team-monitoring 