### PR TITLE
Bug 1905331: Set requests on multus components

### DIFF
--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -47,6 +47,7 @@ spec:
         resources:
           requests:
             cpu: 10m
+            memory: 50Mi
         ports:
         - name: metrics-port
           containerPort: 9091

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -120,6 +120,10 @@ spec:
       - name: multus-binary-copy
         image: {{.MultusImage}}
         command: ["/entrypoint/cnibincopy.sh"]
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
         volumeMounts:
         - mountPath: /entrypoint
           name: cni-binary-copy
@@ -192,6 +196,10 @@ spec:
       - name: whereabouts-cni-bincopy
         image: {{.WhereaboutsImage}}
         command: ["/entrypoint/cnibincopy.sh"]
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
         volumeMounts:
         - mountPath: /entrypoint
           name: cni-binary-copy
@@ -307,6 +315,10 @@ spec:
                 sleep 1000000000000
             done
 
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
         volumeMounts:
         - mountPath: /host/opt/cni/bin
           name: cnibin


### PR DESCRIPTION
All containers should make reasonable cpu and memory requests.
Correct a few places where they were still missing.

Supercedes #925 (some of which merged elsewhere)