### PR TITLE
Bug 1973770: Reduce SSL sec level for ovsdb connections 

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -76,7 +76,8 @@ spec:
             --pidfile /var/run/ovn/ovn-northd.pid \
             -p /ovn-cert/tls.key \
             -c /ovn-cert/tls.crt \
-            -C /ovn-ca/ca-bundle.crt 
+            -C /ovn-ca/ca-bundle.crt \
+            --ssl-ciphers 'HIGH:!aNULL:!MD5:@SECLEVEL=1'
         env:
         - name: OVN_LOG_LEVEL
           value: info 
@@ -268,7 +269,9 @@ spec:
 
                   # set the connection and disable inactivity probe
                   retries=0
-                  while ! ovn-nbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_NB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe=60000; do
+                  while ! ovn-nbctl --no-leader-only -t 5 set-ssl '' '' '' '' 'HIGH:!aNULL:!MD5:@SECLEVEL=1' \
+                    -- set-connection pssl:{{.OVN_NB_PORT}}{{.LISTEN_DUAL_STACK}} \
+                    -- set connection . inactivity_probe=60000; do
                     (( retries += 1 ))
                   if [[ "${retries}" -gt 40 ]]; then
                     echo "$(date -Iseconds) - ERROR RESTARTING - nbdb - too many failed ovn-nbctl attempts, giving up"
@@ -658,7 +661,9 @@ spec:
 
                   # set the connection and disable inactivity probe
                   retries=0
-                  while ! ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe=60000; do
+                  while ! ovn-sbctl --no-leader-only -t 5 set-ssl '' '' '' '' 'HIGH:!aNULL:!MD5:@SECLEVEL=1' \
+                    -- set-connection pssl:{{.OVN_SB_PORT}}{{.LISTEN_DUAL_STACK}} \
+                    -- set connection . inactivity_probe=60000; do
                     (( retries += 1 ))
                   if [[ "${retries}" -gt 40 ]]; then
                     echo "$(date -Iseconds) - ERROR RESTARTING - sbdb - too many failed ovn-sbctl attempts, giving up"

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -51,6 +51,7 @@ spec:
           exec ovn-controller unix:/var/run/openvswitch/db.sock -vfile:off \
             --no-chdir --pidfile=/var/run/ovn/ovn-controller.pid \
             -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt \
+            --ssl-ciphers 'HIGH:!aNULL:!MD5:@SECLEVEL=1' \
             -vconsole:"${OVN_LOG_LEVEL}"
         securityContext:
           privileged: true


### PR DESCRIPTION
When upgrading from 4.5 to 4.6 the more recent openssl defaults to
stricter security requirements and rejects the use of 1024 bit dh params
when ovn-controller 4.6 tries to connect to sbdb 4.5, blocking the
upgrade.

This patch softens the security requirement back to allow 1024 bit dh
params.

Note that this should not affect once the upgrade is completed and these
connections are among 4.6 components with a recent openssl version on
both sides as this will cause to negotiate a cipher that does not use
fixed dh params.

fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1973770

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>