### PR TITLE
Bug 1934711: Use 10% for ovnkube-node for maxUnavailable

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -14,6 +14,8 @@ spec:
       app: ovnkube-node
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       labels:


### PR DESCRIPTION
rolling update default is 1 and can be inefficient with
larger clusters

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>