### PR TITLE
Bug 1882569: Add support for OVN DB Management

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -115,35 +115,144 @@ spec:
           fi
 
           bracketify() { case "$1" in *:*) echo "[$1]" ;; *) echo "$1" ;; esac }
+          # initialize variables
+          ovn_kubernetes_namespace=openshift-ovn-kubernetes
+          ovndb_ctl_ssl_opts="-p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt"
+          transport="ssl"
+          ovn_raft_conn_ip_url_suffix=""
+          if [[ "${K8S_NODE_IP}" == *":"* ]]; then
+            ovn_raft_conn_ip_url_suffix=":[::]"
+          fi
+          db="nb"
+          db_port="{{.OVN_NB_PORT}}"
+          ovn_db_file="/etc/ovn/ovn${db}_db.db"
+          # checks if a db pod is part of a current cluster
+          db_part_of_cluster() {
+            local pod=${1}
+            local db=${2}
+            local port=${3}
+            echo "Checking if ${pod} is part of cluster"
+            # TODO: change to use '--request-timeout=5s', if https://github.com/kubernetes/kubernetes/issues/49343 is fixed. 
+            init_ip=$(timeout 5 kubectl get pod -n ${ovn_kubernetes_namespace} ${pod} -o=jsonpath='{.status.podIP}')
+            if [[ $? != 0 ]]; then
+              echo "Unable to get ${pod} ip "
+              return 1
+            fi
+            echo "Found ${pod} ip: $init_ip"
+            init_ip=$(bracketify $init_ip)
+            target=$(ovn-${db}ctl --timeout=5 --db=${transport}:${init_ip}:${port} ${ovndb_ctl_ssl_opts} \
+                      --data=bare --no-headings --columns=target list connection)
+            if [[ "${target}" != "p${transport}:${port}${ovn_raft_conn_ip_url_suffix}" ]]; then
+              echo "Unable to check correct target ${target} "
+              return 1
+            fi
+            echo "${pod} is part of cluster"
+            return 0
+          }
+          # end of db_part_of_cluster
+          
+          # Checks if cluster has already been initialized.
+          # If not it returns false and sets init_ip to MASTER_IP
+          cluster_exists() {
+            local db=${1}
+            local port=${2}
+            # TODO: change to use '--request-timeout=5s', if https://github.com/kubernetes/kubernetes/issues/49343 is fixed. 
+            db_pods=$(timeout 5 kubectl get pod -n ${ovn_kubernetes_namespace} -o=jsonpath='{.items[*].metadata.name}' | egrep -o 'ovnkube-master-\w+' | grep -v "metrics")
 
+            for db_pod in $db_pods; do
+              if db_part_of_cluster $db_pod $db $port; then
+                echo "${db_pod} is part of current cluster with ip: ${init_ip}!"
+                return 0
+              fi
+            done
+            # if we get here  there is no cluster, set init_ip and get out
+            init_ip=$(bracketify $MASTER_IP)
+            return 1
+          }
+          # end of cluster_exists()
+          
           MASTER_IP="{{.OVN_MASTER_IP}}"
