### PR TITLE
[SDN-1364] Update CNO for OVN acl audit logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,24 @@ spec:
       ipsecConfig: {}
 ```
 
+#### Configuring Network Policy audit logging with OVNKubernetes 
+
+OVNKubernetes supports audit logging of network policy traffic events.  Add the following to the `spec:` section of the operator config: 
+
+```yaml
+spec:
+  defaultNetwork:
+    type: OVNKubernetes
+    ovnKubernetesConfig: 
+      policyAuditingConfig:
+        maxFileSize: 1
+        rateLimit: 5
+        destination: libc
+        syslogFacility: local0
+```
+
+To understand more about each field, and to see the default values check out the [Openshift api definition](https://github.com/openshift/api/blob/master/operator/v1/types_network.go#L397)
+
 ### Configuring Kuryr-Kubernetes
 Kuryr-Kubernetes is a CNI plugin that uses OpenStack Neutron to network OpenShift Pods, and OpenStack Octavia to create load balancers for Services. In general it is useful when OpenShift is running on an OpenStack cluster, as you can use the same SDN (OpenStack Neutron) to provide networking for both the VMs OpenShift is running on, and the Pods created by OpenShift. In such case avoidance of double encapsulation gives you two advantages: improved performace (in terms of both latency and throughput) and lower complexity of the networking architecture.
 

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -835,7 +835,8 @@ spec:
             --nbctl-daemon-mode \
             --nb-cert-common-name "{{.OVN_CERT_CN}}" \
             --enable-multicast \
-            --disable-snat-multiple-gws
+            --disable-snat-multiple-gws \
+            --acl-logging-rate-limit "{{.OVNPolicyAuditRateLimit}}"
         lifecycle:
           preStop:
             exec:

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -48,12 +48,18 @@ spec:
             set -o allexport
             source "/env/${K8S_NODE}"
             set +o allexport
-          fi
+          fi  
+          
           echo "$(date -Iseconds) - starting ovn-controller"
           exec ovn-controller unix:/var/run/openvswitch/db.sock -vfile:off \
             --no-chdir --pidfile=/var/run/ovn/ovn-controller.pid \
+            --syslog-method="{{.OVNPolicyAuditDestination}}" \
+            --log-file=/var/log/ovn/acl-audit-log.log \
+            -vFACILITY:"{{.OVNPolicyAuditSyslogFacility}}" \
             -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt \
-            -vconsole:"${OVN_LOG_LEVEL}"
+            -vconsole:"${OVN_LOG_LEVEL}" -vconsole:"acl_log:off" \
+            -vsyslog:"acl_log:info" \
+            -vfile:"acl_log:info"
         securityContext:
           privileged: true
         env:
@@ -80,12 +86,62 @@ spec:
           name: ovn-cert
         - mountPath: /ovn-ca
           name: ovn-ca
+        - mountPath: /var/log/ovn
+          name: node-log
+        - mountPath: /dev/log
+          name: log-socket
         terminationMessagePolicy: FallbackToLogsOnError
         resources:
           requests:
             cpu: 10m
             memory: 300Mi
+      - name: ovn-acl-logging
+        image: "{{.OvnImage}}"
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -euo pipefail
 
+          # Rotate audit log files when then get to max size (in bytes)
+          MAXFILESIZE=$(( "{{.OVNPolicyAuditMaxFileSize}}"*1000000 )) 
+          LOGFILE=/var/log/ovn/acl-audit-log.log
+          CONTROLLERPID=$(cat /run/ovn/ovn-controller.pid)
+
+          # Redirect err to null so no messages are shown upon rotation
+          tail -F ${LOGFILE} 2> /dev/null &
+
+          while true
+          do
+            # Make sure ovn-controller's logfile exists, and get current size in bytes 
+            if [ -f "$LOGFILE" ]; then 
+              file_size=`du -b ${LOGFILE} | tr -s '\t' ' ' | cut -d' ' -f1`
+            else 
+              ovs-appctl -t /var/run/ovn/ovn-controller.${CONTROLLERPID}.ctl vlog/reopen
+              file_size=`du -b ${LOGFILE} | tr -s '\t' ' ' | cut -d' ' -f1`
+            fi 
+            
+            if [ $file_size -gt $MAXFILESIZE ];then
+              echo "Rotating OVN ACL Log File"
+              timestamp=`date '+%Y-%m-%dT%H-%M-%S'`
+              mv ${LOGFILE} /var/log/ovn/acl-audit-log.$timestamp.log
+              ovs-appctl -t /run/ovn/ovn-controller.${CONTROLLERPID}.ctl vlog/reopen
+              CONTROLLERPID=$(cat /run/ovn/ovn-controller.pid)
+            fi
+
+            # sleep for 30 seconds to avoid wasting CPU 
+            sleep 30 
+          done
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/log/ovn
+          name: node-log
+        - mountPath: /run/ovn/
+          name: run-ovn
       - name: kube-rbac-proxy
         image: {{.KubeRBACProxyImage}}
         command:
@@ -138,7 +194,6 @@ spec:
         - name: ovn-node-metrics-cert
           mountPath: /etc/pki/tls/metrics-cert
           readOnly: True
-
       # ovnkube-node: does node-level bookkeeping and configuration
       - name: ovnkube-node
         image: "{{.OvnImage}}"
@@ -329,6 +384,13 @@ spec:
       - name: run-ovn
         hostPath:
           path: /var/run/ovn
+      # Used for placement of ACL audit logs 
+      - name: node-log
+        hostPath: 
+          path: /var/log/ovn
+      - name: log-socket
+        hostPath: 
+          path: /dev/log
       # For CNI server
       - name: host-run-ovn-kubernetes
         hostPath:

--- a/go.sum
+++ b/go.sum
@@ -462,8 +462,6 @@ github.com/openshift/api v0.0.0-20201019163320-c6a5ec25f267 h1:d6qOoblJz8DjQ44PR
 github.com/openshift/api v0.0.0-20201019163320-c6a5ec25f267/go.mod h1:RDvBcRQMGLa3aNuDuejVBbTEQj/2i14NXdpOLqbNBvM=
 github.com/openshift/api v0.0.0-20201214114959-164a2fb63b5f h1:MhuCP7+M9hmUnZaz6EwOh3+W6FQp+BezIXbL99Q4xq4=
 github.com/openshift/api v0.0.0-20201214114959-164a2fb63b5f/go.mod h1:aqU5Cq+kqKKPbDMqxo9FojgDeSpNJI7iuskjXjtojDg=
-github.com/openshift/api v0.0.0-20210304195353-475eac5412b1 h1:u+npe3/OgwWfttikHLgI2+fnb4BgtL0KIBc7VHvMF0I=
-github.com/openshift/api v0.0.0-20210304195353-475eac5412b1/go.mod h1:aqU5Cq+kqKKPbDMqxo9FojgDeSpNJI7iuskjXjtojDg=
 github.com/openshift/api v0.0.0-20210325163602-e37aaed4c278 h1:v36R7Yzq/CvWnYaPM+eh09ffZtmURq0k6gLmyhxOc3c=
 github.com/openshift/api v0.0.0-20210325163602-e37aaed4c278/go.mod h1:aqU5Cq+kqKKPbDMqxo9FojgDeSpNJI7iuskjXjtojDg=
 github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -365,6 +365,12 @@ func TestFillOVNKubernetesDefaults(t *testing.T) {
 			OVNKubernetesConfig: &operv1.OVNKubernetesConfig{
 				MTU:        ptrToUint32(8900),
 				GenevePort: ptrToUint32(6081),
+				PolicyAuditConfig: &operv1.PolicyAuditConfig{
+					RateLimit:      ptrToUint32(20),
+					MaxFileSize:    ptrToUint32(50),
+					Destination:    "null",
+					SyslogFacility: "local0",
+				},
 			},
 		},
 	}
@@ -400,6 +406,12 @@ func TestFillOVNKubernetesDefaultsIPsec(t *testing.T) {
 				MTU:         ptrToUint32(8854),
 				GenevePort:  ptrToUint32(8061),
 				IPsecConfig: &operv1.IPsecConfig{},
+				PolicyAuditConfig: &operv1.PolicyAuditConfig{
+					RateLimit:      ptrToUint32(20),
+					MaxFileSize:    ptrToUint32(50),
+					Destination:    "null",
+					SyslogFacility: "local0",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Changes for [SDN-1364](https://issues.redhat.com/browse/SDN-1364)

See [Enhancement](https://github.com/openshift/enhancements/pull/617) for
details on the changes

1. Allows `ovn-kubernetes.go` to digest the new API changes 

2. Adds a new sidecar container to the `ocnkube-node` daemonset named acl-audit-logging
It does the following 
        - Pipes the audit logs(which are persisted to the node at `var/log/ovn/` ) to stdout so they can be consumed by the logging 
          stack if desired 
        - Handles log rotation since COREOS doesn't include logrotate modules
