### PR TITLE
Bug 1851549: Backport daemonset to drop icmp frag needed packets received from other nodes in the cluster to Rel 4.6

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -231,6 +231,63 @@ spec:
         - name: sdn-metrics-certs
           mountPath: /etc/pki/tls/metrics-certs
           readOnly: True
+      {{- if .SDNPlatformAzure}}
+      - name: drop-icmp
+        image: {{.SDNImage}}
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -xe
+
+          touch /var/run/add_iptables.sh
+          chmod 0755 /var/run/add_iptables.sh
+          cat <<'EOF' > /var/run/add_iptables.sh
+          #!/bin/sh
+          if [ -z "$3" ]
+          then
+               echo "Called with host address missing, ignore"
+               exit 0
+          fi
+          echo "Adding ICMP drop rule for '$3' "
+          if iptables -C CHECK_ICMP_SOURCE -p icmp -s $3 -j ICMP_ACTION
+          then
+               echo "iptables already set for $3"
+          else
+               iptables -A CHECK_ICMP_SOURCE -p icmp -s $3 -j ICMP_ACTION
+          fi
+          EOF
+
+          echo "I$(date "+%m%d %H:%M:%S.%N") - drop-icmp - start drop-icmp ${K8S_NODE}"
+          iptables -X CHECK_ICMP_SOURCE || true
+          iptables -N CHECK_ICMP_SOURCE || true
+          iptables -F CHECK_ICMP_SOURCE
+          iptables -D INPUT -p icmp --icmp-type fragmentation-needed -j CHECK_ICMP_SOURCE || true
+          iptables -I INPUT -p icmp --icmp-type fragmentation-needed -j CHECK_ICMP_SOURCE
+          iptables -N ICMP_ACTION || true
+          iptables -F ICMP_ACTION
+          iptables -A ICMP_ACTION -j LOG
+          iptables -A ICMP_ACTION -j DROP
+          oc observe pods -n openshift-sdn -l app=sdn -a '{ .status.hostIP }' -- /var/run/add_iptables.sh
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/bash", "-c", "echo drop-icmp done"]
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /
+          name: host-slash
+        resources:
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        env:
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+      {{- end}}
       nodeSelector:
         kubernetes.io/os: linux
       volumes:

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"github.com/gophercloud/utils/openstack/clientconfig"
 
+	configv1 "github.com/openshift/api/config/v1"
 	appsv1 "k8s.io/api/apps/v1"
 )
 
