### PR TITLE
Bug 1889696: Increase termination grace period to 45s for save-flows to complete

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -158,7 +158,7 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 5
           timeoutSeconds: 11
-        terminationGracePeriodSeconds: 10
+        terminationGracePeriodSeconds: 45
       nodeSelector:
         kubernetes.io/os: linux
       affinity:


### PR DESCRIPTION
The default value of 10s isn't enough when saving a large number of
flows. This PR changes the termination grace period to 45s.

Backport of #511 