### PR TITLE
[WIP] Enable ovs-vswitchd/ovn-controller debug logging by default.

### DIFF
--- a/bindata/network/ovn-kubernetes/006-ovs-node.yaml
+++ b/bindata/network/ovn-kubernetes/006-ovs-node.yaml
@@ -59,6 +59,7 @@ spec:
             if [[ ! -S /run/openvswitch/db.sock ]]; then
               systemctl restart ovsdb-server
             fi
+            ovs-appctl -t ovsdb-server vlog/set "file:jsonrpc:dbg"
             # Don't need to worry about restoring flows; this can only change if we've rebooted
             exec tail -F /host/var/log/openvswitch/ovs-vswitchd.log /host/var/log/openvswitch/ovsdb-server.log
           else
@@ -73,7 +74,6 @@ spec:
             }
             trap quit SIGTERM
             /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --system-id=random
-            ovs-appctl vlog/set "file:${OVS_LOG_LEVEL}"
             /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol
             echo "$(date -Iseconds) - ovs-daemons running"
 

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -51,7 +51,7 @@ spec:
           exec ovn-controller unix:/var/run/openvswitch/db.sock -vfile:off \
             --no-chdir --pidfile=/var/run/ovn/ovn-controller.pid \
             -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt \
-            -vconsole:"${OVN_LOG_LEVEL}"
+            -vconsole:dbg
         securityContext:
           privileged: true
         env:


### PR DESCRIPTION
Just to gather more debug information from CI runs.

Signed-off-by: Dumitru Ceara <dceara@redhat.com>