### PR TITLE
Bug 1920769: override the default node-selector for network-connectivity check

### DIFF
--- a/bindata/network-diagnostics/000-ns.yaml
+++ b/bindata/network-diagnostics/000-ns.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-network-diagnostics
+annotations:
+  openshift.io/node-selector: "" #override default node selector


### PR DESCRIPTION
If the default node selector is not overridden then during upgrade the
network never comes up because the network diagnostics assumes the
network-checker pods are on all nodes and if the default node selector
is present and not overridden they could be restricted.