### PR TITLE
Add egress-router-cni init container

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -133,6 +133,24 @@ spec:
           value: "/usr/src/multus-cni/rhel8/bin/"
         - name: DEFAULT_SOURCE_DIRECTORY
           value: "/usr/src/multus-cni/bin/"
+      - name: egress-router-binary-copy
+        image: {{.EgressRouterImage}}
+        command: ["/entrypoint/cnibincopy.sh"]
+        volumeMounts:
+        - mountPath: /entrypoint
+          name: cni-binary-copy
+        - mountPath: /host/opt/cni/bin
+          name: cnibin
+        - mountPath: /host/etc/os-release
+          name: os-release
+          readOnly: true
+        env:
+        - name: RHEL7_SOURCE_DIRECTORY
+          value: "/usr/src/egress-router-cni/rhel7/bin/"
+        - name: RHEL8_SOURCE_DIRECTORY
+          value: "/usr/src/egress-router-cni/rhel8/bin/"
+        - name: DEFAULT_SOURCE_DIRECTORY
+          value: "/usr/src/egress-router-cni/bin/"
       - name: cni-plugins
         image: {{.CNIPluginsImage}}
         command: ["/entrypoint/cnibincopy.sh"]

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -55,6 +55,8 @@ spec:
           value: "5000"
         - name: OVN_CONTROLLER_INACTIVITY_PROBE
           value: "30000"
+        - name: EGRESS_ROUTER_CNI_IMAGE
+          value: "quay.io/openshift/origin-egress-router-cni:latest"
         - name: KURYR_DAEMON_IMAGE
           value: "quay.io/openshift/origin-kuryr-cni:latest"
         - name: KURYR_CONTROLLER_IMAGE

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -42,6 +42,10 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-ovn-kubernetes:latest
+  - name: egress-router-cni
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-egress-router-cni:latest
   - name: kuryr-cni
     from:
       kind: DockerImage

--- a/pkg/network/multus.go
+++ b/pkg/network/multus.go
@@ -57,6 +57,7 @@ func renderMultusConfig(manifestDir, defaultNetworkType string, useDHCP bool) ([
 	data.Data["MultusImage"] = os.Getenv("MULTUS_IMAGE")
 	data.Data["CNIPluginsImage"] = os.Getenv("CNI_PLUGINS_IMAGE")
 	data.Data["WhereaboutsImage"] = os.Getenv("WHEREABOUTS_CNI_IMAGE")
+	data.Data["EgressRouterImage"] = os.Getenv("EGRESS_ROUTER_CNI_IMAGE")
 	data.Data["RouteOverrideImage"] = os.Getenv("ROUTE_OVERRRIDE_CNI_IMAGE")
 	data.Data["KUBERNETES_SERVICE_HOST"] = os.Getenv("KUBERNETES_SERVICE_HOST")
 	data.Data["KUBERNETES_SERVICE_PORT"] = os.Getenv("KUBERNETES_SERVICE_PORT")


### PR DESCRIPTION
This commit adds a new init container for the deployment of the
egress-router-cni plugin to the hosts.
