### PR TITLE
Bug 1948718: IBM Cloud manifest profile patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,16 @@ all: build
 include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	golang.mk \
 	targets/openshift/deps-gomod.mk \
+	targets/openshift/operator/profile-manifests.mk \
 )
+
+# This will include additional actions on the update and verify targets to ensure that profile patches are applied
+# to manifest files
+# $0 - macro name
+# $1 - target name
+# $2 - profile patches directory
+# $3 - manifests directory
+$(call add-profile-manifests,manifests,./profile-patches,./manifests)
 
 # Run core verification and all self contained tests.
 #

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/onsi/gomega v1.10.2
 	github.com/openshift/api v0.0.0-20210420151714-a3c8fa53e01b
-	github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359
+	github.com/openshift/build-machinery-go v0.0.0-20210412141922-56d6e6c51074
 	github.com/openshift/client-go v0.0.0-20201214125552-e615e336eb49
 	github.com/openshift/library-go v0.0.0-20201130154959-bd449d1e2e25
 	github.com/openshift/machine-api-operator v0.2.1-0.20201203125141-79567cb3368e

--- a/go.sum
+++ b/go.sum
@@ -442,8 +442,9 @@ github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mo
 github.com/openshift/build-machinery-go v0.0.0-20200424080330-082bf86082cc/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
-github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359 h1:ehSDsWQiUVzJZrSEXMC7ceV9JIPEyTYqrpqu3m4Wa08=
 github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
+github.com/openshift/build-machinery-go v0.0.0-20210412141922-56d6e6c51074 h1:ws/+ESEYJWDmb0LfZUNbyeP0lCoxKa/d42AXGcOoqjM=
+github.com/openshift/build-machinery-go v0.0.0-20210412141922-56d6e6c51074/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0/go.mod h1:uUQ4LClRO+fg5MF/P6QxjMCb1C9f7Oh4RKepftDnEJE=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
 github.com/openshift/client-go v0.0.0-20201020074620-f8fd44879f7c/go.mod h1:yZ3u8vgWC19I9gbDMRk8//9JwG/0Sth6v7C+m6R8HXs=

--- a/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
@@ -1,13 +1,13 @@
+# *** AUTOMATICALLY GENERATED FILE - DO NOT EDIT ***
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: network-operator
-  namespace: openshift-network-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
   labels:
     name: network-operator
-  annotations:
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
+  name: network-operator
+  namespace: openshift-network-operator
 spec:
   selector:
     matchLabels:
@@ -20,9 +20,7 @@ spec:
         name: network-operator
     spec:
       containers:
-      - name: network-operator
-        image: quay.io/openshift/origin-cluster-network-operator:latest
-        command:
+      - command:
         - /bin/bash
         - -c
         - |
@@ -34,33 +32,29 @@ spec:
             URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
           fi
           exec /usr/bin/cluster-network-operator start --listen=0.0.0.0:9104
-        resources:
-          requests:
-            cpu: 10m
-            memory: 50Mi
         env:
         - name: RELEASE_VERSION
-          value: "0.0.1-snapshot"
+          value: 0.0.1-snapshot
         - name: SDN_IMAGE
-          value: "quay.io/openshift/origin-sdn:latest"
+          value: quay.io/openshift/origin-sdn:latest
         - name: KUBE_PROXY_IMAGE
-          value: "quay.io/openshift/origin-kube-proxy:latest"
+          value: quay.io/openshift/origin-kube-proxy:latest
         - name: KUBE_RBAC_PROXY_IMAGE
-          value: "quay.io/openshift/origin-kube-rbac-proxy:latest"
+          value: quay.io/openshift/origin-kube-rbac-proxy:latest
         - name: MULTUS_IMAGE
-          value: "quay.io/openshift/origin-multus-cni:latest"
+          value: quay.io/openshift/origin-multus-cni:latest
         - name: MULTUS_ADMISSION_CONTROLLER_IMAGE
-          value: "quay.io/openshift/origin-multus-admission-controller:latest"
+          value: quay.io/openshift/origin-multus-admission-controller:latest
         - name: CNI_PLUGINS_IMAGE
-          value: "quay.io/openshift/origin-container-networking-plugins:latest"
+          value: quay.io/openshift/origin-container-networking-plugins:latest
         - name: WHEREABOUTS_CNI_IMAGE
-          value: "quay.io/openshift/origin-multus-whereabouts-ipam-cni:latest"
+          value: quay.io/openshift/origin-multus-whereabouts-ipam-cni:latest
         - name: ROUTE_OVERRRIDE_CNI_IMAGE
-          value: "quay.io/openshift/origin-multus-route-override-cni:latest"
+          value: quay.io/openshift/origin-multus-route-override-cni:latest
         - name: MULTUS_NETWORKPOLICY_IMAGE
-          value: "quay.io/openshift/origin-multus-networkpolicy:latest"
+          value: quay.io/openshift/origin-multus-networkpolicy:latest
         - name: OVN_IMAGE
-          value: "quay.io/openshift/origin-ovn-kubernetes:latest"
+          value: quay.io/openshift/origin-ovn-kubernetes:latest
         - name: OVN_NB_RAFT_ELECTION_TIMER
           value: "10000"
         - name: OVN_SB_RAFT_ELECTION_TIMER
