### PR TITLE
Bug 1909502: pkg/util/proxyconfig: remove unused etcd records from proxy config

### DIFF
--- a/pkg/util/proxyconfig/no_proxy.go
+++ b/pkg/util/proxyconfig/no_proxy.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"strconv"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -102,20 +101,6 @@ func MergeUserSystemNoProxy(proxy *configv1.Proxy, infra *configv1.Infrastructur
 			// "metadata.google.internal." added due to https://bugzilla.redhat.com/show_bug.cgi?id=1754049
 			set.Insert("metadata", "metadata.google.internal", "metadata.google.internal.")
 		}
-	}
-
-	if len(ic.ControlPlane.Replicas) > 0 {
-		replicas, err := strconv.Atoi(ic.ControlPlane.Replicas)
-		if err != nil {
-			return "", fmt.Errorf("failed to parse install config replicas: %v", err)
-		}
-		for i := int64(0); i < int64(replicas); i++ {
-			etcdHost := fmt.Sprintf("etcd-%d.%s", i, infra.Status.EtcdDiscoveryDomain)
-			set.Insert(etcdHost)
-		}
-	} else {
-		return "", fmt.Errorf("controlplane replicas missing from install config configmap '%s/%s'",
-			cluster.Namespace, cluster.Name)
 	}
 
 	if len(network.Status.ClusterNetwork) > 0 {

--- a/pkg/util/proxyconfig/no_proxy_test.go
+++ b/pkg/util/proxyconfig/no_proxy_test.go
@@ -116,8 +116,7 @@ func TestMergeUserSystemNoProxy(t *testing.T) {
 				cluster: cfgMapWithInstallConfig(cfgMapKey, cfgMapData),
 			},
 			want: ".cluster.local,.svc,.us-west-2.compute.internal,10.0.0.0/16,10.128.0.0/14,127.0.0.1," +
-				"169.254.169.254,172.30.0.0/16,api-int.test.cluster.com,etcd-0.test.cluster.com," +
-				"etcd-1.test.cluster.com,etcd-2.test.cluster.com,localhost",
+				"169.254.169.254,172.30.0.0/16,api-int.test.cluster.com,localhost",
 			wantErr: false,
 		},
 		{name: "valid proxy config with gcp provider",
@@ -128,8 +127,7 @@ func TestMergeUserSystemNoProxy(t *testing.T) {
 				cluster: cfgMapWithInstallConfig(cfgMapKey, cfgMapData),
 			},
 			want: ".cluster.local,.svc,10.0.0.0/16,10.128.0.0/14,127.0.0.1,169.254.169.254,172.30.0.0/16," +
-				"api-int.test.cluster.com,etcd-0.test.cluster.com,etcd-1.test.cluster.com,etcd-2.test.cluster.com," +
-				"localhost,metadata,metadata.google.internal,metadata.google.internal.",
+				"api-int.test.cluster.com,localhost,metadata,metadata.google.internal,metadata.google.internal.",
 			wantErr: false,
 		},
 		{name: "valid proxy config using us-east-1 aws region",
@@ -140,8 +138,7 @@ func TestMergeUserSystemNoProxy(t *testing.T) {
 				cluster: cfgMapWithInstallConfig(cfgMapKey, cfgMapData),
 			},
 			want: ".cluster.local,.ec2.internal,.svc,10.0.0.0/16,10.128.0.0/14,127.0.0.1," +
-				"169.254.169.254,172.30.0.0/16,api-int.test.cluster.com,etcd-0.test.cluster.com," +
-				"etcd-1.test.cluster.com,etcd-2.test.cluster.com,localhost",
+				"169.254.169.254,172.30.0.0/16,api-int.test.cluster.com,localhost",
 			wantErr: false,
 		},
 		{name: "valid proxy config with single user noProxy",
@@ -152,8 +149,7 @@ func TestMergeUserSystemNoProxy(t *testing.T) {
 				cluster: cfgMapWithInstallConfig(cfgMapKey, cfgMapData),
 			},
 			want: ".cluster.local,.svc,.us-west-2.compute.internal,10.0.0.0/16,10.128.0.0/14,127.0.0.1," +
-				"169.254.169.254,172.30.0.0/16,172.30.0.1,api-int.test.cluster.com,etcd-0.test.cluster.com," +
-				"etcd-1.test.cluster.com,etcd-2.test.cluster.com,localhost",
+				"169.254.169.254,172.30.0.0/16,172.30.0.1,api-int.test.cluster.com,localhost",
 			wantErr: false,
 		},
 		{name: "valid proxy config with multiple user noProxy",
@@ -164,8 +160,7 @@ func TestMergeUserSystemNoProxy(t *testing.T) {
 				cluster: cfgMapWithInstallConfig(cfgMapKey, cfgMapData),
 			},
 			want: ".cluster.local,.foo.test.com,.svc,.us-west-2.compute.internal,10.0.0.0/16,10.128.0.0/14,127.0.0.1," +
-				"169.254.169.254,172.30.0.0/16,172.30.0.1,199.161.0.0/16,api-int.test.cluster.com," +
-				"etcd-0.test.cluster.com,etcd-1.test.cluster.com,etcd-2.test.cluster.com,localhost",
+				"169.254.169.254,172.30.0.0/16,172.30.0.1,199.161.0.0/16,api-int.test.cluster.com,localhost",
 			wantErr: false,
 		},
 		{name: "invalid api server url",


### PR DESCRIPTION
Since 4.4 etcd no longer has a DNS dependency. Currently, we are still passing etcd records to the proxy config which should be removed.

This PR removes the unused etcd records from NoProxy which can result in sync issues with MCD.

depends on: https://github.com/openshift/machine-config-operator/pull/2315
related to: https://github.com/openshift/installer/pull/4518