### PR TITLE
sdn: Add list/watch RBAC for endpointslices to openshift-sdn

### DIFF
--- a/bindata/network/openshift-sdn/002-rbac.yaml
+++ b/bindata/network/openshift-sdn/002-rbac.yaml
@@ -24,6 +24,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
 - apiGroups: [""]
   resources:
   - nodes


### PR DESCRIPTION
The SDN pod will need to read these, like ovn already does.

Prereq for testing https://github.com/openshift/sdn/pull/271