### PR TITLE
Add alerts for OVN DB high election timer intervals

### DIFF
--- a/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
@@ -66,3 +66,21 @@ spec:
       for: 10m
       labels:
         severity: warning
+    - alert: NBDBLongElectionTimer
+      annotations:
+        message: |
+          OVN NB DB raft cluster has a high election timer interval.
+      expr: |
+        ovn_db_cluster_election_timer{db_name="OVN_Northbound"} > 3000
+      for: 10m
+      labels:
+        severity: warning
+    - alert: SBDBLongElectionTimer
+      annotations:
+        message: |
+          OVN SBDB raft cluster has a high election timer interval.
+      expr: |
+        ovn_db_cluster_election_timer{db_name="OVN_Southbound"} > 3000
+      for: 10m
+      labels:
+        severity: warning


### PR DESCRIPTION
This PR adds alerts for high OVN North and SouthBound DB election timer intervals.

Co-authored by : Sayandeep sayandes@in.ibm.com

Signed-off-by: Palani Kodeswaran palani.kodeswaran@in.ibm.com