### PR TITLE
Bug 1916601: guard against the deletion of the network CRD: `network.operator.openshift.io`

### DIFF
--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -236,6 +236,11 @@ func (r *ReconcileOperConfig) Reconcile(request reconcile.Request) (reconcile.Re
 		})
 	}
 
+	// Be very careful of the objects added to `relatedObjects`,
+	// if the `ObjectReference` points to a specific object and
+	// that object is not explcitly skipped in `deleteRelatedObjectsNotRendered`
+	// then we'll delete it on a downgrade. Background:
+	// https://github.com/openshift/cluster-network-operator/pull/945
 	relatedObjects = append(relatedObjects, configv1.ObjectReference{
 		Resource: "namespaces",
 		Name:     names.APPLIED_NAMESPACE,

--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -91,6 +91,10 @@ func (status *StatusManager) deleteRelatedObjectsNotRendered(co *configv1.Cluste
 				log.Printf("Object Kind is Namespace, skip")
 				continue
 			}
+			if gvk.Kind == "Network" && gvk.Group == "operator.openshift.io" {
+				log.Printf("Object Kind is network.operator.openshift.io, skip")
+				continue
+			}
 			log.Printf("Detected related object with GVK %+v, namespace %v and name %v not rendered by manifests, deleting...", gvk, currentObj.Namespace, currentObj.Name)
 			objToDelete := &uns.Unstructured{}
 			objToDelete.SetName(currentObj.Name)


### PR DESCRIPTION
4.6 backport of #945 

Given that 4.6 supports egress IP, egress firewall, etc, and that those objects have been added to "related objects" in 4.7, we need to add them in 4.6 too, since: on a downgrade those CRDs would be deleted. This is not bad since we'll have them in the must-gathers on 4.6. 

I am also removing the skip in `status_manager.go` (see: https://github.com/openshift/cluster-network-operator/blob/master/pkg/controller/statusmanager/status_manager.go#L99-L102) on the CRD `network.operator.openshift.io`, since on a 4.6 -> 4.5 - once we have the 4.5 backport in - it should not get deleted anymore since that CRD will be in the "related objects" in both versions.

/assign @squeed @juanluisvaladas @danwinship 
