### PR TITLE
Rename workload annotations

### DIFF
--- a/bindata/egress-router/001-deployment.yaml
+++ b/bindata/egress-router/001-deployment.yaml
@@ -18,6 +18,7 @@ spec:
       labels:
         app: egress-router-cni
       annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         k8s.v1.cni.cncf.io/networks: egress-router-cni-nad
     spec:
       containers:

--- a/bindata/kube-proxy/kube-proxy.yaml
+++ b/bindata/kube-proxy/kube-proxy.yaml
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: kube-proxy
         component: network

--- a/bindata/network-diagnostics/network-check-source.yaml
+++ b/bindata/network-diagnostics/network-check-source.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: network-check-source
         kubernetes.io/os: "linux"

--- a/bindata/network-diagnostics/network-check-target.yaml
+++ b/bindata/network-diagnostics/network-check-target.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: network-check-target
         kubernetes.io/os: "linux"

--- a/bindata/network/kuryr/005-daemon.yaml
+++ b/bindata/network/kuryr/005-daemon.yaml
@@ -15,7 +15,7 @@ spec:
     metadata:
       name: kuryr-cni
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: kuryr-cni
         component: network

--- a/bindata/network/kuryr/006-controller.yaml
+++ b/bindata/network/kuryr/006-controller.yaml
@@ -18,7 +18,7 @@ spec:
     metadata:
       name: kuryr-controller
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: kuryr-controller
         component: network

--- a/bindata/network/kuryr/010-admission-controller.yaml
+++ b/bindata/network/kuryr/010-admission-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: kuryr-dns-admission-controller
         namespace: openshift-kuryr

--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: multus-admission-controller
         namespace: openshift-multus

--- a/bindata/network/multus-networkpolicy/multus-networkpolicy.yaml
+++ b/bindata/network/multus-networkpolicy/multus-networkpolicy.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: multus-networkpolicy
         component: network

--- a/bindata/network/multus/003-dhcp-daemon.yaml
+++ b/bindata/network/multus/003-dhcp-daemon.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: dhcp-daemon
         component: network

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -104,7 +104,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: multus
         component: network

--- a/bindata/network/network-metrics/001-daemonset.yaml
+++ b/bindata/network/network-metrics/001-daemonset.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: network-metrics-daemon
         component: network

--- a/bindata/network/openshift-sdn/controller.yaml
+++ b/bindata/network/openshift-sdn/controller.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: sdn-controller
     spec:

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: sdn
         component: network

--- a/bindata/network/ovn-kubernetes/ipsec.yaml
+++ b/bindata/network/ovn-kubernetes/ipsec.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: ovn-ipsec
         component: network

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -37,7 +37,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: ovnkube-master
         ovn-db-pod: "true"

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: ovnkube-node
         component: network

--- a/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: network-operator
     spec:

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: network-operator
     spec:


### PR DESCRIPTION
As per https://github.com/openshift/enhancements/pull/739, the workload
annotations names are changing.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>

/hold
Hold until after openshift/kubernetes#632 is merged please