### PR TITLE
Bug 1885002: Fix kube-rbac-proxy startup scripts

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -200,9 +200,9 @@ spec:
                 --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
                 -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
                 "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/openshift-sdn/services/sdn" |
-                  python -c 'import json,sys; print(json.load(sys.stdin)["metadata"]["creationTimestamp"])'
+                  python -c 'import json,sys; print(json.load(sys.stdin)["metadata"]["creationTimestamp"])' 2>/dev/null || true
             )
-            if [ ! -z "TS" ]; then
+            if [ -n "${TS}" ]; then
               break
             fi
             (( retries += 1 ))

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -456,9 +456,9 @@ spec:
                 --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
                 -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
                 "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/ovn-kubernetes/services/ovnkube-master" |
-                  python -c 'import json,sys; print(json.load(sys.stdin)["metadata"]["creationTimestamp"])'
+                  python -c 'import json,sys; print(json.load(sys.stdin)["metadata"]["creationTimestamp"])' 2>/dev/null || true
             ) || :
-            if [ ! -z "TS" ]; then
+            if [ -n "${TS}" ]; then
               break
             fi
             (( retries += 1 ))

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -105,9 +105,9 @@ spec:
                 --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
                 -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
                 "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/ovn-kubernetes/services/ovnkube-node" |
-                  python -c 'import json,sys; print(json.load(sys.stdin)["metadata"]["creationTimestamp"])'
+                  python -c 'import json,sys; print(json.load(sys.stdin)["metadata"]["creationTimestamp"])' 2>/dev/null || true
             ) || :
-            if [ ! -z "TS" ]; then
+            if [ -n "${TS}" ]; then
               break
             fi
             (( retries += 1 ))


### PR DESCRIPTION
When the cert wasn't available yet the script would crash with a python json-parsing error rather than looping like it was supposed to.

It is possible there are further problems here...

/assign @juanluisvaladas 