### PR TITLE
Bug 1905331: Multus containers should specify resource requests & limits

### DIFF
--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -46,7 +46,11 @@ spec:
         imagePullPolicy: IfNotPresent
         resources:
           requests:
-            cpu: 10m
+            cpu: "100m"
+            memory: "50Mi"
+          limits:
+            cpu: "250m"
+            memory: "100Mi"
         ports:
         - name: metrics-port
           containerPort: 9091

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -118,6 +118,13 @@ spec:
       - name: multus-binary-copy
         image: {{.MultusImage}}
         command: ["/entrypoint/cnibincopy.sh"]
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "10Mi"
+          limits:
+            cpu: "100m"
+            memory: "25Mi"
         volumeMounts:
         - mountPath: /entrypoint
           name: cni-binary-copy
@@ -136,6 +143,13 @@ spec:
       - name: egress-router-binary-copy
         image: {{.EgressRouterImage}}
         command: ["/entrypoint/cnibincopy.sh"]
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "10Mi"
+          limits:
+            cpu: "100m"
+            memory: "25Mi"
         volumeMounts:
         - mountPath: /entrypoint
           name: cni-binary-copy
@@ -154,6 +168,13 @@ spec:
       - name: cni-plugins
         image: {{.CNIPluginsImage}}
         command: ["/entrypoint/cnibincopy.sh"]
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "10Mi"
+          limits:
+            cpu: "100m"
+            memory: "25Mi"
         volumeMounts:
         - mountPath: /entrypoint
           name: cni-binary-copy
@@ -172,6 +193,13 @@ spec:
       - name: routeoverride-cni
         image: {{.RouteOverrideImage}}
         command: ["/entrypoint/cnibincopy.sh"]
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "10Mi"
+          limits:
+            cpu: "100m"
+            memory: "25Mi"
         volumeMounts:
         - mountPath: /entrypoint
           name: cni-binary-copy
@@ -190,6 +218,13 @@ spec:
       - name: whereabouts-cni-bincopy
         image: {{.WhereaboutsImage}}
         command: ["/entrypoint/cnibincopy.sh"]
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "10Mi"
+          limits:
+            cpu: "100m"
+            memory: "25Mi"
         volumeMounts:
         - mountPath: /entrypoint
           name: cni-binary-copy
@@ -304,7 +339,13 @@ spec:
             while [ "$should_sleep" == "true"  ]; do
                 sleep 1000000000000
             done
-
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "10Mi"
+          limits:
+            cpu: "100m"
+            memory: "25Mi"
         volumeMounts:
         - mountPath: /host/opt/cni/bin
           name: cnibin
@@ -327,6 +368,13 @@ spec:
       - name: kube-multus
         image: {{.MultusImage}}
         command: ["/entrypoint.sh"]
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "10Mi"
+          limits:
+            cpu: "100m"
+            memory: "25Mi"
         args:
         - "--multus-conf-file=auto"
         - "--multus-autoconfig-dir=/host/var/run/multus/cni/net.d"


### PR DESCRIPTION
This adds a fairly low request and limit, as the Multus daemonset must run in order for a cluster to become ready.

Additionally, these are primarily bash scripts that copy binaries, with the notable exception being the admission controller (which gets a more liberal request/limit).

Happy to take another opinion on how these are set, mostly my thinking was "bash by itself can take a meg of program space, I'll multiply that by 10." and then these utilize very little CPU.