### PR TITLE
Update remaining CRDs and webhooks to v1

### DIFF
--- a/bindata/network/additional-networks/crd/001-crd.yaml
+++ b/bindata/network/additional-networks/crd/001-crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: network-attachment-definitions.k8s.cni.cncf.io
@@ -10,149 +10,142 @@ spec:
     plural: network-attachment-definitions
     singular: network-attachment-definition
     kind: NetworkAttachmentDefinition
+    listKind: NetworkAttachmentDefinitionList
     shortNames:
     - net-attach-def
   versions:
   - name: v1
     served: true
     storage: true
-  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      description: 'NetworkAttachmentDefinition is a CRD schema specified by the Network Plumbing
-        Working Group to express the intent for attaching pods to one or more logical or physical
-        networks. More information available at: https://github.com/k8snetworkplumbingwg/multi-net-spec'
-      type: object
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this represen
-            tation of an object. Servers should convert recognized schemas to the
-            latest internal value, and may reject unrecognized values. More info:
-            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: 'NetworkAttachmentDefinition spec defines the desired state of a network attachment'
-          type: object
-          properties:
-            config:
-              description: 'NetworkAttachmentDefinition config is a JSON-formatted CNI configuration'
-              type: string
+    schema:
+      openAPIV3Schema:
+        description: 'NetworkAttachmentDefinition is a CRD schema specified by the Network Plumbing
+          Working Group to express the intent for attaching pods to one or more logical or physical
+          networks. More information available at: https://github.com/k8snetworkplumbingwg/multi-net-spec'
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this represen
+              tation of an object. Servers should convert recognized schemas to the
+              latest internal value, and may reject unrecognized values. More info:
+              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'NetworkAttachmentDefinition spec defines the desired state of a network attachment'
+            type: object
+            properties:
+              config:
+                description: 'NetworkAttachmentDefinition config is a JSON-formatted CNI configuration'
+                type: string
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  creationTimestamp: null
   name: ippools.whereabouts.cni.cncf.io
 spec:
   group: whereabouts.cni.cncf.io
   names:
     kind: IPPool
+    listKind: IPPoolList
     plural: ippools
-  scope: ""
-  validation:
-    openAPIV3Schema:
-      description: IPPool is the Schema for Whereabouts for IP address allocation
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: IPPoolSpec defines the desired state of IPPool
-          properties:
-            allocations:
-              additionalProperties:
-                description: IPAllocation represents metadata about the pod/container
-                  owner of a specific IP
-                properties:
-                  id:
-                    type: string
-                required:
-                - id
-                type: object
-              description: Allocations is the set of allocated IPs for the given range.
-                Its indices are a direct mapping to the IP with the same index/offset
-                for the pool's range.
-              type: object
-            range:
-              description: Range is a RFC 4632/4291-style string that represents an
-                IP address and prefix length in CIDR notation
-              type: string
-          required:
-          - allocations
-          - range
-          type: object
-      type: object
-  version: v1alpha1
+    singular: ippool
+  scope: Namespaced
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IPPool is the Schema for Whereabouts for IP address allocation
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPPoolSpec defines the desired state of IPPool
+            properties:
+              allocations:
+                additionalProperties:
+                  description: IPAllocation represents metadata about the pod/container
+                    owner of a specific IP
+                  properties:
+                    id:
+                      type: string
+                  required:
+                  - id
+                  type: object
+                description: Allocations is the set of allocated IPs for the given range.
+                  Its indices are a direct mapping to the IP with the same index/offset
+                  for the pool's range.
+                type: object
+              range:
+                description: Range is a RFC 4632/4291-style string that represents an
+                  IP address and prefix length in CIDR notation
+                type: string
+            required:
+            - allocations
+            - range
+            type: object
+        type: object
     served: true
     storage: true
-  preserveUnknownFields: false
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  creationTimestamp: null
   name: overlappingrangeipreservations.whereabouts.cni.cncf.io
 spec:
   group: whereabouts.cni.cncf.io
   names:
     kind: OverlappingRangeIPReservation
+    listKind: OverlappingRangeIPReservationList
     plural: overlappingrangeipreservations
