### PR TITLE
Bug  1951158: Fix generated JSON format

### DIFF
--- a/bindata/egress-router/000-nad.yaml
+++ b/bindata/egress-router/000-nad.yaml
@@ -15,9 +15,9 @@ spec:
       "addresses": [
         "{{.Addresses}}"
         ],
-      "destinations": "{{.AllowedDestinations}}"
+      "destinations": {{.AllowedDestinations}},
       {{ $fallbackip := .FallbackIP}} {{ if ne $fallbackip "" }}
-        "fallbackIP": "{{$fallbackip}}"
+        "fallbackIP": "{{$fallbackip}}",
       {{ end }}
       "gateway": "{{.Gateway}}"
         },


### PR DESCRIPTION
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>
there was JSON format issue leading to this error

```
0602 19:44:10.396859 1 egress_router_controller.go:228] could not apply egress router object: ApplyObject of (k8s.cni.cncf.io/v1, Kind=NetworkAttachmentDefinition) test2/egress-router-cni-nad was unsuccessful: admission webhook "multus-validating-config.k8s.io" denied the request: configuration string is not in JSON format
E0602 19:44:10.396873 1 egress_router_controller.go:131] ApplyObject of (k8s.cni.cncf.io/v1, Kind=NetworkAttachmentDefinition) test2/egress-router-cni-nad was unsuccessful: admission webhook "multus-validating-config.k8s.io" denied the request: configuration string is not in JSON format
```
used Json linter to find the format issue and confirm the fix
```
{
 	"cniVersion": "0.4.0",
 	"type": "egress-router",
 	"name": "egress-router-cni-nad",
 	"ip": {
 		"addresses": ["192.168.3.10/24"],
 		"destinations": ["65 TCP 203.0.113.25 75", "65535 SCTP 203.0.113.26", "65534 UDP 203.0.113.27"],
 		"fallbackIP": "203.0.113.28",
 		"gateway": "192.168.3.1"
 	},
 	"log_file": "/tmp/egress-router-log",
 	"log_level": "debug"
 }
 ```

Unit-Test: 
created cluster-bot cluster with #1116 and #1117
```
 oc get clusterversion
NAME      VERSION                                                  AVAILABLE   PROGRESSING   SINCE   STATUS
version   4.8.0-0.ci.test-2021-06-02-225626-ci-ln-t5ipd1b-latest   True        False         6m20s   Cluster version is 4.8.0-0.ci.test-2021-06-02-225626-ci-ln-t5ipd1b-latest

oc get network-attachment-definition
NAME                    AGE
egress-router-cni-nad   56s

oc get deployment
NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
egress-router-cni-deployment   0/1     1            0           67s

oc describe network-attachment-definition egress-router-cni-nad
Name:         egress-router-cni-nad
Namespace:    test
Labels:       <none>
Annotations:  release.openshift.io/version: 4.8.0-0.ci.test-2021-06-02-225626-ci-ln-t5ipd1b-latest
API Version:  k8s.cni.cncf.io/v1
Kind:         NetworkAttachmentDefinition
Metadata:
  Creation Timestamp:  2021-06-02T23:44:29Z
  Generation:          1
  Managed Fields:
    API Version:  k8s.cni.cncf.io/v1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .:
          f:release.openshift.io/version:
        f:ownerReferences:
          .:
          k:{"uid":"c16fff19-0427-4938-a21e-d0dbae8bae55"}:
            .:
            f:apiVersion:
            f:controller:
            f:kind:
            f:name:
            f:uid:
      f:spec:
        .:
        f:config:
    Manager:    cluster-network-operator
    Operation:  Update
    Time:       2021-06-02T23:44:29Z
  Owner References:
    API Version:     network.operator.openshift.io/v1
    Controller:      true
    Kind:            EgressRouter
    Name:            egress-router-test
    UID:             c16fff19-0427-4938-a21e-d0dbae8bae55
  Resource Version:  33815
  UID:               4a28f350-1a40-4fcf-b9ef-6258e8f99c19
Spec:
  Config:  { "cniVersion": "0.4.0", "type": "egress-router", "name": "egress-router-cni-nad", "ip": { "addresses": [ "192.168.3.10/24" ], "destinations": ["65 TCP 203.0.113.25 75","65535 SCTP 203.0.113.26","65534 UDP 203.0.113.27"],
"fallbackIP": "203.0.113.28",
"gateway": "192.168.3.1" }, "log_file": "/tmp/egress-router-log", "log_level": "debug" }
Events:  <none>
```

- egress-router cni logs
```
2021-06-02T23:44:31Z [debug] Gateway: 192.168.3.1
2021-06-02T23:44:31Z [debug] IP Source Addresses: [192.168.3.10/24]
2021-06-02T23:44:31Z [debug] IP Destinations: [65 TCP 203.0.113.25 75 65535 SCTP 203.0.113.26 65534 UDP 203.0.13.27]
2021-06-02T23:44:31Z [debug] Created macvlan interface
2021-06-02T23:44:31Z [debug] Renamed macvlan to "net1"
2021-06-02T23:44:31Z [debug] Adding route to gateway 192.168.3.1 on macvlan interface
2021-06-02T23:44:31Z [debug] deleted default route {Ifindex: 3 Dst: <nil> Src: <nil> Gw: 10.128.10.1 Flags: [] able: 254}
2021-06-02T23:44:31Z [debug] Added new default route with gateway 192.168.3.1
2021-06-02T23:44:31Z [debug] Added iptables rule: iptables -t nat PREROUTING -i eth0 -p tcp --dport 65 -j DNAT -to-destination 203.0.113.25:75
2021-06-02T23:44:31Z [debug] Added iptables rule: iptables -t nat PREROUTING -i eth0 -p sctp --dport 65535 -j DAT --to-destination 203.0.113.26
2021-06-02T23:44:31Z [debug] Added iptables rule: iptables -t nat PREROUTING -i eth0 -p udp --dport 65534 -j DNT --to-destination 203.0.113.27
2021-06-02T23:44:31Z [debug] Added iptables rule: iptables -t nat -o net1 -j SNAT --to-source 192.168.3.10
```