### PR TITLE
Bug 1920769: Fix the spacing for the node-selector override annotation

### DIFF
--- a/bindata/network-diagnostics/000-ns.yaml
+++ b/bindata/network-diagnostics/000-ns.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-network-diagnostics
-annotations:
-  openshift.io/node-selector: "" #override default node selector
+  annotations:
+    openshift.io/node-selector: "" #override default node selector


### PR DESCRIPTION
commit cc38b9510e828462ab740bbffe5ed834c8a442d0 adds an annotation
section to the namespace definition for openshift-network-diagnostics.
The spacing was wrong so the override is ignored. Correctly add the
annotation as part of the metadata field so the correct propogation will
happen