### PR TITLE
Bug 1874385: OVN: Handle OVN db upgrades.

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -166,6 +166,22 @@ spec:
                   fi
                   sleep 2
                   done
+
+                  # Upgrade the db if required.
+                  DB_SCHEMA="/usr/share/ovn/ovn-nb.ovsschema"
+                  DB_SERVER="unix:/var/run/ovn/ovnnb_db.sock"
+                  schema_name=$(ovsdb-tool schema-name $DB_SCHEMA)
+                  db_version=$(ovsdb-client -t 10 get-schema-version "$DB_SERVER" "$schema_name")
+                  target_version=$(ovsdb-tool schema-version "$DB_SCHEMA")
+
+                  if ovsdb-tool compare-versions "$db_version" == "$target_version"; then
+                    :
+                  elif ovsdb-tool compare-versions "$db_version" ">" "$target_version"; then
+                      echo "Database $schema_name has newer schema version ($db_version) than our local schema ($target_version), possibly an upgrade is partially complete?"
+                  else
+                      echo "Upgrading database $schema_name from schema version $db_version to $target_version"
+                      ovsdb-client -t 30 convert "$DB_SERVER" "$DB_SCHEMA"
+                  fi
                 fi
                 #configure northd_probe_interval
                 OVN_NB_CTL="ovn-nbctl -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt \
@@ -371,6 +387,22 @@ spec:
                   fi
                   sleep 2
                   done
+
+                  # Upgrade the db if required.
+                  DB_SCHEMA="/usr/share/ovn/ovn-sb.ovsschema"
+                  DB_SERVER="unix:/var/run/ovn/ovnsb_db.sock"
+                  schema_name=$(ovsdb-tool schema-name $DB_SCHEMA)
+                  db_version=$(ovsdb-client -t 10 get-schema-version "$DB_SERVER" "$schema_name")
+                  target_version=$(ovsdb-tool schema-version "$DB_SCHEMA")
+
+                  if ovsdb-tool compare-versions "$db_version" == "$target_version"; then
+                    :
+                  elif ovsdb-tool compare-versions "$db_version" ">" "$target_version"; then
+                      echo "Database $schema_name has newer schema version ($db_version) than our local schema ($target_version), possibly an upgrade is partially complete?"
+                  else
+                      echo "Upgrading database $schema_name from schema version $db_version to $target_version"
+                      ovsdb-client -t 30 convert "$DB_SERVER" "$DB_SCHEMA"
+                  fi
                 fi
 
                 election_timer="${OVN_SB_RAFT_ELECTION_TIMER}"


### PR DESCRIPTION
The ovnkube master daemonset starts the ovsdb-servers using ovn-ctl commands - run_nb_ovsdb
and run_sb_ovsdb. These versions of the command don't daemonize the ovsdb-servers and hence
the code to handle the DB upragdes in these functions never gets run.

This results in the OVN dbs in the old schema. Upgraded ovn-controllers will not see
any new columns because of this resulting in datapath disruptions.

This patch adds the code to handle the db upgrade in the 'postStart' stage.

Bug 1868392: [FDP 20.F] OVN 2.13 breaks pod-pod networking across the projects on OCP

Signed-off-by: Numan Siddique <nusiddiq@redhat.com>
