### PR TITLE
Fix IPsec CI

### DIFF
--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -114,14 +114,6 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 
 	if c.IPsecConfig != nil {
 		data.Data["EnableIPsec"] = true
-		// Only render ipsec manifest if ipsec has been enabled at cluster
-		// installation time. We will never have to delete the ipsec pod
-		// because it cannot be disabled at runtime
-		ipsecManifests, err := render.RenderDir(filepath.Join(manifestDir, "network/ovn-kubernetes-ipsec"), &data)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to render ipsec manifest")
-		}
-		objs = append(objs, ipsecManifests...)
 	} else {
 		data.Data["EnableIPsec"] = false
 	}
@@ -133,6 +125,21 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	}
 
 	objs = append(objs, manifests...)
+
+	if c.IPsecConfig != nil {
+		// Only render ipsec manifest if ipsec has been enabled at cluster
+		// installation time. We will never have to delete the ipsec pod
+		// because it cannot be disabled at runtime
+		//
+		// We must render these manifests after ovn-kubernetes manifests
+		// as they create the openshift-ovn-kubernetes namespace
+		ipsecManifests, err := render.RenderDir(filepath.Join(manifestDir, "network/ovn-kubernetes-ipsec"), &data)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to render ipsec manifest")
+		}
+		objs = append(objs, ipsecManifests...)
+	}
+
 	return objs, nil
 }
 


### PR DESCRIPTION
IPsec CI is unable to start pods due to lack of openshift-ovn-kubernetes namespace.