### PR TITLE
Added alerts for high number of ovn db logs not committed

### DIFF
--- a/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
@@ -66,3 +66,21 @@ spec:
       for: 10m
       labels:
         severity: warning
+    - alert: NorthBoundLogsNotCommitted
+      annotations:
+        message: |
+          NorthBound DB has too many logs not committed.
+      expr: |
+        ovn_db_cluster_log_not_applied{db_name="OVN_Northbound"} > 100
+      for: 10m
+      labels:
+        severity: warning
+    - alert: SouthBoundLogsNotCommitted
+      annotations:
+        message: |
+          SouthBound DB has too many logs not committed.
+      expr: |
+        ovn_db_cluster_log_not_applied{db_name="OVN_Southbound"} > 100
+      for: 10m
+      labels:
+        severity: warning 


### PR DESCRIPTION
This PR adds alerts for high number of logs not committed in  OVN North and South bound DBs. 

Co-authored by : Palani Kodeswaran palani.kodeswaran@in.ibm.com

Signed-off-by: Sayandeep <sayandes@in.ibm.com>