### PR TITLE
Bug 1893362: Ensure tail processes exit with parent

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -62,8 +62,14 @@ spec:
             if [[ ! -S /run/openvswitch/db.sock ]]; then
               systemctl_restart ovsdb-server
             fi
+            # We need to explicitly exit on SIGTERM, see https://github.com/openshift/cluster-dns-operator/issues/65
+            function quit {
+                exit 0
+            }
+            trap quit SIGTERM
             # Don't need to worry about restoring flows; this can only change if we've rebooted
-            exec tail -F /host/var/log/openvswitch/ovs-vswitchd.log /host/var/log/openvswitch/ovsdb-server.log
+            tail --pid=$BASHPID -F /host/var/log/openvswitch/ovs-vswitchd.log /host/var/log/openvswitch/ovsdb-server.log &
+            wait
           else
 
             echo "openvswitch is running in container"

--- a/bindata/network/ovn-kubernetes/006-ovs-node.yaml
+++ b/bindata/network/ovn-kubernetes/006-ovs-node.yaml
@@ -75,12 +75,19 @@ spec:
             if [[ ! -S /run/openvswitch/db.sock ]]; then
               systemctl_restart ovsdb-server
             fi
+            # We need to explicitly exit on SIGTERM, see https://github.com/openshift/cluster-dns-operator/issues/65
+            function quit {
+                exit 0
+            }
+            trap quit SIGTERM
             # Don't need to worry about restoring flows; this can only change if we've rebooted
-            exec tail -F /host/var/log/openvswitch/ovs-vswitchd.log /host/var/log/openvswitch/ovsdb-server.log
+            tail --pid=$BASHPID -F /host/var/log/openvswitch/ovs-vswitchd.log /host/var/log/openvswitch/ovsdb-server.log &
+            wait
           else
             echo "$(date -Iseconds) - starting ovs-daemons"
             chown -R openvswitch:openvswitch /run/openvswitch
             chown -R openvswitch:openvswitch /etc/openvswitch
+            # We need to explicitly exit on SIGTERM, see https://github.com/openshift/cluster-dns-operator/issues/65
             function quit {
                 # Don't allow ovs-vswitchd to clear datapath flows on exit
                 kill -9 $(cat /var/run/openvswitch/ovs-vswitchd.pid 2>/dev/null) 2>/dev/null || true


### PR DESCRIPTION
There's a great Linux-specific feature that allows sending a signal
to a child process when its parent dies.  This allows strongly
"lifecycle binding" two processes together and avoiding the default
Unix behavior where the child process will just be reparented.

I think this will help avoid problems like
https://bugzilla.redhat.com/show_bug.cgi?id=1893362
where when the bash process exits, the tail process sticks around.
Perhaps something isn't removing the pid file?  In any case when
this pod is requested to terminate, the tail processes should die too.