### PR TITLE
Bug 1908775: ovn-ipsec: Adjust MTU to account for additional ESP overhead

### DIFF
--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -231,6 +231,14 @@ func fillOVNKubernetesDefaults(conf, previous *operv1.NetworkSpec, hostMTU int) 
 		conf.DefaultNetwork.OVNKubernetesConfig = &operv1.OVNKubernetesConfig{}
 	}
 
+	const ipsecOverhead = 46 // Transport mode, AES-GCM
+	const geneveOverhead = 100
+
+	var encapOverhead uint32 = geneveOverhead
+	if conf.DefaultNetwork.OVNKubernetesConfig.IPsecConfig != nil {
+		encapOverhead += ipsecOverhead
+	}
+
 	sc := conf.DefaultNetwork.OVNKubernetesConfig
 	// MTU  is currently the only field we pull from previous.
 	// If MTU is not supplied, we infer it from the host on which CNO is running
@@ -239,7 +247,7 @@ func fillOVNKubernetesDefaults(conf, previous *operv1.NetworkSpec, hostMTU int) 
 
 	// TODO - Need to check as IPsec will additional headers
 	if sc.MTU == nil {
-		var mtu uint32 = uint32(hostMTU) - 100 // 100 byte geneve header
+		var mtu uint32 = uint32(hostMTU) - encapOverhead
 		if previous != nil && previous.DefaultNetwork.OVNKubernetesConfig != nil &&
 			previous.DefaultNetwork.OVNKubernetesConfig.MTU != nil {
 			mtu = *previous.DefaultNetwork.OVNKubernetesConfig.MTU

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -368,6 +368,40 @@ func TestFillOVNKubernetesDefaults(t *testing.T) {
 
 }
 
+func TestFillOVNKubernetesDefaultsIPsec(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	crd := OVNKubernetesConfig.DeepCopy()
+	conf := &crd.Spec
+	conf.DefaultNetwork.OVNKubernetesConfig.IPsecConfig = &operv1.IPsecConfig{}
+
+	expected := operv1.NetworkSpec{
+		ServiceNetwork: []string{"172.30.0.0/16"},
+		ClusterNetwork: []operv1.ClusterNetworkEntry{
+			{
+				CIDR:       "10.128.0.0/15",
+				HostPrefix: 23,
+			},
+			{
+				CIDR:       "10.0.0.0/14",
+				HostPrefix: 24,
+			},
+		},
+		DefaultNetwork: operv1.DefaultNetworkDefinition{
+			Type: operv1.NetworkTypeOVNKubernetes,
+			OVNKubernetesConfig: &operv1.OVNKubernetesConfig{
+				MTU:         ptrToUint32(8854),
+				GenevePort:  ptrToUint32(8061),
+				IPsecConfig: &operv1.IPsecConfig{},
+			},
+		},
+	}
+
+	fillOVNKubernetesDefaults(conf, conf, 9000)
+
+	g.Expect(conf).To(Equal(&expected))
+
+}
 func TestValidateOVNKubernetes(t *testing.T) {
 	g := NewGomegaWithT(t)
 


### PR DESCRIPTION
OVN IPsec currently uses esp=aes_gcm256 for phase2 algorithm.
The following RFCs describe the packet format for AEC-GCM ESP:

https://tools.ietf.org/html/rfc4106
https://tools.ietf.org/html/rfc2406

ESP Transport packets using AES-GCM should add the following
additional overhead to packets:

* ESP Header -  SPI:             4B
* ESP Header -  Sequence Number: 4B/8B
* ESP Header -  IV:              8B
* ESP Header -  Salt:            4B
* ESP Trailer - Pad:             <4B
* ESP Trailer - Pad Length:      1B
* ESP Trailer - Next Header:     1B
* ESP Trailer - ICV:             8B/12B/16B

This gives a worst-case of 46B of packet overhead.

Signed-off-by: Mark Gray <mark.d.gray@redhat.com>