### PR TITLE
Bug 1868078: Fixes providing empty slice for HybridClusterNetwork

### DIFF
--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -91,7 +91,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["OVN_service_cidr"] = svcpools
 
 	if c.HybridOverlayConfig != nil {
-		if c.HybridOverlayConfig.HybridClusterNetwork != nil {
+		if len(c.HybridOverlayConfig.HybridClusterNetwork) > 0 {
 			data.Data["OVNHybridOverlayNetCIDR"] = c.HybridOverlayConfig.HybridClusterNetwork[0].CIDR
 		} else {
 			data.Data["OVNHybridOverlayNetCIDR"] = ""


### PR DESCRIPTION
In order to deploy without using HybridClusterNetwork with
OVN-Kubernetes, the user is required to specify:

    ovnKubernetesConfig:
      hybridOverlayConfig:
        hybridClusterNetwork: []

The code was assuming the slice always had values.

Signed-off-by: Tim Rozet <trozet@redhat.com>