### PR TITLE
add 'single-node-production-edge' annotations to CVO manifests.

### DIFF
--- a/manifests/0000_70_cluster-network-operator_00_namespace.yaml
+++ b/manifests/0000_70_cluster-network-operator_00_namespace.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     name: openshift-network-operator
     openshift.io/run-level: "0"

--- a/manifests/0000_70_cluster-network-operator_01_crd.yaml
+++ b/manifests/0000_70_cluster-network-operator_01_crd.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: networks.operator.openshift.io
 spec:
   group: operator.openshift.io

--- a/manifests/0000_70_cluster-network-operator_01_credentialsrequest.yaml
+++ b/manifests/0000_70_cluster-network-operator_01_credentialsrequest.yaml
@@ -9,6 +9,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1

--- a/manifests/0000_70_cluster-network-operator_01_pki_crd.yaml
+++ b/manifests/0000_70_cluster-network-operator_01_pki_crd.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   creationTimestamp: null
   name: operatorpkis.network.operator.openshift.io
 spec:

--- a/manifests/0000_70_cluster-network-operator_02_rbac.yaml
+++ b/manifests/0000_70_cluster-network-operator_02_rbac.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 subjects:
 - kind: ServiceAccount
   name: default

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   selector:
     matchLabels:

--- a/manifests/0000_70_cluster-network-operator_04_kubeapiserver_flowschema.yaml
+++ b/manifests/0000_70_cluster-network-operator_04_kubeapiserver_flowschema.yaml
@@ -4,6 +4,7 @@ metadata:
   name: openshift-sdn
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   distinguisherMethod:
     type: ByUser

--- a/manifests/0000_70_cluster-network-operator_05_clusteroperator.yaml
+++ b/manifests/0000_70_cluster-network-operator_05_clusteroperator.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 status:
   versions:
   - name: operator


### PR DESCRIPTION
This adds annotations for the single-node-production-edge cluster profile. There's a growing requirement from several customers to enable creation of single-node (not high-available) Openshift clusters.
In stage one (following openshift/enhancements#504) there should be no implication on components logic.
In the next stage, the component's behavior will match a non high-availability profile if the customer is specifically interested in one.
This PR is separate from the 'single-node-developer' work, which will implement a different behavior and is currently on another stage of implementation.

For more info, please refer to the enhancement link and participate in the discussion.