### PR TITLE
Bug 1970453: Replace to correct OpenFlow version when replacing flows

### DIFF
--- a/bindata/network/openshift-sdn/sdn-ovs.yaml
+++ b/bindata/network/openshift-sdn/sdn-ovs.yaml
@@ -127,6 +127,11 @@ spec:
             # Load any flows that we saved
             echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Loading previous flows ..." 2>&1
             if [[ -f /var/run/openvswitch/flows.sh ]]; then
+
+              # There's a bug in the ovs-save script which causes flows.sh to specify
+              # OpenFlow14, replace that to OpenFlow13 which is the only version we support.
+              sed -i 's/OpenFlow[0-9][0-9]/OpenFlow13/g' /var/run/openvswitch/flows.sh
+
               echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Adding br0 if it doesn't exist ..." 2>&1
               /usr/bin/ovs-vsctl --may-exist add-br br0 -- set Bridge br0 fail_mode=secure protocols=OpenFlow13
               echo "$(date -u "+%Y-%m-%d %H:%M:%S") info: Created br0, now adding flows ..." 2>&1


### PR DESCRIPTION
The ovs-save script restoring flows when running OVS in a container on 4.6 defaults to OpenFlow14, which is not supported by openshift-sdn. This leads to flow restore errors on upgrades from 4.5 and hence a larger downtime window. See: https://github.com/openshift/sdn/pull/306#issuecomment-849773314

Force the script to use OpenFlow13, which is the only version of OpenFlow openshift-sdn supports.

