### PR TITLE
Bug 1903660: Don't error when expected master node amount is not met 

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -153,7 +153,7 @@ spec:
           # end of db_part_of_cluster
           
           # Checks if cluster has already been initialized.
-          # If not it returns false and sets init_ip to MASTER_IP
+          # If not it returns false and sets init_ip to CLUSTER_INITIATOR_IP
           cluster_exists() {
             local db=${1}
             local port=${2}
@@ -167,13 +167,13 @@ spec:
               fi
             done
             # if we get here  there is no cluster, set init_ip and get out
-            init_ip=$(bracketify $MASTER_IP)
+            init_ip=$(bracketify $CLUSTER_INITIATOR_IP)
             return 1
           }
           # end of cluster_exists()
           
-          MASTER_IP="{{.OVN_MASTER_IP}}"
-          echo "$(date -Iseconds) - starting nbdb  MASTER_IP=${MASTER_IP}, K8S_NODE_IP=${K8S_NODE_IP}"
+          CLUSTER_INITIATOR_IP="{{.OVN_DB_CLUSTER_INITIATOR}}"
+          echo "$(date -Iseconds) - starting nbdb  CLUSTER_INITIATOR_IP=${CLUSTER_INITIATOR_IP}, K8S_NODE_IP=${K8S_NODE_IP}"
           initial_raft_create=true
           initialize="false"
           
@@ -213,7 +213,7 @@ spec:
               run_nb_ovsdb
             else
               # either we need to initialize a new cluster or wait for master to create it
-              if [[ "${K8S_NODE_IP}" == "${MASTER_IP}" ]]; then
+              if [[ "${K8S_NODE_IP}" == "${CLUSTER_INITIATOR_IP}" ]]; then
                 exec /usr/share/ovn/scripts/ovn-ctl \
                 --db-nb-cluster-local-port={{.OVN_NB_RAFT_PORT}} \
                 --db-nb-cluster-local-addr=$(bracketify ${K8S_NODE_IP}) \
@@ -262,8 +262,8 @@ spec:
               - -c
               - |
                 set -x
-                MASTER_IP="{{.OVN_MASTER_IP}}"
-                if [[ "${K8S_NODE_IP}" == "${MASTER_IP}" ]]; then
+                CLUSTER_INITIATOR_IP="{{.OVN_DB_CLUSTER_INITIATOR}}"
+                if [[ "${K8S_NODE_IP}" == "${CLUSTER_INITIATOR_IP}" ]]; then
                   echo "$(date -Iseconds) - nbdb - postStart - waiting for master to be selected"
 
                   # set the connection and disable inactivity probe
@@ -544,7 +544,7 @@ spec:
           # end of db_part_of_cluster
           
           # Checks if cluster has already been initialized.
-          # If not it returns false and sets init_ip to MASTER_IP
+          # If not it returns false and sets init_ip to CLUSTER_INITIATOR_IP
           cluster_exists() {
             local db=${1}
             local port=${2}
@@ -558,13 +558,13 @@ spec:
               fi
             done
             # if we get here  there is no cluster, set init_ip and get out
-            init_ip=$(bracketify $MASTER_IP)
+            init_ip=$(bracketify $CLUSTER_INITIATOR_IP)
             return 1
           }
           # end of cluster_exists()
           
-          MASTER_IP="{{.OVN_MASTER_IP}}"
-          echo "$(date -Iseconds) - starting sbdb  MASTER_IP=${MASTER_IP}"
+          CLUSTER_INITIATOR_IP="{{.OVN_DB_CLUSTER_INITIATOR}}"
+          echo "$(date -Iseconds) - starting sbdb  CLUSTER_INITIATOR_IP=${CLUSTER_INITIATOR_IP}"
           initial_raft_create=true
           initialize="false"
           
@@ -604,7 +604,7 @@ spec:
               run_sb_ovsdb
             else
               # either we need to initialize a new cluster or wait for master to create it
-              if [[ "${K8S_NODE_IP}" == "${MASTER_IP}" ]]; then
+              if [[ "${K8S_NODE_IP}" == "${CLUSTER_INITIATOR_IP}" ]]; then
                 exec /usr/share/ovn/scripts/ovn-ctl \
                 --db-sb-cluster-local-port={{.OVN_SB_RAFT_PORT}} \
                 --db-sb-cluster-local-addr=$(bracketify ${K8S_NODE_IP}) \
@@ -651,8 +651,8 @@ spec:
               - -c
               - |
                 set -x
