### PR TITLE
Use kube-rbac-proxy for standalone kube-proxy metrics

### DIFF
--- a/bindata/kube-proxy/kube-proxy.yaml
+++ b/bindata/kube-proxy/kube-proxy.yaml
@@ -66,8 +66,6 @@ spec:
         ports:
         - name: healthz
           containerPort: {{.HealthzPort}}
-        - name: metrics
-          containerPort: {{.MetricsPort}}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -82,6 +80,80 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+      - name: kube-rbac-proxy
+        image: {{.KubeRBACProxyImage}}
+        command:
+        - /bin/bash
+        - -c
+        - |
+          #!/bin/bash
+          set -euo pipefail
+          TLS_PK=/etc/pki/tls/metrics-certs/tls.key
+          TLS_CERT=/etc/pki/tls/metrics-certs/tls.crt
+
+          # As the secret mount is optional we must wait for the files to be present.
+          # The service is created in monitor.yaml and this is created in kube-proxy.yaml.
+          # If it isn't created there is probably an issue so we want to crashloop.
+          retries=0
+          while [[ "${retries}" -lt 100 ]]; do
+            TS=$(
+              curl \
+                -s \
+                --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+                -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+                "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/openshift-kube-proxy/services/openshift-kube-proxy" |
+                  python -c 'import json,sys; print(json.load(sys.stdin)["metadata"]["creationTimestamp"])' 2>/dev/null || true
+            )
+            if [ -n "${TS}" ]; then
+              break
+            fi
+            (( retries += 1 ))
+            echo $(date -Iseconds) INFO: Failed to get openshift-kube-proxy service from API. Retry "${retries}"/100 1>&2
+            sleep 20
+          done
+          if [ "${retries}" -ge 20 ]; then
+            echo $(date -Iseconds) FATAL: Unable to get openshift-kube-proxy service from API.
+            exit 1
+          fi
+
+          TS=$(date -d "${TS}" +%s)
+          WARN_TS=$(( ${TS} + $(( 20 * 60)) ))
+          HAS_LOGGED_INFO=0
+
+          log_missing_certs(){
+              CUR_TS=$(date +%s)
+              if [[ "${CUR_TS}" -gt "WARN_TS"  ]]; then
+                echo $(date -Iseconds) WARN: kube-proxy-metrics-certs not mounted after 20 minutes.
+              elif [[ "${HAS_LOGGED_INFO}" -eq 0 ]] ; then
+                echo $(date -Iseconds) INFO: kube-proxy-metrics-certs not mounted. Waiting 20 minutes.
+                HAS_LOGGED_INFO=1
+              fi
+          }
+
+          while [[ ! -f "${TLS_PK}" ||  ! -f "${TLS_CERT}" ]] ; do
+            log_missing_certs
+            sleep 5
+          done
+
+          exec /usr/bin/kube-rbac-proxy \
+            --logtostderr \
+            --secure-listen-address=:{{.MetricsPort}} \
+            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 \
+            --upstream=http://127.0.0.1:29102/ \
+            --tls-private-key-file=${TLS_PK} \
+            --tls-cert-file=${TLS_CERT}
+        ports:
+        - containerPort: {{.MetricsPort}}
+          name: https
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: kube-proxy-metrics-certs
+          mountPath: /etc/pki/tls/metrics-certs
+          readOnly: True
       restartPolicy: Always
       tolerations:
       - operator: Exists
@@ -94,3 +166,10 @@ spec:
       - name: config
         configMap:
           name: proxy-config
+      # Must be optional because the sdn-metrics-certs is a service serving
+      # certificate and those cannot be generated without the service proxy
+      # running
+      - name: kube-proxy-metrics-certs
+        secret:
+          secretName: kube-proxy-metrics-certs
+          optional: true

--- a/bindata/kube-proxy/monitor.yaml
+++ b/bindata/kube-proxy/monitor.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -11,6 +12,11 @@ spec:
   endpoints:
   - interval: 30s
     port: metrics
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: openshift-kube-proxy.openshift-kube-proxy.svc
   jobLabel: app
   namespaceSelector:
     matchNames:
@@ -22,6 +28,8 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: kube-proxy-metrics-certs
   labels:
     app: kube-proxy
   name: openshift-kube-proxy
