### PR TITLE
Bug 1933179: Use 10% for nw-check-target maxUnavailable

### DIFF
--- a/bindata/network-diagnostics/network-check-target.yaml
+++ b/bindata/network-diagnostics/network-check-target.yaml
@@ -12,6 +12,10 @@ spec:
   selector:
       matchLabels:
         app: network-check-target
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       labels:


### PR DESCRIPTION
rolling update default is 1 and can be inefficient with
larger clusters

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>