### PR TITLE
Bug 1954755: Multus configuration should allow for net-attach-defs in certain namespaces to be used across namespaces

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -342,6 +342,7 @@ spec:
         - "--cni-version=0.3.1"
         - "--additional-bin-dir=/opt/multus/bin"
         - "--skip-multus-binary-copy=true"
+        - "--global-namespaces=default,openshift-multus,openshift-sriov-network-operator"
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
In OpenShift, we have a feature for Multus known as "namespace isolation" this allows pods to only
have annotations for additional networks that refer to the same namespace as a given pod. The expection
is the default namespace, where net-attach-defs in the default namespace can be referred to by pods
in any namespace.

Sometimes, operators need to manage their own net-attach-defs, and dumping them all into the default
namespace is not ideal. This extends the CNO to use the Multus "--global-namespaces" option, and sets
for the openshift-multus, as well as the SRIOV network operator namespace to be used.