### PR TITLE
Bug 1872750: ovn-k: add prestop actions for nbdb and sbdb

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -254,7 +254,13 @@ spec:
                     done
                   fi
                 fi
-
+          preStop:
+            exec:
+              command:
+                - /usr/bin/ovn-appctl
+                - -t
+                - /var/run/ovn/ovnnb_db.ctl
+                - exit
         readinessProbe:
           initialDelaySeconds: 30
           timeoutSeconds: 5
@@ -426,7 +432,13 @@ spec:
                     done
                   fi
                 fi
-
+          preStop:
+            exec:
+              command:
+                - /usr/bin/ovn-appctl
+                - -t
+                - /var/run/ovn/ovnsb_db.ctl
+                - exit
         readinessProbe:
           initialDelaySeconds: 30
           timeoutSeconds: 5


### PR DESCRIPTION
This adds a preStop hook to call ovs-appctl exit for both nbdb and sbdb. Hopefully this reduces instances of database corruption.

/cc @trozet @dceara 