### PR TITLE
Bug 1951158: Update egress router CRD from vendor to manifests

### DIFF
--- a/manifests/0000_70_cluster-network-operator_01_egr_crd.yaml
+++ b/manifests/0000_70_cluster-network-operator_01_egr_crd.yaml
@@ -59,9 +59,6 @@ spec:
                       description: IP address of the next-hop gateway, if it cannot be automatically determined. Can be IPv4 or IPv6.
                       type: string
                     ip:
-                      anyOf:
-                      - format: ipv4
-                      - format: ipv6
                       description: IP is the address to configure on the router's interface. Can be IPv4 or IPv6.
                       type: string
                   required:


### PR DESCRIPTION
Copy vendored file to manifests, this was missing in: https://github.com/openshift/cluster-network-operator/pull/1094

/assign @squeed @msherif1234 