### PR TITLE
Bug 1933174: Use 10% for ovs maxUnavailable for rolling update

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -14,6 +14,8 @@ spec:
       app: ovs
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       labels:


### PR DESCRIPTION
default is 1 and can be inefficient with larger clusters

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>