### PR TITLE
Bug 1933159: network-metrics-daemon should use 33% maxUnavailable

### DIFF
--- a/bindata/network/network-metrics/001-daemonset.yaml
+++ b/bindata/network/network-metrics/001-daemonset.yaml
@@ -15,6 +15,8 @@ spec:
       app: network-metrics-daemon
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 33%
   template:
     metadata:
       labels:


### PR DESCRIPTION
network-metrics-daemon has no impact on availability of the cluster,
but should rollout no more than one third of all pods at a time so
that an upgrade doesn't completely remove the function.

Consistent with direction expressed in openshift/origin#25928