### PR TITLE
Bug 1875062: openshift-sdn: mark sdn-metrics "non-critical" to fix status reporting

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -234,6 +234,7 @@ metadata:
       This daemon set launches the OpenShift networking components (kube-proxy and openshift-sdn).
       It expects that OVS is running on the node.
     release.openshift.io/version: "{{.ReleaseVersion}}"
+    networkoperator.openshift.io/non-critical: ""
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
CNO should only report that networking is Degraded when actual networking is degraded. In particular, it should not report that networking is Degraded because it can't start a pod that depends on there being worker nodes (which includes any pod that depends on the service cert signing thing), because if we do, then any time the cluster install fails before getting the point of having worker nodes, CNO will be reporting Degraded and then everyone will assume that this is the _cause_ of the failure rather than a _symptom_ of it.

/cc @juanluisvaladas @dcbw @JacobTanenbaum @rcarrillocruz 
and me, who all looked at #574 and failed to notice the bug

cf, eg, https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ocp-4.6-e2e-vsphere/1301147570361339904, where CNO is reporting

```
                    {
                        "lastTransitionTime": "2020-09-02T13:41:04Z",
                        "message": "DaemonSet \"openshift-sdn/sdn-metrics\" rollout is not making progress - last change 2020-09-02T13:31:04Z",
                        "reason": "RolloutHung",
                        "status": "True",
                        "type": "Degraded"
                    },
```
