### PR TITLE
Bug 1954870: Add priorityClass to allow user load to preempt tests

### DIFF
--- a/bindata/network-diagnostics/network-check-source.yaml
+++ b/bindata/network-diagnostics/network-check-source.yaml
@@ -24,6 +24,7 @@ spec:
         app: network-check-source
         kubernetes.io/os: "linux"
     spec:
+      priorityClassName: openshift-user-critical
       serviceAccountName: network-diagnostics
       containers:
       - name: check-endpoints

--- a/bindata/network-diagnostics/network-check-target.yaml
+++ b/bindata/network-diagnostics/network-check-target.yaml
@@ -25,6 +25,7 @@ spec:
         app: network-check-target
         kubernetes.io/os: "linux"
     spec:
+      priorityClassName: openshift-user-critical
       containers:
       - image: "{{.NetworkCheckTargetImage}}"
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Priority classes for all components in openshift namespaces have been mandated and the network-check-source and network-check-target were missing it. This sets the priority to allow these components to be preempted by user workload and OOMKilled.

Signed-off-by: Ben Pickard <bpickard@redhat.com>