### PR TITLE
Add support for exporting network flows

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -185,6 +185,16 @@ spec:
             gateway_mode_flags="--gateway-mode local --gateway-interface none"
           fi
 
+          export_network_flows_flags=
+          if [[ -n "${NETFLOW_COLLECTORS}" ]] ; then
+            export_network_flows_flags="--netflow-targets ${NETFLOW_COLLECTORS}"
+          fi
+          if [[ -n "${SFLOW_COLLECTORS}" ]] ; then
+            export_network_flows_flags="$export_network_flows_flags --sflow-targets ${SFLOW_COLLECTORS}"
+          fi
+          if [[ -n "${IPFIX_COLLECTORS}" ]] ; then
+            export_network_flows_flags="$export_network_flows_flags --ipfix-targets ${IPFIX_COLLECTORS}"
+          fi
           exec /usr/bin/ovnkube --init-node "${K8S_NODE}" \
             --nb-address "{{.OVN_NB_DB_LIST}}" \
             --sb-address "{{.OVN_SB_DB_LIST}}" \
@@ -201,7 +211,8 @@ spec:
             --inactivity-probe="${OVN_CONTROLLER_INACTIVITY_PROBE}" \
             ${gateway_mode_flags} \
             --disable-snat-multiple-gws \
-            --metrics-bind-address "127.0.0.1:29103"
+            --metrics-bind-address "127.0.0.1:29103" \
+            ${export_network_flows_flags}
         env:
         # for kubectl
         - name: KUBERNETES_SERVICE_PORT
@@ -212,6 +223,18 @@ spec:
           value: "{{.OVN_CONTROLLER_INACTIVITY_PROBE}}"
         - name: OVN_KUBE_LOG_LEVEL
           value: "4"
+        {{ if .NetFlowCollectors }}
+        - name: NETFLOW_COLLECTORS
+          value: "{{.NetFlowCollectors}}"
+        {{ end }}
+        {{ if .SFlowCollectors }}
+        - name: SFLOW_COLLECTORS
+          value: "{{.SFlowCollectors}}"
+        {{ end }}
+        {{ if .IPFIXCollectors }}
+        - name: IPFIX_COLLECTORS
+          value: "{{.IPFIXCollectors}}"
+        {{ end }}
         - name: K8S_NODE
           valueFrom:
             fieldRef:

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -81,6 +81,9 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["LISTEN_DUAL_STACK"] = listenDualStack(bootstrapResult.OVN.MasterIPs[0])
 	data.Data["OVN_CERT_CN"] = OVN_CERT_CN
 	data.Data["OVN_NORTHD_PROBE_INTERVAL"] = os.Getenv("OVN_NORTHD_PROBE_INTERVAL")
+	data.Data["NetFlowCollectors"] = ""
+	data.Data["SFlowCollectors"] = ""
+	data.Data["IPFIXCollectors"] = ""
 
 	var ippools string
 	for _, net := range conf.ClusterNetwork {
@@ -133,6 +136,31 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 			// IPsec has never started
 			data.Data["OVNIPsecDaemonsetEnable"] = false
 			data.Data["OVNIPsecEnable"] = false
+		}
+	}
+
+	exportNetworkFlows := conf.ExportNetworkFlows
+	if exportNetworkFlows != nil {
+		if exportNetworkFlows.NetFlow != nil {
+			var collectors strings.Builder
+			for _, v := range exportNetworkFlows.NetFlow.Collectors {
+				collectors.WriteString(string(v) + ",")
+			}
+			data.Data["NetFlowCollectors"] = strings.TrimSuffix(collectors.String(), ",")
+		}
+		if exportNetworkFlows.SFlow != nil {
+			var collectors strings.Builder
+			for _, v := range exportNetworkFlows.SFlow.Collectors {
+				collectors.WriteString(string(v) + ",")
+			}
+			data.Data["SFlowCollectors"] = strings.TrimSuffix(collectors.String(), ",")
+		}
+		if exportNetworkFlows.IPFIX != nil {
+			var collectors strings.Builder
+			for _, v := range exportNetworkFlows.IPFIX.Collectors {
+				collectors.WriteString(string(v) + ",")
+			}
+			data.Data["IPFIXCollectors"] = strings.TrimSuffix(collectors.String(), ",")
 		}
 	}
 


### PR DESCRIPTION
This change allows to export network flows metadata by using
NetFlow/SFlow/IPFIX in OVN-Kubernetes clusters.
In order to use it:

* oc edit networks.operator.openshift.io
* Add exportNetworkFlows options as depicted in
https://github.com/openshift/api/pull/846.