### PR TITLE
Bug 1960711: Revert "ipsec: Allow enablement/disablement at runtime"

### DIFF
--- a/bindata/network/ovn-kubernetes/ipsec.yaml
+++ b/bindata/network/ovn-kubernetes/ipsec.yaml
@@ -1,4 +1,4 @@
-{{if .OVNIPsecDaemonsetEnable}}
+{{if .EnableIPsec}}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -372,10 +372,8 @@ spec:
                   fi
                 fi
 
-                {{ if .OVNIPsecEnable }}
+                {{ if .EnableIPsec }}
                 ${OVN_NB_CTL} set nb_global . ipsec=true
-                {{ else }}
-                ${OVN_NB_CTL} set nb_global . ipsec=false
                 {{ end }}
           preStop:
             exec:

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -32,7 +32,6 @@ type OVNBootstrapResult struct {
 	ClusterInitiator        string
 	ExistingMasterDaemonset *appsv1.DaemonSet
 	ExistingNodeDaemonset   *appsv1.DaemonSet
-	ExistingIPsecDaemonset  *appsv1.DaemonSet
 	GatewayMode             string
 	Platform                configv1.PlatformType
 }

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -119,29 +119,10 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 		data.Data["OVNHybridOverlayVXLANPort"] = ""
 	}
 
-	// If IPsec is enabled for the first time, we start the daemonset. If it is
-	// disabled after that, we do not stop the daemonset but only stop IPsec.
-	//
-	// TODO: We need to do this as, by default, we maintain IPsec state on the
-	// node in order to maintain encrypted connectivity in the case of upgrades.
-	// If we only unrender the IPsec daemonset, we will be unable to cleanup
-	// the IPsec state on the node and the traffic will continue to be
-	// encrypted.
 	if c.IPsecConfig != nil {
-		// IPsec is enabled
-		data.Data["OVNIPsecDaemonsetEnable"] = true
-		data.Data["OVNIPsecEnable"] = true
+		data.Data["EnableIPsec"] = true
 	} else {
-		if bootstrapResult.OVN.ExistingIPsecDaemonset != nil {
-			// IPsec has previously started and
-			// now it has been requested to be disabled
-			data.Data["OVNIPsecDaemonsetEnable"] = true
-			data.Data["OVNIPsecEnable"] = false
-		} else {
-			// IPsec has never started
-			data.Data["OVNIPsecDaemonsetEnable"] = false
-			data.Data["OVNIPsecEnable"] = false
-		}
+		data.Data["EnableIPsec"] = false
 	}
 
 	exportNetworkFlows := conf.ExportNetworkFlows
@@ -308,7 +289,10 @@ func isOVNKubernetesChangeSafe(prev, next *operv1.NetworkSpec) []error {
 			errs = append(errs, errors.Errorf("cannot edit a running hybrid overlay network"))
 		}
 	}
-	if pn.IPsecConfig != nil && nn.IPsecConfig != nil {
+	if pn.IPsecConfig == nil && nn.IPsecConfig != nil {
+		errs = append(errs, errors.Errorf("cannot enable IPsec after install time"))
+	}
+	if pn.IPsecConfig != nil {
 		if !reflect.DeepEqual(pn.IPsecConfig, nn.IPsecConfig) {
 			errs = append(errs, errors.Errorf("cannot edit IPsec configuration at runtime"))
 		}
@@ -493,23 +477,12 @@ func bootstrapOVN(conf *operv1.Network, kubeClient client.Client) (*bootstrap.Bo
 		}
 	}
 
-	ipsecDS := &appsv1.DaemonSet{}
-	nsn = types.NamespacedName{Namespace: "openshift-ovn-kubernetes", Name: "ovn-ipsec"}
-	if err := kubeClient.Get(context.TODO(), nsn, ipsecDS); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return nil, fmt.Errorf("Failed to retrieve existing ipsec DaemonSet: %w", err)
-		} else {
-			ipsecDS = nil
-		}
-	}
-
 	res := bootstrap.BootstrapResult{
 		OVN: bootstrap.OVNBootstrapResult{
 			MasterIPs:               ovnMasterIPs,
 			ClusterInitiator:        clusterInitiator,
 			ExistingMasterDaemonset: masterDS,
 			ExistingNodeDaemonset:   nodeDS,
-			ExistingIPsecDaemonset:  ipsecDS,
 			GatewayMode:             gatewayMode,
 		},
 	}


### PR DESCRIPTION
Due to https://bugzilla.redhat.com/1960711, IPsec cannot be enabled
at runtime. IPsec requires an additional 46B overhead for packet headers,
therefore we will need to be able to dynamically adjust the MTU at
runtime before enabling this feature.

This reverts commit 59a50f93ea671564412334ee181c0404588f2cb5.