### PR TITLE
Bug 1909791: Fix EndpointSlice addition to standalone kube-proxy RBAC role

### DIFF
--- a/bindata/kube-proxy/001-rbac.yaml
+++ b/bindata/kube-proxy/001-rbac.yaml
@@ -7,10 +7,16 @@ rules:
   resources:
   - namespaces
   - endpoints
-  - endpointslices
   - services
   - pods
   - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["discovery.k8s.io"]
+  resources:
+  - endpointslices
   verbs:
   - get
   - list


### PR DESCRIPTION
#926 was supposed to fix this but I actually added support for watching "v1.EndpointSlice", not "discoveryv1.EndpointSlice".

/hold
until I test it