### PR TITLE
Enable EgressIP for OpenShift

### DIFF
--- a/bindata/network/ovn-kubernetes/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/004-config.yaml
@@ -16,6 +16,9 @@ data:
     service-cidrs="{{.OVN_service_cidr}}"
     ovn-config-namespace="openshift-ovn-kubernetes"
     apiserver="{{.K8S_APISERVER}}"
+ 
+    [ovnkubernetesfeature]
+    enable-egress-ip=true
 
     [gateway]
     mode=local


### PR DESCRIPTION
Egress IP has been disabled for OpenShift due to critical bugs rendering the functionality "un-testable". 

Now that PR https://github.com/openshift/ovn-kubernetes/pull/243 merged, we got a bunch of fixes in OVN-Kubernetes. Hopefully once PR: https://github.com/openshift/ovn-kubernetes/pull/240 merges we'll get the essential OVN fix to make egress IP work.

This enablement is independent of any of that though. 

/assign @dcbw 