### PR TITLE
ipsec: Always render IPsec DaemonSet

### DIFF
--- a/bindata/network/ovn-kubernetes/ipsec.yaml
+++ b/bindata/network/ovn-kubernetes/ipsec.yaml
@@ -1,4 +1,3 @@
-{{if .OVNIPsecDaemonsetEnable}}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -274,4 +273,3 @@ spec:
           path: "{{.CNIConfDir}}"
       tolerations:
       - operator: "Exists"
-{{end}}

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -370,11 +370,8 @@ spec:
                   fi
                 fi
 
-                {{ if .OVNIPsecEnable }}
-                ${OVN_NB_CTL} set nb_global . ipsec=true
-                {{ else }}
-                ${OVN_NB_CTL} set nb_global . ipsec=false
-                {{ end }}
+                ${OVN_NB_CTL} set nb_global . ipsec={{ .OVNIPsecEnable }}
+
           preStop:
             exec:
               command:


### PR DESCRIPTION
The IPsec pod is only used for IPsec control plane traffic
(i.e. IKE traffic for configured connections, and monitoring
the OVS Open_vSwitch and Interface table for changes). It
uses very minimal resources when not configured and only
marginally more when configured. The DaemonSet can always be rendered
in order to run the two required daemons and will be configured
when the 'ipsec' field is set to 'true' in the OVN NB database
table.

Signed-off-by: Mark Gray <mark.d.gray@redhat.com>