### PR TITLE
Bug 1947795: Remove reference to v1beta1 API

### DIFF
--- a/manifests/0000_70_cluster-network-operator_02_rbac.yaml
+++ b/manifests/0000_70_cluster-network-operator_02_rbac.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: default-account-cluster-network-operator
   annotations:


### PR DESCRIPTION
Removing the reference to v1beta1 clusterrolebindings.