### PR TITLE
Bug 1921184: Kuryr: Let Kuryr autodetect primary CNI interface

### DIFF
--- a/bindata/network/kuryr/003-config.yaml
+++ b/bindata/network/kuryr/003-config.yaml
@@ -13,7 +13,6 @@ data:
 
     [binding]
     default_driver = kuryr.lib.binding.drivers.vlan
-    link_iface = ens3
 
     [cni_daemon]
     daemon_enabled = true


### PR DESCRIPTION
Kuryr has a mechanism in place that attempts to autodetect the primary
trunk interface that the kuryr-cni should bind the subports to. The
mechanism checks if the interface that's configured as link_iface exists
and if not attempts to do autodetection by looking where kubelet's
bound.

We hardcoded `link_iface=ens3` in the config anyway, assuming that if in
some configurations interface is named differently we'll just do the
autodetection.

The problem with that approach is when there are multiple interfaces and
they're swapped, we'll just keep using the wrong one never attempting
autodetection. And we were told that this sometimes happens.

This patch removes the [binding]link_iface from the kuryr.conf in order
to always force the autodetection and make sure kuryr-cni will bind fine
even if interface order is reversed.