-  scope: ""
-  validation:
-    openAPIV3Schema:
-      description: OverlappingRangeIPReservation is the Schema for the OverlappingRangeIPReservations
-        API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: OverlappingRangeIPReservationSpec defines the desired state
-            of OverlappingRangeIPReservation
-          properties:
-            containerid:
-              type: string
-          required:
-          - containerid
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1alpha1
+    singular: overlappingrangeipreservation
+  scope: Namespaced
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OverlappingRangeIPReservation is the Schema for the OverlappingRangeIPReservations
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OverlappingRangeIPReservationSpec defines the desired state 
+              of OverlappingRangeIPReservation
+            properties:
+              containerid:
+                type: string
+            required:
+            - containerid
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true

--- a/bindata/network/multus-admission-controller/003-webhook.yaml
+++ b/bindata/network/multus-admission-controller/003-webhook.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{.MultusValidatingWebhookName}}
@@ -19,3 +19,7 @@ webhooks:
         apiGroups: ["k8s.cni.cncf.io"]
         apiVersions: ["v1"]
         resources: ["network-attachment-definitions"]
+    sideEffects: NoneOnDryRun
+    admissionReviewVersions:
+    - v1beta1
+    timeoutSeconds: 30

--- a/bindata/network/openshift-sdn/001-crd.yaml
+++ b/bindata/network/openshift-sdn/001-crd.yaml
@@ -1,8 +1,7 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  creationTimestamp: null
   name: clusternetworks.network.openshift.io
 spec:
   group: network.openshift.io
@@ -12,133 +11,124 @@ spec:
     plural: clusternetworks
     singular: clusternetwork
   scope: Cluster
-  preserveUnknownFields: false
-  validation:
-    # As compared to ValidateClusterNetwork, this does not validate that:
-    #   - the hostSubnetLengths are valid for their CIDRs
-    #   - the cluster/service networks do not overlap
-    #   - .network and .hostsubnetlength are set if name == 'default'
-    #   - .network and .hostsubnetlength are either unset, or equal to
-    #     .clusterNetworks[0].CIDR and .clusterNetworks[0].hostSubnetLength
-    openAPIV3Schema:
-      description: ClusterNetwork describes the cluster network. There is normally
-        only one object of this type, named "default", which is created by the SDN
-        network plugin based on the master configuration when the cluster is brought
-        up for the first time.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        clusterNetworks:
-          description: ClusterNetworks is a list of ClusterNetwork objects that defines
-            the global overlay network's L3 space by specifying a set of CIDR and
-            netmasks that the SDN can allocate addresses from.
-          items:
-            description: ClusterNetworkEntry defines an individual cluster network.
-              The CIDRs cannot overlap with other cluster network CIDRs, CIDRs reserved
-              for external ips, CIDRs reserved for service networks, and CIDRs reserved
-              for ingress ips.
-            properties:
-              CIDR:
-                description: CIDR defines the total range of a cluster networks address
-                  space.
-                type: string
-                pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$'
-              hostSubnetLength:
-                description: HostSubnetLength is the number of bits of the accompanying
-                  CIDR address to allocate to each node. eg, 8 would mean that each
-                  node would have a /24 slice of the overlay network for its pods.
-                format: int32
-                type: integer
-                minimum: 2
-                maximum: 30
-            required:
-            - CIDR
-            - hostSubnetLength
-            type: object
-          type: array
-        hostsubnetlength:
-          description: HostSubnetLength is the number of bits of network to allocate
-            to each node. eg, 8 would mean that each node would have a /24 slice of
-            the overlay network for its pods
-          format: int32
-          type: integer
-          minimum: 2
-          maximum: 30
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        mtu:
-          description: MTU is the MTU for the overlay network. This should be 50 less
-            than the MTU of the network connecting the nodes. It is normally autodetected
-            by the cluster network operator.
-          format: int32
-          type: integer
-          minimum: 576
-          maximum: 65536
-        network:
-          description: Network is a CIDR string specifying the global overlay network's
-            L3 space
-          type: string
-          pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$'
-        pluginName:
-          description: PluginName is the name of the network plugin being used
-          type: string
-        serviceNetwork:
-          description: ServiceNetwork is the CIDR range that Service IP addresses
-            are allocated from
-          type: string
-          pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$'
-        vxlanPort:
-          description: VXLANPort sets the VXLAN destination port used by the cluster.
-            It is set by the master configuration file on startup and cannot be edited
-            manually. Valid values for VXLANPort are integers 1-65535 inclusive and
-            if unset defaults to 4789. Changing VXLANPort allows users to resolve
-            issues between openshift SDN and other software trying to use the same
-            VXLAN destination port.
-          format: int32
-          type: integer
-          minimum: 1
-          maximum: 65535
-      required:
-      - clusterNetworks
-      - serviceNetwork
-      type: object
-  additionalPrinterColumns:
-  - name: Cluster Network
-    type: string
-    description: The primary cluster network CIDR
-    JSONPath: .network
-  - name: Service Network
-    type: string
-    description: The service network CIDR
-    JSONPath: .serviceNetwork
-  - name: Plugin Name
-    type: string
-    description: The OpenShift SDN network plug-in in use
-    JSONPath: .pluginName
-  version: v1
   versions:
   - name: v1
