### PR TITLE
set ovn inactivity_probe to 15s

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -259,7 +259,7 @@ spec:
 
                   # set the connection and disable inactivity probe
                   retries=0
-                  while ! ovn-nbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_NB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe=60000; do
+                  while ! ovn-nbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_NB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe=15000; do
                     (( retries += 1 ))
                   if [[ "${retries}" -gt 40 ]]; then
                     echo "$(date -Iseconds) - ERROR RESTARTING - nbdb - too many failed ovn-nbctl attempts, giving up"
@@ -644,7 +644,7 @@ spec:
 
                   # set the connection and disable inactivity probe
                   retries=0
-                  while ! ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe=60000; do
+                  while ! ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe=15000; do
                     (( retries += 1 ))
                   if [[ "${retries}" -gt 40 ]]; then
                     echo "$(date -Iseconds) - ERROR RESTARTING - sbdb - too many failed ovn-sbctl attempts, giving up"


### PR DESCRIPTION
From ovn-sb man

inactivity_probe: optional integer
    Maximum number of milliseconds of idle time on connection
    to the client before sending an inactivity probe message.
    If Open vSwitch does not communicate with the client for
    the specified number of seconds, it will send a probe. If
    a response is not received for the same additional amount
    of time, Open vSwitch assumes the connection has been
    broken and attempts to reconnect. Default is
    implementation-specific. A value of 0 disables inactivity
    probes.

ovsdb-server will clear the lock once it clears the connection.

Signed-off-by: Antonio Ojea <aojea@redhat.com>