### PR TITLE
Bug 1958126: Remove OVN "--disable-snat-multiple-gws" parameter

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -838,7 +838,6 @@ spec:
             --nbctl-daemon-mode \
             --nb-cert-common-name "{{.OVN_CERT_CN}}" \
             --enable-multicast \
-            --disable-snat-multiple-gws \
             --acl-logging-rate-limit "{{.OVNPolicyAuditRateLimit}}"
         lifecycle:
           preStop:

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -267,7 +267,6 @@ spec:
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
             --inactivity-probe="${OVN_CONTROLLER_INACTIVITY_PROBE}" \
             ${gateway_mode_flags} \
-            --disable-snat-multiple-gws \
             --metrics-bind-address "127.0.0.1:29103" \
             ${export_network_flows_flags}
         env:


### PR DESCRIPTION
This parameter was added in https://github.com/openshift/cluster-network-operator/commit/14a5e41bb9b8fedaec0037b8551be4888e0ac821
and scrambles the egress IP feature for OVN-Kubernetes. The reason is
that egress IP for OVN-Kubernetes relies on SNAT-ing pod traffic to the
egress IP on the cluster's GW router when traffic exists the nodes (so
that the server sees the egress IP addresses as source IP addresses). This
flag is used for ICNI traffic where the goal is to SNAT egress traffic
to the pod's IP (so that the server sees the pod IP addresses as source
IP addresses). Naturally, these two features don't go very well
together.

The reason was that we were thinking that customer ** would be moving to
shared GW mode in 4.8 and that we would need to enable ICNI pod SNAT-ing.
This is not the case anymore. And we thus buy ourselves one release to
think of a better solution.

/assign @trozet 
