### PR TITLE
Bug 1886855: Make ovn-cert secret mandatory for both master and node

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -986,7 +986,6 @@ spec:
       - name: ovn-cert
         secret:
           secretName: ovn-cert
-          optional: true
       - name: ovn-master-metrics-cert
         secret:
           secretName: ovn-master-metrics-cert

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -349,7 +349,6 @@ spec:
       - name: ovn-cert
         secret:
           secretName: ovn-cert
-          optional: true
       - name: ovn-node-metrics-cert
         secret:
           secretName: ovn-node-metrics-cert


### PR DESCRIPTION
With commit 518118bb9 we accidentlly made ovn-cert secret mount
optional, this secret is never optional.