### PR TITLE
WiP: Kuryr: Support setting neutron availability zones

### DIFF
--- a/bindata/network/kuryr/003-config.yaml
+++ b/bindata/network/kuryr/003-config.yaml
@@ -64,6 +64,7 @@ data:
     resource_tags = {{ default "" .ResourceTags }}
     external_svc_net = {{ .ExternalNetwork }}
     network_device_mtu = {{ .NodesNetworkMTU }}
+    network_availablity_zones = {{ .NetworkAZs }}
 
     [neutron]
     auth_type = {{ default "password" .OpenStackCloud.AuthType }}

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -12,6 +12,7 @@ type KuryrBootstrapResult struct {
 	WorkerNodesRouter        string
 	WorkerNodesSubnets       []string
 	NodesNetworkMTU          int
+	NetworkAZs               []string
 	PodSecurityGroups        []string
 	ExternalNetwork          string
 	ClusterID                string

--- a/pkg/network/kuryr.go
+++ b/pkg/network/kuryr.go
@@ -112,8 +112,9 @@ func renderKuryr(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapR
 	data.Data["WebhookCert"] = b.WebhookCert
 	data.Data["WebhookKey"] = b.WebhookKey
 
-	// Nodes Network MTU
+	// Nodes Network MTU and AZs
 	data.Data["NodesNetworkMTU"] = b.NodesNetworkMTU
+	data.Data["NetworkAZs"] = strings.Join(b.NetworkAZs, ",")
 
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/kuryr"), &data)
 	if err != nil {

--- a/pkg/platform/openstack/kuryr_bootstrap.go
+++ b/pkg/platform/openstack/kuryr_bootstrap.go
@@ -389,13 +389,13 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient client.Client) (*bootst
 	}
 	log.Printf("Found worker nodes subnet %s", workerSubnet.ID)
 
-	mtu, err := getOpenStackNetworkMTU(client, workerSubnet.NetworkID)
+	mtu, azs, err := getOpenStackNetworkMTUAndAZs(client, workerSubnet.NetworkID)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get network MTU")
 	}
-	log.Printf("Found Nodes Network MTU %d", mtu)
+	log.Printf("Found Nodes Network MTU %d and AZs %v", mtu, azs)
 
-	router, err := ensureOpenStackRouter(client, generateName("external-router", clusterID), tag, workerSubnet.NetworkID)
+	router, err := ensureOpenStackRouter(client, generateName("external-router", clusterID), tag, workerSubnet.NetworkID, azs)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find worker nodes router")
 	}


### PR DESCRIPTION
This is required for the deployments at the edge.