### PR TITLE
Bug 1901034: proxyconfig: get basedomain from dns config

### DIFF
--- a/pkg/controller/proxyconfig/status.go
+++ b/pkg/controller/proxyconfig/status.go
@@ -12,7 +12,7 @@ import (
 
 // syncProxyStatus computes the current status of proxy and
 // updates status of any changes since last sync.
-func (r *ReconcileProxyConfig) syncProxyStatus(proxy *configv1.Proxy, infra *configv1.Infrastructure, network *configv1.Network, cluster *corev1.ConfigMap) error {
+func (r *ReconcileProxyConfig) syncProxyStatus(proxy *configv1.Proxy, infra *configv1.Infrastructure, network *configv1.Network, cluster *corev1.ConfigMap, dns *configv1.DNS) error {
 	var err error
 	var noProxy string
 	updated := proxy.DeepCopy()
@@ -21,7 +21,7 @@ func (r *ReconcileProxyConfig) syncProxyStatus(proxy *configv1.Proxy, infra *con
 		if proxy.Spec.NoProxy == noProxyWildcard {
 			noProxy = proxy.Spec.NoProxy
 		} else {
-			noProxy, err = proxyconfig.MergeUserSystemNoProxy(proxy, infra, network, cluster)
+			noProxy, err = proxyconfig.MergeUserSystemNoProxy(proxy, infra, network, cluster, dns)
 			if err != nil {
 				return fmt.Errorf("failed to merge user/system noProxy settings: %v", err)
 			}

--- a/pkg/util/proxyconfig/no_proxy.go
+++ b/pkg/util/proxyconfig/no_proxy.go
@@ -20,7 +20,7 @@ import (
 // string of noProxy settings. If no user supplied noProxy settings are
 // provided, a comma-separated string of cluster-wide noProxy settings
 // are returned.
-func MergeUserSystemNoProxy(proxy *configv1.Proxy, infra *configv1.Infrastructure, network *configv1.Network, cluster *corev1.ConfigMap) (string, error) {
+func MergeUserSystemNoProxy(proxy *configv1.Proxy, infra *configv1.Infrastructure, network *configv1.Network, cluster *corev1.ConfigMap, dns *configv1.DNS) (string, error) {
 	// TODO: This will be flexible when master machine management is more dynamic.
 	type machineNetworkEntry struct {
 		// CIDR is the IP block address pool for machines within the cluster.
@@ -110,7 +110,7 @@ func MergeUserSystemNoProxy(proxy *configv1.Proxy, infra *configv1.Infrastructur
 			return "", fmt.Errorf("failed to parse install config replicas: %v", err)
 		}
 		for i := int64(0); i < int64(replicas); i++ {
-			etcdHost := fmt.Sprintf("etcd-%d.%s", i, infra.Status.EtcdDiscoveryDomain)
+			etcdHost := fmt.Sprintf("etcd-%d.%s", i, dns.Spec.BaseDomain)
 			set.Insert(etcdHost)
 		}
 	} else {


### PR DESCRIPTION
The noproxy field includes the names of the etcd servers. The domain name used is obtained from the etcdDiscoveryDomain field of the infrastructure resource. However, that field is deprecated and no longer populated. Instead, get the domain name from the baseDomain field of the dns resource.