### PR TITLE
WIP Edits to monitor.yaml to scrape /ovnmetrics to ingest ovn db metrics

### DIFF
--- a/bindata/network/ovn-kubernetes/monitor.yaml
+++ b/bindata/network/ovn-kubernetes/monitor.yaml
@@ -17,7 +17,35 @@ spec:
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: ovn-kubernetes-master.openshift-ovn-kubernetes.svc
-  jobLabel: app
+    jobLabel: app
+  namespaceSelector:
+    matchNames:
+    - openshift-ovn-kubernetes
+  selector:
+    matchLabels:
+      app: ovnkube-master
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: ovnkube-master
+  annotations:
+    networkoperator.openshift.io/ignore-errors: ""
+  name: monitor-ovn-db-master-metrics
+  namespace: openshift-ovn-kubernetes
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    path: /ovnmetrics
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: ovn-kubernetes-master.openshift-ovn-kubernetes.svc
+    jobLabel: app
   namespaceSelector:
     matchNames:
     - openshift-ovn-kubernetes
@@ -25,6 +53,7 @@ spec:
     matchLabels:
       app: ovnkube-master
 ---
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -46,8 +75,8 @@ spec:
     targetPort: 9102
   sessionAffinity: None
   type: ClusterIP
----
 
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -95,6 +124,7 @@ spec:
     targetPort: 9103
   sessionAffinity: None
   type: ClusterIP
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -122,6 +152,30 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ovnmetrics
+rules:
+- nonResourceURLs: ["/ovnmetrics"]
+  verbs: ["get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-ovn-k8s-binding
+  namespace: openshift-ovn-kubernetes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ovnmetrics
 subjects:
 - kind: ServiceAccount
   name: prometheus-k8s


### PR DESCRIPTION
- **What this PR does and why is it needed**

This PR exposes ovn db metrics to prometheus for OVN-Kubernetes deployments by CNO.

This PR modifies StartMetricsServer() in ovnkube.go to take in an additional boolean parameter to expose Ovn db metrics on path=/ovnmetrics on the same mux that exposes Node-exporter metrics. It depends on https://github.com/ovn-org/ovn-kubernetes/pull/1882 for needed mods to ovn-kubernetes.

- **How to verify it**

Verify with the following:
The OVN-DB specific metrics will show up Prometheus console.

Co-authored by: Palani Kodeswaran palani.kodeswaran@in.ibm.com

Signed-off-by: Sayandeep <sayandes@in.ibm.com>