### PR TITLE
Bug 1891716: Remove spurious label in the pod selector of the master daemonset.

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -27,7 +27,6 @@ spec:
   selector:
     matchLabels:
       app: ovnkube-master
-      ovn-db-pod: "true"
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
Remove the ovn-db-pod=true label from matchLabels since the daemonset
pod selector doesn't need to select on that label.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>