### PR TITLE
Updating cluster-network-operator builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-network-operator
 COPY . .
 RUN hack/build-go.sh; \
@@ -6,7 +6,7 @@ RUN hack/build-go.sh; \
     cp /go/src/github.com/openshift/cluster-network-operator/_output/linux/$(go env GOARCH)/cluster-network-operator /tmp/build/; \
     cp /go/src/github.com/openshift/cluster-network-operator/_output/linux/$(go env GOARCH)/cluster-network-renderer /tmp/build/
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 COPY --from=builder /tmp/build/cluster-network-operator /usr/bin/
 COPY --from=builder /tmp/build/cluster-network-renderer /usr/bin/
 COPY manifests /manifests


### PR DESCRIPTION
Updating cluster-network-operator builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/cluster-network-operator.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.