### PR TITLE
Bug 1825219: Fix nil checks in bootstrapSDN

### DIFF
--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -290,12 +290,10 @@ func bootstrapSDN(conf *operv1.Network, kubeClient client.Client) (*bootstrap.Bo
 		return nil, fmt.Errorf("failed to get infrastructure 'config': %v", err)
 	}
 
-	if infraConfig != nil {
-		klog.V(2).Infof("Openshift-SDN: Bootstrap SDN infraConfig Platform: %v ", infraConfig.Status.PlatformStatus.Type)
-		if infraConfig.Status.PlatformStatus.Type != "" {
-			platformType = infraConfig.Status.PlatformStatus.Type
-		}
+	if infraConfig.Status.PlatformStatus != nil {
+		platformType = infraConfig.Status.PlatformStatus.Type
 	}
+	klog.V(2).Infof("Openshift-SDN: Bootstrap SDN infraConfig Platform: %q", platformType)
 
 	res := bootstrap.BootstrapResult{
 		SDN: bootstrap.SDNBootstrapResult{


### PR DESCRIPTION
Follow-up to #1059.

* `pkg/network/openshift_sdn.go` (`bootstrapSDN`): Delete an unnecessary check for nil `infraConfig`.  Check if `infraConfig.Status.PlatformStatus` is nil, which is possible if the cluster was originally installed using OpenShift 4.1 and then upgraded.