### PR TITLE
Bug 1949099: Fix up network-check-target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-cluster-network-operator
-cluster-network-check-endpoints
-cluster-network-check-target
+/cluster-network-operator
+/cluster-network-check-endpoints
+/cluster-network-check-target
 
 # Temporary Build Files
 tmp/_output

--- a/bindata/network-diagnostics/network-check-target.yaml
+++ b/bindata/network-diagnostics/network-check-target.yaml
@@ -42,6 +42,11 @@ spec:
             path: /
           initialDelaySeconds: 30
           timeoutSeconds: 10
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
       serviceAccount: default
       terminationGracePeriodSeconds: 10
       tolerations:


### PR DESCRIPTION
#1046 imported hello-openshift as cluster-network-check-target, but if we're going to have our own copy we should customize it a little...

(the gitignore change fixes spurious error messages where it thinks it's supposed to be ignoring `cmd/cluster-network-check-target/` rather than just the top-level `cluster-network-check-target` binary)