### PR TITLE
Bug 1916809: mount node ovs db for multi-gather gather_network_logs

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -31,7 +31,7 @@ spec:
       priorityClassName: "system-node-critical"
       # volumes in all containers:
       # (container) -> (host)
-      # /etc/openvswitch -> /host/etc/openvswitch - ovsdb system id
+      # /etc/openvswitch -> /etc/openvswitch - ovsdb system id
       # /var/lib/openvswitch -> /var/lib/openvswitch/data - ovsdb data
       # /run/openvswitch -> tmpfs - ovsdb sockets
       # /env -> configmap env-overrides - debug overrides
@@ -298,7 +298,7 @@ spec:
           path: /var/lib/openvswitch/data
       - name: etc-openvswitch
         hostPath:
-          path: /host/etc/openvswitch
+          path: /etc/openvswitch
       - name: run-openvswitch
         hostPath:
           path: /var/run/openvswitch

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -298,7 +298,7 @@ spec:
           path: /var/lib/openvswitch/data
       - name: etc-openvswitch
         hostPath:
-          path: /var/lib/openvswitch/etc
+          path: /host/etc/openvswitch
       - name: run-openvswitch
         hostPath:
           path: /var/run/openvswitch

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -31,7 +31,7 @@ spec:
       priorityClassName: "system-node-critical"
       # volumes in all containers:
       # (container) -> (host)
-      # /etc/openvswitch -> /var/lib/openvswitch/etc - ovsdb system id
+      # /etc/openvswitch -> /host/etc/openvswitch - ovsdb system id
       # /var/lib/openvswitch -> /var/lib/openvswitch/data - ovsdb data
       # /run/openvswitch -> tmpfs - ovsdb sockets
       # /env -> configmap env-overrides - debug overrides


### PR DESCRIPTION
Description
modify openvswitch mount volume so it will mount ovsdb inside ovn-kube container so it can be consumed by multi-gather tool

Type of change
Enhance debugging of openshift cluster.

How Has This Been Tested?
created Openshift cluster then run

drop in ovnkube node and check the mount is done correctly
[root@ci-ln-kzbqhr2-f76d1-mw92h-worker-d-hnqqd ~]# ls -l /etc/openvswitch/
total 200
-rw-r-----. 1 800 801 129157 Mar 23 14:49 conf.db
-rw-r--r--. 1 800 801    163 Mar 12 23:22 default.conf
-rw-r--r--. 1 800 801     37 Mar 23 12:49 system-id.conf