-          echo "$(date -Iseconds) - starting nbdb  MASTER_IP=${MASTER_IP}"
-          if [[ "${K8S_NODE_IP}" == "${MASTER_IP}" ]]; then
-            exec /usr/share/ovn/scripts/ovn-ctl \
-            --db-nb-cluster-local-port={{.OVN_NB_RAFT_PORT}} \
-            --db-nb-cluster-local-addr=$(bracketify ${K8S_NODE_IP}) \
-            --no-monitor \
-            --db-nb-cluster-local-proto=ssl \
-            --ovn-nb-db-ssl-key=/ovn-cert/tls.key \
-            --ovn-nb-db-ssl-cert=/ovn-cert/tls.crt \
-            --ovn-nb-db-ssl-ca-cert=/ovn-ca/ca-bundle.crt \
-            --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
-            run_nb_ovsdb
+          echo "$(date -Iseconds) - starting nbdb  MASTER_IP=${MASTER_IP}, K8S_NODE_IP=${K8S_NODE_IP}"
+          initial_raft_create=true
+          initialize="false"
+          
+          if [[ ! -e ${ovn_db_file} ]]; then
+            initialize="true"
+          fi
+
+          if [[ "${initialize}" == "true" ]]; then
+            # check to see if a cluster already exists. If it does, just join it.
+            counter=0
+            cluster_found=false
+            while [ $counter -lt 5 ]; do
+              if cluster_exists ${db} ${db_port}; then
+                cluster_found=true
+                break
+              fi
+              sleep 1
+              counter=$((counter+1))
+            done
+
+            if ${cluster_found}; then
+              echo "Cluster already exists for DB: ${db}"
+              initial_raft_create=false
+              # join existing cluster
+              exec /usr/share/ovn/scripts/ovn-ctl \
+              --db-nb-cluster-local-port={{.OVN_NB_RAFT_PORT}} \
+              --db-nb-cluster-remote-port={{.OVN_NB_RAFT_PORT}} \
+              --db-nb-cluster-local-addr=$(bracketify ${K8S_NODE_IP}) \
+              --db-nb-cluster-remote-addr=$(bracketify ${init_ip}) \
+              --no-monitor \
+              --db-nb-cluster-local-proto=ssl \
+              --db-nb-cluster-remote-proto=ssl \
+              --ovn-nb-db-ssl-key=/ovn-cert/tls.key \
+              --ovn-nb-db-ssl-cert=/ovn-cert/tls.crt \
+              --ovn-nb-db-ssl-ca-cert=/ovn-ca/ca-bundle.crt \
+              --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
+              run_nb_ovsdb
+            else
+              # either we need to initialize a new cluster or wait for master to create it
+              if [[ "${K8S_NODE_IP}" == "${MASTER_IP}" ]]; then
+                exec /usr/share/ovn/scripts/ovn-ctl \
+                --db-nb-cluster-local-port={{.OVN_NB_RAFT_PORT}} \
+                --db-nb-cluster-local-addr=$(bracketify ${K8S_NODE_IP}) \
+                --no-monitor \
+                --db-nb-cluster-local-proto=ssl \
+                --ovn-nb-db-ssl-key=/ovn-cert/tls.key \
+                --ovn-nb-db-ssl-cert=/ovn-cert/tls.crt \
+                --ovn-nb-db-ssl-ca-cert=/ovn-ca/ca-bundle.crt \
+                --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
+                run_nb_ovsdb
+              else
+                echo "Joining the nbdb cluster with init_ip=${init_ip}..."
+                exec /usr/share/ovn/scripts/ovn-ctl \
+                --db-nb-cluster-local-port={{.OVN_NB_RAFT_PORT}} \
+                --db-nb-cluster-remote-port={{.OVN_NB_RAFT_PORT}} \
+                --db-nb-cluster-local-addr=$(bracketify ${K8S_NODE_IP}) \
+                --db-nb-cluster-remote-addr=$(bracketify ${init_ip}) \
+                --no-monitor \
+                --db-nb-cluster-local-proto=ssl \
+                --db-nb-cluster-remote-proto=ssl \
+                --ovn-nb-db-ssl-key=/ovn-cert/tls.key \
+                --ovn-nb-db-ssl-cert=/ovn-cert/tls.crt \
+                --ovn-nb-db-ssl-ca-cert=/ovn-ca/ca-bundle.crt \
+                --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
+                run_nb_ovsdb
+              fi
+            fi
           else
             exec /usr/share/ovn/scripts/ovn-ctl \
             --db-nb-cluster-local-port={{.OVN_NB_RAFT_PORT}} \
-            --db-nb-cluster-remote-port={{.OVN_NB_RAFT_PORT}} \
             --db-nb-cluster-local-addr=$(bracketify ${K8S_NODE_IP}) \
-            --db-nb-cluster-remote-addr=$(bracketify ${MASTER_IP}) \
             --no-monitor \
             --db-nb-cluster-local-proto=ssl \
