### PR TITLE
Bug 1868259: Fixes OVN upgrade with shared gateway mode

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -495,6 +495,15 @@ spec:
             fi
           fi
 
+          gateway_mode_flags=
+          # Check to see if ovs is provided by the node. This is only for upgrade from 4.5->4.6 or
+          # openshift-sdn to ovn-kube conversion
+          if [ -f /etc/systemd/system/network-online.target.wants/ovs-configuration.service ]; then
+            gateway_mode_flags="--gateway-mode shared --gateway-interface br-ex"
+          else
+            gateway_mode_flags="--gateway-mode local"
+          fi
+
           # start nbctl daemon for caching
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-master - start nbctl daemon for caching"
           export OVN_NB_DAEMON=$(ovn-nbctl --pidfile=/var/run/ovn/ovn-nbctl.pid \
@@ -513,8 +522,7 @@ spec:
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
             ${hybrid_overlay_flags} \
             --metrics-bind-address "127.0.0.1:29102" \
-            --gateway-mode shared \
-            --gateway-interface br-ex \
+            ${gateway_mode_flags} \
             --sb-address "{{.OVN_SB_DB_LIST}}" \
             --sb-client-privkey /ovn-cert/tls.key \
             --sb-client-cert /ovn-cert/tls.crt \
@@ -532,6 +540,10 @@ spec:
             exec:
               command: ["/bin/bash", "-c", "kill $(cat /var/run/ovn/ovn-nbctl.pid) && unset OVN_NB_DAEMON"]
         volumeMounts:
+        # for checking ovs-configuration service
+        - mountPath: /etc/systemd/system
+          name: systemd-units
+          readOnly: true
         - mountPath: /etc/openvswitch/
           name: etc-openvswitch
         - mountPath: /etc/ovn/
@@ -570,6 +582,10 @@ spec:
         node-role.kubernetes.io/master: ""
         beta.kubernetes.io/os: "linux"
       volumes:
+      # for checking ovs-configuration service
+      - name: systemd-units
+        hostPath:
+          path: /etc/systemd/system
       - name: etc-openvswitch
         hostPath:
           path: /var/lib/ovn/etc

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -129,7 +129,16 @@ spec:
               hybrid_overlay_flags="${hybrid_overlay_flags} --hybrid-overlay-vxlan-port={{.OVNHybridOverlayVXLANPort}}"
             fi
           fi
-          
+
+          gateway_mode_flags=
+          # Check to see if ovs is provided by the node. This is only for upgrade from 4.5->4.6 or
+          # openshift-sdn to ovn-kube conversion
+          if [ -f /etc/systemd/system/network-online.target.wants/ovs-configuration.service ]; then
+            gateway_mode_flags="--gateway-mode shared --gateway-interface br-ex"
+          else
+            gateway_mode_flags="--gateway-mode local"
+          fi
+
           exec /usr/bin/ovnkube --init-node "${K8S_NODE}" \
             --nb-address "{{.OVN_NB_DB_LIST}}" \
             --sb-address "{{.OVN_SB_DB_LIST}}" \
@@ -145,8 +154,7 @@ spec:
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
             --inactivity-probe="${OVN_CONTROLLER_INACTIVITY_PROBE}" \
             ${hybrid_overlay_flags} \
-            --gateway-mode shared \
-            --gateway-interface br-ex \
+            ${gateway_mode_flags} \
             --metrics-bind-address "127.0.0.1:29103"
         env:
         # for kubectl
@@ -169,6 +177,10 @@ spec:
           privileged: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
+        # for checking ovs-configuration service
+        - mountPath: /etc/systemd/system
+          name: systemd-units
+          readOnly: true
         # for the iptables wrapper
         - mountPath: /host
           name: host-slash
@@ -225,6 +237,10 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: "linux"
       volumes:
+      # for checking ovs-configuration service
+      - name: systemd-units
+        hostPath:
+          path: /etc/systemd/system
       # used for iptables wrapper scripts
       - name: host-slash
         hostPath:


### PR DESCRIPTION
With OCP upgrade today, CNO happens before MCO. When upgrading from 4.5
to 4.6, 4.6 OVN expects system OVS to be there and configured which will
not happen until MCO upgrade finishes. Therefore upon initial CNO
upgrade, we will run in local gateway mode until the node is rebooted
via MCO with a machine-os-content change to include system OVS and run
the ovs-configuration service.

We also need to temporarily use local gateway when converting from
openshift-sdn to ovn-kubernetes, so use the enabled system service path
for checking.

Signed-off-by: Tim Rozet <trozet@redhat.com>