### PR TITLE
Bug 1920159: Reduce CPU requests of ovs daemonset

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -85,7 +85,7 @@ spec:
           readOnly: true
         resources:
           requests:
-            cpu: 100m
+            cpu: 15m
             memory: 400Mi
         terminationMessagePolicy: FallbackToLogsOnError
         terminationGracePeriodSeconds: 45

--- a/bindata/network/ovn-kubernetes/006-ovs-node.yaml
+++ b/bindata/network/ovn-kubernetes/006-ovs-node.yaml
@@ -109,7 +109,7 @@ spec:
           readOnly: true
         resources:
           requests:
-            cpu: 100m
+            cpu: 15m
             memory: 300Mi
         terminationMessagePolicy: FallbackToLogsOnError
         terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Now that OVS has moved to the node in 4.7, the daemonset pods have
less to do. Looking at some production systems data, the OVS pod
uses about 5 millicores on 4.6 and less than 1 millicore on 4.7.
Reduce the request from 100m to 15m to retain some headroom for users
upgrading from 4.6 and running the new pod on the old nodes. In a
future release the daemonset will be fully removed.

/hold

Testing with other PRs