@@ -70,46 +64,50 @@ spec:
         - name: OVN_CONTROLLER_INACTIVITY_PROBE
           value: "30000"
         - name: EGRESS_ROUTER_CNI_IMAGE
-          value: "quay.io/openshift/origin-egress-router-cni:latest"
+          value: quay.io/openshift/origin-egress-router-cni:latest
         - name: KURYR_DAEMON_IMAGE
-          value: "quay.io/openshift/origin-kuryr-cni:latest"
+          value: quay.io/openshift/origin-kuryr-cni:latest
         - name: KURYR_CONTROLLER_IMAGE
-          value: "quay.io/openshift/origin-kuryr-controller:latest"
+          value: quay.io/openshift/origin-kuryr-controller:latest
         - name: NETWORK_METRICS_DAEMON_IMAGE
-          value: "quay.io/openshift/origin-network-metrics-daemon:latest"
+          value: quay.io/openshift/origin-network-metrics-daemon:latest
         - name: NETWORK_CHECK_SOURCE_IMAGE
-          value: "quay.io/openshift/origin-cluster-network-operator:latest"
+          value: quay.io/openshift/origin-cluster-network-operator:latest
         - name: NETWORK_CHECK_TARGET_IMAGE
-          value: "quay.io/openshift/origin-cluster-network-operator:latest"
+          value: quay.io/openshift/origin-cluster-network-operator:latest
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        image: quay.io/openshift/origin-cluster-network-operator:latest
+        name: network-operator
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes
           name: host-etc-kube
           readOnly: true
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
-      priorityClassName: "system-cluster-critical"
-      volumes:
-        - name: host-etc-kube
-          hostPath:
-            path: /etc/kubernetes
-            type: Directory
+      priorityClassName: system-cluster-critical
       restartPolicy: Always
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
       tolerations:
-      - key: "node-role.kubernetes.io/master"
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
         operator: Exists
-        effect: NoSchedule
-      - key: "node.kubernetes.io/not-ready"
+      - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
         operator: Exists
-        effect: NoSchedule
-      - key: node.kubernetes.io/network-unavailable
+      - effect: NoSchedule
+        key: node.kubernetes.io/network-unavailable
         operator: Exists
-        effect: NoSchedule
+      volumes:
+      - hostPath:
+          path: /etc/kubernetes
+          type: Directory
+        name: host-etc-kube

--- a/profile-patches/ibm-cloud-managed/0000_70_cluster-network-operator_03_deployment.yaml-patch
+++ b/profile-patches/ibm-cloud-managed/0000_70_cluster-network-operator_03_deployment.yaml-patch
@@ -1,0 +1,6 @@
+- op: replace
+  path: /metadata/annotations
+  value:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+- op: remove
+  path: /spec/template/spec/nodeSelector

--- a/vendor/github.com/openshift/build-machinery-go/README.md
+++ b/vendor/github.com/openshift/build-machinery-go/README.md
@@ -40,5 +40,5 @@ Extends [#Default]().
 ### Updating generated files
 We track the log output from the makefile tests to make sure any change is visible and can be audited. Unfortunately due to subtle linux tooling differences in distributions and versions, `make update` may not get you the exact output as the CI. To avoid it, just run the command in the same container as CI:   
 ```
-podman run -it --rm --pull=always -v $( pwd ):/go/src/$( go list -m ) --workdir=/go/src/$( go list -m ) registry.svc.ci.openshift.org/openshift/release:rhel-8-release-golang-1.15-openshift-4.7 make update
+podman run -it --rm --pull=always -v $( pwd ):/go/src/$( go list -m ) --workdir=/go/src/$( go list -m ) registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.15-openshift-4.7 make update
 ```

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/operator/profile-manifests.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/operator/profile-manifests.mk
@@ -6,6 +6,7 @@ self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
 # $3 - output file
 define patch-manifest-yq
 	$(YQ) m -x '$(2)' '$(1)' > '$(3)'
+	sed -i '$(3)' -e '1s/^/# *** AUTOMATICALLY GENERATED FILE - DO NOT EDIT ***\n/'
 
 endef
 
@@ -15,6 +16,7 @@ endef
 # $3 - output file
 define patch-manifest-yaml-patch
 	$(YAML_PATCH) -o '$(1)' < '$(2)' > '$(3)'
+	sed -i '$(3)' -e '1s/^/# *** AUTOMATICALLY GENERATED FILE - DO NOT EDIT ***\n/'
 
 endef
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -226,7 +226,7 @@ github.com/openshift/api/template
 github.com/openshift/api/template/v1
 github.com/openshift/api/user
 github.com/openshift/api/user/v1
-# github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359
+# github.com/openshift/build-machinery-go v0.0.0-20210412141922-56d6e6c51074
 ## explicit
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make


### PR DESCRIPTION
Part 2 of cluster profiles support for IBM Cloud:
- Bumps github.com/openshift/build-machinery-go to latest version
- Adds targets to Makefile for updating/verifying profile patches
- Adds profile patch for ibm-cloud-managed

On IBM Cloud the network operator needs to run on worker nodes, thus the
master node selector needs to be removed from the operator deployment
manifest.
