### PR TITLE
Add ovn-db-pod label on the master pods

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -27,6 +27,7 @@ spec:
   selector:
     matchLabels:
       app: ovnkube-master
+      ovn-db-pod: "true"
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -38,6 +39,7 @@ spec:
     metadata:
       labels:
         app: ovnkube-master
+        ovn-db-pod: "true"
         component: network
         type: infra
         openshift.io/component: network


### PR DESCRIPTION
Add ovn-db-pod label on the master pods

The problem we are seeing is that when the master gets replaced, the new master starts off with a config that has itself in the list of masters, but the old masters don't see the updated config till the new master pod starts up fully. That results in the ovn-dbchecker container on the existing masters to kick the newly joined master out of the raft cluster. So we have a bit of chicken-and-egg problem. In order to handle stale config on the existing masters, Tim and I decided to make a `list all db pods` call to check for the presence of a pod with the IP of the raft member prior to kicking the member out. The `ovn-db-pod: "true"` label lets us select all the pods that are running db containers in a consistent manner for upstream and downstream.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>