### PR TITLE
[WIP][SDN-1486] Enable ACL audit Logging 

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,14 @@ spec:
       ipsecConfig: {}
 ```
 
+### Configuring ACL logging for OVNKubernetes
+OVN features logging for all ACL drop/reject actions, add the following `spec:` section to the operator config to configure the feature at the cluster scope
+
+```yaml 
+spec: 
+
+```
+
 ### Configuring Kuryr-Kubernetes
 Kuryr-Kubernetes is a CNI plugin that uses OpenStack Neutron to network OpenShift Pods, and OpenStack Octavia to create load balancers for Services. In general it is useful when OpenShift is running on an OpenStack cluster, as you can use the same SDN (OpenStack Neutron) to provide networking for both the VMs OpenShift is running on, and the Pods created by OpenShift. In such case avoidance of double encapsulation gives you two advantages: improved performace (in terms of both latency and throughput) and lower complexity of the networking architecture.
 

--- a/README.md
+++ b/README.md
@@ -271,8 +271,12 @@ spec:
 OVN features logging for all ACL drop/reject actions, add the following `spec:` section to the operator config to configure the feature at the cluster scope
 
 ```yaml 
-spec: 
-
+spec:
+  defaultNework: 
+    type: OVNKubernetes
+    ovnKubernetesConfig:
+      aclLogging: true
+      aclLoggingRateLimit: 20
 ```
 
 ### Configuring Kuryr-Kubernetes

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -841,7 +841,9 @@ spec:
             --nb-client-cacert /ovn-ca/ca-bundle.crt \
             --nbctl-daemon-mode \
             --nb-cert-common-name "{{.OVN_CERT_CN}}" \
-            --enable-multicast
+            --enable-multicast \
+            --acl-logging "{{.AclLogging}}" \
+            --acl-logging-rate-limit "{{.AclLoggingRateLimit}}"
         lifecycle:
           preStop:
             exec:

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -199,6 +199,8 @@ spec:
             --inactivity-probe="${OVN_CONTROLLER_INACTIVITY_PROBE}" \
             ${gateway_mode_flags} \
             --metrics-bind-address "127.0.0.1:29103"
+            --acl-logging "{{.AclLogging}}" \
+            --acl-logging-rate-limit "{{.AclLoggingRateLimit}}"
         env:
         # for kubectl
         - name: KUBERNETES_SERVICE_PORT

--- a/manifests/0000_70_cluster-network-operator_01_crd.yaml
+++ b/manifests/0000_70_cluster-network-operator_01_crd.yaml
@@ -222,6 +222,14 @@ spec:
                       ipsecConfig:
                         description: ipsecConfig enables and configures IPsec for pods on the pod network within the cluster.
                         type: object
+                      aclLogging: 
+                        description: aclLogging enables or disables ACL logging for drop/allow packet actions within the cluster
+                        type: boolean 
+                      aclLoggingRateLimit: 
+                        description: aclLoggingRateLimit allows for configuration of max acl logging rate 
+                        format: int32
+                        minimum: 0
+                        type: integer
                       mtu:
                         description: mtu is the MTU to use for the tunnel interface. This must be 100 bytes smaller than the uplink mtu. Default is 1400
                         format: int32

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -75,6 +75,8 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["LISTEN_DUAL_STACK"] = listenDualStack(bootstrapResult.OVN.MasterIPs[0])
 	data.Data["OVN_CERT_CN"] = OVN_CERT_CN
 	data.Data["OVN_NORTHD_PROBE_INTERVAL"] = os.Getenv("OVN_NORTHD_PROBE_INTERVAL")
+	data.Data["ACLLOGGING"] = c.AclLogging
+	data.Data["ACLLOGGINGRATELIMIT"] = c.AclLoggingRateLimit
 
 	var ippools string
 	for _, net := range conf.ClusterNetwork {
@@ -220,6 +222,10 @@ func isOVNKubernetesChangeSafe(prev, next *operv1.NetworkSpec) []error {
 		if !reflect.DeepEqual(pn.IPsecConfig, nn.IPsecConfig) {
 			errs = append(errs, errors.Errorf("cannot edit IPsec configuration at runtime"))
 		}
+	}
+	// This might change 
+	if !reflect.DeepEqual(pn.AclLogging, nn.AclLogging) { 
+		errs = append(errs, errors.Errorf("cannot toggle ACL logging after install time"))
 	}
 
 	return errs


### PR DESCRIPTION
This PR is in relation to https://issues.redhat.com/browse/SDN-1486 

It exposes two flags to specify the enablement of ACL logging for OVNKubernetes through the `ovnKubernetesConfig` flags `aclLogging` and `aclLoggingRateLimit` 

TODO test once the upstream OVN-K PR lands 