### PR TITLE
Bug 1920209: The pods in the Multus daemonset should exit in a reasonable time during an upgrade.

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -348,6 +348,7 @@ spec:
             memory: 150Mi
         securityContext:
           privileged: true
+        terminationGracePeriodSeconds: 10
         volumeMounts:
         - name: system-cni-dir
           mountPath: /host/etc/cni/net.d


### PR DESCRIPTION
Without setting the gracePeriodSeconds lower, a pod in the Multus daemonset can take ~35 seconds to exit.

When setting to 10 seconds, the pods will exit in approximately 17 seconds.

~Additionally, this sets the maxUnavailable to 10%, which allows for a larger amount of pods to be upgraded at once
in larger deployments.~