-            --db-nb-cluster-remote-proto=ssl \
             --ovn-nb-db-ssl-key=/ovn-cert/tls.key \
             --ovn-nb-db-ssl-cert=/ovn-cert/tls.crt \
             --ovn-nb-db-ssl-ca-cert=/ovn-ca/ca-bundle.crt \
             --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
             run_nb_ovsdb
           fi
+
         lifecycle:
           postStart:
             exec:
@@ -278,7 +387,7 @@ spec:
                 - /var/run/ovn/ovnnb_db.ctl
                 - exit
         readinessProbe:
-          initialDelaySeconds: 30
+          initialDelaySeconds: 60
           timeoutSeconds: 5
           exec:
             command:
@@ -342,29 +451,136 @@ spec:
 
           bracketify() { case "$1" in *:*) echo "[$1]" ;; *) echo "$1" ;; esac }
 
+          # initialize variables
+          ovn_kubernetes_namespace=openshift-ovn-kubernetes
+          ovndb_ctl_ssl_opts="-p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt"
+          transport="ssl"
+          ovn_raft_conn_ip_url_suffix=""
+          if [[ "${K8S_NODE_IP}" == *":"* ]]; then
+            ovn_raft_conn_ip_url_suffix=":[::]"
+          fi
+          db="sb"
+          db_port="{{.OVN_SB_PORT}}"
+          ovn_db_file="/etc/ovn/ovn${db}_db.db"
+          # checks if a db pod is part of a current cluster
+          db_part_of_cluster() {
+            local pod=${1}
+            local db=${2}
+            local port=${3}
+            echo "Checking if ${pod} is part of cluster"
+            # TODO: change to use '--request-timeout=5s', if https://github.com/kubernetes/kubernetes/issues/49343 is fixed. 
+            init_ip=$(timeout 5 kubectl get pod -n ${ovn_kubernetes_namespace} ${pod} -o=jsonpath='{.status.podIP}')
+            if [[ $? != 0 ]]; then
+              echo "Unable to get ${pod} ip "
+              return 1
+            fi
+            echo "Found ${pod} ip: $init_ip"
+            init_ip=$(bracketify $init_ip)
+            target=$(ovn-${db}ctl --timeout=5 --db=${transport}:${init_ip}:${port} ${ovndb_ctl_ssl_opts} \
+                      --data=bare --no-headings --columns=target list connection)
+            if [[ "${target}" != "p${transport}:${port}${ovn_raft_conn_ip_url_suffix}" ]]; then
+              echo "Unable to check correct target ${target} "
+              return 1
+            fi
+            echo "${pod} is part of cluster"
+            return 0
+          }
+          # end of db_part_of_cluster
+          
+          # Checks if cluster has already been initialized.
+          # If not it returns false and sets init_ip to MASTER_IP
+          cluster_exists() {
+            local db=${1}
+            local port=${2}
+            # TODO: change to use '--request-timeout=5s', if https://github.com/kubernetes/kubernetes/issues/49343 is fixed. 
+            db_pods=$(timeout 5 kubectl get pod -n ${ovn_kubernetes_namespace} -o=jsonpath='{.items[*].metadata.name}' | egrep -o 'ovnkube-master-\w+' | grep -v "metrics")
+
+            for db_pod in $db_pods; do
+              if db_part_of_cluster $db_pod $db $port; then
+                echo "${db_pod} is part of current cluster with ip: ${init_ip}!"
+                return 0
+              fi
+            done
+            # if we get here  there is no cluster, set init_ip and get out
+            init_ip=$(bracketify $MASTER_IP)
+            return 1
+          }
+          # end of cluster_exists()
+          
           MASTER_IP="{{.OVN_MASTER_IP}}"
           echo "$(date -Iseconds) - starting sbdb  MASTER_IP=${MASTER_IP}"
