### PR TITLE
Bug 1954773: update the cno to use the egressfirewall flag

### DIFF
--- a/bindata/network/ovn-kubernetes/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/004-config.yaml
@@ -23,6 +23,7 @@ data:
  
     [ovnkubernetesfeature]
     enable-egress-ip=true
+    enable-egress-firewall=true
 
     [gateway]
     mode=local

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -171,6 +171,7 @@ host-network-namespace="openshift-host-network"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
+enable-egress-firewall=true
 
 [gateway]
 mode=local
@@ -194,6 +195,7 @@ no-hostsubnet-nodes="kubernetes.io/os=windows"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
+enable-egress-firewall=true
 
 [gateway]
 mode=local
@@ -225,6 +227,7 @@ no-hostsubnet-nodes="kubernetes.io/os=windows"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
+enable-egress-firewall=true
 
 [gateway]
 mode=local
@@ -259,6 +262,7 @@ no-hostsubnet-nodes="kubernetes.io/os=windows"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
+enable-egress-firewall=true
 
 [gateway]
 mode=local


### PR DESCRIPTION
ovn-kubernetes has changed to use a flag to enable egressFirewall, the cno needs to use that flag