### PR TITLE
Bug 1914958: handle corrupt flows backup

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -92,7 +92,9 @@ spec:
              echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Adding br0 if it doesn't exist ..." 2>&1
              /usr/bin/ovs-vsctl --may-exist add-br br0 -- set Bridge br0 fail_mode=secure protocols=OpenFlow13
              echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Created br0, now adding flows ..." 2>&1
-             sh -x /var/run/openvswitch/flows.sh
+             mv /var/run/openvswitch/flows.sh /var/run/openvswitch/flows-old.sh
+             sh -x /var/run/openvswitch/flows-old.sh
+             rm /var/run/openvswitch/flows-old.sh
              echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Done restoring the existing flows ..." 2>&1
           fi
           


### PR DESCRIPTION
We'll crashloop once, but at least we won't kill the node.

This is a backport of part of #833 