### PR TITLE
Bug 1852593: SDN mount host's /var/run/netns

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -119,6 +119,10 @@ spec:
           name: host-run-netns
           readOnly: true
           mountPropagation: HostToContainer
+        - name: host-var-run-netns
+          mountPath: /host/var/run/netns
+          mountPropagation: HostToContainer
+          readOnly: true
         # We mount our socket here
         - mountPath: /var/run/openshift-sdn
           name: host-var-run-openshift-sdn
@@ -197,6 +201,9 @@ spec:
       - name: host-run-netns
         hostPath:
           path: /run/netns
+      - name: host-var-run-netns
+        hostPath:
+          path: /var/run/netns
       - name: host-var-run-dbus
         hostPath:
           path: /var/run/dbus


### PR DESCRIPTION
When creating an egress-router pod, openshift-sdn fails during the CNI_ADD with the error message:

```
'could not open netns "/var/run/netns/11cb808b-c141-40e9-86fe-c74643b481aa": unknown FS magic on "/var/run/netns/11cb808b-c141-40e9-86fe-c74643b481aa": 1021994
```

PR: https://github.com/openshift/cluster-network-operator/pull/696 already made an attempt months ago at fixing this, but didn't.  

Now, this is going to sound strange to say: but I am not entirely sure why this fixes the issue...but it does (tested on AWS). So needless to say, I am open to any suggestion / complaint detailing why this should not be done. 

I inspired myself off of: https://github.com/openshift/cluster-network-operator/pull/648/files 

/assign @danwinship 