### PR TITLE
Bug 1967933: Add network-tools to image-stream

### DIFF
--- a/manifests/image-references
+++ b/manifests/image-references
@@ -62,3 +62,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-network-metrics-daemon:latest
+  - name: network-tools
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-network-tools:latest


### PR DESCRIPTION
We need to reference the network-tools imagestream from an
operator for it to be a part of the payload.