### PR TITLE
Bug 1937594: Split SDN migration into 2 phase

### DIFF
--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -175,17 +175,14 @@ func (r *ReconcileOperConfig) Reconcile(request reconcile.Request) (reconcile.Re
 	// Compare against previous applied configuration to see if this change
 	// is safe.
 	if prev != nil {
-		// Check if the operator is put in the 'Network Migration' mode.
-		if _, ok := operConfig.GetAnnotations()[names.NetworkMigrationAnnotation]; !ok {
-			// We may need to fill defaults here -- sort of as a poor-man's
-			// upconversion scheme -- if we add additional fields to the config.
-			err = network.IsChangeSafe(prev, &operConfig.Spec)
-			if err != nil {
-				log.Printf("Not applying unsafe change: %v", err)
-				r.status.SetDegraded(statusmanager.OperatorConfig, "InvalidOperatorConfig",
-					fmt.Sprintf("Not applying unsafe configuration change: %v. Use 'oc edit network.operator.openshift.io cluster' to undo the change.", err))
-				return reconcile.Result{}, err
-			}
+		// We may need to fill defaults here -- sort of as a poor-man's
+		// upconversion scheme -- if we add additional fields to the config.
+		err = network.IsChangeSafe(prev, &operConfig.Spec)
+		if err != nil {
+			log.Printf("Not applying unsafe change: %v", err)
+			r.status.SetDegraded(statusmanager.OperatorConfig, "InvalidOperatorConfig",
+				fmt.Sprintf("Not applying unsafe configuration change: %v. Use 'oc edit network.operator.openshift.io cluster' to undo the change.", err))
+			return reconcile.Result{}, err
 		}
 	}
 

--- a/pkg/network/cluster_config.go
+++ b/pkg/network/cluster_config.go
@@ -164,5 +164,11 @@ func StatusFromOperatorConfig(operConf *operv1.NetworkSpec, oldStatus *configv1.
 		status.ClusterNetworkMTU = int(*operConf.DefaultNetwork.KuryrConfig.MTU)
 	}
 
+	// Set migration in the config status
+	if operConf.Migration != nil {
+		status.Migration = &configv1.NetworkMigration{NetworkType: string(operConf.Migration.NetworkType)}
+	} else {
+		status.Migration = nil
+	}
 	return &status
 }


### PR DESCRIPTION
Phase1, Users add the spec.migration feild in network.operator
CR. The only changes the migration field under the status of
Network.config. It will trigger MCO to provision ovs-configuration
service on every node and reboot. After rebooting, openshift-sdn
will use br-ex as L3 gateway.

Phase2, Users update the spec.networkType in network.config.
CNO starts to swap the network provider for the cluster to ovnkube.
Users need to manually reboot all nodes to make all pods attach to
the new cluster network.