### PR TITLE
Bug 1942555: Rely on status for ingress controller for endpointPublishingStrategy

### DIFF
--- a/pkg/controller/ingressconfig/ingressconfig_controller.go
+++ b/pkg/controller/ingressconfig/ingressconfig_controller.go
@@ -91,8 +91,8 @@ func (r *ReconcileIngressConfigs) Reconcile(request reconcile.Request) (reconcil
 		log.Printf("Unable to retrieve IngressController.operator.openshift.io object: %v", err)
 		return reconcile.Result{}, err
 	}
-	addLabel := ingressControllerConfig.Spec.EndpointPublishingStrategy != nil &&
-		ingressControllerConfig.Spec.EndpointPublishingStrategy.Type == operv1.HostNetworkStrategyType
+	addLabel := ingressControllerConfig.Status.EndpointPublishingStrategy != nil &&
+		ingressControllerConfig.Status.EndpointPublishingStrategy.Type == operv1.HostNetworkStrategyType
 
 	err = r.updatePolicyGroupLabelOnNamespace(names.HostNetworkNamespace, addLabel)
 	if err != nil {


### PR DESCRIPTION
The default ingress config controller on certain platforms such as
vsphere and baremetal implicitly has HostNetwork as endpoint
publishing strategy. So the spec for the default controller on these
platforms will not have an endpointPublishingStrategy object. But
the reconciled object's status fields show the right value for the
type. This change is to rely on status field than the spec field
for setting the host-network traffic related labels.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>