### PR TITLE
Bug 1854306: Run ovn in shared gw mode when configure-ovs.sh run with parameter OVNKubernetes

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -531,7 +531,7 @@ spec:
           gateway_mode_flags=
           # Check to see if ovs is provided by the node. This is only for upgrade from 4.5->4.6 or
           # openshift-sdn to ovn-kube conversion
-          if [ -f /etc/systemd/system/network-online.target.wants/ovs-configuration.service ]; then
+          if grep -q OVNKubernetes /etc/systemd/system/ovs-configuration.service ; then
             gateway_mode_flags="--gateway-mode local --gateway-interface br-ex"
           else
             gateway_mode_flags="--gateway-mode local --gateway-interface none"

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -123,7 +123,7 @@ spec:
           gateway_mode_flags=
           # Check to see if ovs is provided by the node. This is only for upgrade from 4.5->4.6 or
           # openshift-sdn to ovn-kube conversion
-          if [ -f /etc/systemd/system/network-online.target.wants/ovs-configuration.service ]; then
+          if grep -q OVNKubernetes /etc/systemd/system/ovs-configuration.service ; then
             gateway_mode_flags="--gateway-mode local --gateway-interface br-ex"
           else
             gateway_mode_flags="--gateway-mode local --gateway-interface none"


### PR DESCRIPTION
ovs-configuration.service is enabled for both ovn-kube and openshift-sdn. So using the parameter of configure-ovs.sh as the condition to tell whether ovnkube shall be in a shared gw or local gw mode. In 4.5, this parameter is not added yet.