### PR TITLE
Bug 1906650: Add NetworkPolicy, EgressIP, and EgressFirewall to related-objects

### DIFF
--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -253,6 +253,22 @@ func (r *ReconcileOperConfig) Reconcile(request reconcile.Request) (reconcile.Re
 		Name:     "cluster",
 	})
 
+	// Add NetworkPolicy, EgressFirewall, EgressIP, for must-gather
+	relatedObjects = append(relatedObjects, configv1.ObjectReference{
+		Group:    "networking.k8s.io",
+		Resource: "NetworkPolicy",
+	})
+
+	relatedObjects = append(relatedObjects, configv1.ObjectReference{
+		Group:    "k8s.ovn.org",
+		Resource: "EgressFirewall",
+	})
+
+	relatedObjects = append(relatedObjects, configv1.ObjectReference{
+		Group:    "k8s.ovn.org",
+		Resource: "EgressIP",
+	})
+
 	r.status.SetDaemonSets(daemonSets)
 	r.status.SetDeployments(deployments)
 	r.status.SetRelatedObjects(relatedObjects)


### PR DESCRIPTION
This PR adds the  NetworkPolicy, EgressIP, and EgressFirewall to the CNO's related object list so they are collected across the entire cluster when a must-gather is run. 

The Egress IPs are collected under `cluster-scoped-resources` 

The NetworyPolicies and EgressFirewall's are collected on a per `namespace` basis 

