### PR TITLE
Bug 1883662: Tune sb-db raft cluster election-timer

### DIFF
--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -46,9 +46,9 @@ spec:
         - name: OVN_IMAGE
           value: "quay.io/openshift/origin-ovn-kubernetes:4.3"
         - name: OVN_NB_RAFT_ELECTION_TIMER
-          value: "5000"
+          value: "10000"
         - name: OVN_SB_RAFT_ELECTION_TIMER
-          value: "5000"
+          value: "16000"
         - name: OVN_NORTHD_PROBE_INTERVAL
           value: "5000"
         - name: OVN_CONTROLLER_INACTIVITY_PROBE


### PR DESCRIPTION
At current scale test (100 nodes, 3000+ services, 15K+ pods), sb-db
cluster is partitioning very frequently with the current default
election time of 5 seconds. This makes the cluster
stable and once it goes to unstable state, it takes longer to recover.
Given the huge number of flows being installed, using any utility tool to
dump the logical flows from sb-db causes the cluster partition with the
current election timer.

Signed-off-by: Anil Vishnoi <avishnoi@redhat.com>