### PR TITLE
Bug 1874696: Remove systemctl calls

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -35,8 +35,23 @@ spec:
           #!/bin/bash
           set -euo pipefail
           export SYSTEMD_IGNORE_CHROOT=yes
+
+          # systemctl cannot be used in a separate PID namespace to reach
+          # the systemd running in PID 1. Therefore we need to use the dbus API
+          systemctl_restart(){
+            gdbus call \
+              --system \
+              --dest org.freedesktop.systemd1 \
+              --object-path /org/freedesktop/systemd1/unit/"$(svc_encode_name ${1})"_2eservice \
+              --method org.freedesktop.systemd1.Unit.Restart "replace"
+          }
+          svc_encode_name(){
+            # systemd encodes some characters, so far we only need to encode
+            # the character "-" but there may be more in the future.
+            echo "${1//-/_2d}"
+          }
           # Check to see if ovs is provided by the node:
-          if systemctl status ovsdb-server; then
+          if [[ -f '/host/usr/local/bin/configure-ovs.sh' ]]; then
             echo "openvswitch is running in systemd"
             # In some very strange corner cases, the owner for /run/openvswitch
             # can be wrong, so we need to clean up and restart.
@@ -44,9 +59,8 @@ spec:
             ovs_gid=$(chroot /host id -g openvswitch)
             chown -R "${ovs_uid}:${ovs_gid}" /run/openvswitch
             if [[ ! -S /run/openvswitch/db.sock ]]; then
-              systemctl restart ovsdb-server
+              systemctl_restart ovsdb-server
             fi
-
             # Don't need to worry about restoring flows; this can only change if we've rebooted
             exec tail -F /host/var/log/openvswitch/ovs-vswitchd.log /host/var/log/openvswitch/ovsdb-server.log
           else

--- a/bindata/network/ovn-kubernetes/006-ovs-node.yaml
+++ b/bindata/network/ovn-kubernetes/006-ovs-node.yaml
@@ -48,8 +48,24 @@ spec:
             set +o allexport
           fi
           export SYSTEMD_IGNORE_CHROOT=yes
+
+          # systemctl cannot be used in a separate PID namespace to reach
+          # the systemd running in PID 1. Therefore we need to use the dbus API
+          systemctl_restart(){
+            gdbus call \
+              --system \
+              --dest org.freedesktop.systemd1 \
+              --object-path /org/freedesktop/systemd1/unit/"$(svc_encode_name ${1})"_2eservice \
+              --method org.freedesktop.systemd1.Unit.Restart "replace"
+          }
+          svc_encode_name(){
+            # systemd encodes some characters, so far we only need to encode
+            # the character "-" but there may be more in the future.
+            echo "${1//-/_2d}"
+          }
+
           # Check to see if ovs is provided by the node:
-          if systemctl status ovsdb-server; then
+          if [[ -f '/host/usr/local/bin/configure-ovs.sh' ]]; then
             echo "openvswitch is running in systemd"
             # In some very strange corner cases, the owner for /run/openvswitch
             # can be wrong, so we need to clean up and restart.
@@ -57,7 +73,7 @@ spec:
             ovs_gid=$(chroot /host id -g openvswitch)
             chown -R "${ovs_uid}:${ovs_gid}" /run/openvswitch
             if [[ ! -S /run/openvswitch/db.sock ]]; then
-              systemctl restart ovsdb-server
+              systemctl_restart ovsdb-server
             fi
             # Don't need to worry about restoring flows; this can only change if we've rebooted
             exec tail -F /host/var/log/openvswitch/ovs-vswitchd.log /host/var/log/openvswitch/ovsdb-server.log


### PR DESCRIPTION
/assign @pliurh 

When systemctl is run in a separate PID namespace where PID 1 isn't systemd, it doesn't behave the normal way: https://github.com/systemd/systemd/issues/11300

The solution for this is to entirely remove calls to systemctl calls.