### PR TITLE
Bug 1952079: Don't try to disable the EndpointSlice feature gate

### DIFF
--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -60,7 +60,7 @@ func renderOpenShiftSDN(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Un
 	// the value from conf (which we know is either "9101" or unspecified).
 	kpcOverrides := map[string]operv1.ProxyArgumentList{
 		"metrics-port":  {"29101"},
-		"feature-gates": {"EndpointSlice=false,EndpointSliceProxying=false"},
+		"feature-gates": {"EndpointSliceProxying=false"},
 	}
 	if *c.EnableUnidling {
 		// We already validated that proxy-mode was either unset or iptables.

--- a/pkg/network/openshift_sdn_test.go
+++ b/pkg/network/openshift_sdn_test.go
@@ -441,7 +441,6 @@ conntrack:
 detectLocalMode: ""
 enableProfiling: true
 featureGates:
-  EndpointSlice: false
   EndpointSliceProxying: false
 healthzBindAddress: 0.0.0.0:10256
 hostnameOverride: ""
@@ -498,7 +497,6 @@ conntrack:
 detectLocalMode: ""
 enableProfiling: true
 featureGates:
-  EndpointSlice: false
   EndpointSliceProxying: false
 healthzBindAddress: 0.0.0.0:10256
 hostnameOverride: ""


### PR DESCRIPTION
`EndpointSlice` is no longer optional in 1.21. However, the only feature gate we need to disable is `EndpointSliceProxying` anyway.

blocks https://github.com/openshift/sdn/pull/267