### PR TITLE
Simplify kube-rbac-proxy startup script

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -192,29 +192,7 @@ spec:
           # As the secret mount is optional we must wait for the files to be present.
           # The service is created in monitor.yaml and this is created in sdn.yaml.
           # If it isn't created there is probably an issue so we want to crashloop.
-          retries=0
-          while [[ "${retries}" -lt 100 ]]; do
-            TS=$(
-              curl \
-                -s \
-                --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
-                -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
-                "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/openshift-sdn/services/sdn" |
-                  python -c 'import json,sys; print(json.load(sys.stdin)["metadata"]["creationTimestamp"])' 2>/dev/null || true
-            )
-            if [ -n "${TS}" ]; then
-              break
-            fi
-            (( retries += 1 ))
-            echo $(date -Iseconds) INFO: Failed to get sdn service from API. Retry "${retries}"/100 1>&2
-            sleep 20
-          done
-          if [ "${retries}" -ge 20 ]; then
-            echo $(date -Iseconds) FATAL: Unable to get sdn service from API.
-            exit 1
-          fi
-
-          TS=$(date -d "${TS}" +%s)
+          TS=$(date +%s)
           WARN_TS=$(( ${TS} + $(( 20 * 60)) ))
           HAS_LOGGED_INFO=0
           
@@ -232,7 +210,8 @@ spec:
             log_missing_certs
             sleep 5
           done
-          
+
+          echo $(date -Iseconds) INFO: sdn-metrics-certs mounted, starting kube-rbac-proxy
           exec /usr/bin/kube-rbac-proxy \
             --logtostderr \
             --secure-listen-address=:9101 \

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -448,30 +448,7 @@ spec:
           TLS_CERT=/etc/pki/tls/metrics-cert/tls.crt
           # As the secret mount is optional we must wait for the files to be present.
           # The service is created in monitor.yaml and this is created in sdn.yaml.
-          # If it isn't created there is probably an issue so we want to crashloop.
-          retries=0
-          while [[ "${retries}" -lt 100 ]]; do
-            TS=$(
-              curl \
-                -s \
-                --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
-                -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
-                "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/openshift-ovn-kubernetes/services/ovn-kubernetes-master" |
-                  python -c 'import json,sys; print(json.load(sys.stdin)["metadata"]["creationTimestamp"])' 2>/dev/null || true
-            ) || :
-            if [ -n "${TS}" ]; then
-              break
-            fi
-            (( retries += 1 ))
-            echo $(date -Iseconds) INFO: Failed to get ovnkube-master service from API. Retry "${retries}"/100 1>&2
-            sleep 20
-          done
-          if [ "${retries}" -ge 100 ]; then
-            echo $(date -Iseconds) FATAL: Unable to get ovnkube-master service from API.
-            exit 1
-          fi
-
-          TS=$(date -d "${TS}" +%s)
+          TS=$(date +%s)
           WARN_TS=$(( ${TS} + $(( 20 * 60)) ))
           HAS_LOGGED_INFO=0
           
@@ -489,6 +466,7 @@ spec:
             sleep 5
           done
           
+          echo $(date -Iseconds) INFO: ovn-master-metrics-certs mounted, starting kube-rbac-proxy
           exec /usr/bin/kube-rbac-proxy \
             --logtostderr \
             --secure-listen-address=:9102 \

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -98,28 +98,7 @@ spec:
           # The service is created in monitor.yaml and this is created in sdn.yaml.
           # If it isn't created there is probably an issue so we want to crashloop.
           retries=0
-          while [[ "${retries}" -lt 100 ]]; do
-            TS=$(
-              curl \
-                -s \
-                --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
-                -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
-                "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/openshift-ovn-kubernetes/services/ovn-kubernetes-node" |
-                  python -c 'import json,sys; print(json.load(sys.stdin)["metadata"]["creationTimestamp"])' 2>/dev/null || true
-            ) || :
-            if [ -n "${TS}" ]; then
-              break
-            fi
-            (( retries += 1 ))
-            echo $(date -Iseconds) INFO: Failed to get ovnkube-node service from API. Retry "${retries}"/100 1>&2
-            sleep 20
-          done
-          if [ "${retries}" -ge 100 ]; then
-            echo $(date -Iseconds) FATAL: Unable to get ovnkube-node service from API.
-            exit 1
-          fi
-
-          TS=$(date -d "${TS}" +%s)
+          TS=$(date +%s)
           WARN_TS=$(( ${TS} + $(( 20 * 60)) ))
           HAS_LOGGED_INFO=0
           
@@ -137,6 +116,7 @@ spec:
             sleep 5
           done
           
+          echo $(date -Iseconds) INFO: ovn-node-metrics-certs mounted, starting kube-rbac-proxy
           exec /usr/bin/kube-rbac-proxy \
             --logtostderr \
             --secure-listen-address=:9103 \


### PR DESCRIPTION
CNO tries to create the objects defined in bindata's files in
lexicographic order, so we can rely on the secret being created when
this starts.

I don't know what happens if during an upgrade the CNO
fails to create the services, so it's probably a good idea not to
backport this to 4.6.

/assign @tssurya 