### PR TITLE
Bug 1907454: install podnetworkconnectivitycheck crd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY --from=builder  /go/src/github.com/openshift/cluster-network-operator/clust
 COPY --from=builder  /go/src/github.com/openshift/cluster-network-operator/cluster-network-check-endpoints /usr/bin/
 
 COPY manifests /manifests
+COPY vendor/github.com/openshift/api/operatorcontrolplane/v1alpha1/0000_10-pod-network-connectivity-check.crd.yaml /manifests
 COPY bindata /bindata
 ENV OPERATOR_NAME=cluster-network-operator
 CMD ["/usr/bin/cluster-network-operator"]

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -7,6 +7,7 @@ FROM registry.svc.ci.openshift.org/ocp/4.7:base
 COPY --from=builder  /go/src/github.com/openshift/cluster-network-operator/cluster-network-operator /usr/bin/
 COPY --from=builder  /go/src/github.com/openshift/cluster-network-operator/cluster-network-check-endpoints /usr/bin/
 COPY manifests /manifests
+COPY vendor/github.com/openshift/api/operatorcontrolplane/v1alpha1/0000_10-pod-network-connectivity-check.crd.yaml /manifests
 COPY bindata /bindata
 ENV OPERATOR_NAME=cluster-network-operator
 CMD ["/usr/bin/cluster-network-operator"]


### PR DESCRIPTION
PodNetworkConnectivityCheck resources were introduced in 4.6. Due to their highly experimental status at the time, the CRD was not installed by default, but instead managed by various controllers.

With the PR the PodNetworkConnectivityCheck CRD will be installed via the installation manifests. It is done in the network operator, as to better match the owner of the CRD.