### PR TITLE
Bug 1959406: ovn-kube: enable pprof on the metrics endpoint

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -825,6 +825,7 @@ spec:
             --ovn-empty-lb-events \
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
             --metrics-bind-address "127.0.0.1:29102" \
+            --metrics-enable-pprof \
             ${gateway_mode_flags} \
             --sb-address "{{.OVN_SB_DB_LIST}}" \
             --sb-client-privkey /ovn-cert/tls.key \

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -269,6 +269,7 @@ spec:
             ${gateway_mode_flags} \
             --disable-snat-multiple-gws \
             --metrics-bind-address "127.0.0.1:29103" \
+            --metrics-enable-pprof \
             ${export_network_flows_flags}
         env:
         # for kubectl


### PR DESCRIPTION
This is 100% safe; the metrics endpoint is behind kube-rbac-proxy.

/cc @dcbw