### PR TITLE
Bug 1912820: openshift-apiserver Available is False with 3 pods not ready for a while during upgrade 

### DIFF
--- a/manifests/0000_11_cluster-network-operator_00_upgrade_check.yaml
+++ b/manifests/0000_11_cluster-network-operator_00_upgrade_check.yaml
@@ -1,0 +1,13 @@
+apiVersion: controlplane.operator.openshift.io/v1alpha1
+kind: PodNetworkConnectivityCheck
+metadata:
+  name: 46-to-47-upgrade
+  namespace: openshift-network-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  sourcePod: '46-to-47-upgrade'
+  targetEndpoint: '127.0.0.1:8080'
+


### PR DESCRIPTION
Create a "dummy" PodNetworkConnectivityCheck instance that will [prevent the PodNetworkConnectivityCheck CRD from being deleted](https://github.com/openshift/library-go/blob/e59ac21aada35d4562cf96a1eaf6cec3929b9778/pkg/operator/connectivitycheckcontroller/connectivity_check_controller.go#L139-L146) by v4.6 ConnectivityCheckController instances during a 4.6->4.7 upgrade
