### PR TITLE
Whereabouts IPAM CNI, add entrypoint logging methods. Update CRDs to v1

### DIFF
--- a/bindata/network/additional-networks/crd/001-crd.yaml
+++ b/bindata/network/additional-networks/crd/001-crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: network-attachment-definitions.k8s.cni.cncf.io
@@ -45,7 +45,7 @@ spec:
               description: 'NetworkAttachmentDefinition config is a JSON-formatted CNI configuration'
               type: string
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
@@ -111,7 +111,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -213,6 +213,23 @@ spec:
             SERVICEACCOUNT_TOKEN=$(cat $SERVICE_ACCOUNT_PATH/token)
             SKIP_TLS_VERIFY=${SKIP_TLS_VERIFY:-false}
 
+            # Setup our logging routines
+
+            function log()
+            {
+              echo "$(date --iso-8601=seconds) ${1}"
+            }
+
+            function error()
+            {
+              log "ERR:  {$1}"
+            }
+
+            function warn()
+            {
+              log "WARN: {$1}"
+            }
+
 
             # Check if we're running as a k8s pod.
             if [ -f "$SERVICE_ACCOUNT_PATH/token" ]; then


### PR DESCRIPTION
The error() method when called would produce no output and an error from /bin/sh otherwise.