### PR TITLE
Bug 1912577: get rid of support for running OVS in a container

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -51,9 +51,6 @@ spec:
             echo "${1//-/_2d}"
           }
 
-          # Check to see if ovs is provided by the node:
-          if [[ -L '/host/etc/systemd/system/network-online.target.wants/ovs-configuration.service' ]]; then
-            echo "openvswitch is running in systemd"
             # In some very strange corner cases, the owner for /run/openvswitch
             # can be wrong, so we need to clean up and restart.
             ovs_uid=$(chroot /host id -u openvswitch)
@@ -70,87 +67,6 @@ spec:
             # Don't need to worry about restoring flows; this can only change if we've rebooted
             tail --pid=$BASHPID -F /host/var/log/openvswitch/ovs-vswitchd.log /host/var/log/openvswitch/ovsdb-server.log &
             wait
-          else
-
-            echo "openvswitch is running in container"
-            # if another process is listening on the cni-server socket, wait until it exits
-            retries=0
-            while true; do
-              if /usr/share/openvswitch/scripts/ovs-ctl status &>/dev/null; then
-                echo "warning: Another process is currently managing OVS, waiting 15s ..." 2>&1
-                sleep 15 & wait
-                (( retries += 1 ))
-              else
-                break
-              fi
-              if [[ "${retries}" -gt 40 ]]; then
-                echo "error: Another process is currently managing OVS, exiting" 2>&1
-                exit 1
-              fi
-            done
-
-            function quit {
-                # Save the flows
-                echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Saving flows ..." 2>&1
-                bridges=$(ovs-vsctl -- --real list-br)
-                TMPDIR=/var/run/openvswitch /usr/share/openvswitch/scripts/ovs-save save-flows $bridges > /var/run/openvswitch/flows.sh
-                echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Saved flows" 2>&1
-
-                # Don't allow ovs-vswitchd to clear datapath flows on exit
-                kill -9 $(cat /var/run/openvswitch/ovs-vswitchd.pid 2>/dev/null) 2>/dev/null || true
-                kill $(cat /var/run/openvswitch/ovsdb-server.pid 2>/dev/null) 2>/dev/null || true
-                exit 0
-            }
-            trap quit SIGTERM
-
-            function deletePid {
-                rm /var/run/openvswitch/ovs-vswitchd.pid
-                rm /var/run/openvswitch/ovsdb-server.pid
-            }
-            trap deletePid EXIT
-
-            chown -R openvswitch:openvswitch /var/run/openvswitch
-            chown -R openvswitch:openvswitch /etc/openvswitch
-
-            # launch OVS
-            # Start the ovsdb so that we can prep it before we start the ovs-vswitchd
-            /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --no-ovs-vswitchd --system-id=random --no-monitor
-
-            # Set the flow-restore-wait to true so ovs-vswitchd will wait till flows are restored
-            ovs-vsctl --no-wait set Open_vSwitch . other_config:flow-restore-wait=true
-
-            # Restrict the number of pthreads ovs-vswitchd creates to reduce the
-            # amount of RSS it uses on hosts with many cores
-            # https://bugzilla.redhat.com/show_bug.cgi?id=1571379
-            # https://bugzilla.redhat.com/show_bug.cgi?id=1572797
-            if [[ `nproc` -gt 12 ]]; then
-                ovs-vsctl --no-wait set Open_vSwitch . other_config:n-revalidator-threads=4
-                ovs-vsctl --no-wait set Open_vSwitch . other_config:n-handler-threads=10
-            fi
-
-            # And finally start the ovs-vswitchd now the DB is prepped
-            /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --no-ovsdb-server --system-id=random --no-monitor
-
-            # Load any flows that we saved
-            echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Loading previous flows ..." 2>&1
-            if [[ -f /var/run/openvswitch/flows.sh ]]; then
-              echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Adding br0 if it doesn't exist ..." 2>&1
-              /usr/bin/ovs-vsctl --may-exist add-br br0 -- set Bridge br0 fail_mode=secure protocols=OpenFlow13
-              echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Created br0, now adding flows ..." 2>&1
-              mv /var/run/openvswitch/flows.sh /var/run/openvswitch/flows-old.sh
-              sh -x /var/run/openvswitch/flows-old.sh
-              echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Done restoring the existing flows ..." 2>&1
-              rm /var/run/openvswitch/flows-old.sh
-            fi
-
-            echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Remove other config ..." 2>&1
-            ovs-vsctl --no-wait --if-exists remove Open_vSwitch . other_config flow-restore-wait=true
-            echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Removed other config ..." 2>&1
-
-            tail -F --pid=$(cat /var/run/openvswitch/ovs-vswitchd.pid) /var/log/openvswitch/ovs-vswitchd.log &
-            tail -F --pid=$(cat /var/run/openvswitch/ovsdb-server.pid) /var/log/openvswitch/ovsdb-server.log &
-            wait
-          fi
         securityContext:
           privileged: true
         volumeMounts:
