### PR TITLE
Bug 1948582: Allow for local gateway mode to be configured

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -795,13 +795,13 @@ spec:
             set +o allexport
           fi
 
-          gateway_mode_flags=
-          # Check to see if ovs is provided by the node. This is only for upgrade from 4.5->4.6 or
-          # openshift-sdn to ovn-kube conversion
-          if grep -q OVNKubernetes /etc/systemd/system/ovs-configuration.service ; then
+          if [ "{{.OVN_GATEWAY_MODE}}" == "shared" ]; then
             gateway_mode_flags="--gateway-mode shared --gateway-interface br-ex"
+          elif [ "{{.OVN_GATEWAY_MODE}}" == "local" ]; then
+            gateway_mode_flags="--gateway-mode local --gateway-interface br-ex"
           else
-            gateway_mode_flags="--gateway-mode local --gateway-interface none"
+            echo "Invalid OVN_GATEWAY_MODE: \"{{.OVN_GATEWAY_MODE}}\". Must be \"local\" or \"shared\"."
+            exit 1
           fi
 
           # start nbctl daemon for caching

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -233,13 +233,13 @@ spec:
 
           echo "I$(date "+%m%d %H:%M:%S.%N") - starting ovnkube-node db_ip ${db_ip}"
 
-          gateway_mode_flags=
-          # Check to see if ovs is provided by the node. This is only for upgrade from 4.5->4.6 or
-          # openshift-sdn to ovn-kube conversion
-          if grep -q OVNKubernetes /etc/systemd/system/ovs-configuration.service ; then
+          if [ "{{.OVN_GATEWAY_MODE}}" == "shared" ]; then
             gateway_mode_flags="--gateway-mode shared --gateway-interface br-ex"
+          elif [ "{{.OVN_GATEWAY_MODE}}" == "local" ]; then
+            gateway_mode_flags="--gateway-mode local --gateway-interface br-ex"
           else
-            gateway_mode_flags="--gateway-mode local --gateway-interface none"
+            echo "Invalid OVN_GATEWAY_MODE: \"{{.OVN_GATEWAY_MODE}}\". Must be \"local\" or \"shared\"."
+            exit 1
           fi
 
           export_network_flows_flags=

--- a/hack/KIND_CNO.md
+++ b/hack/KIND_CNO.md
@@ -79,6 +79,10 @@ $ IP_FAMILY=ipv6 ovn-kind-cno.sh
 This will build an OVN K8S docker image to use with the deployment from a local git workspace. By default the script will use
 a path relative to your GOPATH. To override this, specify `CNO_PATH` or `OVN_K8S_PATH` when executing the above.
 
+If there is a desire to deploy with `local` gateway mode (default is `shared`), you can modify the `ovn-kind-cno.sh`
+script to create a configMap using the example found [here](./gateway-mode.yaml). Do this as a step right after the
+cluster-config-v1 configMap is created.
+
 ### Post deployment
 
 Post deployment you can simply use kubectl to interact with your cluster. Additionally you may wish to exec into the

--- a/hack/gateway-mode.yaml
+++ b/hack/gateway-mode.yaml
@@ -1,0 +1,10 @@
+# Example ConfigMap to use if wanting to use local gateway mode instead of the default shared mode
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: gateway-mode-config
+    namespace: openshift-network-operator
+data:
+    mode: "local"
+immutable: true
+

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -32,6 +32,7 @@ type OVNBootstrapResult struct {
 	ExistingMasterDaemonset *appsv1.DaemonSet
 	ExistingNodeDaemonset   *appsv1.DaemonSet
 	ExistingIPsecDaemonset  *appsv1.DaemonSet
+	GatewayMode             string
 }
 
 type BootstrapResult struct {


### PR DESCRIPTION
- if a configMap openshift-ovn-kubernetes/gateway-mode-config
  has a value of "local" or "shared", it will be honored. Otherwise
  the default (currently "shared") is used.

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>