### PR TITLE
Bug 1884101: Fixes systemd ovs check for ovn/sdn

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -50,8 +50,9 @@ spec:
             # the character "-" but there may be more in the future.
             echo "${1//-/_2d}"
           }
+
           # Check to see if ovs is provided by the node:
-          if [[ -f '/host/usr/local/bin/configure-ovs.sh' ]]; then
+          if [[ -L '/host/etc/systemd/system/network-online.target.wants/ovs-configuration.service' ]]; then
             echo "openvswitch is running in systemd"
             # In some very strange corner cases, the owner for /run/openvswitch
             # can be wrong, so we need to clean up and restart.

--- a/bindata/network/ovn-kubernetes/006-ovs-node.yaml
+++ b/bindata/network/ovn-kubernetes/006-ovs-node.yaml
@@ -65,7 +65,7 @@ spec:
           }
 
           # Check to see if ovs is provided by the node:
-          if [[ -f '/host/usr/local/bin/configure-ovs.sh' ]]; then
+          if [[ -L '/host/etc/systemd/system/network-online.target.wants/ovs-configuration.service' ]]; then
             echo "openvswitch is running in systemd"
             # In some very strange corner cases, the owner for /run/openvswitch
             # can be wrong, so we need to clean up and restart.


### PR DESCRIPTION
There is a period of time where MCO will lay down the files for 4.6
before it reboots the node into the new OS. If the ovs pods are coming
up at this time they could accidentally think systemd ovs is running,
which it is not. This patch modifies the check to look in systemd, where
the ovs-configuration service will be enabled only when 4.6 is booted.

Signed-off-by: Tim Rozet <trozet@redhat.com>