@@ -29,9 +30,17 @@ type OVNBootstrapResult struct {
 	MasterIPs               []string
 	ExistingMasterDaemonset *appsv1.DaemonSet
 	ExistingNodeDaemonset   *appsv1.DaemonSet
+	ExistingIPsecDaemonset  *appsv1.DaemonSet
+	GatewayMode             string
+	Platform                configv1.PlatformType
 }
 
 type BootstrapResult struct {
 	Kuryr KuryrBootstrapResult
 	OVN   OVNBootstrapResult
+	SDN   SDNBootstrapResult
+}
+
+type SDNBootstrapResult struct {
+	Platform configv1.PlatformType
 }

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -186,7 +186,7 @@ func (r *ReconcileOperConfig) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	// Bootstrap any resources
-	bootstrapResult, err := network.Bootstrap(&operConfig.Spec, r.client)
+	bootstrapResult, err := network.Bootstrap(operConfig, r.client)
 	if err != nil {
 		log.Printf("Failed to reconcile platform networking resources: %v", err)
 		r.status.SetDegraded(statusmanager.OperatorConfig, "BootstrapError",

--- a/pkg/network/bootstrap.go
+++ b/pkg/network/bootstrap.go
@@ -9,10 +9,10 @@ import (
 )
 
 // Bootstrap creates resources required by SDN on the cloud.
-func Bootstrap(conf *operv1.NetworkSpec, client client.Client) (*bootstrap.BootstrapResult, error) {
-	switch conf.DefaultNetwork.Type {
+func Bootstrap(conf *operv1.Network, client client.Client) (*bootstrap.BootstrapResult, error) {
+	switch conf.Spec.DefaultNetwork.Type {
 	case operv1.NetworkTypeKuryr:
-		return openstack.BootstrapKuryr(conf, client)
+		return openstack.BootstrapKuryr(&conf.Spec, client)
 	case operv1.NetworkTypeOpenShiftSDN:
 		return bootstrapSDN(conf, client)
 	case operv1.NetworkTypeOVNKubernetes:

--- a/pkg/network/bootstrap.go
+++ b/pkg/network/bootstrap.go
@@ -14,7 +14,7 @@ func Bootstrap(conf *operv1.NetworkSpec, client client.Client) (*bootstrap.Boots
 	case operv1.NetworkTypeKuryr:
 		return openstack.BootstrapKuryr(conf, client)
 	case operv1.NetworkTypeOpenShiftSDN:
-		return nil, nil
+		return bootstrapSDN(conf, client)
 	case operv1.NetworkTypeOVNKubernetes:
 		return boostrapOVN(client)
 	}

--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -278,12 +278,10 @@ func bootstrapSDN(conf *operv1.Network, kubeClient client.Client) (*bootstrap.Bo
 		return nil, fmt.Errorf("failed to get infrastructure 'config': %v", err)
 	}
 
-	if infraConfig != nil {
-		klog.V(2).Infof("Openshift-SDN: Bootstrap SDN infraConfig Platform: %v ", infraConfig.Status.PlatformStatus.Type)
-		if infraConfig.Status.PlatformStatus.Type != "" {
-			platformType = infraConfig.Status.PlatformStatus.Type
-		}
+	if infraConfig.Status.PlatformStatus != nil {
+		platformType = infraConfig.Status.PlatformStatus.Type
 	}
+	klog.V(2).Infof("Openshift-SDN: Bootstrap SDN infraConfig Platform: %q", platformType)
 
 	res := bootstrap.BootstrapResult{
 		SDN: bootstrap.SDNBootstrapResult{

--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -1,6 +1,8 @@
 package network
 
 import (
+	"context"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -9,9 +11,15 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 
+	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
+	types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	configv1 "github.com/openshift/api/config/v1"
 	netv1 "github.com/openshift/api/network/v1"
 	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/render"
@@ -24,7 +32,7 @@ import (
 // - the sdn daemonset
 // - the openvswitch daemonset
 // and some other small things.
-func renderOpenShiftSDN(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Unstructured, error) {
+func renderOpenShiftSDN(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapResult, manifestDir string) ([]*uns.Unstructured, error) {
 	c := conf.DefaultNetwork.OpenShiftSDNConfig
 
 	objs := []*uns.Unstructured{}
@@ -40,6 +48,11 @@ func renderOpenShiftSDN(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Un
 	data.Data["Mode"] = c.Mode
 	data.Data["CNIConfDir"] = pluginCNIConfDir(conf)
 	data.Data["CNIBinDir"] = CNIBinDir
+	if bootstrapResult.SDN.Platform == configv1.AzurePlatformType {
+		data.Data["SDNPlatformAzure"] = true
+	} else {
+		data.Data["SDNPlatformAzure"] = false
+	}
 
 	clusterNetwork, err := clusterNetwork(conf)
 	if err != nil {
@@ -73,6 +86,7 @@ func renderOpenShiftSDN(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Un
 	}
 
 	objs = append(objs, manifests...)
+
 	return objs, nil
 }
 
@@ -253,4 +267,28 @@ func clusterNetwork(conf *operv1.NetworkSpec) (string, error) {
 	}
 
 	return string(cnBuf), nil
+}
+
+func bootstrapSDN(conf *operv1.Network, kubeClient client.Client) (*bootstrap.BootstrapResult, error) {
+
+	var platformType configv1.PlatformType
+
+	infraConfig := &configv1.Infrastructure{}
+	if err := kubeClient.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, infraConfig); err != nil {
+		return nil, fmt.Errorf("failed to get infrastructure 'config': %v", err)
+	}
+
+	if infraConfig != nil {
+		klog.V(2).Infof("Openshift-SDN: Bootstrap SDN infraConfig Platform: %v ", infraConfig.Status.PlatformStatus.Type)
+		if infraConfig.Status.PlatformStatus.Type != "" {
+			platformType = infraConfig.Status.PlatformStatus.Type
+		}
+	}
+
+	res := bootstrap.BootstrapResult{
+		SDN: bootstrap.SDNBootstrapResult{
+			Platform: platformType,
+		},
+	}
+	return &res, nil
 }

--- a/pkg/network/openshift_sdn_test.go
+++ b/pkg/network/openshift_sdn_test.go
@@ -63,7 +63,7 @@ func TestRenderOpenShiftSDN(t *testing.T) {
 
 	// enable openvswitch
 	sdnConfig.UseExternalOpenvswitch = nil
-	objs, err = renderOpenShiftSDN(config, manifestDir)
+	objs, err = renderOpenShiftSDN(config, bootstrapResult, manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-sdn", "ovs")))
 

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -276,7 +276,7 @@ func RenderDefaultNetwork(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.B
 
 	switch dn.Type {
 	case operv1.NetworkTypeOpenShiftSDN:
-		return renderOpenShiftSDN(conf, manifestDir)
+		return renderOpenShiftSDN(conf, bootstrapResult, manifestDir)
 	case operv1.NetworkTypeOVNKubernetes:
 		return renderOVNKubernetes(conf, bootstrapResult, manifestDir)
 	case operv1.NetworkTypeKuryr:


### PR DESCRIPTION
Add daemonset to drop icmp frag needed packets received from other nodes in the cluster
Add logic to SDN to determine what platform we are running on.
Only use drop icmp frag needed daemonset when on Azure platform

Signed-off-by: Michael Cambria <mcambria@redhat.com>
(cherry picked from commit 401ea0cff5c967151e101bd97b4ac63cc46ac3e7)

Bug 1825219: Fix nil checks in bootstrapSDN
(cherry picked from commit 89cf5ffdbb34c0f43b86515e133becf2b92a8c45)
