### PR TITLE
Bug 1937306: Set the network-check-source DS update strategy to maxUnavailable 10%

### DIFF
--- a/bindata/network-diagnostics/network-check-source.yaml
+++ b/bindata/network-diagnostics/network-check-source.yaml
@@ -14,6 +14,10 @@ spec:
   selector:
     matchLabels:
       app: network-check-source
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   strategy:
     type: Recreate
   template:


### PR DESCRIPTION
We change this in order to scale better on clusters with large number of nodes.