### PR TITLE
Bug 1962951: enable ovs column diffs feature

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -180,15 +180,6 @@ spec:
             --ovn-nb-db-ssl-cert=/ovn-cert/tls.crt \
             --ovn-nb-db-ssl-ca-cert=/ovn-ca/ca-bundle.crt"
 
-          # if ovsdb supports column diffs, disable them, since they can cause upgrade issues
-          set +e
-          /usr/share/ovn/scripts/ovn-ctl --help 2>&1 | grep -q disable-file-column-diff; RC=$?
-          set -e
-          if [[ "$RC" -eq 0 ]]; then
-            echo "column diffs supported but disabled"
-            OVN_ARGS="${OVN_ARGS} --ovsdb-disable-file-column-diff=yes"
-          fi
-
           CLUSTER_INITIATOR_IP="{{.OVN_DB_CLUSTER_INITIATOR}}"
           echo "$(date -Iseconds) - starting nbdb  CLUSTER_INITIATOR_IP=${CLUSTER_INITIATOR_IP}, K8S_NODE_IP=${K8S_NODE_IP}"
           initial_raft_create=true
@@ -567,15 +558,6 @@ spec:
             --ovn-sb-db-ssl-cert=/ovn-cert/tls.crt \
             --ovn-sb-db-ssl-ca-cert=/ovn-ca/ca-bundle.crt"
 
-          # if ovsdb supports column diffs, disable them, since they can cause upgrade issues
-          set +e
-          /usr/share/ovn/scripts/ovn-ctl --help 2>&1 | grep -q disable-file-column-diff; RC=$?
-          set -e
-          if [[ "$RC" -eq 0 ]]; then
-            echo "column diffs supported but disabled"
-            OVN_ARGS="${OVN_ARGS} --ovsdb-disable-file-column-diff=yes"
-          fi
-          
           CLUSTER_INITIATOR_IP="{{.OVN_DB_CLUSTER_INITIATOR}}"
           echo "$(date -Iseconds) - starting sbdb  CLUSTER_INITIATOR_IP=${CLUSTER_INITIATOR_IP}"
           initial_raft_create=true


### PR DESCRIPTION
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>
enable ovs column diffs feature for release 4.9
Note: after this commit is merged we no longer can downgrade to older releases.
New ovsdb-server will be able to read old database format, but older ovsdb-server will fail to read database created by this new OVS version.

changes in ovs2.15: https://github.com/openvswitch/ovs/blob/0b3ff31d35f56c9401d868613581b4d35bb42724/NEWS#L17
package details : https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1584628