-                MASTER_IP="{{.OVN_MASTER_IP}}"
-                if [[ "${K8S_NODE_IP}" == "${MASTER_IP}" ]]; then
+                CLUSTER_INITIATOR_IP="{{.OVN_DB_CLUSTER_INITIATOR}}"
+                if [[ "${K8S_NODE_IP}" == "${CLUSTER_INITIATOR_IP}" ]]; then
                   echo "$(date -Iseconds) - sdb - postStart - waiting for master to be selected"
 
                   # set the connection and disable inactivity probe

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -25,7 +25,8 @@ type KuryrBootstrapResult struct {
 }
 
 type OVNBootstrapResult struct {
-	MasterIPs []string
+	MasterIPs        []string
+	ClusterInitiator string
 }
 
 type BootstrapResult struct {

--- a/pkg/controller/operconfig/cluster.go
+++ b/pkg/controller/operconfig/cluster.go
@@ -2,6 +2,7 @@ package operconfig
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"reflect"
 
@@ -50,14 +51,20 @@ func (r *ReconcileOperConfig) MergeClusterConfig(ctx context.Context, operConfig
 	// If there are changes to the "downstream" networkconfig, commit it back
 	// to the apiserver
 	log.Println("WARNING: Network.operator.openshift.io has fields being overwritten by Network.config.openshift.io configuration")
-	// Have to restore the typemeta due to some weird shared cache bug --cdc
+	if updateErr := r.UpdateOperConfig(operConfig); updateErr != nil {
+		errors.Wrap(err, updateErr.Error())
+	}
+	return nil
+}
+
+func (r *ReconcileOperConfig) UpdateOperConfig(operConfig *operv1.Network) error {
 	operConfig.TypeMeta = metav1.TypeMeta{APIVersion: operv1.GroupVersion.String(), Kind: "Network"}
 	us, err := k8sutil.ToUnstructured(operConfig)
 	if err != nil {
-		return errors.Wrapf(err, "failed to transmute operator config")
+		return fmt.Errorf("failed to transmute operator config, err: %v", err)
 	}
 	if err = apply.ApplyObject(context.TODO(), r.client, us); err != nil {
-		return errors.Wrapf(err, "could not apply (%s) %s/%s", operConfig.GroupVersionKind(), operConfig.GetNamespace(), operConfig.GetName())
+		return fmt.Errorf("could not apply (%s) %s/%s, err: %v", operConfig.GroupVersionKind(), operConfig.GetNamespace(), operConfig.GetName(), err)
 	}
 	return nil
 }

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"reflect"
 	"time"
 
 	"github.com/pkg/errors"
@@ -190,13 +191,24 @@ func (r *ReconcileOperConfig) Reconcile(request reconcile.Request) (reconcile.Re
 		}
 	}
 
+	newOperConfig := operConfig.DeepCopy()
+
 	// Bootstrap any resources
-	bootstrapResult, err := network.Bootstrap(&operConfig.Spec, r.client)
+	bootstrapResult, err := network.Bootstrap(newOperConfig, r.client)
 	if err != nil {
 		log.Printf("Failed to reconcile platform networking resources: %v", err)
 		r.status.SetDegraded(statusmanager.OperatorConfig, "BootstrapError",
 			fmt.Sprintf("Internal error while reconciling platform networking resources: %v", err))
 		return reconcile.Result{}, err
+	}
+
+	if !reflect.DeepEqual(operConfig, newOperConfig) {
+		if err := r.UpdateOperConfig(newOperConfig); err != nil {
+			log.Printf("Failed to update the operator configuration: %v", err)
+			r.status.SetDegraded(statusmanager.OperatorConfig, "UpdateOperatorConfig",
+				fmt.Sprintf("Internal error while updating operator configuration: %v", err))
+			return reconcile.Result{}, err
+		}
 	}
 
 	// Generate the objects

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -37,6 +37,10 @@ const NonCriticalAnnotation = "networkoperator.openshift.io/non-critical"
 // that executing network migration (switching the default network type of the cluster) is allowed.
 const NetworkMigrationAnnotation = "networkoperator.openshift.io/network-migration"
 
+// OVNRaftClusterInitiator is an annotation on the networks.operator.openshift.io CR to indicate
+// which node IP was the raft cluster initiator. The NB and SB DB will be initialized by the same member.
+const OVNRaftClusterInitiator = "networkoperator.openshift.io/ovn-cluster-initiator"
+
 // KuryrOctaviaProviderAnnotation is used to save latest Octavia provider that was configured in order to
 // prevent from reconfiguring it automatically when underlying Octavia changes.
 const KuryrOctaviaProviderAnnotation = "networkoperator.openshift.io/kuryr-octavia-provider"

--- a/pkg/network/bootstrap.go
+++ b/pkg/network/bootstrap.go
@@ -9,14 +9,14 @@ import (
 )
 
 // Bootstrap creates resources required by SDN on the cloud.
