### PR TITLE
Bug 1924137: Increase the initialDelaySeconds for liveness and readiness probes

### DIFF
--- a/bindata/network/ovn-kubernetes/006-ovs-node.yaml
+++ b/bindata/network/ovn-kubernetes/006-ovs-node.yaml
@@ -97,14 +97,14 @@ spec:
             command:
             - /usr/share/openvswitch/scripts/ovs-ctl
             - status
-          initialDelaySeconds: 15
+          initialDelaySeconds: 45
           periodSeconds: 5
         readinessProbe:
           exec:
             command:
             - /usr/share/openvswitch/scripts/ovs-ctl
             - status
-          initialDelaySeconds: 15
+          initialDelaySeconds: 45
           periodSeconds: 5
         terminationGracePeriodSeconds: 10
 


### PR DESCRIPTION
In cases where we run ovs in a container, sometimes ovs-vswitchd
will take a bit longer to come up as a daemon. In this case liveness
probes will start failing if the initial delay is too small and this
will prevent ovs-daemons container from coming up. This fixes the
initial delay parameter to make sure liveness and readiness probes
start after giving ovs a chance to start.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>