### PR TITLE
Bug 1968565: Set check-source update strategy

### DIFF
--- a/bindata/network-diagnostics/network-check-source.yaml
+++ b/bindata/network-diagnostics/network-check-source.yaml
@@ -10,12 +10,14 @@ metadata:
     release.openshift.io/version: "{{.ReleaseVersion}}"
     networkoperator.openshift.io/non-critical: ""
 spec:
-  replicas: 1
+  replicas: 1 
   selector:
     matchLabels:
       app: network-check-source
-  strategy:
-    type: Recreate
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate: 
+      maxUnavailable: 10%
   template:
     metadata:
       annotations:


### PR DESCRIPTION
set the update strategy of network-check-source to rolling update with a maxUnavailable of 10% to match network-check-target. This was done to meet the platform requirement that cluster Daemonsets have a rolling update with max unavailable of 10%