@@ -172,17 +88,6 @@ spec:
             cpu: 100m
             memory: 400Mi
         terminationMessagePolicy: FallbackToLogsOnError
-        readinessProbe:
-          exec:
-            command:
-            - /bin/bash
-            - -c
-            - |
-              #!/bin/bash
-              /usr/bin/ovs-vsctl -t 5 show > /dev/null
-          initialDelaySeconds: 15
-          periodSeconds: 5
-          timeoutSeconds: 6
         terminationGracePeriodSeconds: 45
       nodeSelector:
         kubernetes.io/os: linux

--- a/bindata/network/ovn-kubernetes/006-ovs-node.yaml
+++ b/bindata/network/ovn-kubernetes/006-ovs-node.yaml
@@ -64,9 +64,6 @@ spec:
             echo "${1//-/_2d}"
           }
 
-          # Check to see if ovs is provided by the node:
-          if [[ -L '/host/etc/systemd/system/network-online.target.wants/ovs-configuration.service' ]]; then
-            echo "openvswitch is running in systemd"
             # In some very strange corner cases, the owner for /run/openvswitch
             # can be wrong, so we need to clean up and restart.
             ovs_uid=$(chroot /host id -u openvswitch)
@@ -83,27 +80,6 @@ spec:
             # Don't need to worry about restoring flows; this can only change if we've rebooted
             tail --pid=$BASHPID -F /host/var/log/openvswitch/ovs-vswitchd.log /host/var/log/openvswitch/ovsdb-server.log &
             wait
-          else
-            echo "$(date -Iseconds) - starting ovs-daemons"
-            chown -R openvswitch:openvswitch /run/openvswitch
-            chown -R openvswitch:openvswitch /etc/openvswitch
-            # We need to explicitly exit on SIGTERM, see https://github.com/openshift/cluster-dns-operator/issues/65
-            function quit {
-                # Don't allow ovs-vswitchd to clear datapath flows on exit
-                kill -9 $(cat /var/run/openvswitch/ovs-vswitchd.pid 2>/dev/null) 2>/dev/null || true
-                kill $(cat /var/run/openvswitch/ovsdb-server.pid 2>/dev/null) 2>/dev/null || true
-                exit 0
-            }
-            trap quit SIGTERM
-            /usr/share/openvswitch/scripts/ovs-ctl start --ovs-user=openvswitch:openvswitch --system-id=random
-            ovs-appctl vlog/set "file:${OVS_LOG_LEVEL}"
-            /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol
-            echo "$(date -Iseconds) - ovs-daemons running"
-
-            tail -F --pid=$(cat /var/run/openvswitch/ovs-vswitchd.pid) /var/log/openvswitch/ovs-vswitchd.log &
-            tail -F --pid=$(cat /var/run/openvswitch/ovsdb-server.pid) /var/log/openvswitch/ovsdb-server.log &
-            wait
-          fi
         env:
         - name: OVS_LOG_LEVEL
           value: info
@@ -136,17 +112,6 @@ spec:
             cpu: 100m
             memory: 300Mi
         terminationMessagePolicy: FallbackToLogsOnError
-        readinessProbe:
-          exec:
-            command:
-            - /bin/bash
-            - -c
-            - |
-              #!/bin/bash
-              /usr/bin/ovs-vsctl -t 5 show > /dev/null
-          initialDelaySeconds: 15
-          periodSeconds: 5
-          timeoutSeconds: 6
         terminationGracePeriodSeconds: 10
       nodeSelector:
         beta.kubernetes.io/os: "linux"


### PR DESCRIPTION
#876 ("remove OVS daemonsets") has been postponed, but we should still at least get rid of the now-dead code for running OVS in a container since (a) in 4.7 we should *never ever* do that, and (b) apparently sometimes we can still get tricked into doing it.

We could get rid of a lot more dead code here but, eh, it's late in the release cycle.
