### PR TITLE
Bug 1874242: Revert "Bug 1857387: Do not reset the election-timer value"

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -218,7 +218,7 @@ spec:
                   fi
                 done
 
-                if [[ ${election_timer} -lt ${current_election_timer} ]]; then
+                if [[ ${election_timer} -ne ${current_election_timer} ]]; then
                   retries=0
                   while is_candidate=$(ovs-appctl -t /var/run/ovn/ovnnb_db.ctl cluster/status OVN_Northbound 2>/dev/null \
                     | grep "Role: candidate" ); do
@@ -390,7 +390,7 @@ spec:
                   fi
                 done
 
-                if [[ ${election_timer} -lt ${current_election_timer} ]]; then
+                if [[ ${election_timer} -ne ${current_election_timer} ]]; then
                   retries=0
                   while is_candidate=$(ovs-appctl -t /var/run/ovn/ovnsb_db.ctl cluster/status OVN_Southbound 2>/dev/null \
                     | grep "Role: candidate" ); do


### PR DESCRIPTION
Reverts openshift/cluster-network-operator#748

This PR stops election leader timers from being set to the default value of 5 seconds, because 5 is never less than 1.