### PR TITLE
Bug 1854306: Remove ovs bridges when sdn/ovnkube pod is terminated

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -167,7 +167,12 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["rm","-f","/etc/cni/net.d/80-openshift-network.conf", "/host/opt/cni/bin/openshift-sdn"]
+              command:
+              - /bin/bash
+              - -c
+              - |
+                rm -f /etc/cni/net.d/80-openshift-network.conf /host/opt/cni/bin/openshift-sdn
+                ovs-vsctl --timeout=30 --if-exists del-br br0
         readinessProbe:
           exec:
             # openshift-sdn writes this file when it is ready to handle pod requests.

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -228,7 +228,12 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["rm","-f","/etc/cni/net.d/10-ovn-kubernetes.conf"]
+              command:
+              - /bin/bash
+              - -c
+              - |
+                rm -f /etc/cni/net.d/10-ovn-kubernetes.conf
+                ovs-vsctl --timeout=30 --if-exists del-br br-int -- --if-exists del-br br-local
         readinessProbe:
           exec:
             command: ["test", "-f", "/etc/cni/net.d/10-ovn-kubernetes.conf"]


### PR DESCRIPTION
Remove bridge br0 when sdn pod is terminated.
Remove bridge br-int and br-local when ovnkube-node pod is terminated.