### PR TITLE
increasing logging when waiting for Masters during bootstrap for OVN

### DIFF
--- a/pkg/network/bootstrap.go
+++ b/pkg/network/bootstrap.go
@@ -16,7 +16,7 @@ func Bootstrap(conf *operv1.NetworkSpec, client client.Client) (*bootstrap.Boots
 	case operv1.NetworkTypeOpenShiftSDN:
 		return nil, nil
 	case operv1.NetworkTypeOVNKubernetes:
-		return boostrapOVN(client)
+		return bootstrapOVN(client)
 	}
 
 	return nil, nil


### PR DESCRIPTION
Waiting 280 seconds for the bootstrap to fail without any timeout is too
long and does not reflect to the user what is going on appropriatly.

adding a log that prints out every 15 seconds while waiting for the
master nodes to become avalible telling the user how many have been seen
and how many are expected.

Also changed a typo boostrapOVN() -> bootstrapOVN() and changed the
timeouts to a const so that they can be changted and be reflected in the
new logging without additional changes

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>