### PR TITLE
Revert "Add ovn-db-pod label on the master pods"

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -27,7 +27,6 @@ spec:
   selector:
     matchLabels:
       app: ovnkube-master
-      ovn-db-pod: "true"
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -39,7 +38,6 @@ spec:
     metadata:
       labels:
         app: ovnkube-master
-        ovn-db-pod: "true"
         component: network
         type: infra
         openshift.io/component: network


### PR DESCRIPTION
Reverts openshift/cluster-network-operator#828

Changing the match-labels that included the `ovn-db-pod=true` label breaks upgrades from 4.6.1 to 4.7. Reverting this change and instead relying on matchExpressions style syntax for the ovndb-manager and ovn_db metrics collection.