### PR TITLE
Bug 1874696: Set hostPID for sdn ovs DaemonSet

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -24,6 +24,7 @@ spec:
     spec:
       serviceAccountName: sdn #needed to run privileged pods; not used for api access
       hostNetwork: true
+      hostPID: true
       priorityClassName: system-node-critical
       containers:
       - name: openvswitch


### PR DESCRIPTION
Set hostPID to 'true', so that systemctl in container can talk to the host systemd which has host PID 1.