### PR TITLE
Bug 1905730: ipsec: Suppress benign error messages on startup of ovs-monitor-ipsec

### DIFF
--- a/bindata/network/ovn-kubernetes/ipsec.yaml
+++ b/bindata/network/ovn-kubernetes/ipsec.yaml
@@ -193,8 +193,6 @@ spec:
           /usr/libexec/ipsec/_stackmanager start
           # Check nss database status
           /usr/sbin/ipsec --checknss
-          # Check nflog setup
-          /usr/sbin/ipsec --checknflog
           # Start the pluto IKE daemon
           /usr/libexec/ipsec/pluto --leak-detective --config /etc/ipsec.conf --logfile /var/log/openvswitch/libreswan.log
 

--- a/bindata/network/ovn-kubernetes/ipsec.yaml
+++ b/bindata/network/ovn-kubernetes/ipsec.yaml
@@ -202,7 +202,7 @@ spec:
           # We now start ovs-monitor-ipsec which will monitor for changes in the ovs
           # tunnelling configuration (for example addition of a node) and configures
           # libreswan appropriately.
-          OVS_LOGDIR=/var/log/openvswitch OVS_RUNDIR=/var/run/openvswitch OVS_PKGDATADIR=/usr/share/openvswitch /usr/share/openvswitch/scripts/ovs-ctl --ike-daemon=libreswan start-ovs-ipsec
+          OVS_LOGDIR=/var/log/openvswitch OVS_RUNDIR=/var/run/openvswitch OVS_PKGDATADIR=/usr/share/openvswitch /usr/share/openvswitch/scripts/ovs-ctl --ike-daemon=libreswan --no-restart-ike-daemon start-ovs-ipsec
 
           while true; do
             sleep 60


### PR DESCRIPTION
ovn-ipsec pods have the following benign error messages on startup. This PR removes these error messages.

+ /usr/sbin/ipsec --checknflog
**chroot: cannot change root directory to '/host': No such file or directory**
nflog ipsec capture disabled
+ /usr/libexec/ipsec/pluto --leak-detective --config /etc/openvswitch/ipsec.conf --logfile /var/log/openvswitch/libreswan.log
+ OVS_LOGDIR=/var/log/openvswitch
+ OVS_RUNDIR=/var/run/openvswitch
+ OVS_PKGDATADIR=/usr/share/openvswitch
+ /usr/share/openvswitch/scripts/ovs-ctl --ike-daemon=libreswan start-ovs-ipsec
**2020-12-08T15:41:54Z |  1  | ovs-monitor-ipsec | INFO | Restarting LibreSwan
Redirecting to: systemctl restart ipsec.service
System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to connect to bus: Host is down**