### PR TITLE
Bug 1949677: The Multus daemonset should be separate other CNI binary installation

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -11,6 +11,7 @@ metadata:
 data:
   cnibincopy.sh: |-
     #!/bin/bash
+    set -e
 
     DESTINATION_DIRECTORY=/host/opt/cni/bin/
 
@@ -118,22 +119,47 @@ spec:
       tolerations:
       - operator: Exists
       serviceAccountName: multus
-      initContainers:
-      - name: multus-binary-copy
+      containers:
+      - name: kube-multus
         image: {{.MultusImage}}
-        command: ["/entrypoint/cnibincopy.sh"]
+        command: [ "/bin/bash", "-ec", "--" ]
+        args:
+          - >
+            /entrypoint/cnibincopy.sh;
+            exec /entrypoint.sh
+            --multus-conf-file=auto
+            --multus-autoconfig-dir=/host/var/run/multus/cni/net.d
+            --multus-kubeconfig-file-host=/etc/kubernetes/cni/net.d/multus.d/multus.kubeconfig
+{{- if eq .DefaultNetworkType "OpenShiftSDN"}}
+            --readiness-indicator-file=/var/run/multus/cni/net.d/80-openshift-network.conf
+{{- else if eq .DefaultNetworkType "OVNKubernetes"}}
+            --readiness-indicator-file=/var/run/multus/cni/net.d/10-ovn-kubernetes.conf
+{{- end}}
+            --cleanup-config-on-exit=true
+            --namespace-isolation=true
+            --multus-log-level=verbose
+            --cni-version=0.3.1
+            --additional-bin-dir=/opt/multus/bin
+            --skip-multus-binary-copy=true
+            - "--global-namespaces=default,openshift-multus,openshift-sriov-network-operator"
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 65Mi
+        securityContext:
+          privileged: true
+        terminationGracePeriodSeconds: 10
         volumeMounts:
         - mountPath: /entrypoint
           name: cni-binary-copy
-        - mountPath: /host/opt/cni/bin
-          name: cnibin
         - mountPath: /host/etc/os-release
           name: os-release
-          readOnly: true
+        - name: system-cni-dir
+          mountPath: /host/etc/cni/net.d
+        - name: multus-cni-dir
+          mountPath: /host/var/run/multus/cni/net.d
+        - name: cnibin
+          mountPath: /host/opt/cni/bin
         env:
         - name: RHEL7_SOURCE_DIRECTORY
           value: "/usr/src/multus-cni/rhel7/bin/"
@@ -141,6 +167,62 @@ spec:
           value: "/usr/src/multus-cni/rhel8/bin/"
         - name: DEFAULT_SOURCE_DIRECTORY
           value: "/usr/src/multus-cni/bin/"
+        - name: KUBERNETES_SERVICE_PORT
+          value: "{{.KUBERNETES_SERVICE_PORT}}"
+        - name: KUBERNETES_SERVICE_HOST
+          value: "{{.KUBERNETES_SERVICE_HOST}}"
+      volumes:
+        - name: system-cni-dir
+          hostPath:
+            path: {{ .SystemCNIConfDir }}
+        - name: multus-cni-dir
+          hostPath:
+            path: {{ .MultusCNIConfDir }}
+        - name: cnibin
+          hostPath:
+            path: {{ .CNIBinDir }}
+        - name: os-release
+          hostPath:
+            path: /etc/os-release
+            type: File
+        - name: cni-binary-copy
+          configMap:
+            name: cni-binary-copy-script
+            defaultMode: 0744
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: multus-additional-cni-plugins
+  namespace: openshift-multus
+  annotations:
+    kubernetes.io/description: |
+      This daemon installs and configures auxiliary CNI plugins on each node.
+    release.openshift.io/version: "{{.ReleaseVersion}}"
+spec:
+  selector:
+    matchLabels:
+      app: multus-additional-cni-plugins
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
+  template:
+    metadata:
+      labels:
+        app: multus-additional-cni-plugins
+        component: network
+        type: infra
+        openshift.io/component: network
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: "system-node-critical"
+      tolerations:
+      - operator: Exists
+      serviceAccountName: multus
+      initContainers:
       - name: egress-router-binary-copy
         image: {{.EgressRouterImage}}
         command: ["/entrypoint/cnibincopy.sh"]
