### PR TITLE
Bug 1867538: Kuryr: Update KuryrPort CRD to move vifs to status

### DIFF
--- a/bindata/network/kuryr/002-crds.yaml
+++ b/bindata/network/kuryr/002-crds.yaml
@@ -265,12 +265,16 @@ spec:
             required:
             - podUid
             - podNodeName
-            - vifs
             properties:
               podUid:
                 type: string
               podNodeName:
                 type: string
+          status:
+            type: object
+            required:
+            - vifs
+            properties:
               vifs:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
The vifs field totally belongs to the status part of the KuryrPort CR
and this commit moves it there. This is handled in kuryr-kubernetes too.
Should be safe as version with previous CRD wasn't yet released.