+    schema:
+      # As compared to ValidateClusterNetwork, this does not validate that:
+      #   - the hostSubnetLengths are valid for their CIDRs
+      #   - the cluster/service networks do not overlap
+      #   - .network and .hostsubnetlength are set if name == 'default'
+      #   - .network and .hostsubnetlength are either unset, or equal to
+      #     .clusterNetworks[0].CIDR and .clusterNetworks[0].hostSubnetLength
+      openAPIV3Schema:
+        description: ClusterNetwork describes the cluster network. There is normally
+          only one object of this type, named "default", which is created by the SDN
+          network plugin based on the master configuration when the cluster is brought
+          up for the first time.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          clusterNetworks:
+            description: ClusterNetworks is a list of ClusterNetwork objects that defines
+              the global overlay network's L3 space by specifying a set of CIDR and
+              netmasks that the SDN can allocate addresses from.
+            items:
+              description: ClusterNetworkEntry defines an individual cluster network.
+                The CIDRs cannot overlap with other cluster network CIDRs, CIDRs reserved
+                for external ips, CIDRs reserved for service networks, and CIDRs reserved
+                for ingress ips.
+              properties:
+                CIDR:
+                  description: CIDR defines the total range of a cluster networks address 
+                    space.
+                  type: string
+                  pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$'
+                hostSubnetLength:
+                  description: HostSubnetLength is the number of bits of the accompanying
+                    CIDR address to allocate to each node. eg, 8 would mean that each
+                    node would have a /24 slice of the overlay network for its pods.
+                  format: int32
+                  type: integer
+                  minimum: 2
+                  maximum: 30
+              required:
+              - CIDR
+              - hostSubnetLength
+              type: object
+            type: array
+          hostsubnetlength:
+            description: HostSubnetLength is the number of bits of network to allocate
+              to each node. eg, 8 would mean that each node would have a /24 slice of
+              the overlay network for its pods
+            format: int32
+            type: integer
+            minimum: 2
+            maximum: 30
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          mtu:
+            description: MTU is the MTU for the overlay network. This should be 50 less
+              than the MTU of the network connecting the nodes. It is normally autodetected
+              by the cluster network operator.
+            format: int32
+            type: integer
+            minimum: 576
+            maximum: 65536
+          network:
+            description: Network is a CIDR string specifying the global overlay network's
+              L3 space
+            type: string
+            pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$'
+          pluginName:
+            description: PluginName is the name of the network plugin being used
+            type: string
+          serviceNetwork:
+            description: ServiceNetwork is the CIDR range that Service IP addresses
+              are allocated from
+            type: string
+            pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$'
+          vxlanPort:
+            description: VXLANPort sets the VXLAN destination port used by the cluster.
+              It is set by the master configuration file on startup and cannot be edited
+              manually. Valid values for VXLANPort are integers 1-65535 inclusive and
+              if unset defaults to 4789. Changing VXLANPort allows users to resolve
+              issues between openshift SDN and other software trying to use the same
+              VXLAN destination port.
+            format: int32
+            type: integer
+            minimum: 1
+            maximum: 65535
+        required:
+        - clusterNetworks
+        - serviceNetwork
+        type: object
+    additionalPrinterColumns:
+    - name: Cluster Network
+      type: string
+      description: The primary cluster network CIDR
+      jsonPath: .network
+    - name: Service Network
+      type: string
+      description: The service network CIDR
+      jsonPath: .serviceNetwork
+    - name: Plugin Name
+      type: string
+      description: The OpenShift SDN network plug-in in use
+      jsonPath: .pluginName
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  creationTimestamp: null
   name: hostsubnets.network.openshift.io
 spec:
   group: network.openshift.io