@@ -30,6 +38,7 @@ spec:
   selector:
     app: kube-proxy
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
   - name: metrics
     port: {{.MetricsPort}}

--- a/pkg/network/kube_proxy.go
+++ b/pkg/network/kube_proxy.go
@@ -19,7 +19,7 @@ import (
 // - pluginDefaults
 // - conf.KubeProxyConfig.ProxyArguments
 // - pluginOverrides
-func kubeProxyConfiguration(pluginDefaults map[string]operv1.ProxyArgumentList, conf *operv1.NetworkSpec, pluginOverrides map[string]operv1.ProxyArgumentList) (jsonConf, metricsPort, healthzPort string, err error) {
+func kubeProxyConfiguration(pluginDefaults map[string]operv1.ProxyArgumentList, conf *operv1.NetworkSpec, pluginOverrides map[string]operv1.ProxyArgumentList) (string, error) {
 	p := conf.KubeProxyConfig
 
 	args := map[string]operv1.ProxyArgumentList{}
@@ -33,14 +33,7 @@ func kubeProxyConfiguration(pluginDefaults map[string]operv1.ProxyArgumentList, 
 	args = k8sutil.MergeKubeProxyArguments(args, p.ProxyArguments)
 	args = k8sutil.MergeKubeProxyArguments(args, pluginOverrides)
 
-	if len(args["metrics-port"]) == 1 {
-		metricsPort = args["metrics-port"][0]
-	}
-	if len(args["healthz-port"]) == 1 {
-		healthzPort = args["healthz-port"][0]
-	}
-	jsonConf, err = k8sutil.GenerateKubeProxyConfiguration(args)
-	return
+	return k8sutil.GenerateKubeProxyConfiguration(args)
 }
 
 // acceptsKubeProxyConfig determines if the desired network type allows
@@ -103,20 +96,18 @@ func validateKubeProxy(conf *operv1.NetworkSpec) []error {
 		}
 	}
 
-	// Don't allow ports to be overridden. Before 4.7, standalone kube-proxy used the
-	// same ports as openshift-sdn (metrics 9101, healthz 10256). In 4.7 and later,
-	// the defaults are 9102 and 10255 to allow openshift-sdn and kube-proxy to be run
-	// together, but we still allow the old values to avoid breaking old clusters.
+	// Don't allow ports to be overridden. For backward compatibility, we allow
+	// explicitly specifying the (old) default values, though we prefer for them to be
+	// left blank.
 	if p.ProxyArguments != nil {
 		if val, ok := p.ProxyArguments["metrics-port"]; ok {
-			if len(val) != 1 || (val[0] != "9102" && val[0] != "9101") {
-				out = append(out, errors.Errorf("kube-proxy --metrics-port must be 9102 or 9101"))
+			if len(val) != 1 || val[0] != "9101" {
+				out = append(out, errors.Errorf("kube-proxy --metrics-port cannot be overridden"))
 			}
 		}
-
 		if val, ok := p.ProxyArguments["healthz-port"]; ok {
-			if len(val) != 1 || (val[0] != "10255" && val[0] != "10256") {
-				out = append(out, errors.Errorf("kube-proxy --healthz-port must be 10255 or 10256"))
+			if len(val) != 1 || val[0] != "10256" {
+				out = append(out, errors.Errorf("kube-proxy --healthz-port cannot be overridden"))
 			}
 		}
 	}
@@ -187,14 +178,22 @@ func renderStandaloneKubeProxy(conf *operv1.NetworkSpec, manifestDir string) ([]
 		return nil, nil
 	}
 
+	metricsPort := "9102"
+	healthzPort := "10255"
+	if val, ok := conf.KubeProxyConfig.ProxyArguments["metrics-port"]; ok {
+		metricsPort = val[0]
+	}
+	if val, ok := conf.KubeProxyConfig.ProxyArguments["healthz-port"]; ok {
+		healthzPort = val[0]
+	}
+
 	kpcDefaults := map[string]operv1.ProxyArgumentList{
 		"metrics-bind-address": {"0.0.0.0"},
 		"metrics-port":         {"9102"},
 		"healthz-port":         {"10255"},
 		"proxy-mode":           {"iptables"},
 	}
-
-	kpc, metricsPort, healthzPort, err := kubeProxyConfiguration(kpcDefaults, conf, nil)
+	kpc, err := kubeProxyConfiguration(kpcDefaults, conf, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to generate kube-proxy configuration file")
 	}

--- a/pkg/network/kube_proxy_test.go
+++ b/pkg/network/kube_proxy_test.go
@@ -73,7 +73,7 @@ func TestKubeProxyConfig(t *testing.T) {
 	errs := validateKubeProxy(&config)
 	g.Expect(errs).To(HaveLen(0))
 
-	cfg, metricsPort, _, err := kubeProxyConfiguration(map[string]operv1.ProxyArgumentList{
+	cfg, err := kubeProxyConfiguration(map[string]operv1.ProxyArgumentList{
 		// special address+port combo
 		"metrics-bind-address":   {"1.2.3.4"},
 		"metrics-port":           {"999"},
@@ -84,7 +84,6 @@ func TestKubeProxyConfig(t *testing.T) {
 			"conntrack-max-per-core": {"15"},
 		})
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(metricsPort).To(Equal("999"))
 	g.Expect(cfg).To(MatchYAML(`apiVersion: kubeproxy.config.k8s.io/v1alpha1
 bindAddress: "0.0.0.0"
 bindAddressHardFail: false
@@ -140,7 +139,7 @@ func TestKubeProxyIPv6Config(t *testing.T) {
 	errs := validateKubeProxy(&configIPv6)
 	g.Expect(errs).To(HaveLen(0))
 
-	cfg, metricsPort, _, err := kubeProxyConfiguration(
+	cfg, err := kubeProxyConfiguration(
 		map[string]operv1.ProxyArgumentList{
 			// special address+port combo
 			"metrics-bind-address":   {"fd00:1234::4"},
@@ -152,7 +151,6 @@ func TestKubeProxyIPv6Config(t *testing.T) {
 			"conntrack-max-per-core": {"15"},
 		})
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(metricsPort).To(Equal("51999"))
 	g.Expect(cfg).To(MatchYAML(`apiVersion: kubeproxy.config.k8s.io/v1alpha1
 bindAddress: "::"
 bindAddressHardFail: false

--- a/pkg/network/kube_proxy_test.go
+++ b/pkg/network/kube_proxy_test.go
@@ -412,7 +412,7 @@ ipvs:
   tcpTimeout: 0s
   udpTimeout: 0s
 kind: KubeProxyConfiguration
-metricsBindAddress: 0.0.0.0:9102
+metricsBindAddress: 0.0.0.0:29102
 mode: iptables
 nodePortAddresses: null
 oomScoreAdj: null

--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -49,13 +49,17 @@ func renderOpenShiftSDN(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Un
 
 	kpcDefaults := map[string]operv1.ProxyArgumentList{
 		"metrics-bind-address":    {"0.0.0.0"},
-		"metrics-port":            {"29101"},
 		"healthz-port":            {"10256"},
 		"proxy-mode":              {"iptables"},
 		"iptables-masquerade-bit": {"0"},
 	}
-
-	kpcOverrides := map[string]operv1.ProxyArgumentList{}
+	// For backward compatibility we allow conf to specify `metrics-port: 9101` but
+	// the daemonset always configures 9101 as the secure metrics port and 29101 as
+	// the insecure metrics port exposed by kube-proxy itself. So just override
+	// the value from conf (which we know is either "9101" or unspecified).
+	kpcOverrides := map[string]operv1.ProxyArgumentList{
+		"metrics-port": {"29101"},
+	}
 	if *c.EnableUnidling {
 		// We already validated that proxy-mode was either unset or iptables.
 		kpcOverrides["proxy-mode"] = operv1.ProxyArgumentList{"unidling+iptables"}

--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -67,7 +67,7 @@ func renderOpenShiftSDN(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Un
 		kpcOverrides["proxy-mode"] = operv1.ProxyArgumentList{"disabled"}
 	}
 
-	kpc, _, _, err := kubeProxyConfiguration(kpcDefaults, conf, kpcOverrides)
+	kpc, err := kubeProxyConfiguration(kpcDefaults, conf, kpcOverrides)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to build kube-proxy config")
 	}


### PR DESCRIPTION
As with openshift-sdn and ovn-kubernetes, we should run the standalone kube-proxy metrics behind an authenticated proxy.

To avoid possible problems with upgrading old clusters, I made it conditional on using the new metrics port.