### PR TITLE
[release-4.6] Bug 1972587: config: Allow enable-profiling to be used to set profiling

### DIFF
--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -53,6 +53,7 @@ func renderOpenShiftSDN(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Un
 		"healthz-port":            {"10256"},
 		"proxy-mode":              {"iptables"},
 		"iptables-masquerade-bit": {"0"},
+		"enable-profiling":        {"true"},
 	}
 
 	kpcOverrides := map[string]operv1.ProxyArgumentList{}

--- a/pkg/network/openshift_sdn_test.go
+++ b/pkg/network/openshift_sdn_test.go
@@ -412,7 +412,7 @@ conntrack:
   tcpCloseWaitTimeout: null
   tcpEstablishedTimeout: null
 detectLocalMode: ""
-enableProfiling: false
+enableProfiling: true
 healthzBindAddress: 0.0.0.0:10256
 hostnameOverride: ""
 iptables:
@@ -465,7 +465,7 @@ conntrack:
   tcpCloseWaitTimeout: null
   tcpEstablishedTimeout: null
 detectLocalMode: ""
-enableProfiling: false
+enableProfiling: true
 healthzBindAddress: 0.0.0.0:10256
 hostnameOverride: ""
 iptables:

--- a/pkg/util/k8s/kubeproxy.go
+++ b/pkg/util/k8s/kubeproxy.go
@@ -81,6 +81,8 @@ func GenerateKubeProxyConfiguration(args map[string]operv1.ProxyArgumentList) (s
 
 	kpc.NodePortAddresses = ka.getCIDRList("node-port-addresses")
 
+	kpc.EnableProfiling = ka.getBool("enable-profiling")
+
 	if err := ka.getError(); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Cherry pick of #988 (#1129 was for 4.7 release)