### PR TITLE
Bug 1938920: Set maxUnavailable for ovs-node daemonset

### DIFF
--- a/bindata/network/ovn-kubernetes/006-ovs-node.yaml
+++ b/bindata/network/ovn-kubernetes/006-ovs-node.yaml
@@ -13,6 +13,8 @@ spec:
       app: ovs-node
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       labels:


### PR DESCRIPTION
Default settings are inefficient on larger clusters. This PR changes
~~* `ovnkube-master` maxUnavailable to 33% (one node at a time, third of control plane masters)~~
* `ovs-node` - 10% (as it runs on workers as well)