### PR TITLE
[release-4.7] Bug 1967388: annotate flowcontrol with `networkoperator.openshift.io/ignore-errors`

### DIFF
--- a/bindata/network/openshift-sdn/006-flowschema.yaml
+++ b/bindata/network/openshift-sdn/006-flowschema.yaml
@@ -4,6 +4,7 @@ metadata:
   name: openshift-sdn
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    networkoperator.openshift.io/ignore-errors: ""
 spec:
   distinguisherMethod:
     type: ByUser

--- a/bindata/network/ovn-kubernetes/007-flowschema.yaml
+++ b/bindata/network/ovn-kubernetes/007-flowschema.yaml
@@ -4,6 +4,7 @@ metadata:
   name: openshift-ovn-kubernetes
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    networkoperator.openshift.io/ignore-errors: ""
 spec:
   distinguisherMethod:
     type: ByUser


### PR DESCRIPTION
PR https://github.com/openshift/cluster-network-operator/pull/920 added flowcontrol to 4.7 with `v1alpha1` and PR https://github.com/openshift/cluster-network-operator/pull/937 bumped flowcontrol on 4.8 to `v1beta1`. Given the kube-apiserver bump between these version, and the fact that a 4.8 kube-apiserver does not support `flowcontrol.apiserver.k8s.io/v1alpha1` at all: all upgrades from 4.7 -> 4.8 result in a degraded network operator (because the network operator upgrades after the kube-apiserver, so we'll have a 4.7 network operator talking to a 4.8 kube-apiserver) - and subsequently a failed upgrade job. 

The original concern with bumping 4.7 flowcontrol to `v1beta1` was: https://bugzilla.redhat.com/show_bug.cgi?id=1913399#c1, but that concerns itself only with 4.7 -> 4.6 downgrades, which are not officially supported (_I believe_). Hence, let's bump 4.7 to `v1beta1`

EDIT: instead of promoting the flowcontrol to `v1beta1` we can annotate it with `networkoperator.openshift.io/ignore-errors` to avoid degrading the CNO during a 4.7 -> 4.8 upgrade. 

