### PR TITLE
config: Set enable-profiling true by default and allow `enable-profiling` as a proxy argument

### DIFF
--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -52,6 +52,7 @@ func renderOpenShiftSDN(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Un
 		"healthz-port":            {"10256"},
 		"proxy-mode":              {"iptables"},
 		"iptables-masquerade-bit": {"0"},
+		"enable-profiling":        {"true"},
 	}
 	// For backward compatibility we allow conf to specify `metrics-port: 9101` but
 	// the daemonset always configures 9101 as the secure metrics port and 29101 as

--- a/pkg/network/openshift_sdn_test.go
+++ b/pkg/network/openshift_sdn_test.go
@@ -439,7 +439,7 @@ conntrack:
   tcpCloseWaitTimeout: null
   tcpEstablishedTimeout: null
 detectLocalMode: ""
-enableProfiling: false
+enableProfiling: true
 featureGates:
   EndpointSlice: false
   EndpointSliceProxying: false
@@ -496,7 +496,7 @@ conntrack:
   tcpCloseWaitTimeout: null
   tcpEstablishedTimeout: null
 detectLocalMode: ""
-enableProfiling: false
+enableProfiling: true
 featureGates:
   EndpointSlice: false
   EndpointSliceProxying: false

--- a/pkg/util/k8s/kubeproxy.go
+++ b/pkg/util/k8s/kubeproxy.go
@@ -82,6 +82,8 @@ func GenerateKubeProxyConfiguration(args map[string]operv1.ProxyArgumentList) (s
 	kpc.NodePortAddresses = ka.getCIDRList("node-port-addresses")
 	kpc.FeatureGates = ka.getFeatureGates("feature-gates")
 
+	kpc.EnableProfiling = ka.getBool("enable-profiling")
+
 	if err := ka.getError(); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Turn it on default (protected by RBAC).  Allows a user to configure this post deployment.

Verified we RBAC protect this.  Because it's rbac protected (like kubelet and apiserver) on by default is acceptable.

```
curl https://localhost:9101/debug/pprof -k -H "Authorization: bearer $( oc sa get-token -n openshift-sdn default )"
Handling connection for 9101
Forbidden (user=system:serviceaccount:openshift-sdn:default, verb=get, resource=, subresource=)
```
