### PR TITLE
Bug 1879910: openshift-sdn: bump EgressNetworkPolicy maxItems to 1000

### DIFF
--- a/bindata/network/openshift-sdn/001-crd.yaml
+++ b/bindata/network/openshift-sdn/001-crd.yaml
@@ -393,7 +393,7 @@ spec:
                 - type
                 type: object
               type: array
-              maxItems: 50
+              maxItems: 1000
           required:
           - egress
           type: object


### PR DESCRIPTION
The max items per EgressNetworkPolicy was always completely arbitrary; the code blindly assumes that there won't be more items there than there are possible `priority` values in an OpenFlow rule, but it doesn't really care beyond that. We picked 50 arbitrarily because it should have been more than enough _given the way that we intended for people to use the feature_, but people have always been using the feature to do things we didn't really originally intend.

Anyway, this bumps it to 1000.

@abhat there is no `maxItems` in openshift/api's version of this CRD... are those CRDs supposed to be in sync with these ones? Should we be validating that somewhere?