### PR TITLE
Fixes gateway mode parameters for OVN

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -532,9 +532,9 @@ spec:
           # Check to see if ovs is provided by the node. This is only for upgrade from 4.5->4.6 or
           # openshift-sdn to ovn-kube conversion
           if [ -f /etc/systemd/system/network-online.target.wants/ovs-configuration.service ]; then
-            gateway_mode_flags="--gateway-mode shared --gateway-interface br-ex"
+            gateway_mode_flags="--gateway-mode local --gateway-interface br-ex"
           else
-            gateway_mode_flags="--gateway-mode local"
+            gateway_mode_flags="--gateway-mode local --gateway-interface none"
           fi
 
           # start nbctl daemon for caching

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -124,9 +124,9 @@ spec:
           # Check to see if ovs is provided by the node. This is only for upgrade from 4.5->4.6 or
           # openshift-sdn to ovn-kube conversion
           if [ -f /etc/systemd/system/network-online.target.wants/ovs-configuration.service ]; then
-            gateway_mode_flags="--gateway-mode shared --gateway-interface br-ex"
+            gateway_mode_flags="--gateway-mode local --gateway-interface br-ex"
           else
-            gateway_mode_flags="--gateway-mode local"
+            gateway_mode_flags="--gateway-mode local --gateway-interface none"
           fi
 
           exec /usr/bin/ovnkube --init-node "${K8S_NODE}" \


### PR DESCRIPTION
We have now switched back to using local gateway mode in ovn-kubernetes.
This is currently forced in ovn-k8s with a hack. This patch sets it
correctly in CNO and we will revert the hack in ovn-k8s.

Additionally, this passes the gateway-interface of "none" when
ovs-configuration is not available. This allows us to do upgrade via

https://github.com/openshift/ovn-kubernetes/pull/281

Signed-off-by: Tim Rozet <trozet@redhat.com>