### PR TITLE
Bug 1924383: update the resource requests made by pods in openshift-network-diagnostics namespace

### DIFF
--- a/bindata/network-diagnostics/network-check-source.yaml
+++ b/bindata/network-diagnostics/network-check-source.yaml
@@ -50,7 +50,7 @@ spec:
             protocol: TCP
         resources:
           requests:
-            memory: 50Mi
+            memory: 40Mi
             cpu: 10m
       nodeSelector:
         beta.kubernetes.io/os: "linux"

--- a/bindata/network-diagnostics/network-check-target.yaml
+++ b/bindata/network-diagnostics/network-check-target.yaml
@@ -28,7 +28,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 150Mi
+            memory: 15Mi
         readinessProbe:
           httpGet:
             port: 8080


### PR DESCRIPTION
The resource requests made by pods in the openshift-network-diagnostics
namespace is way too high, this can cause the kube-scheduler to
needlessly error in deploying these pods as the documentation states

"The scheduler ensures that, for each resource type, the sum of the
resource requests of the scheduled Containers is less than the capacity
of the node."

https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits

this is the memory usage I see on a running cluster

```
$ kubectl top pod  -n
openshift-network-diagnostics
NAME                                    CPU(cores)   MEMORY(bytes)
network-check-source-744c4f7fbf-djmbl   3m           36Mi
network-check-target-28zd8              0m           10Mi
network-check-target-5c8dd              0m           7Mi
network-check-target-jjxrt              0m           5Mi
network-check-target-m28lm              0m           5Mi
network-check-target-v5zfs              0m           5Mi
network-check-target-zvnfl              0m           11Mi
```

vastly reduce memory requests for these pods to bring it more inline
with reality