### PR TITLE
Bug 1951158: Fix egress-router-cni CRD parsing

### DIFF
--- a/bindata/egress-router/000-nad.yaml
+++ b/bindata/egress-router/000-nad.yaml
@@ -13,13 +13,13 @@ spec:
     "name": "egress-router-cni-nad",
     "ip": {
       "addresses": [
-        "{{.Addresses}}"
+        "{{.Addresses}}/24"
         ],
       "destinations": [
-        "{{.AllowedDestinations}}"
+      {{range $i, $val := .AllowedDestinations}}{{if $i}},{{end}}{{if and ($val.Port) ($val.Protocol)}}{{if $val.TargetPort}}"{{$val.Port}} {{$val.Protocol}} {{$val.DestinationIP}}/30 {{$val.TargetPort}}"{{else}}"{{$val.Port}} {{$val.Protocol}} {{$val.DestinationIP}}/30"{{end}}{{else}}"{{$val.DestinationIP}}/30"{{end}}{{end}}
         ],
       "gateway": "{{.Gateway}}"
         },
       "log_file": "/tmp/egress-router-log",
       "log_level": "debug"
-    }'
+      }'

--- a/pkg/controller/egress_router/egress_router_controller.go
+++ b/pkg/controller/egress_router/egress_router_controller.go
@@ -173,7 +173,7 @@ func (r *EgressRouterReconciler) ensureEgressRouter(manifestDir string, namespac
 	data := render.MakeRenderData()
 	data.Data["ReleaseVersion"] = os.Getenv("RELEASE_VERSION")
 	data.Data["EgressRouterNamespace"] = namespace
-	if isItValidCidr(string(router.Spec.Addresses[0].IP)) {
+	if isItValidIPAddress(router.Spec.Addresses[0].IP) {
 		data.Data["Addresses"] = router.Spec.Addresses[0].IP
 	}
 	if isItValidIPAddress(router.Spec.Addresses[0].Gateway) {
@@ -182,7 +182,7 @@ func (r *EgressRouterReconciler) ensureEgressRouter(manifestDir string, namespac
 	data.Data["AllowedDestinations"] = router.Spec.Redirect.RedirectRules
 	data.Data["mode"] = router.Spec.Mode
 	data.Data["network_interfaces"] = router.Spec.NetworkInterface
-	data.Data["EgressRouterPodImage"] = os.Getenv("EGRESS_ROUTER_CNI_IMAGE")
+	data.Data["EgressRouterPodImage"] = "registry.redhat.io/openshift3/ose-pod"
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "egress-router"), &data)
 	if err != nil {
 		return err
@@ -200,15 +200,6 @@ func (r *EgressRouterReconciler) ensureEgressRouter(manifestDir string, namespac
 	}
 
 	return nil
-}
-
-func isItValidCidr(cidr string) bool {
-	_, _, err := net.ParseCIDR(cidr)
-	if err != nil {
-		klog.Error(err)
-		return false
-	}
-	return true
 }
 
 func isItValidIPAddress(ip string) bool {


### PR DESCRIPTION
This PR fixes an issue where parsing from the openshift/api egressrouter
would use an IP instead of a CIDR, and was non-properly detected by the
CNO controller.