### PR TITLE
Bug 1932114: kuryr: Detect Nodes Network MTU

### DIFF
--- a/bindata/network/kuryr/003-config.yaml
+++ b/bindata/network/kuryr/003-config.yaml
@@ -60,7 +60,7 @@ data:
     pod_security_groups = {{ default "default" .PodSecurityGroups }}
     resource_tags = {{ default "" .ResourceTags }}
     external_svc_net = {{ .ExternalNetwork }}
-    #network_device_mtu = 1500
+    network_device_mtu = {{ .NodesNetworkMTU }}
 
     [neutron]
     auth_type = {{ default "password" .OpenStackCloud.AuthType }}

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -9,6 +9,7 @@ type KuryrBootstrapResult struct {
 	PodSubnetpool            string
 	WorkerNodesRouter        string
 	WorkerNodesSubnet        string
+	NodesNetworkMTU          int
 	PodSecurityGroups        []string
 	ExternalNetwork          string
 	ClusterID                string

--- a/pkg/network/kuryr.go
+++ b/pkg/network/kuryr.go
@@ -112,6 +112,9 @@ func renderKuryr(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapR
 	data.Data["WebhookCert"] = b.WebhookCert
 	data.Data["WebhookKey"] = b.WebhookKey
 
+	// Nodes Network MTU
+	data.Data["NodesNetworkMTU"] = b.NodesNetworkMTU
+
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/kuryr"), &data)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to render manifests")

--- a/pkg/platform/openstack/kuryr_bootstrap.go
+++ b/pkg/platform/openstack/kuryr_bootstrap.go
@@ -330,6 +330,11 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient client.Client) (*bootst
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find worker nodes subnet")
 	}
+	mtu, err := getOpenStackNetworkMTU(client, workerSubnet.NetworkID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get network MTU")
+	}
+	log.Printf("Found Nodes Network MTU %d", mtu)
 
 	log.Printf("Found worker nodes subnet %s", workerSubnet.ID)
 	router, err := ensureOpenStackRouter(client, generateName("external-router", clusterID), tag, workerSubnet.NetworkID)
@@ -642,6 +647,7 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient client.Client) (*bootst
 			PodSubnetpool:            podSubnetpoolId,
 			WorkerNodesRouter:        routerId,
 			WorkerNodesSubnet:        workerSubnet.ID,
+			NodesNetworkMTU:          mtu,
 			PodSecurityGroups:        []string{podSgId},
 			ExternalNetwork:          externalNetwork,
 			ClusterID:                clusterID,

--- a/pkg/platform/openstack/networking.go
+++ b/pkg/platform/openstack/networking.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/mtu"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools"
@@ -112,6 +113,21 @@ func findOpenStackNetwork(client *gophercloud.ServiceClient, tag string) (networ
 	} else {
 		return empty, errors.New("multiple matching networks")
 	}
+}
+
+// Gets the MTU of a Network
+func getOpenStackNetworkMTU(client *gophercloud.ServiceClient, networkID string) (int, error) {
+	networkMTU := 0
+	type NetworkMTU struct {
+		networks.Network
+		mtu.NetworkMTUExt
+	}
+	var mtu NetworkMTU
+	err := networks.Get(client, networkID).ExtractInto(&mtu)
+	if err != nil {
+		return networkMTU, errors.Wrap(err, "failed to extract network MTU")
+	}
+	return mtu.MTU, nil
 }
 
 // Looks for a Neutron subnet by name and tag. In case of not found, looks for a

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/mtu/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/mtu/requests.go
@@ -1,0 +1,87 @@
+package mtu
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+)
+
+// ListOptsExt adds an MTU option to the base ListOpts.
+type ListOptsExt struct {
+	networks.ListOptsBuilder
+
+	// The maximum transmission unit (MTU) value to address fragmentation.
+	// Minimum value is 68 for IPv4, and 1280 for IPv6.
+	MTU int `q:"mtu"`
+}
+
+// ToNetworkListQuery adds the router:external option to the base network
+// list options.
+func (opts ListOptsExt) ToNetworkListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts.ListOptsBuilder)
+	if err != nil {
+		return "", err
+	}
+
+	params := q.Query()
+	if opts.MTU > 0 {
+		params.Add("mtu", fmt.Sprintf("%d", opts.MTU))
+	}
+
+	q = &url.URL{RawQuery: params.Encode()}
+	return q.String(), err
+}
+
+// CreateOptsExt adds an MTU option to the base Network CreateOpts.
+type CreateOptsExt struct {
+	networks.CreateOptsBuilder
+
+	// The maximum transmission unit (MTU) value to address fragmentation.
+	// Minimum value is 68 for IPv4, and 1280 for IPv6.
+	MTU int `json:"mtu,omitempty"`
+}
+
+// ToNetworkCreateMap adds an MTU to the base network creation options.
+func (opts CreateOptsExt) ToNetworkCreateMap() (map[string]interface{}, error) {
+	base, err := opts.CreateOptsBuilder.ToNetworkCreateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.MTU == 0 {
+		return base, nil
+	}
+
+	networkMap := base["network"].(map[string]interface{})
+	networkMap["mtu"] = opts.MTU
+
+	return base, nil
+}
+
+// CreateOptsExt adds an MTU option to the base Network UpdateOpts.
+type UpdateOptsExt struct {
+	networks.UpdateOptsBuilder
+
+	// The maximum transmission unit (MTU) value to address fragmentation.
+	// Minimum value is 68 for IPv4, and 1280 for IPv6.
+	MTU int `json:"mtu,omitempty"`
+}
+
+// ToNetworkUpdateMap adds an MTU to the base network uptade options.
+func (opts UpdateOptsExt) ToNetworkUpdateMap() (map[string]interface{}, error) {
+	base, err := opts.UpdateOptsBuilder.ToNetworkUpdateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.MTU == 0 {
+		return base, nil
+	}
+
+	networkMap := base["network"].(map[string]interface{})
+	networkMap["mtu"] = opts.MTU
+
+	return base, nil
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/mtu/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/mtu/results.go
@@ -1,0 +1,8 @@
+package mtu
+
+// NetworkMTUExt represents an extended form of a Network with additional MTU field.
+type NetworkMTUExt struct {
+	// The maximum transmission unit (MTU) value to address fragmentation.
+	// Minimum value is 68 for IPv4, and 1280 for IPv6.
+	MTU int `json:"mtu"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -71,6 +71,7 @@ github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools
 github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/providers
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers
+github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/mtu
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools


### PR DESCRIPTION
This commit adds the support to detect the Nodes
Network MTU so that the Namespace Networks use the
same MTU as the host.