### PR TITLE
Bug 1885165: Fix ovnkube metrics

### DIFF
--- a/bindata/network/ovn-kubernetes/002-rbac.yaml
+++ b/bindata/network/ovn-kubernetes/002-rbac.yaml
@@ -59,6 +59,12 @@ rules:
     - get
     - list
     - watch
+- apiGroups: ['authentication.k8s.io']
+  resources: ['tokenreviews']
+  verbs: ['create']
+- apiGroups: ['authorization.k8s.io']
+  resources: ['subjectaccessreviews']
+  verbs: ['create']
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/bindata/network/ovn-kubernetes/003-rbac-controller.yaml
+++ b/bindata/network/ovn-kubernetes/003-rbac-controller.yaml
@@ -88,6 +88,12 @@ rules:
     - get
     - list
     - watch
+- apiGroups: ['authentication.k8s.io']
+  resources: ['tokenreviews']
+  verbs: ['create']
+- apiGroups: ['authorization.k8s.io']
+  resources: ['subjectaccessreviews']
+  verbs: ['create']
 
 
 ---
@@ -132,55 +138,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: ovn-kubernetes-controller
-  namespace: openshift-ovn-kubernetes
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: openshift-ovn-kubernetes-metrics
-rules:
-- apiGroups: [""]
-  resources:
-  - namespaces
-  - endpoints
-  - services
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups: [""]
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-  - update
-- apiGroups: ['authentication.k8s.io']
-  resources: ['tokenreviews']
-  verbs: ['create']
-- apiGroups: ['authorization.k8s.io']
-  resources: ['subjectaccessreviews']
-  verbs: ['create']
-
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: openshift-ovn-kubernetes-metrics
-  namespace: openshift-ovn-kubernetes
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: openshift-ovn-kubernetes-metrics
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: openshift-ovn-kubernetes-metrics
-subjects:
-- kind: ServiceAccount
-  name: openshift-ovn-kubernetes-metrics
   namespace: openshift-ovn-kubernetes

--- a/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
@@ -17,7 +17,7 @@ spec:
         message: |
           There is no running ovn-kubernetes master
       expr: |
-        absent(up{job="ovnkube-master-metrics", namespace="openshift-ovn-kubernetes"} == 1)
+        absent(up{job="ovnkube-master", namespace="openshift-ovn-kubernetes"} == 1)
       for: 10m
       labels:
         severity: warning

--- a/bindata/network/ovn-kubernetes/monitor.yaml
+++ b/bindata/network/ovn-kubernetes/monitor.yaml
@@ -16,7 +16,7 @@ spec:
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: ovn-kubernetes-master-metrics.openshift-ovn-kubernetes.svc
+      serverName: ovn-kubernetes-master.openshift-ovn-kubernetes.svc
   jobLabel: app
   namespaceSelector:
     matchNames:
@@ -65,7 +65,7 @@ spec:
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: ovn-kubernetes-node-metrics.openshift-ovn-kubernetes.svc
+      serverName: ovn-kubernetes-node.openshift-ovn-kubernetes.svc
   jobLabel: app
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
With PR #778 (commit 518118b) we changed the service monitor definition,
and the daemonset serviceaccount.
    
With this PR we fix the serverName in the serviceMonitors, the
serviceAccount permissions and the prometheusRule alert expression.