@@ -148,103 +138,94 @@ spec:
     plural: hostsubnets
     singular: hostsubnet
   scope: Cluster
-  preserveUnknownFields: false
-  validation:
-    # As compared to ValidateHostSubnet, this does not validate that:
-    #   - .host == .name
-    #   - either .subnet is set or the assign-subnet annotation is present
-    # As compared to ValidateHostSubnetUpdate, this does not validate that:
-    #   - .subnet is not changed on an existing object
-    openAPIV3Schema:
-      description: HostSubnet describes the container subnet network on a node. The
-        HostSubnet object must have the same name as the Node object it corresponds
-        to.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        egressCIDRs:
-          description: EgressCIDRs is the list of CIDR ranges available for automatically
-            assigning egress IPs to this node from. If this field is set then EgressIPs
-            should be treated as read-only.
-          items:
-            type: string
-            pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$'
-          type: array
-        egressIPs:
-          description: EgressIPs is the list of automatic egress IP addresses currently
-            hosted by this node. If EgressCIDRs is empty, this can be set by hand;
-            if EgressCIDRs is set then the master will overwrite the value here with
-            its own allocation of egress IPs.
-          items:
-            type: string
-            pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$'
-          type: array
-        host:
-          description: Host is the name of the node. (This is the same as the object's
-            name, but both fields must be set.)
-          type: string
-          pattern: '^[a-z0-9.-]+$'
-        hostIP:
-          description: HostIP is the IP address to be used as a VTEP by other nodes
-            in the overlay network
-          type: string
-          pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$'
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        subnet:
-          description: Subnet is the CIDR range of the overlay network assigned to
-            the node for its pods
-          type: string
-          pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$'
-      required:
-      - host
-      - hostIP
-      type: object
-  additionalPrinterColumns:
-  - name: Host
-    type: string
-    description: The name of the node
-    JSONPath: .host
-  - name: Host IP
-    type: string
-    description: The IP address to be used as a VTEP by other nodes in the overlay network
-    JSONPath: .hostIP
-  - name: Subnet
-    type: string
-    description: The CIDR range of the overlay network assigned to the node for its pods
-    JSONPath: .subnet
-  - name: Egress CIDRs
-    type: string
-    description: The network egress CIDRs
-    JSONPath: .egressCIDRs
-  - name: Egress IPs
-    type: string
-    description: The network egress IP addresses
-    JSONPath: .egressIPs
-  version: v1
   versions:
   - name: v1
+    schema:
+      # As compared to ValidateHostSubnet, this does not validate that:
+      #   - .host == .name
+      #   - either .subnet is set or the assign-subnet annotation is present
+      # As compared to ValidateHostSubnetUpdate, this does not validate that:
+      #   - .subnet is not changed on an existing object
+      openAPIV3Schema:
+        description: HostSubnet describes the container subnet network on a node. The
+          HostSubnet object must have the same name as the Node object it corresponds
+          to.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          egressCIDRs:
+            description: EgressCIDRs is the list of CIDR ranges available for automatically
+              assigning egress IPs to this node from. If this field is set then EgressIPs
+              should be treated as read-only.
+            items:
+              type: string
+              pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$'
+            type: array
+          egressIPs:
+            description: EgressIPs is the list of automatic egress IP addresses currently
+              hosted by this node. If EgressCIDRs is empty, this can be set by hand;
+              if EgressCIDRs is set then the master will overwrite the value here with
+              its own allocation of egress IPs.
+            items:
+              type: string
+              pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$'
+            type: array
+          host:
+            description: Host is the name of the node. (This is the same as the object's
+              name, but both fields must be set.)
+            type: string
+            pattern: '^[a-z0-9.-]+$'
+          hostIP:
+            description: HostIP is the IP address to be used as a VTEP by other nodes
+              in the overlay network
+            type: string
+            pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$'
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          subnet:
+            description: Subnet is the CIDR range of the overlay network assigned to
+              the node for its pods
+            type: string
+            pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$'
+        required:
+        - host
+        - hostIP
+        type: object
+    additionalPrinterColumns:
+    - name: Host
+      type: string
+      description: The name of the node
+      jsonPath: .host
+    - name: Host IP
+      type: string
+      description: The IP address to be used as a VTEP by other nodes in the overlay network
+      jsonPath: .hostIP
+    - name: Subnet
+      type: string
+      description: The CIDR range of the overlay network assigned to the node for its pods
+      jsonPath: .subnet
+    - name: Egress CIDRs
+      type: string
+      description: The network egress CIDRs
+      jsonPath: .egressCIDRs
+    - name: Egress IPs
+      type: string
+      description: The network egress IP addresses
+      jsonPath: .egressIPs
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  creationTimestamp: null
   name: netnamespaces.network.openshift.io
 spec:
   group: network.openshift.io
