### PR TITLE
Bug 1975016: Kuryr: Store OpenStack credentials in a secret

### DIFF
--- a/bindata/network/kuryr/003-config.yaml
+++ b/bindata/network/kuryr/003-config.yaml
@@ -65,26 +65,6 @@ data:
     external_svc_net = {{ .ExternalNetwork }}
     network_device_mtu = {{ .PodsNetworkMTU }}
 
-    [neutron]
-    auth_type = {{ default "password" .OpenStackCloud.AuthType }}
-    auth_url = {{ $AuthInfo.AuthURL }}
-    insecure = {{ .OpenStackInsecureAPI }}
-    token = {{ default "\"\"" (iniEscapeCharacters $AuthInfo.Token) }}
-    password = {{ default "\"\"" (iniEscapeCharacters $AuthInfo.Password) }}
-    username = {{ default "\"\"" (iniEscapeCharacters $AuthInfo.Username) }}
-    project_domain_name = {{ default "\"\"" (iniEscapeCharacters $AuthInfo.ProjectDomainName) }}
-    project_domain_id = {{ default "\"\"" $AuthInfo.ProjectDomainID }}
-    project_id = {{ default "\"\"" $AuthInfo.ProjectID }}
-    project_name = {{ default "\"\"" (iniEscapeCharacters $AuthInfo.ProjectName) }}
-    user_domain_name = {{ default "\"\"" (iniEscapeCharacters $AuthInfo.UserDomainName) }}
-    user_domain_id = {{ default "\"\"" $AuthInfo.UserDomainID }}
-    region_name = {{ default "\"\"" (iniEscapeCharacters .OpenStackCloud.RegionName) }}
-{{- if .UserCACertificate }}
-    # There's no good way to just "append" user-provided certs to system ones,
-    # so just configure openstacksdk to use it.
-    cafile = /etc/ssl/certs/user-ca-bundle.crt
-{{- end }}
-
     [vif_pool]
     ports_pool_max = {{ .PoolMaxPorts }}
     ports_pool_min = {{ .PoolMinPorts }}

--- a/bindata/network/kuryr/003-credentials.yaml
+++ b/bindata/network/kuryr/003-credentials.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kuryr-config-credentials
+  namespace: openshift-kuryr
+stringData:
+  kuryr-credentials.conf: |+
+    {{- $AuthInfo := .OpenStackCloud.AuthInfo }}
+    [neutron]
+    auth_type = {{ default "password" .OpenStackCloud.AuthType }}
+    auth_url = {{ $AuthInfo.AuthURL }}
+    insecure = {{ .OpenStackInsecureAPI }}
+    token = {{ default "\"\"" (iniEscapeCharacters $AuthInfo.Token) }}
+    password = {{ default "\"\"" (iniEscapeCharacters $AuthInfo.Password) }}
+    username = {{ default "\"\"" (iniEscapeCharacters $AuthInfo.Username) }}
+    project_domain_name = {{ default "\"\"" (iniEscapeCharacters $AuthInfo.ProjectDomainName) }}
+    project_domain_id = {{ default "\"\"" $AuthInfo.ProjectDomainID }}
+    project_id = {{ default "\"\"" $AuthInfo.ProjectID }}
+    project_name = {{ default "\"\"" (iniEscapeCharacters $AuthInfo.ProjectName) }}
+    user_domain_name = {{ default "\"\"" (iniEscapeCharacters $AuthInfo.UserDomainName) }}
+    user_domain_id = {{ default "\"\"" $AuthInfo.UserDomainID }}
+    region_name = {{ default "\"\"" (iniEscapeCharacters .OpenStackCloud.RegionName) }}
+{{- if .UserCACertificate }}
+    # There's no good way to just "append" user-provided certs to system ones,
+    # so just configure openstacksdk to use it.
+    cafile = /etc/ssl/certs/user-ca-bundle.crt
+{{- end }}

--- a/bindata/network/kuryr/006-controller.yaml
+++ b/bindata/network/kuryr/006-controller.yaml
@@ -56,7 +56,11 @@ spec:
           value: "{{.KUBERNETES_SERVICE_HOST}}"
         volumeMounts:
         - name: config-volume
-          mountPath: "/etc/kuryr"
+          subPath: kuryr.conf
+          mountPath: "/etc/kuryr/kuryr.conf"
+        - name: credentials-volume
+          subPath: kuryr-credentials.conf
+          mountPath: "/etc/kuryr/kuryr-credentials.conf"
 {{- if .UserCACertificate }}
         - name: user-ca-certificate-volume
           subPath: user-ca-bundle.crt
@@ -78,6 +82,9 @@ spec:
       - name: config-volume
         configMap:
           name: kuryr-config
+      - name: credentials-volume
+        secret:
+          secretName: kuryr-config-credentials
 {{- if .UserCACertificate }}
       - name: user-ca-certificate-volume
         configMap:


### PR DESCRIPTION
This commit moves options filled with OpenStack credentials from a
ConfigMap to a Secret and makes sure kuryr-controller gets it mounted.