### PR TITLE
Bug 1910097: ovn-ipsec: Add resource limits

### DIFF
--- a/bindata/network/ovn-kubernetes-ipsec/ovn-ipsec.yaml
+++ b/bindata/network/ovn-kubernetes-ipsec/ovn-ipsec.yaml
@@ -132,6 +132,10 @@ spec:
           name: signer-ca
         - mountPath: /etc/openvswitch
           name: etc-openvswitch
+        resources:
+          requests:
+            cpu: 10m
+            memory: 100Mi
         terminationMessagePolicy: FallbackToLogsOnError
         terminationGracePeriodSeconds: 10
       containers:
@@ -209,6 +213,10 @@ spec:
           name: host-var-log-ovs
         - mountPath: /etc/openvswitch
           name: etc-openvswitch
+        resources:
+          requests:
+            cpu: 10m
+            memory: 100Mi
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:


### PR DESCRIPTION
Fix test case in e2e-ovn-ipsec-step-registry:
"Managed cluster should ensure control plane pods do not run in
best-effort QoS" by requesting cpu and memory resources.

Signed-off-by: Mark Gray <mark.d.gray@redhat.com>