### PR TITLE
Allow running openshift-sdn with standalone kube-proxy

### DIFF
--- a/bindata/kube-proxy/kube-proxy.yaml
+++ b/bindata/kube-proxy/kube-proxy.yaml
@@ -65,9 +65,9 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - name: healthz
-          containerPort: 10256
+          containerPort: {{.HealthzPort}}
         - name: metrics
-          containerPort: 9101
+          containerPort: {{.MetricsPort}}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/bindata/kube-proxy/monitor.yaml
+++ b/bindata/kube-proxy/monitor.yaml
@@ -32,9 +32,9 @@ spec:
   clusterIP: None
   ports:
   - name: metrics
-    port: 9101
+    port: {{.MetricsPort}}
     protocol: TCP
-    targetPort: 9101
+    targetPort: {{.MetricsPort}}
   sessionAffinity: None
   type: ClusterIP
 ---

--- a/cmd/cluster-network-renderer/main.go
+++ b/cmd/cluster-network-renderer/main.go
@@ -48,7 +48,7 @@ func render() error {
 		return err
 	}
 
-	network.Canonicalize(&conf.Spec)
+	network.DeprecatedCanonicalize(&conf.Spec)
 
 	err = network.Validate(&conf.Spec)
 	if err != nil {

--- a/pkg/apply/merge.go
+++ b/pkg/apply/merge.go
@@ -9,7 +9,7 @@ import (
 // MergeMetadataForUpdate merges the read-only fields of metadata.
 // This is to be able to do a a meaningful comparison in apply,
 // since objects created on runtime do not have these fields populated.
-func MergeMetadataForUpdate(current, updated *uns.Unstructured) error {
+func mergeMetadataForUpdate(current, updated *uns.Unstructured) error {
 	updated.SetCreationTimestamp(current.GetCreationTimestamp())
 	updated.SetSelfLink(current.GetSelfLink())
 	updated.SetGeneration(current.GetGeneration())
@@ -26,22 +26,22 @@ func MergeMetadataForUpdate(current, updated *uns.Unstructured) error {
 // Some objects, such as Deployments and Services require
 // some semantic-aware updates
 func MergeObjectForUpdate(current, updated *uns.Unstructured) error {
-	if err := MergeDeploymentForUpdate(current, updated); err != nil {
+	if err := mergeDeploymentForUpdate(current, updated); err != nil {
 		return err
 	}
 
-	if err := MergeServiceForUpdate(current, updated); err != nil {
+	if err := mergeServiceForUpdate(current, updated); err != nil {
 		return err
 	}
 
-	if err := MergeServiceAccountForUpdate(current, updated); err != nil {
+	if err := mergeServiceAccountForUpdate(current, updated); err != nil {
 		return err
 	}
 
 	// For all object types, merge metadata.
 	// Run this last, in case any of the more specific merge logic has
 	// changed "updated"
-	MergeMetadataForUpdate(current, updated)
+	mergeMetadataForUpdate(current, updated)
 
 	return nil
 }
@@ -50,9 +50,9 @@ const (
 	deploymentRevisionAnnotation = "deployment.kubernetes.io/revision"
 )
 
-// MergeDeploymentForUpdate updates Deployment objects.
+// mergeDeploymentForUpdate updates Deployment objects.
 // We merge annotations, keeping ours except the Deployment Revision annotation.
-func MergeDeploymentForUpdate(current, updated *uns.Unstructured) error {
+func mergeDeploymentForUpdate(current, updated *uns.Unstructured) error {
 	gvk := updated.GroupVersionKind()
 	if gvk.Group == "apps" && gvk.Kind == "Deployment" {
 
@@ -76,8 +76,8 @@ func MergeDeploymentForUpdate(current, updated *uns.Unstructured) error {
 	return nil
 }
 
-// MergeServiceForUpdate ensures the ClusterIP/IPFamily is never modified
-func MergeServiceForUpdate(current, updated *uns.Unstructured) error {
+// mergeServiceForUpdate ensures the ClusterIP/IPFamily is never modified
+func mergeServiceForUpdate(current, updated *uns.Unstructured) error {
 	gvk := updated.GroupVersionKind()
 	if gvk.Group == "" && gvk.Kind == "Service" {
 		clusterIP, found, err := uns.NestedString(current.Object, "spec", "clusterIP")
@@ -106,11 +106,11 @@ func MergeServiceForUpdate(current, updated *uns.Unstructured) error {
 	return nil
 }
 
-// MergeServiceAccountForUpdate copies secrets from current to updated.
+// mergeServiceAccountForUpdate copies secrets from current to updated.
 // This is intended to preserve the auto-generated token.
 // Right now, we just copy current to updated and don't support supplying
 // any secrets ourselves.
-func MergeServiceAccountForUpdate(current, updated *uns.Unstructured) error {
+func mergeServiceAccountForUpdate(current, updated *uns.Unstructured) error {
 	gvk := updated.GroupVersionKind()
 	if gvk.Group == "" && gvk.Kind == "ServiceAccount" {
 		curSecrets, ok, err := uns.NestedSlice(current.Object, "secrets")

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -142,8 +142,8 @@ func (r *ReconcileOperConfig) Reconcile(request reconcile.Request) (reconcile.Re
 		return reconcile.Result{}, err
 	}
 
-	// Convert to a canonicalized form
-	network.Canonicalize(&operConfig.Spec)
+	// Convert certain fields to canonicalized form for backward compatibility
+	network.DeprecatedCanonicalize(&operConfig.Spec)
 
 	// Validate the configuration
 	if err := network.Validate(&operConfig.Spec); err != nil {

--- a/pkg/network/dhcp_daemon.go
+++ b/pkg/network/dhcp_daemon.go
@@ -6,8 +6,8 @@ import (
 	"log"
 )
 
-// UseDHCPRaw determines if the the DHCP CNI plugin running as a daemon should be rendered.
-func UseDHCPRaw(addnet *operv1.AdditionalNetworkDefinition) bool {
+// useDHCPRaw determines if the the DHCP CNI plugin running as a daemon should be rendered.
+func useDHCPRaw(addnet *operv1.AdditionalNetworkDefinition) bool {
 	// Parse the RawCNIConfig
 	var rawConfig map[string]interface{}
 	var err error
@@ -44,8 +44,8 @@ func UseDHCPRaw(addnet *operv1.AdditionalNetworkDefinition) bool {
 	return false
 }
 
-// UseDHCPSimpleMacvlan determines if the the DHCP CNI plugin running as a daemon should be rendered in case of SimpleMacvlan.
-func UseDHCPSimpleMacvlan(conf *operv1.SimpleMacvlanConfig) bool {
+// useDHCPSimpleMacvlan determines if the the DHCP CNI plugin running as a daemon should be rendered in case of SimpleMacvlan.
+func useDHCPSimpleMacvlan(conf *operv1.SimpleMacvlanConfig) bool {
 	// if IPAMConfig is not configured, DHCP is used (as default IPAM is DHCP)
 	if conf == nil || conf.IPAMConfig == nil {
 		return true
@@ -58,8 +58,8 @@ func UseDHCPSimpleMacvlan(conf *operv1.SimpleMacvlanConfig) bool {
 	return false
 }
 
-// UseDHCP determines if the the DHCP CNI plugin running as a daemon should be rendered in case of Raw.
-func UseDHCP(conf *operv1.NetworkSpec) bool {
+// useDHCP determines if the the DHCP CNI plugin running as a daemon should be rendered in case of Raw.
+func useDHCP(conf *operv1.NetworkSpec) bool {
 	renderdhcp := false
 
 	// This isn't useful without Multinetwork.
@@ -72,9 +72,9 @@ func UseDHCP(conf *operv1.NetworkSpec) bool {
 		for _, addnet := range conf.AdditionalNetworks {
 			switch addnet.Type {
 			case operv1.NetworkTypeRaw:
-				renderdhcp = renderdhcp || UseDHCPRaw(&addnet)
+				renderdhcp = renderdhcp || useDHCPRaw(&addnet)
 			case operv1.NetworkTypeSimpleMacvlan:
-				renderdhcp = renderdhcp || UseDHCPSimpleMacvlan(addnet.SimpleMacvlanConfig)
+				renderdhcp = renderdhcp || useDHCPSimpleMacvlan(addnet.SimpleMacvlanConfig)
 			}
 
 			if renderdhcp == true {

--- a/pkg/network/dhcp_daemon_test.go
+++ b/pkg/network/dhcp_daemon_test.go
@@ -170,7 +170,7 @@ func TestRenderWithDHCP(t *testing.T) {
 	config := &crd.Spec
 	FillDefaults(config, nil)
 
-	objs, err := RenderMultus(config, manifestDir)
+	objs, err := renderMultus(config, manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "dhcp-daemon")))
 }
@@ -183,7 +183,7 @@ func TestRenderNoDHCP(t *testing.T) {
 	config := &crd.Spec
 	FillDefaults(config, nil)
 
-	objs, err := RenderMultus(config, manifestDir)
+	objs, err := renderMultus(config, manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "dhcp-daemon")))
 }
@@ -196,7 +196,7 @@ func TestRenderInvalidDHCP(t *testing.T) {
 	config := &crd.Spec
 	FillDefaults(config, nil)
 
-	objs, err := RenderMultus(config, manifestDir)
+	objs, err := renderMultus(config, manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "dhcp-daemon")))
 }
@@ -209,7 +209,7 @@ func TestRenderWithDHCPSimpleMacvlan(t *testing.T) {
 	config := &crd.Spec
 	FillDefaults(config, nil)
 
-	objs, err := RenderMultus(config, manifestDir)
+	objs, err := renderMultus(config, manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "dhcp-daemon")))
 }
@@ -222,7 +222,7 @@ func TestRenderNoDHCPSimpleMacvlan(t *testing.T) {
 	config := &crd.Spec
 	FillDefaults(config, nil)
 
-	objs, err := RenderMultus(config, manifestDir)
+	objs, err := renderMultus(config, manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "dhcp-daemon")))
 }

--- a/pkg/network/kube_proxy.go
+++ b/pkg/network/kube_proxy.go
@@ -14,12 +14,12 @@ import (
 	k8sutil "github.com/openshift/cluster-network-operator/pkg/util/k8s"
 )
 
-// ShouldDeployKubeProxy determines if the desired network type should
+// shouldDeployKubeProxy determines if the desired network type should
 // install kube-proxy.
 // openshift-sdn deploys its own kube-proxy. ovn-kubernetes and
 // Kuryr-Kubernetes handle services on their own. All other
 // network providers are assumed to require kube-proxy
-func ShouldDeployKubeProxy(conf *operv1.NetworkSpec) bool {
+func shouldDeployKubeProxy(conf *operv1.NetworkSpec) bool {
 	switch conf.DefaultNetwork.Type {
 	case operv1.NetworkTypeOpenShiftSDN:
 		return false
@@ -54,10 +54,10 @@ func kubeProxyConfiguration(pluginDefaults map[string]operv1.ProxyArgumentList, 
 	return k8sutil.GenerateKubeProxyConfiguration(args)
 }
 
-// ValidateStandaloneKubeProxy validates the kube-proxy configuration if
+// validateStandaloneKubeProxy validates the kube-proxy configuration if
 // installation is requested.
-func ValidateStandaloneKubeProxy(conf *operv1.NetworkSpec) []error {
-	if ShouldDeployKubeProxy(conf) {
+func validateStandaloneKubeProxy(conf *operv1.NetworkSpec) []error {
+	if shouldDeployKubeProxy(conf) {
 		return validateKubeProxy(conf)
 	}
 	return nil
@@ -104,11 +104,11 @@ func validateKubeProxy(conf *operv1.NetworkSpec) []error {
 	return out
 }
 
-// FillKubeProxyDefaults inserts kube-proxy defaults, but only if
+// fillKubeProxyDefaults inserts kube-proxy defaults, but only if
 // kube-proxy will be deployed explicitly.
-func FillKubeProxyDefaults(conf, previous *operv1.NetworkSpec) {
+func fillKubeProxyDefaults(conf, previous *operv1.NetworkSpec) {
 	if conf.DeployKubeProxy == nil {
-		v := ShouldDeployKubeProxy(conf)
+		v := shouldDeployKubeProxy(conf)
 		conf.DeployKubeProxy = &v
 	}
 
@@ -136,16 +136,16 @@ func FillKubeProxyDefaults(conf, previous *operv1.NetworkSpec) {
 	}
 }
 
-// IsKubeProxyChangeSafe is noop, but it would check if the proposed kube-proxy
+// isKubeProxyChangeSafe is noop, but it would check if the proposed kube-proxy
 // change is safe.
-func IsKubeProxyChangeSafe(prev, next *operv1.NetworkSpec) []error {
+func isKubeProxyChangeSafe(prev, next *operv1.NetworkSpec) []error {
 	// At present, all kube-proxy changes are safe to deploy
 	return nil
 }
 
-// RenderStandaloneKubeProxy renders the standalone kube-proxy if installation was
+// renderStandaloneKubeProxy renders the standalone kube-proxy if installation was
 // requested.
-func RenderStandaloneKubeProxy(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Unstructured, error) {
+func renderStandaloneKubeProxy(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Unstructured, error) {
 	if !*conf.DeployKubeProxy {
 		return nil, nil
 	}

--- a/pkg/network/kube_proxy_test.go
+++ b/pkg/network/kube_proxy_test.go
@@ -73,7 +73,7 @@ func TestKubeProxyConfig(t *testing.T) {
 	errs := validateKubeProxy(&config)
 	g.Expect(errs).To(HaveLen(0))
 
-	cfg, err := kubeProxyConfiguration(map[string]operv1.ProxyArgumentList{
+	cfg, metricsPort, _, err := kubeProxyConfiguration(map[string]operv1.ProxyArgumentList{
 		// special address+port combo
 		"metrics-bind-address":   {"1.2.3.4"},
 		"metrics-port":           {"999"},
@@ -84,6 +84,7 @@ func TestKubeProxyConfig(t *testing.T) {
 			"conntrack-max-per-core": {"15"},
 		})
 	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(metricsPort).To(Equal("999"))
 	g.Expect(cfg).To(MatchYAML(`apiVersion: kubeproxy.config.k8s.io/v1alpha1
 bindAddress: "0.0.0.0"
 clientConnection:
@@ -138,7 +139,7 @@ func TestKubeProxyIPv6Config(t *testing.T) {
 	errs := validateKubeProxy(&configIPv6)
 	g.Expect(errs).To(HaveLen(0))
 
-	cfg, err := kubeProxyConfiguration(
+	cfg, metricsPort, _, err := kubeProxyConfiguration(
 		map[string]operv1.ProxyArgumentList{
 			// special address+port combo
 			"metrics-bind-address":   {"fd00:1234::4"},
@@ -150,6 +151,7 @@ func TestKubeProxyIPv6Config(t *testing.T) {
 			"conntrack-max-per-core": {"15"},
 		})
 	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(metricsPort).To(Equal("51999"))
 	g.Expect(cfg).To(MatchYAML(`apiVersion: kubeproxy.config.k8s.io/v1alpha1
 bindAddress: "::"
 clientConnection:
@@ -248,8 +250,8 @@ func TestValidateKubeProxy(t *testing.T) {
 	// Break something
 	c.KubeProxyConfig.BindAddress = "invalid"
 	c.KubeProxyConfig.IptablesSyncPeriod = "asdf"
-	c.KubeProxyConfig.ProxyArguments["healthz-port"] = []string{"9101"}
-	c.KubeProxyConfig.ProxyArguments["metrics-port"] = []string{"10256"}
+	c.KubeProxyConfig.ProxyArguments["healthz-port"] = []string{"9102"}
+	c.KubeProxyConfig.ProxyArguments["metrics-port"] = []string{"10255"}
 	g.Expect(validateKubeProxy(c)).To(HaveLen(4))
 }
 
@@ -392,7 +394,7 @@ conntrack:
   tcpEstablishedTimeout: null
 detectLocalMode: ""
 enableProfiling: false
-healthzBindAddress: 0.0.0.0:10256
+healthzBindAddress: 0.0.0.0:10255
 hostnameOverride: ""
 iptables:
   masqueradeAll: false
@@ -409,7 +411,7 @@ ipvs:
   tcpTimeout: 0s
   udpTimeout: 0s
 kind: KubeProxyConfiguration
-metricsBindAddress: 0.0.0.0:9101
+metricsBindAddress: 0.0.0.0:9102
 mode: iptables
 nodePortAddresses: null
 oomScoreAdj: null

--- a/pkg/network/kube_proxy_test.go
+++ b/pkg/network/kube_proxy_test.go
@@ -207,16 +207,16 @@ func TestShouldDeployKubeProxy(t *testing.T) {
 		},
 	}
 
-	g.Expect(ShouldDeployKubeProxy(c)).To(BeFalse())
+	g.Expect(shouldDeployKubeProxy(c)).To(BeFalse())
 
 	c.DefaultNetwork.Type = operv1.NetworkTypeOVNKubernetes
-	g.Expect(ShouldDeployKubeProxy(c)).To(BeFalse())
+	g.Expect(shouldDeployKubeProxy(c)).To(BeFalse())
 
 	c.DefaultNetwork.Type = operv1.NetworkTypeKuryr
-	g.Expect(ShouldDeployKubeProxy(c)).To(BeFalse())
+	g.Expect(shouldDeployKubeProxy(c)).To(BeFalse())
 
 	c.DefaultNetwork.Type = "Flannel"
-	g.Expect(ShouldDeployKubeProxy(c)).To(BeTrue())
+	g.Expect(shouldDeployKubeProxy(c)).To(BeTrue())
 }
 
 func TestValidateKubeProxy(t *testing.T) {
@@ -330,7 +330,7 @@ func TestFillKubeProxyDefaults(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		FillKubeProxyDefaults(tc.in, nil)
+		fillKubeProxyDefaults(tc.in, nil)
 		g.Expect(tc.in).To(Equal(tc.out))
 	}
 }
@@ -351,9 +351,9 @@ func TestRenderKubeProxy(t *testing.T) {
 		},
 	}
 
-	FillKubeProxyDefaults(c, nil)
+	fillKubeProxyDefaults(c, nil)
 
-	objs, err := RenderStandaloneKubeProxy(c, manifestDir)
+	objs, err := renderStandaloneKubeProxy(c, manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	g.Expect(objs).To(HaveLen(10))

--- a/pkg/network/kube_proxy_test.go
+++ b/pkg/network/kube_proxy_test.go
@@ -207,16 +207,20 @@ func TestShouldDeployKubeProxy(t *testing.T) {
 		},
 	}
 
-	g.Expect(shouldDeployKubeProxy(c)).To(BeFalse())
+	g.Expect(acceptsKubeProxyConfig(c)).To(BeTrue())
+	g.Expect(defaultDeployKubeProxy(c)).To(BeFalse())
 
 	c.DefaultNetwork.Type = operv1.NetworkTypeOVNKubernetes
-	g.Expect(shouldDeployKubeProxy(c)).To(BeFalse())
+	g.Expect(acceptsKubeProxyConfig(c)).To(BeFalse())
+	g.Expect(defaultDeployKubeProxy(c)).To(BeFalse())
 
 	c.DefaultNetwork.Type = operv1.NetworkTypeKuryr
-	g.Expect(shouldDeployKubeProxy(c)).To(BeFalse())
+	g.Expect(acceptsKubeProxyConfig(c)).To(BeFalse())
+	g.Expect(defaultDeployKubeProxy(c)).To(BeFalse())
 
 	c.DefaultNetwork.Type = "Flannel"
-	g.Expect(shouldDeployKubeProxy(c)).To(BeTrue())
+	g.Expect(acceptsKubeProxyConfig(c)).To(BeTrue())
+	g.Expect(defaultDeployKubeProxy(c)).To(BeTrue())
 }
 
 func TestValidateKubeProxy(t *testing.T) {

--- a/pkg/network/mtu.go
+++ b/pkg/network/mtu.go
@@ -7,8 +7,8 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-// GetDefaultMTU gets the mtu of the default route.
-func GetDefaultMTU() (int, error) {
+// getDefaultMTU gets the mtu of the default route.
+func getDefaultMTU() (int, error) {
 	// Get the interface with the default route
 	// TODO(cdc) handle v6-only nodes
 	routes, err := netlink.RouteList(nil, netlink.FAMILY_ALL)

--- a/pkg/network/mtu_unsupported.go
+++ b/pkg/network/mtu_unsupported.go
@@ -2,4 +2,4 @@
 
 package network
 
-func GetDefaultMTU() (int, error) { return 1500, nil }
+func getDefaultMTU() (int, error) { return 1500, nil }

--- a/pkg/network/multus.go
+++ b/pkg/network/multus.go
@@ -16,8 +16,8 @@ const (
 	CNIBinDir        = "/var/lib/cni/bin"
 )
 
-// RenderMultus generates the manifests of Multus
-func RenderMultus(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Unstructured, error) {
+// renderMultus generates the manifests of Multus
+func renderMultus(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Unstructured, error) {
 	if *conf.DisableMultiNetwork {
 		return nil, nil
 	}
@@ -31,7 +31,7 @@ func RenderMultus(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Unstruct
 	}
 	out = append(out, objs...)
 
-	usedhcp := UseDHCP(conf)
+	usedhcp := useDHCP(conf)
 	objs, err = renderMultusConfig(manifestDir, string(conf.DefaultNetwork.Type), usedhcp)
 	if err != nil {
 		return nil, err

--- a/pkg/network/multus_admission_controller_test.go
+++ b/pkg/network/multus_admission_controller_test.go
@@ -38,14 +38,14 @@ func TestRenderMultusAdmissionController(t *testing.T) {
 	FillDefaults(config, nil)
 
 	// disable MultusAdmissionController
-	objs, err := RenderMultusAdmissionController(config, manifestDir)
+	objs, err := renderMultusAdmissionController(config, manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "multus-admission-controller")))
 
 	// enable MultusAdmissionController
 	enabled := false
 	config.DisableMultiNetwork = &enabled
-	objs, err = RenderMultusAdmissionController(config, manifestDir)
+	objs, err = renderMultusAdmissionController(config, manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "multus-admission-controller")))
 

--- a/pkg/network/multus_test.go
+++ b/pkg/network/multus_test.go
@@ -38,14 +38,14 @@ func TestRenderMultus(t *testing.T) {
 	FillDefaults(config, nil)
 
 	// disable Multus
-	objs, err := RenderMultus(config, manifestDir)
+	objs, err := renderMultus(config, manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "multus")))
 
 	// enable Multus
 	enabled := false
 	config.DisableMultiNetwork = &enabled
-	objs, err = RenderMultus(config, manifestDir)
+	objs, err = renderMultus(config, manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "multus")))
 

--- a/pkg/network/network_metrics_test.go
+++ b/pkg/network/network_metrics_test.go
@@ -37,14 +37,14 @@ func TestRenderNetworkMetricsDaemon(t *testing.T) {
 	FillDefaults(config, nil)
 
 	// disable MultusAdmissionController
-	objs, err := RenderMultus(config, manifestDir)
+	objs, err := renderMultus(config, manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "network-metrics-daemon")))
 
 	// enable MultusAdmissionController
 	enabled := false
 	config.DisableMultiNetwork = &enabled
-	objs, err = RenderMultus(config, manifestDir)
+	objs, err = renderMultus(config, manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "network-metrics-daemon")))
 

--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -113,9 +113,6 @@ func validateOpenShiftSDN(conf *operv1.NetworkSpec) []error {
 		}
 	}
 
-	proxyErrs := validateKubeProxy(conf)
-	out = append(out, proxyErrs...)
-
 	return out
 }
 
@@ -164,7 +161,6 @@ func fillOpenShiftSDNDefaults(conf, previous *operv1.NetworkSpec, hostMTU int) {
 	if conf.KubeProxyConfig.BindAddress == "" {
 		conf.KubeProxyConfig.BindAddress = "0.0.0.0"
 	}
-
 	if conf.KubeProxyConfig.ProxyArguments == nil {
 		conf.KubeProxyConfig.ProxyArguments = map[string]operv1.ProxyArgumentList{}
 	}

--- a/pkg/network/previous_test.go
+++ b/pkg/network/previous_test.go
@@ -47,7 +47,6 @@ func TestPreviousVersionsSafe(t *testing.T) {
 			FillDefaults(applied, applied)
 
 			// This is the exact config transformation flow in the operator
-			Canonicalize(input)
 			g.Expect(Validate(input)).NotTo(HaveOccurred())
 			FillDefaults(input, applied)
 			g.Expect(IsChangeSafe(applied, input)).NotTo(HaveOccurred())

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -148,7 +148,7 @@ func Validate(conf *operv1.NetworkSpec) error {
 	errs = append(errs, validateIPPools(conf)...)
 	errs = append(errs, validateDefaultNetwork(conf)...)
 	errs = append(errs, validateMultus(conf)...)
-	errs = append(errs, validateStandaloneKubeProxy(conf)...)
+	errs = append(errs, validateKubeProxy(conf)...)
 
 	if len(errs) > 0 {
 		return errors.Errorf("invalid configuration: %v", errs)

--- a/pkg/util/k8s/kubeproxy_test.go
+++ b/pkg/util/k8s/kubeproxy_test.go
@@ -11,7 +11,7 @@ func TestGenerateKubeProxyConfiguration(t *testing.T) {
 	defaults := map[string]operv1.ProxyArgumentList{
 		"bind-address":            {"0.0.0.0"},
 		"metrics-bind-address":    {"0.0.0.0"},
-		"metrics-port":            {"9101"},
+		"metrics-port":            {"9102"},
 		"proxy-mode":              {"iptables"},
 		"iptables-masquerade-bit": {"0"},
 	}
@@ -60,7 +60,7 @@ ipvs:
   tcpTimeout: 0s
   udpTimeout: 0s
 kind: KubeProxyConfiguration
-metricsBindAddress: 0.0.0.0:9101
+metricsBindAddress: 0.0.0.0:9102
 mode: iptables
 nodePortAddresses: null
 oomScoreAdj: null
@@ -170,7 +170,7 @@ ipvs:
   tcpTimeout: 0s
   udpTimeout: 0s
 kind: KubeProxyConfiguration
-metricsBindAddress: 5.6.7.8:9101
+metricsBindAddress: 5.6.7.8:9102
 mode: iptables
 nodePortAddresses: null
 oomScoreAdj: null
@@ -281,7 +281,7 @@ ipvs:
   tcpTimeout: 0s
   udpTimeout: 0s
 kind: KubeProxyConfiguration
-metricsBindAddress: 0.0.0.0:9101
+metricsBindAddress: 0.0.0.0:9102
 mode: iptables
 nodePortAddresses: null
 oomScoreAdj: null


### PR DESCRIPTION
Spinoff of #819. Along with https://github.com/openshift/sdn/pull/198 this will allow us to run openshift-sdn with a standalone kube-proxy for testing.

The first two commits are drive-by cleanups, with the second (`render: clarify that config "canonicalization" is deprecated`) being inspired by https://bugzilla.redhat.com/show_bug.cgi?id=1877984.

I've tested that a cluster installed with this comes up. Next step is to add a CI job using it