### PR TITLE
Bug 1880591: 4.6 Use ovs-configuration file to determine if OVS is running in systemd

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -52,7 +52,7 @@ spec:
           }
 
           # Check to see if ovs is provided by the node:
-          if [[ -L '/host/etc/systemd/system/network-online.target.wants/ovs-configuration.service' ]]; then
+          if [ -f /host/var/run/ovs-config-executed ]; then
             echo "openvswitch is running in systemd"
             # In some very strange corner cases, the owner for /run/openvswitch
             # can be wrong, so we need to clean up and restart.
@@ -65,7 +65,6 @@ spec:
             # Don't need to worry about restoring flows; this can only change if we've rebooted
             exec tail -F /host/var/log/openvswitch/ovs-vswitchd.log /host/var/log/openvswitch/ovsdb-server.log
           else
-
             echo "openvswitch is running in container"
             # if another process is listening on the cni-server socket, wait until it exits
             retries=0

--- a/bindata/network/ovn-kubernetes/006-ovs-node.yaml
+++ b/bindata/network/ovn-kubernetes/006-ovs-node.yaml
@@ -65,7 +65,7 @@ spec:
           }
 
           # Check to see if ovs is provided by the node:
-          if [[ -L '/host/etc/systemd/system/network-online.target.wants/ovs-configuration.service' ]]; then
+          if [ -f /host/var/run/ovs-config-executed ]; then
             echo "openvswitch is running in systemd"
             # In some very strange corner cases, the owner for /run/openvswitch
             # can be wrong, so we need to clean up and restart.

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -197,7 +197,7 @@ spec:
           gateway_mode_flags=
           # Check to see if ovs is provided by the node. This is only for upgrade from 4.5->4.6 or
           # openshift-sdn to ovn-kube conversion
-          if grep -q OVNKubernetes /etc/systemd/system/ovs-configuration.service ; then
+          if grep -q OVNKubernetes /etc/systemd/system/ovs-configuration.service && [ -f /host/var/run/ovs-config-executed ]; then
             gateway_mode_flags="--gateway-mode local --gateway-interface br-ex"
           else
             gateway_mode_flags="--gateway-mode local --gateway-interface none"


### PR DESCRIPTION
Checking files or symlinks on disks seems to be flaky and there are time
windows where files are laid down on the disk but the running version is
still 4.5. This changes the logic to determine if OVS is running on the
host by checking the for a file generated when ovs-configuration is
executed.

Signed-off-by: Tim Rozet <trozet@redhat.com>