### PR TITLE
Bug 1968567: egress router CNI command is missing

### DIFF
--- a/bindata/egress-router/001-deployment.yaml
+++ b/bindata/egress-router/001-deployment.yaml
@@ -24,3 +24,5 @@ spec:
       containers:
         - name: egress-router-cni-pod
           image: "{{.EgressRouterPodImage}}"
+          command: ['/bin/sh', '-c', 'sleep infinity']
+          terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
egress CNI pod command is missing 

Unit-test
```
oc new-project test
```
```
oc create -f test.yaml 
egressrouter.network.operator.openshift.io/egress-router-test created
```
```
oc get all
NAME                                                READY   STATUS    RESTARTS   AGE
pod/egress-router-cni-deployment-5b9f59477d-96t76   1/1     Running   0          13s

NAME                                           READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/egress-router-cni-deployment   1/1     1            1           13s

NAME                                                      DESIRED   CURRENT   READY   AGE
replicaset.apps/egress-router-cni-deployment-5b9f59477d   1         1         1       13s
```
```
oc describe network-attachment-definition egress-router-cni-nad 
Name:         egress-router-cni-nad
Namespace:    test
Labels:       <none>
Annotations:  release.openshift.io/version: 4.8.0-0.ci.test-2021-06-08-194152-ci-ln-3f9y18b-latest
API Version:  k8s.cni.cncf.io/v1
Kind:         NetworkAttachmentDefinition
Metadata:
  Creation Timestamp:  2021-06-08T20:29:38Z
  Generation:          1
  Managed Fields:
    API Version:  k8s.cni.cncf.io/v1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .:
          f:release.openshift.io/version:
        f:ownerReferences:
          .:
          k:{"uid":"0fa2510c-baa8-4576-bb6d-d362d4d6aa91"}:
            .:
            f:apiVersion:
            f:controller:
            f:kind:
            f:name:
            f:uid:
      f:spec:
        .:
        f:config:
    Manager:    cluster-network-operator
    Operation:  Update
    Time:       2021-06-08T20:29:38Z
  Owner References:
    API Version:     network.operator.openshift.io/v1
    Controller:      true
    Kind:            EgressRouter
    Name:            egress-router-test
    UID:             0fa2510c-baa8-4576-bb6d-d362d4d6aa91
  Resource Version:  33982
  UID:               ec2c0658-54c6-4177-b420-8f22da1db5e5
Spec:
  Config:  { "cniVersion": "0.4.0", "type": "egress-router", "name": "egress-router-cni-nad", "ip": { "addresses": [ "192.168.3.10/24" ], "destinations": ["65 TCP 203.0.113.25 75","65535 SCTP 203.0.113.26","65534 UDP 203.0.113.27"],
"fallbackIP": "203.0.113.28",
"gateway": "192.168.3.1" }, "log_file": "/tmp/egress-router-log", "log_level": "debug" }
Events:  <none>

```