### PR TITLE
Bug 1854306: Set a 30s timeout for kubectl command in ovnkube-node

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -105,7 +105,8 @@ spec:
           iptables -t raw -A OUTPUT -p udp --dport {{.GenevePort}} -j NOTRACK
           retries=0
           while true; do
-            db_ip=$(kubectl get ep -n ${ovn_config_namespace} ovnkube-db -o jsonpath='{.subsets[0].addresses[0].ip}')
+            # TODO: change to use '--request-timeout=30s', if https://github.com/kubernetes/kubernetes/issues/49343 is fixed. 
+            db_ip=$(timeout 30 kubectl get ep -n ${ovn_config_namespace} ovnkube-db -o jsonpath='{.subsets[0].addresses[0].ip}')
             if [[ -n "${db_ip}" ]]; then
               break
             fi


### PR DESCRIPTION
By default the timeout of 'kubectl get' is infinity. If apiserver don't response,
This command can take ~15min to fail(socket timeout). It's too long. This patch
set a 30s timeout to 'kubectl get'.