### PR TITLE
Bug 1874647: Initialize controller-runtime logging

### DIFF
--- a/cmd/cluster-network-operator/log.go
+++ b/cmd/cluster-network-operator/log.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"log"
+
+	"github.com/go-logr/logr"
+	crlog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func initControllerRuntimeLogging() {
+	crlog.SetLogger(&crLogger{})
+}
+
+type crLogger struct {
+	logInfo bool
+}
+
+func (l *crLogger) Info(msg string, keysAndValues ...interface{}) {
+	if l.logInfo {
+		log.Printf("%s", msg)
+	}
+}
+
+func (l *crLogger) Error(err error, msg string, keysAndValues ...interface{}) {
+	log.Printf("ERROR %v - %s", err, msg)
+}
+
+func (l *crLogger) Enabled() bool {
+	return true
+}
+
+func (l *crLogger) V(level int) logr.InfoLogger {
+	return l
+}
+
+func (l *crLogger) WithValues(keysAndValues ...interface{}) logr.Logger {
+	return l
+}
+
+func (l *crLogger) WithName(name string) logr.Logger {
+	return &crLogger{logInfo: name == "leader"}
+}

--- a/cmd/cluster-network-operator/main.go
+++ b/cmd/cluster-network-operator/main.go
@@ -40,6 +40,7 @@ func init() {
 }
 
 func main() {
+	initControllerRuntimeLogging()
 	printVersion()
 	flag.Parse()
 


### PR DESCRIPTION
While trying to figure out how we ended up with three simultaneous copies of CNO running in an IPv6 cluster, I found that we're currently dropping all logs from code in `sigs.k8s.io/controller-runtime`.

This is hacky but we should eventually stop using controller-runtime anyway, so...
