### PR TITLE
Set image versions of CNO deployment to latest

### DIFF
--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: network-operator
-        image: quay.io/openshift/origin-cluster-network-operator:4.3
+        image: quay.io/openshift/origin-cluster-network-operator:latest
         command:
         - "/usr/bin/cluster-network-operator"
         - "--url-only-kubeconfig=/etc/kubernetes/kubeconfig"
@@ -28,23 +28,23 @@ spec:
         - name: RELEASE_VERSION
           value: "0.0.1-snapshot"
         - name: SDN_IMAGE
-          value: "quay.io/openshift/origin-sdn:4.3"
+          value: "quay.io/openshift/origin-sdn:latest"
         - name: KUBE_PROXY_IMAGE
-          value: "quay.io/openshift/origin-kube-proxy:4.3"
+          value: "quay.io/openshift/origin-kube-proxy:latest"
         - name: KUBE_RBAC_PROXY_IMAGE
-          value: "quay.io/openshift/origin-kube-rbac-proxy:4.3"
+          value: "quay.io/openshift/origin-kube-rbac-proxy:latest"
         - name: MULTUS_IMAGE
-          value: "quay.io/openshift/origin-multus-cni:4.3"
+          value: "quay.io/openshift/origin-multus-cni:latest"
         - name: MULTUS_ADMISSION_CONTROLLER_IMAGE
-          value: "quay.io/openshift/origin-multus-admission-controller:4.3"
+          value: "quay.io/openshift/origin-multus-admission-controller:latest"
         - name: CNI_PLUGINS_IMAGE
-          value: "quay.io/openshift/origin-container-networking-plugins:4.3"
+          value: "quay.io/openshift/origin-container-networking-plugins:latest"
         - name: WHEREABOUTS_CNI_IMAGE
-          value: "quay.io/openshift/origin-multus-whereabouts-ipam-cni:4.4"
+          value: "quay.io/openshift/origin-multus-whereabouts-ipam-cni:latest"
         - name: ROUTE_OVERRRIDE_CNI_IMAGE
-          value: "quay.io/openshift/origin-multus-route-override-cni:4.4"
+          value: "quay.io/openshift/origin-multus-route-override-cni:latest"
         - name: OVN_IMAGE
-          value: "quay.io/openshift/origin-ovn-kubernetes:4.3"
+          value: "quay.io/openshift/origin-ovn-kubernetes:latest"
         - name: OVN_NB_RAFT_ELECTION_TIMER
           value: "10000"
         - name: OVN_SB_RAFT_ELECTION_TIMER
@@ -54,11 +54,11 @@ spec:
         - name: OVN_CONTROLLER_INACTIVITY_PROBE
           value: "30000"
         - name: KURYR_DAEMON_IMAGE
-          value: "quay.io/openshift/origin-kuryr-cni:4.3"
+          value: "quay.io/openshift/origin-kuryr-cni:latest"
         - name: KURYR_CONTROLLER_IMAGE
-          value: "quay.io/openshift/origin-kuryr-controller:4.3"
+          value: "quay.io/openshift/origin-kuryr-controller:latest"
         - name: NETWORK_METRICS_DAEMON_IMAGE
-          value: "quay.io/openshift/origin-network-metrics-daemon:4.5"
+          value: "quay.io/openshift/origin-network-metrics-daemon:latest"
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -5,53 +5,53 @@ spec:
   - name: cluster-network-operator
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-cluster-network-operator:4.3
+      name: quay.io/openshift/origin-cluster-network-operator:latest
   - name: sdn
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-sdn:4.3
+      name: quay.io/openshift/origin-sdn:latest
   - name: kube-proxy
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-kube-proxy:4.3
+      name: quay.io/openshift/origin-kube-proxy:latest
   - name: kube-rbac-proxy
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-kube-rbac-proxy:4.3
+      name: quay.io/openshift/origin-kube-rbac-proxy:latest
   - name: multus-cni
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-multus-cni:4.3
+      name: quay.io/openshift/origin-multus-cni:latest
   - name: multus-whereabouts-ipam-cni
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-multus-whereabouts-ipam-cni:4.4
+      name: quay.io/openshift/origin-multus-whereabouts-ipam-cni:latest
   - name: multus-route-override-cni
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-multus-route-override-cni:4.4
+      name: quay.io/openshift/origin-multus-route-override-cni:latest
   - name: multus-admission-controller
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-multus-admission-controller:4.3
+      name: quay.io/openshift/origin-multus-admission-controller:latest
   - name: container-networking-plugins
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-container-networking-plugins:4.3
+      name: quay.io/openshift/origin-container-networking-plugins:latest
   - name: ovn-kubernetes
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-ovn-kubernetes:4.3
+      name: quay.io/openshift/origin-ovn-kubernetes:latest
   - name: kuryr-cni
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-kuryr-cni:4.3
+      name: quay.io/openshift/origin-kuryr-cni:latest
   - name: kuryr-controller
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-kuryr-controller:4.3
+      name: quay.io/openshift/origin-kuryr-controller:latest
   - name: network-metrics-daemon
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-network-metrics-daemon:4.5
+      name: quay.io/openshift/origin-network-metrics-daemon:latest
 


### PR DESCRIPTION
This doesn't affect production deploys nor CI runs, as those
versions are replaced to sane ones.
However when using hack/run_locally we need this otherwise
there is a mismatch between 4.3/4.4 code and master (which is what
we usually use for developing)