### PR TITLE
Bug 1880853: Fix oc explain for operatorPKI

### DIFF
--- a/manifests/0000_70_cluster-network-operator_01_pki_crd.yaml
+++ b/manifests/0000_70_cluster-network-operator_01_pki_crd.yaml
@@ -13,6 +13,7 @@ spec:
     plural: operatorpkis
     singular: operatorpki
   scope: Namespaced
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
       description: "OperatorPKI is a simple certificate authority. It is not intended


### PR DESCRIPTION
Because the CRD's preserveUnknownFields was set to false, oc explain wouldn't work. This PR Fixes it.

Before the PR:
```
$ oc explain operatorpkis
KIND:     OperatorPKI
VERSION:  network.operator.openshift.io/v1

DESCRIPTION:
     <empty>
```

With this PR:

```
$ oc explain operatorpkis
KIND:     OperatorPKI
VERSION:  network.operator.openshift.io/v1

DESCRIPTION:
     OperatorPKI is a simple certificate authority. It is not intended for
     external use - rather, it is internal to the network operator. The CNO
     creates a CA and a certificate signed by that CA. The certificate has both
     ClientAuth and ServerAuth extended usages enabled. More specifically, given
     an OperatorPKI with <name>, the CNO will manage: - A Secret called
     <name>-ca with two data keys: - tls.key - the private key - tls.crt - the
     CA certificate - A ConfigMap called <name>-ca with a single data key: -
     cabundle.crt - the CA certificate(s) - A Secret called <name>-cert with two
     data keys: - tls.key - the private key - tls.crt - the certificate, signed
     by the CA The CA certificate will have a validity of 10 years, rotated
     after 9. The target certificate will have a validity of 6 months, rotated
     after 3 The CA certificate will have a CommonName of
     "<namespace>_<name>-ca@<timestamp>", where <timestamp> is the last rotation
     time.

FIELDS:
   apiVersion	<string>
     APIVersion defines the versioned schema of this representation of an
     object. Servers should convert recognized schemas to the latest internal
     value, and may reject unrecognized values. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources

   kind	<string>
     Kind is a string value representing the REST resource this object
     represents. Servers may infer this from the endpoint the client submits
     requests to. Cannot be updated. In CamelCase. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds

   metadata	<Object>
     Standard object's metadata. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

   spec	<Object> -required-
     OperatorPKISpec is the PKI configuration.

   status	<map[string]>
     OperatorPKIStatus is not implemented.

```

