### PR TITLE
copy the service network slice

### DIFF
--- a/pkg/network/cluster_config.go
+++ b/pkg/network/cluster_config.go
@@ -97,7 +97,8 @@ func ValidateClusterConfig(clusterConfig configv1.NetworkSpec) error {
 // MergeClusterConfig merges the cluster configuration into the real
 // CRD configuration.
 func MergeClusterConfig(operConf *operv1.NetworkSpec, clusterConf configv1.NetworkSpec) {
-	operConf.ServiceNetwork = clusterConf.ServiceNetwork
+	operConf.ServiceNetwork = make([]string, len(clusterConf.ServiceNetwork))
+	copy(operConf.ServiceNetwork, clusterConf.ServiceNetwork)
 
 	operConf.ClusterNetwork = []operv1.ClusterNetworkEntry{}
 	for _, cnet := range clusterConf.ClusterNetwork {

--- a/pkg/network/cluster_config_test.go
+++ b/pkg/network/cluster_config_test.go
@@ -157,6 +157,26 @@ func TestMergeClusterConfig(t *testing.T) {
 			Type: "None",
 		},
 	}))
+
+	cc.ServiceNetwork = append(cc.ServiceNetwork, "2001:db8::2/64")
+	MergeClusterConfig(&oc, cc)
+	g.Expect(oc).To(Equal(operv1.NetworkSpec{
+		OperatorSpec:   operv1.OperatorSpec{ManagementState: "Managed"},
+		ServiceNetwork: []string{"192.168.0.0/20", "2001:db8::2/64"},
+		ClusterNetwork: []operv1.ClusterNetworkEntry{
+			{
+				CIDR:       "10.0.0.0/22",
+				HostPrefix: 24,
+			},
+			{
+				CIDR:       "10.2.0.0/22",
+				HostPrefix: 23,
+			},
+		},
+		DefaultNetwork: operv1.DefaultNetworkDefinition{
+			Type: "None",
+		},
+	}))
 }
 
 func TestStatusFromConfig(t *testing.T) {


### PR DESCRIPTION
I really don't know if this is a real problem, but it is always better to copy this values instead of passing the references

Signed-off-by: Antonio Ojea <aojea@redhat.com>