### PR TITLE
Bug 1933159: The Multus daemonset should handle 10% maxUnavailable 

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -99,6 +99,8 @@ spec:
       app: multus
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       labels:

--- a/bindata/network/network-metrics/001-daemonset.yaml
+++ b/bindata/network/network-metrics/001-daemonset.yaml
@@ -15,6 +15,8 @@ spec:
       app: network-metrics-daemon
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 33%
   template:
     metadata:
       labels:


### PR DESCRIPTION
Being that we have on-host OVS, this shouldn't cause connectivity issues for the nodes to go not ready while Multus upgrades on 10% of the nodes.