### PR TITLE
OSD-6600 network-metrics missing priorityClass

### DIFF
--- a/bindata/network/network-metrics/001-daemonset.yaml
+++ b/bindata/network/network-metrics/001-daemonset.yaml
@@ -25,6 +25,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      priorityClassName: "system-node-critical"
       tolerations:
         - operator: Exists
       containers:


### PR DESCRIPTION
This PR configures the network-metrics DS to use the system-node-critical
priorityClass. This is a result of layered products on OSD/OCP like
RHOAM whom have resource hungry components and have a policyClass set at
1000000. There have been cases where RHOAM component scheduling is being
prioritized against openshift core components like network-metrics.
This PR resolves this issue and protects core.