### PR TITLE
SDN-1571 ipsec: Allow enablement/disablement at runtime

### DIFF
--- a/bindata/network/ovn-kubernetes/ipsec.yaml
+++ b/bindata/network/ovn-kubernetes/ipsec.yaml
@@ -1,4 +1,4 @@
-{{if .EnableIPsec}}
+{{if .OVNIPsecDaemonsetEnable}}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -370,8 +370,10 @@ spec:
                   fi
                 fi
 
-                {{ if .EnableIPsec }}
+                {{ if .OVNIPsecEnable }}
                 ${OVN_NB_CTL} set nb_global . ipsec=true
+                {{ else }}
+                ${OVN_NB_CTL} set nb_global . ipsec=false
                 {{ end }}
           preStop:
             exec:

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -31,6 +31,7 @@ type OVNBootstrapResult struct {
 	ClusterInitiator        string
 	ExistingMasterDaemonset *appsv1.DaemonSet
 	ExistingNodeDaemonset   *appsv1.DaemonSet
+	ExistingIPsecDaemonset  *appsv1.DaemonSet
 }
 
 type BootstrapResult struct {

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -112,10 +112,29 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 		data.Data["OVNHybridOverlayVXLANPort"] = ""
 	}
 
+	// If IPsec is enabled for the first time, we start the daemonset. If it is
+	// disabled after that, we do not stop the daemonset but only stop IPsec.
+	//
+	// TODO: We need to do this as, by default, we maintain IPsec state on the
+	// node in order to maintain encrypted connectivity in the case of upgrades.
+	// If we only unrender the IPsec daemonset, we will be unable to cleanup
+	// the IPsec state on the node and the traffic will continue to be
+	// encrypted.
 	if c.IPsecConfig != nil {
-		data.Data["EnableIPsec"] = true
+		// IPsec is enabled
+		data.Data["OVNIPsecDaemonsetEnable"] = true
+		data.Data["OVNIPsecEnable"] = true
 	} else {
-		data.Data["EnableIPsec"] = false
+		if bootstrapResult.OVN.ExistingIPsecDaemonset != nil {
+			// IPsec has previously started and
+			// now it has been requested to be disabled
+			data.Data["OVNIPsecDaemonsetEnable"] = true
+			data.Data["OVNIPsecEnable"] = false
+		} else {
+			// IPsec has never started
+			data.Data["OVNIPsecDaemonsetEnable"] = false
+			data.Data["OVNIPsecEnable"] = false
+		}
 	}
 
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/ovn-kubernetes"), &data)
@@ -215,10 +234,7 @@ func isOVNKubernetesChangeSafe(prev, next *operv1.NetworkSpec) []error {
 			errs = append(errs, errors.Errorf("cannot edit a running hybrid overlay network"))
 		}
 	}
-	if pn.IPsecConfig == nil && nn.IPsecConfig != nil {
-		errs = append(errs, errors.Errorf("cannot enable IPsec after install time"))
-	}
-	if pn.IPsecConfig != nil {
+	if pn.IPsecConfig != nil && nn.IPsecConfig != nil {
 		if !reflect.DeepEqual(pn.IPsecConfig, nn.IPsecConfig) {
 			errs = append(errs, errors.Errorf("cannot edit IPsec configuration at runtime"))
 		}
@@ -376,12 +392,23 @@ func bootstrapOVN(conf *operv1.Network, kubeClient client.Client) (*bootstrap.Bo
 		}
 	}
 
+	ipsecDS := &appsv1.DaemonSet{}
+	nsn = types.NamespacedName{Namespace: "openshift-ovn-kubernetes", Name: "ovn-ipsec"}
+	if err := kubeClient.Get(context.TODO(), nsn, ipsecDS); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("Failed to retrieve existing ipsec DaemonSet: %w", err)
+		} else {
+			ipsecDS = nil
+		}
+	}
+
 	res := bootstrap.BootstrapResult{
 		OVN: bootstrap.OVNBootstrapResult{
 			MasterIPs:               ovnMasterIPs,
 			ClusterInitiator:        clusterInitiator,
 			ExistingMasterDaemonset: masterDS,
 			ExistingNodeDaemonset:   nodeDS,
+			ExistingIPsecDaemonset:  ipsecDS,
 		},
 	}
 	return &res, nil


### PR DESCRIPTION
OVN-Kubernetes IPsec was originally designed to not allow
runtime enable of IPsec as per the enhancment proposal. This
commit removes this restriction.

Signed-off-by: Mark Gray <mark.d.gray@redhat.com>