@@ -340,44 +422,19 @@ spec:
         - name: WHEREABOUTS_NAMESPACE
           value: "openshift-multus"
       containers:
-      - name: kube-multus
+      - name: kube-multus-additional-cni-plugins
         image: {{.MultusImage}}
-        command: ["/entrypoint.sh"]
+        command: [ "/bin/bash", "-ec", "--" ]
         args:
-        - "--multus-conf-file=auto"
-        - "--multus-autoconfig-dir=/host/var/run/multus/cni/net.d"
-        - "--multus-kubeconfig-file-host=/etc/kubernetes/cni/net.d/multus.d/multus.kubeconfig"
-{{- if eq .DefaultNetworkType "OpenShiftSDN"}}
-        - "--readiness-indicator-file=/var/run/multus/cni/net.d/80-openshift-network.conf"
-{{- else if eq .DefaultNetworkType "OVNKubernetes"}}
-        - "--readiness-indicator-file=/var/run/multus/cni/net.d/10-ovn-kubernetes.conf"
-{{- end}}
-        - "--cleanup-config-on-exit=true"
-        - "--namespace-isolation=true"
-        - "--multus-log-level=verbose"
-        - "--cni-version=0.3.1"
-        - "--additional-bin-dir=/opt/multus/bin"
-        - "--skip-multus-binary-copy=true"
-        - "--global-namespaces=default,openshift-multus,openshift-sriov-network-operator"
+          - >
+            trap : TERM INT; sleep infinity & wait
         resources:
           requests:
             cpu: 10m
-            memory: 150Mi
+            memory: 10Mi
         securityContext:
           privileged: true
         terminationGracePeriodSeconds: 10
-        volumeMounts:
-        - name: system-cni-dir
-          mountPath: /host/etc/cni/net.d
-        - name: multus-cni-dir
-          mountPath: /host/var/run/multus/cni/net.d
-        - name: cnibin
-          mountPath: /host/opt/cni/bin
-        env:
-        - name: KUBERNETES_SERVICE_PORT
-          value: "{{.KUBERNETES_SERVICE_PORT}}"
-        - name: KUBERNETES_SERVICE_HOST
-          value: "{{.KUBERNETES_SERVICE_HOST}}"
       volumes:
         - name: system-cni-dir
           hostPath:

--- a/pkg/network/multus_test.go
+++ b/pkg/network/multus_test.go
@@ -50,7 +50,7 @@ func TestRenderMultus(t *testing.T) {
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "multus")))
 
 	// It's important that the namespace is first
-	g.Expect(len(objs)).To(Equal(19))
+	g.Expect(len(objs)).To(Equal(20))
 	g.Expect(objs[0]).To(HaveKubernetesID("CustomResourceDefinition", "", "network-attachment-definitions.k8s.cni.cncf.io"))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("Namespace", "", "openshift-multus")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "multus")))

--- a/pkg/network/network_metrics_test.go
+++ b/pkg/network/network_metrics_test.go
@@ -50,7 +50,7 @@ func TestRenderNetworkMetricsDaemon(t *testing.T) {
 
 	// Check rendered object
 
-	g.Expect(len(objs)).To(Equal(19))
+	g.Expect(len(objs)).To(Equal(20))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "network-metrics-daemon")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("Service", "openshift-multus", "network-metrics-service")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "metrics-daemon-role")))


### PR DESCRIPTION
This separates into two daemonsets, one for Multus itself, and one for all other CNI binary and configuration installation.

The goal is to improve the time it takes a node to become ready, as images are pulled serially.