@@ -254,79 +235,70 @@ spec:
     plural: netnamespaces
     singular: netnamespace
   scope: Cluster
-  preserveUnknownFields: false
-  validation:
-    # As compared to ValidateNetNamespace, this does not validate that:
-    #   - .netname == .name
-    #   - .netid is not 1-9
-    openAPIV3Schema:
-      description: NetNamespace describes a single isolated network. When using the
-        redhat/openshift-ovs-multitenant plugin, every Namespace will have a corresponding
-        NetNamespace object with the same name. (When using redhat/openshift-ovs-subnet,
-        NetNamespaces are not used.)
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        egressIPs:
-          description: EgressIPs is a list of reserved IPs that will be used as the
-            source for external traffic coming from pods in this namespace. (If empty,
-            external traffic will be masqueraded to Node IPs.)
-          items:
-            type: string
-            pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$'
-          type: array
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        netid:
-          description: NetID is the network identifier of the network namespace assigned
-            to each overlay network packet. This can be manipulated with the "oc adm
-            pod-network" commands.
-          format: int32
-          type: integer
-          minimum: 0
-          maximum: 16777215
-        netname:
-          description: NetName is the name of the network namespace. (This is the
-            same as the object's name, but both fields must be set.)
-          type: string
-          pattern: '^[a-z0-9.-]+$'
-      required:
-      - netid
-      - netname
-      type: object
-  additionalPrinterColumns:
-  - name: NetID
-    type: integer
-    description: The network identifier of the network namespace
-    JSONPath: .netid
-  - name: Egress IPs
-    type: string
-    description: The network egress IP addresses
-    JSONPath: .egressIPs
-  version: v1
   versions:
   - name: v1
+    schema:
+      # As compared to ValidateNetNamespace, this does not validate that:
+      #   - .netname == .name
+      #   - .netid is not 1-9
+      openAPIV3Schema:
+        description: NetNamespace describes a single isolated network. When using the
+          redhat/openshift-ovs-multitenant plugin, every Namespace will have a corresponding
+          NetNamespace object with the same name. (When using redhat/openshift-ovs-subnet, 
+          NetNamespaces are not used.)
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          egressIPs:
+            description: EgressIPs is a list of reserved IPs that will be used as the
+              source for external traffic coming from pods in this namespace. (If empty,
+              external traffic will be masqueraded to Node IPs.)
+            items:
+              type: string
+              pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$'
+            type: array
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          netid:
+            description: NetID is the network identifier of the network namespace assigned
+              to each overlay network packet. This can be manipulated with the "oc adm
+              pod-network" commands.
+            format: int32
+            type: integer
+            minimum: 0
+            maximum: 16777215
+          netname:
+            description: NetName is the name of the network namespace. (This is the
+              same as the object's name, but both fields must be set.)
+            type: string
+            pattern: '^[a-z0-9.-]+$'
+        required:
+        - netid
+        - netname
+        type: object
+    additionalPrinterColumns:
+    - name: NetID
+      type: integer
+      description: The network identifier of the network namespace
+      jsonPath: .netid
+    - name: Egress IPs
+      type: string
+      description: The network egress IP addresses
+      jsonPath: .egressIPs
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  creationTimestamp: null
   name: egressnetworkpolicies.network.openshift.io
 spec:
   group: network.openshift.io
@@ -336,78 +308,70 @@ spec:
     plural: egressnetworkpolicies
     singular: egressnetworkpolicy
   scope: Namespaced
-  preserveUnknownFields: false
-  validation:
-    # This should be mostly equivalent to ValidateEgressNetworkPolicy
-    openAPIV3Schema:
-      description: EgressNetworkPolicy describes the current egress network policy
-        for a Namespace. When using the 'redhat/openshift-ovs-multitenant' network
-        plugin, traffic from a pod to an IP address outside the cluster will be checked
-        against each EgressNetworkPolicyRule in the pod's namespace's EgressNetworkPolicy,
-        in order. If no rule matches (or no EgressNetworkPolicy is present) then the
-        traffic will be allowed by default.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: spec is the specification of the current egress network policy
-          properties:
-            egress:
-              description: egress contains the list of egress policy rules
-              items:
-                description: EgressNetworkPolicyRule contains a single egress network
-                  policy rule
-                properties:
-                  to:
-                    description: to is the target that traffic is allowed/denied to
-                    properties:
-                      cidrSelector:
-                        description: cidrSelector is the CIDR range to allow/deny
-                          traffic to. If this is set, dnsName must be unset
-                        type: string
-                        pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$'
-                      dnsName:
-                        description: dnsName is the domain name to allow/deny traffic
-                          to. If this is set, cidrSelector must be unset
-                        type: string
-                        pattern: '^([A-Za-z0-9-]+\.)*[A-Za-z0-9-]+\.?$'
-                    type: object
-                    minProperties: 1
-                    maxProperties: 1
-                  type:
-                    description: type marks this as an "Allow" or "Deny" rule
-                    type: string
-                    pattern: '^Allow|Deny$'
-                required:
-                - to
-                - type
-                type: object
-              type: array
-              maxItems: 1000
-          required:
-          - egress
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1
   versions:
   - name: v1
+    schema:
+      # This should be mostly equivalent to ValidateEgressNetworkPolicy
+      openAPIV3Schema:
+        description: EgressNetworkPolicy describes the current egress network policy
+          for a Namespace. When using the 'redhat/openshift-ovs-multitenant' network
+          plugin, traffic from a pod to an IP address outside the cluster will be checked
+          against each EgressNetworkPolicyRule in the pod's namespace's EgressNetworkPolicy,
+          in order. If no rule matches (or no EgressNetworkPolicy is present) then the
+          traffic will be allowed by default.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the specification of the current egress network policy
+            properties:
+              egress:
+                description: egress contains the list of egress policy rules
+                items:
+                  description: EgressNetworkPolicyRule contains a single egress network
+                    policy rule
+                  properties:
+                    to:
+                      description: to is the target that traffic is allowed/denied to
+                      properties:
+                        cidrSelector:
+                          description: cidrSelector is the CIDR range to allow/deny
+                            traffic to. If this is set, dnsName must be unset
+                          type: string
+                          pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$'
+                        dnsName:
+                          description: dnsName is the domain name to allow/deny traffic
+                            to. If this is set, cidrSelector must be unset
+                          type: string
+                          pattern: '^([A-Za-z0-9-]+\.)*[A-Za-z0-9-]+\.?$'
+                      type: object
+                      minProperties: 1
+                      maxProperties: 1
+                    type:
+                      description: type marks this as an "Allow" or "Deny" rule
+                      type: string
+                      pattern: '^Allow|Deny$'
+                  required:
+                  - to
+                  - type
+                  type: object
+                type: array
+                maxItems: 1000
+            required:
+            - egress
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
We were still using the v1beta1 versions of the APIs for the SDN and Multus CRDs and multus-admission-webhook.

CRD diffs are best viewed with `-w`

Relevant changes:
  - the CRD for `OverlappingRangeIPReservation` had claimed `preserveUnknownFields: true` before, but based on https://github.com/openshift/whereabouts-cni/blob/master/pkg/api/v1alpha1/overlappingrangeipreservation_types.go that does actually seem to be needed.
  - multus-admission-webhook now has to explicitly specify some things that were previously defaulted/guessed in v1beta1
