### PR TITLE
Bug 1914402: ipsec: Add liveness probe

### DIFF
--- a/bindata/network/ovn-kubernetes/ipsec.yaml
+++ b/bindata/network/ovn-kubernetes/ipsec.yaml
@@ -242,6 +242,16 @@ spec:
           initialDelaySeconds: 120
           periodSeconds: 30
           timeoutSeconds: 40
+        livenessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - |
+              #!/bin/bash
+              ovs-appctl -t ovs-monitor-ipsec ipsec/status && ipsec status
+          initialDelaySeconds: 60
+          periodSeconds: 60
         terminationGracePeriodSeconds: 10
       nodeSelector:
         beta.kubernetes.io/os: "linux"

--- a/bindata/network/ovn-kubernetes/ipsec.yaml
+++ b/bindata/network/ovn-kubernetes/ipsec.yaml
@@ -238,7 +238,7 @@ spec:
             - -c
             - |
               #!/bin/bash
-              ovs-appctl -t ovs-monitor-ipsec ipsec/status
+              ovs-appctl -t ovs-monitor-ipsec ipsec/status && ipsec status
           initialDelaySeconds: 120
           periodSeconds: 30
           timeoutSeconds: 40


### PR DESCRIPTION
In the case of failure of ipsec daemons, add liveness
probe to detect so that the kubelet can restart the
container.

Signed-off-by: Mark Gray <mark.d.gray@redhat.com>