### PR TITLE
Bug 1945333: Backport of maxUnavailable for nw-checks

### DIFF
--- a/bindata/network-diagnostics/network-check-target.yaml
+++ b/bindata/network-diagnostics/network-check-target.yaml
@@ -12,6 +12,10 @@ spec:
   selector:
       matchLabels:
         app: network-check-target
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       labels:


### PR DESCRIPTION
Backporting fix from here https://github.com/openshift/cluster-network-operator/commit/02c6b3e6df7523339774d3381c3d584760dd5ce3#diff-8f4290a3005ea069[%E2%80%A6]ce049190063bface33f56a to 4.7