-          if [[ "${K8S_NODE_IP}" == "${MASTER_IP}" ]]; then
-            exec /usr/share/ovn/scripts/ovn-ctl \
-            --db-sb-cluster-local-port={{.OVN_SB_RAFT_PORT}} \
-            --db-sb-cluster-local-addr=$(bracketify ${K8S_NODE_IP}) \
-            --no-monitor \
-            --db-sb-cluster-local-proto=ssl \
-            --ovn-sb-db-ssl-key=/ovn-cert/tls.key \
-            --ovn-sb-db-ssl-cert=/ovn-cert/tls.crt \
-            --ovn-sb-db-ssl-ca-cert=/ovn-ca/ca-bundle.crt \
-            --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
-            run_sb_ovsdb
+          initial_raft_create=true
+          initialize="false"
+          
+          if [[ ! -e ${ovn_db_file} ]]; then
+            initialize="true"
+          fi
+
+          if [[ "${initialize}" == "true" ]]; then
+            # check to see if a cluster already exists. If it does, just join it.
+            counter=0
+            cluster_found=false
+            while [ $counter -lt 5 ]; do
+              if cluster_exists ${db} ${db_port}; then
+                cluster_found=true
+                break
+              fi
+              sleep 1
+              counter=$((counter+1))
+            done
+
+            if ${cluster_found}; then
+              echo "Cluster already exists for DB: ${db}"
+              initial_raft_create=false
+              # join existing cluster
+              exec /usr/share/ovn/scripts/ovn-ctl \
+              --db-sb-cluster-local-port={{.OVN_SB_RAFT_PORT}} \
+              --db-sb-cluster-remote-port={{.OVN_SB_RAFT_PORT}} \
+              --db-sb-cluster-local-addr=$(bracketify ${K8S_NODE_IP}) \
+              --db-sb-cluster-remote-addr=$(bracketify ${init_ip}) \
+              --no-monitor \
+              --db-sb-cluster-local-proto=ssl \
+              --db-sb-cluster-remote-proto=ssl \
+              --ovn-sb-db-ssl-key=/ovn-cert/tls.key \
+              --ovn-sb-db-ssl-cert=/ovn-cert/tls.crt \
+              --ovn-sb-db-ssl-ca-cert=/ovn-ca/ca-bundle.crt \
+              --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
+              run_sb_ovsdb
+            else
+              # either we need to initialize a new cluster or wait for master to create it
+              if [[ "${K8S_NODE_IP}" == "${MASTER_IP}" ]]; then
+                exec /usr/share/ovn/scripts/ovn-ctl \
+                --db-sb-cluster-local-port={{.OVN_SB_RAFT_PORT}} \
+                --db-sb-cluster-local-addr=$(bracketify ${K8S_NODE_IP}) \
+                --no-monitor \
+                --db-sb-cluster-local-proto=ssl \
+                --ovn-sb-db-ssl-key=/ovn-cert/tls.key \
+                --ovn-sb-db-ssl-cert=/ovn-cert/tls.crt \
+                --ovn-sb-db-ssl-ca-cert=/ovn-ca/ca-bundle.crt \
+                --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
+                run_sb_ovsdb
+              else
+                exec /usr/share/ovn/scripts/ovn-ctl \
+                --db-sb-cluster-local-port={{.OVN_SB_RAFT_PORT}} \
+                --db-sb-cluster-remote-port={{.OVN_SB_RAFT_PORT}} \
+                --db-sb-cluster-local-addr=$(bracketify ${K8S_NODE_IP}) \
+                --db-sb-cluster-remote-addr=$(bracketify ${init_ip}) \
+                --no-monitor \
+                --db-sb-cluster-local-proto=ssl \
+                --db-sb-cluster-remote-proto=ssl \
+                --ovn-sb-db-ssl-key=/ovn-cert/tls.key \
+                --ovn-sb-db-ssl-cert=/ovn-cert/tls.crt \
+                --ovn-sb-db-ssl-ca-cert=/ovn-ca/ca-bundle.crt \
+                --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
+                run_sb_ovsdb
+              fi
+            fi
           else
