### PR TITLE
Add management workload annotations

### DIFF
--- a/bindata/kube-proxy/000-ns.yaml
+++ b/bindata/kube-proxy/000-ns.yaml
@@ -9,3 +9,4 @@ metadata:
   annotations:
     openshift.io/node-selector: "" #override default node selector
     openshift.io/description: "kubernetes service proxy"
+    workload.openshift.io/allowed: "management"

--- a/bindata/kube-proxy/kube-proxy.yaml
+++ b/bindata/kube-proxy/kube-proxy.yaml
@@ -25,6 +25,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: kube-proxy
         component: network

--- a/bindata/network-diagnostics/000-ns.yaml
+++ b/bindata/network-diagnostics/000-ns.yaml
@@ -4,3 +4,4 @@ metadata:
   name: openshift-network-diagnostics
   annotations:
     openshift.io/node-selector: "" #override default node selector
+    workload.openshift.io/allowed: "management"

--- a/bindata/network-diagnostics/network-check-source.yaml
+++ b/bindata/network-diagnostics/network-check-source.yaml
@@ -18,6 +18,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: network-check-source
         kubernetes.io/os: "linux"

--- a/bindata/network-diagnostics/network-check-target.yaml
+++ b/bindata/network-diagnostics/network-check-target.yaml
@@ -19,6 +19,8 @@ spec:
       maxUnavailable: 10%
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: network-check-target
         kubernetes.io/os: "linux"

--- a/bindata/network/kuryr/000-ns.yaml
+++ b/bindata/network/kuryr/000-ns.yaml
@@ -9,3 +9,4 @@ metadata:
   annotations:
     openshift.io/node-selector: "" #override default node selector
     openshift.io/description: "Kuryr-Kubernetes components"
+    workload.openshift.io/allowed: "management"

--- a/bindata/network/kuryr/005-daemon.yaml
+++ b/bindata/network/kuryr/005-daemon.yaml
@@ -14,6 +14,8 @@ spec:
   template:
     metadata:
       name: kuryr-cni
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: kuryr-cni
         component: network

--- a/bindata/network/kuryr/006-controller.yaml
+++ b/bindata/network/kuryr/006-controller.yaml
@@ -17,6 +17,8 @@ spec:
   template:
     metadata:
       name: kuryr-controller
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: kuryr-controller
         component: network

--- a/bindata/network/kuryr/010-admission-controller.yaml
+++ b/bindata/network/kuryr/010-admission-controller.yaml
@@ -18,6 +18,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: kuryr-dns-admission-controller
         namespace: openshift-kuryr

--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -20,6 +20,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: multus-admission-controller
         namespace: openshift-multus

--- a/bindata/network/multus-networkpolicy/multus-networkpolicy.yaml
+++ b/bindata/network/multus-networkpolicy/multus-networkpolicy.yaml
@@ -18,6 +18,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: multus-networkpolicy
         component: network

--- a/bindata/network/multus/000-ns.yaml
+++ b/bindata/network/multus/000-ns.yaml
@@ -9,3 +9,4 @@ metadata:
   annotations:
     openshift.io/node-selector: "" #override default node selector
     openshift.io/description: "Multus network plugin components"
+    workload.openshift.io/allowed: "management"

--- a/bindata/network/multus/003-dhcp-daemon.yaml
+++ b/bindata/network/multus/003-dhcp-daemon.yaml
@@ -16,6 +16,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: dhcp-daemon
         component: network

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -103,6 +103,8 @@ spec:
       maxUnavailable: 10%
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: multus
         component: network

--- a/bindata/network/network-metrics/001-daemonset.yaml
+++ b/bindata/network/network-metrics/001-daemonset.yaml
@@ -19,6 +19,8 @@ spec:
       maxUnavailable: 33%
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: network-metrics-daemon
         component: network

--- a/bindata/network/openshift-sdn/000-ns.yaml
+++ b/bindata/network/openshift-sdn/000-ns.yaml
@@ -9,3 +9,4 @@ metadata:
   annotations:
     openshift.io/node-selector: "" #override default node selector
     openshift.io/description: "OpenShift SDN components"
+    workload.openshift.io/allowed: "management"

--- a/bindata/network/openshift-sdn/controller.yaml
+++ b/bindata/network/openshift-sdn/controller.yaml
@@ -15,6 +15,8 @@ spec:
       app: sdn-controller
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: sdn-controller
     spec:

--- a/bindata/network/openshift-sdn/openshift-host-network-ns.yaml
+++ b/bindata/network/openshift-sdn/openshift-host-network-ns.yaml
@@ -7,4 +7,5 @@ metadata:
     policy-group.network.openshift.io/host-network: ""
   annotations:
     openshift.io/description: "Namespace for enabling network policy specification for host network traffic. Can be used to allow access to or from host network components"
+    workload.openshift.io/allowed: "management"
 

--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -18,6 +18,8 @@ spec:
       maxUnavailable: 10%
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: ovs
         component: network

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -27,6 +27,8 @@ spec:
       maxUnavailable: 10%
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: sdn
         component: network

--- a/bindata/network/ovn-kubernetes/000-ns.yaml
+++ b/bindata/network/ovn-kubernetes/000-ns.yaml
@@ -9,3 +9,4 @@ metadata:
   annotations:
     openshift.io/node-selector: ""
     openshift.io/description: "OVN Kubernetes components"
+    workload.openshift.io/allowed: "management"

--- a/bindata/network/ovn-kubernetes/006-ovs-node.yaml
+++ b/bindata/network/ovn-kubernetes/006-ovs-node.yaml
@@ -17,6 +17,8 @@ spec:
       maxUnavailable: 10%
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: ovs-node
         component: network

--- a/bindata/network/ovn-kubernetes/ipsec.yaml
+++ b/bindata/network/ovn-kubernetes/ipsec.yaml
@@ -18,6 +18,8 @@ spec:
       maxUnavailable: 10%
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: ovn-ipsec
         component: network

--- a/bindata/network/ovn-kubernetes/openshift-host-network-ns.yaml
+++ b/bindata/network/ovn-kubernetes/openshift-host-network-ns.yaml
@@ -7,4 +7,5 @@ metadata:
     policy-group.network.openshift.io/host-network: ""
   annotations:
     openshift.io/description: "Namespace for enabling network policy specification for host network traffic. Can be used to allow access to or from host network components"
+    workload.openshift.io/allowed: "management"
 

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -36,6 +36,8 @@ spec:
       maxUnavailable: 1
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: ovnkube-master
         ovn-db-pod: "true"

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -18,6 +18,8 @@ spec:
       maxUnavailable: 10%
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: ovnkube-node
         component: network

--- a/manifests/0000_70_cluster-network-operator_00_namespace.yaml
+++ b/manifests/0000_70_cluster-network-operator_00_namespace.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     name: openshift-network-operator
     openshift.io/run-level: "0"

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -15,6 +15,8 @@ spec:
       name: network-operator
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: network-operator
     spec:


### PR DESCRIPTION
In support of the workload partitioning feature
(https://github.com/openshift/enhancements/pull/703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.