### PR TITLE
Bug 1914932: Put correct resource name in relatedObjects

### DIFF
--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -249,7 +249,7 @@ func (r *ReconcileOperConfig) Reconcile(request reconcile.Request) (reconcile.Re
 	// Add operator.openshift.io/v1/network to relatedObjects for must-gather
 	relatedObjects = append(relatedObjects, configv1.ObjectReference{
 		Group:    "operator.openshift.io",
-		Resource: "network",
+		Resource: "networks",
 		Name:     "cluster",
 	})
 

--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -70,12 +70,10 @@ func (status *StatusManager) deleteRelatedObjectsNotRendered(co *configv1.Cluste
 	if status.relatedObjects == nil {
 		return
 	}
-
 	for _, currentObj := range co.Status.RelatedObjects {
 		var found bool = false
 		for _, renderedObj := range status.relatedObjects {
 			found = reflect.DeepEqual(currentObj, renderedObj)
-
 			if found {
 				break
 			}
@@ -95,6 +93,11 @@ func (status *StatusManager) deleteRelatedObjectsNotRendered(co *configv1.Cluste
 				// BZ 1820472: During SDN migration, deleting a namespace object may get stuck in 'Terminating' forever if the cluster network doesn't working as expected.
 				// We choose to not delete the namespace here but to ask user do it manually after the cluster is back to normal state.
 				log.Printf("Object Kind is Namespace, skip")
+				continue
+			}
+			// @aconstan: remove this after having the PR implementing this change, integrated.
+			if gvk.Kind == "Network" && gvk.Group == "operator.openshift.io" {
+				log.Printf("Object Kind is network.operator.openshift.io, skip")
 				continue
 			}
 			log.Printf("Detected related object with GVK %+v, namespace %v and name %v not rendered by manifests, deleting...", gvk, currentObj.Namespace, currentObj.Name)


### PR DESCRIPTION
PR: https://github.com/openshift/cluster-network-operator/pull/873 was missing a correct resource name for `networks.operator.openshift.io` to be exported properly to a must-gather. PR: https://github.com/openshift/cluster-network-operator/pull/877 tried fixing this, but was missing a piece to be able to pass the CI upgrade jobs, which this PR now adds. 

Essentially upgrade jobs upgrade from HEAD to HEAD + patch. So with #873: HEAD now has a resource name which is incorrect, if we now want to fix this we will incorrectly delete `networks.operator.openshift.io` on such upgrades. This is not yet a problem for any OpenShift release, since #873 is only on master. The only fix I could think of was to explicitly skip the deletion of the CRD for now. Once this PR has merged we can then delete that explicit skip, since master will have the correct resource name and we won't expect that to change thereafter. I will file a PR for that once this integrates. 

/assign @squeed  