### PR TITLE
ovn/ipsec: set maxUnavailable to 10%

### DIFF
--- a/bindata/network/ovn-kubernetes/ipsec.yaml
+++ b/bindata/network/ovn-kubernetes/ipsec.yaml
@@ -14,6 +14,8 @@ spec:
       app: ovn-ipsec
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       labels:


### PR DESCRIPTION
Fixes issues with:

```
:  [sig-arch] Managed cluster should only include cluster daemonsets that  have maxUnavailable update of 10 or 33 percent  [Suite:openshift/conformance/parallel] expand_less
fail [github.com/onsi/ginkgo@v4.7.0-origin.0+incompatible/internal/leafnodes/runner.go:113]: Mar 16 14:14:30.850: Daemonsets found that do not meet platform requirements for update strategy:
  expected daemonset openshift-ovn-kubernetes/ovn-ipsec to have maxUnavailable 10% or 33% (see comment) instead of 1
```

eg https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-network-operator/1023/pull-ci-openshift-cluster-network-operator-master-e2e-ovn-ipsec-step-registry/1371816352179818496

@markdgray @trozet @abhat 