### PR TITLE
Bug 1909791: Standlone kube-proxy needs to list EndpointSlices now

### DIFF
--- a/bindata/kube-proxy/001-rbac.yaml
+++ b/bindata/kube-proxy/001-rbac.yaml
@@ -7,6 +7,7 @@ rules:
   resources:
   - namespaces
   - endpoints
+  - endpointslices
   - services
   - pods
   - nodes


### PR DESCRIPTION
`EndpointSliceProxying` is on by default in 1.20, so standalone kube-proxy now needs permission to list EndpointSlices