### PR TITLE
ovn rbac for endpoint slices

### DIFF
--- a/bindata/network/ovn-kubernetes/002-rbac.yaml
+++ b/bindata/network/ovn-kubernetes/002-rbac.yaml
@@ -22,6 +22,13 @@ rules:
   - list
   - watch
   - patch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
 - apiGroups: ["extensions", "networking.k8s.io"]
   resources:
   - networkpolicies

--- a/bindata/network/ovn-kubernetes/003-rbac-controller.yaml
+++ b/bindata/network/ovn-kubernetes/003-rbac-controller.yaml
@@ -45,6 +45,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
 - apiGroups: ["extensions", "networking.k8s.io"]
   resources:
   - networkpolicies


### PR DESCRIPTION
OVN needs permission to list and watch slices, needed for dual stack.

Signed-off-by: Antonio Ojea <aojea@redhat.com>