### PR TITLE
automatic dual-stack conversion

### DIFF
--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -37,6 +37,10 @@ const NonCriticalAnnotation = "networkoperator.openshift.io/non-critical"
 // that executing network migration (switching the default network type of the cluster) is allowed.
 const NetworkMigrationAnnotation = "networkoperator.openshift.io/network-migration"
 
+// NetworkIPFamilyAnnotation is an annotation on the OVN networks.operator.openshift.io daemonsets
+// to indicate the current IP Family mode of the cluster: "single-stack" or "dual-stack"
+const NetworkIPFamilyModeAnnotation = "networkoperator.openshift.io/ip-family-mode"
+
 // OVNRaftClusterInitiator is an annotation on the networks.operator.openshift.io CR to indicate
 // which node IP was the raft cluster initiator. The NB and SB DB will be initialized by the same member.
 const OVNRaftClusterInitiator = "networkoperator.openshift.io/ovn-cluster-initiator"
@@ -126,3 +130,9 @@ const PolicyGroupLabelLegacyValue = "ingress"
 
 // default ingress controller name
 const DefaultIngressControllerName = "default"
+
+// single stack IP family mode
+const IPFamilySingleStack = "single-stack"
+
+// dual stack IP family mode
+const IPFamilyDualStack = "dual-stack"


### PR DESCRIPTION
    OVN kubernetes dual-stack conversion
    
    Add a new annotation to the OVN kubernetes daemonsets, ovnkube-master
    and ovnkube-node, indicating the IP family mode configured:
    - single-stack
    - dual-stack
    
    This annotations allow to automate the conversion of the cluster from
    single-stack to dual-stack and viceversa, since the change in the
    annotation triggers a rollout of the daemonset.
    
    Because the conversion requires to update the master daemonsets first,
    we add the same logic used to manage the versions upgrades to this
    process. The dual-stack conversion also blocks the upgrade, so both
    are exclusive.
    
    Signed-off-by: Antonio Ojea <aojea@redhat.com>