### PR TITLE
Bug 1937452: Fix golangci-lint violations

### DIFF
--- a/pkg/controller/statusmanager/status_manager_test.go
+++ b/pkg/controller/statusmanager/status_manager_test.go
@@ -1,5 +1,6 @@
 package statusmanager
 
+//nolint:staticcheck
 import (
 	"context"
 	"encoding/json"


### PR DESCRIPTION
This PR fixed golangci-lint violations in status_manager_test.go which
would make all PR fail on the current CI. I'm ignoring staticcheck on
that file rather than ignoring only the specific SA1019 as per this [1]
issue on golangci-lint.

[1] https://github.com/golangci/golangci-lint/issues/741