### PR TITLE
Bug 1874591: autodect mtu support for ipv6

### DIFF
--- a/pkg/network/mtu.go
+++ b/pkg/network/mtu.go
@@ -11,7 +11,7 @@ import (
 func GetDefaultMTU() (int, error) {
 	// Get the interface with the default route
 	// TODO(cdc) handle v6-only nodes
-	routes, err := netlink.RouteList(nil, netlink.FAMILY_V4)
+	routes, err := netlink.RouteList(nil, netlink.FAMILY_ALL)
 	if err != nil {
 		return 0, errors.Wrapf(err, "could not list routes")
 	}

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -152,7 +152,7 @@ func FillDefaults(conf, previous *operv1.NetworkSpec) {
 	}
 	if previous == nil { // host mtu isn't used in subsequent runs, elide these logs
 		if err != nil {
-			log.Printf("Failed MTU probe, failling back to 1500: %v", err)
+			log.Printf("Failed MTU probe, falling back to 1500: %v", err)
 		} else {
 			log.Printf("Detected uplink MTU %d", hostMTU)
 		}


### PR DESCRIPTION
The code was taking into account IPv4 routes only.
It consider IPv6 routes now

Signed-off-by: Antonio Ojea <aojea@redhat.com>