### PR TITLE
Suppress sleep message in ovn-ipsec container

### DIFF
--- a/bindata/network/ovn-kubernetes/ipsec.yaml
+++ b/bindata/network/ovn-kubernetes/ipsec.yaml
@@ -202,9 +202,7 @@ spec:
           # libreswan appropriately.
           OVS_LOGDIR=/var/log/openvswitch OVS_RUNDIR=/var/run/openvswitch OVS_PKGDATADIR=/usr/share/openvswitch /usr/share/openvswitch/scripts/ovs-ctl --ike-daemon=libreswan --no-restart-ike-daemon start-ovs-ipsec
 
-          while true; do
-            sleep 60
-          done
+          sleep infinity
         env:
         - name: OVS_LOG_LEVEL
           value: info


### PR DESCRIPTION
Sleep messages are useless but printed in ovn-ipsec log every minute