-func Bootstrap(conf *operv1.NetworkSpec, client client.Client) (*bootstrap.BootstrapResult, error) {
-	switch conf.DefaultNetwork.Type {
+func Bootstrap(conf *operv1.Network, client client.Client) (*bootstrap.BootstrapResult, error) {
+	switch conf.Spec.DefaultNetwork.Type {
 	case operv1.NetworkTypeKuryr:
-		return openstack.BootstrapKuryr(conf, client)
+		return openstack.BootstrapKuryr(&conf.Spec, client)
 	case operv1.NetworkTypeOpenShiftSDN:
 		return nil, nil
 	case operv1.NetworkTypeOVNKubernetes:
-		return bootstrapOVN(client)
+		return bootstrapOVN(conf, client)
 	}
 
 	return nil, nil

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -15,6 +15,7 @@ import (
 	yaml "github.com/ghodss/yaml"
 	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
+	"github.com/openshift/cluster-network-operator/pkg/names"
 	"github.com/openshift/cluster-network-operator/pkg/render"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -71,7 +72,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["OVN_CONTROLLER_INACTIVITY_PROBE"] = os.Getenv("OVN_CONTROLLER_INACTIVITY_PROBE")
 	data.Data["OVN_NB_DB_LIST"] = dbList(bootstrapResult.OVN.MasterIPs, OVN_NB_PORT)
 	data.Data["OVN_SB_DB_LIST"] = dbList(bootstrapResult.OVN.MasterIPs, OVN_SB_PORT)
-	data.Data["OVN_MASTER_IP"] = bootstrapResult.OVN.MasterIPs[0]
+	data.Data["OVN_DB_CLUSTER_INITIATOR"] = bootstrapResult.OVN.ClusterInitiator
 	data.Data["OVN_MIN_AVAILABLE"] = len(bootstrapResult.OVN.MasterIPs)/2 + 1
 	data.Data["LISTEN_DUAL_STACK"] = listenDualStack(bootstrapResult.OVN.MasterIPs[0])
 	data.Data["OVN_CERT_CN"] = OVN_CERT_CN
@@ -255,7 +256,7 @@ type replicaCountDecoder struct {
 	} `json:"controlPlane"`
 }
 
-func bootstrapOVN(kubeClient client.Client) (*bootstrap.BootstrapResult, error) {
+func bootstrapOVN(conf *operv1.Network, kubeClient client.Client) (*bootstrap.BootstrapResult, error) {
 	clusterConfig := &corev1.ConfigMap{}
 	clusterConfigLookup := types.NamespacedName{Name: CLUSTER_CONFIG_NAME, Namespace: CLUSTER_CONFIG_NAMESPACE}
 	masterNodeList := &corev1.NodeList{}
@@ -322,12 +323,42 @@ func bootstrapOVN(kubeClient client.Client) (*bootstrap.BootstrapResult, error) 
 
 	sort.Strings(ovnMasterIPs)
 
+	// clusterInitiator is used to avoid a split-brain scenario for the OVN NB/SB DBs. We want to consistently initialize
+	// any OVN cluster which is bootstrapped here, to the same initiator (should it still exists), hence we annotate the
+	// network.operator.openshift.io CRD with this information and always try to re-use the same member for the OVN RAFT
+	// cluster initialization
+	var clusterInitiator string
+	currentAnnotation := conf.GetAnnotations()
+	if cInitiator, ok := currentAnnotation[names.OVNRaftClusterInitiator]; ok && currentInitiatorExists(ovnMasterIPs, cInitiator) {
+		clusterInitiator = cInitiator
+	} else {
+		clusterInitiator = ovnMasterIPs[0]
+		if currentAnnotation == nil {
+			currentAnnotation = map[string]string{
+				names.OVNRaftClusterInitiator: clusterInitiator,
+			}
+		} else {
+			currentAnnotation[names.OVNRaftClusterInitiator] = clusterInitiator
+		}
+		conf.SetAnnotations(currentAnnotation)
+	}
+
 	res := bootstrap.BootstrapResult{
 		OVN: bootstrap.OVNBootstrapResult{
-			MasterIPs: ovnMasterIPs,
+			MasterIPs:        ovnMasterIPs,
+			ClusterInitiator: clusterInitiator,
 		},
 	}
 	return &res, nil
+}
+
+func currentInitiatorExists(ovnMasterIPs []string, configInitiator string) bool {
+	for _, masterIP := range ovnMasterIPs {
+		if masterIP == configInitiator {
+			return true
+		}
+	}
+	return false
 }
 
 func dbList(masterIPs []string, port string) string {


### PR DESCRIPTION
PR #896 tried to unblock the assisted installer team by reverting commit a14003d from #421. However the level entropy introduced by removing that commit can in some situations bring the OVN cluster down. Essentially, if the amount of master nodes are not met during the initial cluster deployment: we risk rolling out successive versions of the OVN DB cluster in a very short time span. Since the NB / SB DB raft clusters does not have the time to stabilize before the new version rolls out, we risk doing bad things in some cases. 

This PR does things as before, except we don't block the cluster deployment if the master node replica count is not met. Thus we will still wait for all master nodes that should be up, are up. However if they are not, we proceed with the deployment of the initial cluster and then proceed to roll out the second version once the new master node(s) join. This has been tested by the assisted installer team using PR #934, and it works for them. 

We will still annotate `network.operator.openshift.io` with the raft join point as #896 did, for cases such as the assisted installer use case.

/assign @squeed @abhat   

   