-            echo "$(date -Iseconds) - joining cluster at ${MASTER_IP}"
             exec /usr/share/ovn/scripts/ovn-ctl \
             --db-sb-cluster-local-port={{.OVN_SB_RAFT_PORT}} \
-            --db-sb-cluster-remote-port={{.OVN_SB_RAFT_PORT}} \
             --db-sb-cluster-local-addr=$(bracketify ${K8S_NODE_IP}) \
-            --db-sb-cluster-remote-addr=$(bracketify ${MASTER_IP}) \
             --no-monitor \
             --db-sb-cluster-local-proto=ssl \
-            --db-sb-cluster-remote-proto=ssl \
             --ovn-sb-db-ssl-key=/ovn-cert/tls.key \
             --ovn-sb-db-ssl-cert=/ovn-cert/tls.crt \
             --ovn-sb-db-ssl-ca-cert=/ovn-ca/ca-bundle.crt \
@@ -472,7 +688,7 @@ spec:
                 - /var/run/ovn/ovnsb_db.ctl
                 - exit
         readinessProbe:
-          initialDelaySeconds: 30
+          initialDelaySeconds: 60
           timeoutSeconds: 5
           exec:
             command:
@@ -609,7 +825,61 @@ spec:
         - name: metrics-port
           containerPort: 29102
         terminationMessagePolicy: FallbackToLogsOnError
+      # ovn-dbchecker: monitor clustered ovn databases for db health and stale raft members
+      - name: ovn-dbchecker
+        image: "{{.OvnImage}}"
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -xe
+          if [[ -f "/env/_master" ]]; then
+            set -o allexport
+            source "/env/_master"
+            set +o allexport
+          fi
 
+          echo "I$(date "+%m%d %H:%M:%S.%N") - ovn-dbchecker - start ovn-dbchecker"
+          exec /usr/bin/ovndbchecker \
+            --config-file=/run/ovnkube-config/ovnkube.conf \
+            --loglevel "${OVN_KUBE_LOG_LEVEL}" \
+            --sb-address "{{.OVN_SB_DB_LIST}}" \
+            --sb-client-privkey /ovn-cert/tls.key \
+            --sb-client-cert /ovn-cert/tls.crt \
+            --sb-client-cacert /ovn-ca/ca-bundle.crt \
+            --sb-cert-common-name "{{.OVN_CERT_CN}}" \
+            --nb-address "{{.OVN_NB_DB_LIST}}" \
+            --nb-client-privkey /ovn-cert/tls.key \
+            --nb-client-cert /ovn-cert/tls.crt \
+            --nb-client-cacert /ovn-ca/ca-bundle.crt \
+            --nb-cert-common-name "{{.OVN_CERT_CN}}"
+        volumeMounts:
+        - mountPath: /etc/openvswitch/
+          name: etc-openvswitch
+        - mountPath: /etc/ovn/
+          name: etc-openvswitch
+        - mountPath: /var/lib/openvswitch/
+          name: var-lib-openvswitch
+        - mountPath: /run/openvswitch/
+          name: run-openvswitch
+        - mountPath: /run/ovn/
+          name: run-ovn
+        - mountPath: /run/ovnkube-config/
+          name: ovnkube-config
+        - mountPath: /env
+          name: env-overrides
+        - mountPath: /ovn-cert
+          name: ovn-cert
+        - mountPath: /ovn-ca
+          name: ovn-ca
+        resources:
+          requests:
+            cpu: 10m
+            memory: 300Mi
+        env:
+        - name: OVN_KUBE_LOG_LEVEL
+          value: "4"
+        terminationMessagePolicy: FallbackToLogsOnError
       nodeSelector:
         node-role.kubernetes.io/master: ""
         beta.kubernetes.io/os: "linux"


### PR DESCRIPTION
This PR adds the following:
  a) ovn-dbchecker to the daemonset.
  b) ability to detect an existing raft cluster and join
     the cluster when the raft leader db pods restart.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>