### PR TITLE
Bug 1937005: kuryr/alerts: change the rule for free count

### DIFF
--- a/bindata/network/kuryr/alert-rules.yaml
+++ b/bindata/network/kuryr/alert-rules.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         message: Running out of quota for {{"{{"}} $labels.resource {{"}}"}}.
       expr: |
-        kuryr_quota_free_count < 10
+        kuryr_quota_free_count > 0 and kuryr_quota_free_count < 10
       labels:
         severity: warning
     - alert: InsuficientResourceQuota


### PR DESCRIPTION
In OpenStack world, a quota count of -1 means unlimited.
Therefore we need to change the rule that says "Running out of quota",
and add a condition "kuryr_quota_free_count > 0" so we raise the alert
when the resource is positive and inferior to 10.

BZ#1937005
Signed-off-by: Emilien Macchi <emilien@redhat.com>
