### PR TITLE
Bug 1927244: Kuryr: Always set worker_nodes_subnets

### DIFF
--- a/bindata/network/kuryr/003-config.yaml
+++ b/bindata/network/kuryr/003-config.yaml
@@ -43,6 +43,9 @@ data:
 
     endpoints_driver_octavia_provider = {{ default "default" .OctaviaProvider }}
 
+    [pod_vif_nested]
+    worker_nodes_subnets = {{ .WorkerNodesSubnets }}
+
     [octavia_defaults]
     member_mode = {{ default "L3" .OctaviaMemberMode }}
     sg_mode = {{ default "update" .OctaviaSGMode }}

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -10,6 +10,7 @@ type KuryrBootstrapResult struct {
 	ServiceSubnet            string
 	PodSubnetpool            string
 	WorkerNodesRouter        string
+	WorkerNodesSubnets       []string
 	NodesNetworkMTU          int
 	PodSecurityGroups        []string
 	ExternalNetwork          string

--- a/pkg/network/kuryr.go
+++ b/pkg/network/kuryr.go
@@ -47,6 +47,7 @@ func renderKuryr(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapR
 	data.Data["ResourceTags"] = "openshiftClusterID=" + b.ClusterID
 	data.Data["PodSecurityGroups"] = strings.Join(b.PodSecurityGroups, ",")
 	data.Data["WorkerNodesRouter"] = b.WorkerNodesRouter
+	data.Data["WorkerNodesSubnets"] = strings.Join(b.WorkerNodesSubnets, ",")
 	data.Data["PodSubnetpool"] = b.PodSubnetpool
 	data.Data["ServiceSubnet"] = b.ServiceSubnet
 	data.Data["ExternalNetwork"] = b.ExternalNetwork

--- a/pkg/platform/openstack/kuryr_bootstrap.go
+++ b/pkg/platform/openstack/kuryr_bootstrap.go
@@ -703,6 +703,7 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient client.Client) (*bootst
 			ServiceSubnet:            svcSubnetId,
 			PodSubnetpool:            podSubnetpoolId,
 			WorkerNodesRouter:        routerId,
+			WorkerNodesSubnets:       []string{workerSubnet.ID},
 			NodesNetworkMTU:          mtu,
 			PodSecurityGroups:        []string{podSgId},
 			ExternalNetwork:          externalNetwork,


### PR DESCRIPTION
Turns out in UPI there are no Machine objects so we still need to
manually tell Kuryr the ID of the Neutron subnet the masters and workers
are running in. This commit makes sure that's done.