### PR TITLE
Bug 1886127: Handle downgrades from 4.6 to 4.5

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -37,6 +37,14 @@ spec:
           chown -R openvswitch:openvswitch /var/run/openvswitch
           chown -R openvswitch:openvswitch /etc/openvswitch
 
+          if [ -f /host/var/run/ovs-config-executed ]; then
+            echo "openvswitch is running in systemd"
+            # Don't need to worry about restoring flows; this can only change if we've rebooted
+            rm /var/run/openvswitch/flows.sh || true
+            exec tail -F /host/var/log/openvswitch/ovs-vswitchd.log /host/var/log/openvswitch/ovsdb-server.log
+            # executes forever
+          fi
+
           # if another process is listening on the cni-server socket, wait until it exits
           retries=0
           while true; do
@@ -92,8 +100,10 @@ spec:
              echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Adding br0 if it doesn't exist ..." 2>&1
              /usr/bin/ovs-vsctl --may-exist add-br br0 -- set Bridge br0 fail_mode=secure protocols=OpenFlow13
              echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Created br0, now adding flows ..." 2>&1
-             sh -x /var/run/openvswitch/flows.sh
+             mv /var/run/openvswitch/flows.sh /var/run/openvswitch/flows-old.sh
+             sh -x /var/run/openvswitch/flows-old.sh
              echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Done restoring the existing flows ..." 2>&1
+             rm /var/run/openvswitch/flows-old.sh
           fi
           
           echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Remove other config ..." 2>&1
@@ -116,6 +126,9 @@ spec:
         - mountPath: /sys
           name: host-sys
           readOnly: true
+        - mountPath: /host
+          name: host-slash
+          readOnly: true
         - mountPath: /etc/openvswitch
           name: host-config-openvswitch
         resources:
@@ -135,7 +148,6 @@ spec:
             - -c
             - |
               #!/bin/bash
-              /usr/share/openvswitch/scripts/ovs-ctl status > /dev/null &&
               /usr/bin/ovs-appctl -T 5 ofproto/list > /dev/null &&
               /usr/bin/ovs-vsctl -t 5 show > /dev/null &&
               if /usr/bin/ovs-vsctl -t 5 br-exists br0; then /usr/bin/ovs-ofctl -t 5 -O OpenFlow13 probe br0; else true; fi
@@ -181,6 +193,9 @@ spec:
       - name: host-config-openvswitch
         hostPath:
           path: /var/lib/openvswitch
+      - name: host-slash
+        hostPath:
+          path: /
       tolerations:
       - operator: "Exists"
 {{- end}}


### PR DESCRIPTION
In 4.6, openvswitch is executed as a systemd service. This is not the case
for 4.5. However, changes are always rolled out to the SDN first, including
on rollback. This means we need to handle, even if sub-optimally, the case
where we're running the 4.5 daemonset on a 4.6 MCO-configured node.
In other words, openvswitch is running as a systemd service.

Fixes: 1885848
Replaces: #830 

Co-authored-by: Casey Callendrello <cdc@redhat.com>
Signed-off-by: Aniket Bhat <anbhat@redhat.com>