### PR TITLE
Kuryr: Update CRDs from upstream

### DIFF
--- a/bindata/network/kuryr/002-crds.yaml
+++ b/bindata/network/kuryr/002-crds.yaml
@@ -563,6 +563,10 @@ spec:
                 type: string
               provider:
                 type: string
+              timeout_client_data:
+                type: integer
+              timeout_member_data:
+                type: integer
           status:
             type: object
             properties:
@@ -590,6 +594,10 @@ spec:
                       type: string
                     protocol:
                       type: string
+                    timeout_client_data:
+                      type: integer
+                    timeout_member_data:
+                      type: integer
               loadbalancer:
                 type: object
                 required:


### PR DESCRIPTION
This includes CRD changes regarding a new upstream feature - being able
to set Octavia listeners timeouts for LBs created to support Services.