### PR TITLE
Bug 1970985: SDN-1955: Add pre-puller ds to reduce upgrade downtime

### DIFF
--- a/bindata/network/ovn-kubernetes/pre-puller.yaml
+++ b/bindata/network/ovn-kubernetes/pre-puller.yaml
@@ -1,0 +1,40 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: ovnkube-upgrades-prepuller
+  namespace: openshift-ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This daemonset launches the pre-puller component during upgrades that pulls the image onto the node.
+    release.openshift.io/version: "{{.ReleaseVersion}}"
+spec:
+  selector:
+    matchLabels:
+      app: ovnkube-upgrades-prepuller
+  template:
+    metadata:
+      labels:
+        app: ovnkube-upgrades-prepuller
+        component: network
+        type: infra
+        openshift.io/component: network
+        kubernetes.io/os: "linux"
+    spec:
+      serviceAccountName: ovn-kubernetes-node
+      hostNetwork: true
+      priorityClassName: "system-node-critical"
+      containers:
+        # ovnkube-upgrades-prepuller: no-op container that simply pulls the new image during upgrades
+      - name: ovnkube-upgrades-prepuller
+        image: "{{.OvnImage}}"
+        imagePullPolicy: Always
+        command:
+        - /bin/bash
+        - -c
+        - |
+          echo "$(date -Iseconds) - finished pulling ovnkube-node image."
+          sleep infinity
+      nodeSelector:
+        beta.kubernetes.io/os: "linux"
+      tolerations:
+      - operator: "Exists"

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -40,6 +40,7 @@ type OVNBootstrapResult struct {
 	ExistingNodeDaemonset   *appsv1.DaemonSet
 	Platform                configv1.PlatformType
 	OVNKubernetesConfig     *OVNConfigBoostrapResult
+	PrePullerDaemonset      *appsv1.DaemonSet
 }
 
 type BootstrapResult struct {

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -179,6 +179,11 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 		updateNode, updateMaster = shouldUpdateOVNKonUpgrade(bootstrapResult.OVN.ExistingNodeDaemonset, bootstrapResult.OVN.ExistingMasterDaemonset, os.Getenv("RELEASE_VERSION"))
 	}
 
+	renderPrePull := false
+	if updateNode {
+		updateNode, renderPrePull = shouldUpdateOVNKonPrepull(bootstrapResult.OVN.ExistingNodeDaemonset, bootstrapResult.OVN.PrePullerDaemonset, os.Getenv("RELEASE_VERSION"))
+	}
+
 	// If we need to delay master or node daemonset rollout, then we'll replace the new one with the existing one
 	if !updateMaster {
 		us, err := k8s.ToUnstructured(bootstrapResult.OVN.ExistingMasterDaemonset)
@@ -193,6 +198,11 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 			return nil, errors.Wrap(err, "failed to transmute existing node daemonset")
 		}
 		objs = k8s.ReplaceObj(objs, us)
+	}
+
+	if !renderPrePull {
+		// remove prepull from the list of objects to render.
+		objs = k8s.RemoveObjByGroupKindName(objs, "apps", "DaemonSet", "openshift-ovn-kubernetes", "ovnkube-upgrades-prepuller")
 	}
 
 	return objs, nil
@@ -493,6 +503,16 @@ func bootstrapOVN(conf *operv1.Network, kubeClient client.Client) (*bootstrap.Bo
 		}
 	}
 
+	prePullerDS := &appsv1.DaemonSet{}
+	nsn = types.NamespacedName{Namespace: "openshift-ovn-kubernetes", Name: "ovnkube-upgrades-prepuller"}
+	if err := kubeClient.Get(context.TODO(), nsn, prePullerDS); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("Failed to retrieve existing prepuller DaemonSet: %w", err)
+		} else {
+			prePullerDS = nil
+		}
+	}
+
 	res := bootstrap.BootstrapResult{
 		OVN: bootstrap.OVNBootstrapResult{
 			MasterIPs:               ovnMasterIPs,
@@ -500,6 +520,7 @@ func bootstrapOVN(conf *operv1.Network, kubeClient client.Client) (*bootstrap.Bo
 			ExistingMasterDaemonset: masterDS,
 			ExistingNodeDaemonset:   nodeDS,
 			OVNKubernetesConfig:     ovnConfigResult,
+			PrePullerDaemonset:      prePullerDS,
 		},
 	}
 	return &res, nil
@@ -564,6 +585,49 @@ func shouldUpdateOVNKonIPFamilyChange(existingNode, existingMaster *appsv1.Daemo
 	}
 	klog.V(2).Infof("OVN-Kubernetes master daemonset rollout complete, updating IP family mode on node daemonset")
 	return true, true
+}
+
+// shouldUpdateOVNKonPrepull implements a simple pre-pulling daemonset. It ensures the ovn-k
+// container image is (probably) already pulled by every node.
+// If the existing node daemonset has a different version then what we would like to apply, we first
+// roll out a no-op daemonset. Then, when that has rolled out to 100% of the cluster or has stopped
+// progressing, proceed with the node upgrade.
+func shouldUpdateOVNKonPrepull(existingNode, prePuller *appsv1.DaemonSet, releaseVersion string) (updateNode, renderPrepull bool) {
+	// Fresh cluster - full steam ahead! No need to wait for pre-puller.
+	if existingNode == nil {
+		klog.V(3).Infof("Fresh cluster, no need for prepuller")
+		return true, false
+	}
+
+	// if node is already upgraded, then no need to pre-pull
+	// Return true so that we reconcile any changes that somehow could have happened.
+	existingNodeVersion := existingNode.GetAnnotations()["release.openshift.io/version"]
+	if existingNodeVersion == releaseVersion {
+		klog.V(3).Infof("OVN-Kubernetes node is already in the expected release.")
+		return true, false
+	}
+
+	// at this point, we've determined we need an upgrade
+	if prePuller == nil {
+		klog.Infof("Rolling out the no-op prepuller daemonset...")
+		return false, true
+	}
+
+	// If pre-puller just pulled a new upgrade image and then we
+	// downgrade immediately, we might wanna make prepuller pull the downgrade image.
+	existingPrePullerVersion := prePuller.GetAnnotations()["release.openshift.io/version"]
+	if existingPrePullerVersion != releaseVersion {
+		klog.Infof("Rendering prepuller daemonset to update its image...")
+		return false, true
+	}
+
+	if daemonSetProgressing(prePuller, true) {
+		klog.Infof("Waiting for ovnkube-upgrades-prepuller daemonset to finish pulling the image before updating node")
+		return false, true
+	}
+
+	klog.Infof("OVN-Kube upgrades-prepuller daemonset rollout complete, now starting node rollouts")
+	return true, false
 }
 
 // shouldUpdateOVNKonUpgrade determines if we should roll out changes to

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -580,17 +580,20 @@ func TestOVNKubernetesIsSafe(t *testing.T) {
 func TestOVNKubernetestShouldUpdateMasterOnUpgrade(t *testing.T) {
 
 	for idx, tc := range []struct {
-		expectNode   bool
-		expectMaster bool
-		node         string
-		master       string
-		rv           string // release version
+		expectNode    bool
+		expectMaster  bool
+		expectPrePull bool
+		node          string
+		master        string
+		prepull       string
+		rv            string // release version
 	}{
 
-		// No node and master - upgrade = true and config the same
+		// No node, prepuller and master - upgrade = true and config the same
 		{
-			expectNode:   true,
-			expectMaster: true,
+			expectNode:    true,
+			expectMaster:  true,
+			expectPrePull: false,
 			node: `
 apiVersion: apps/v1
 kind: DaemonSet
@@ -600,10 +603,11 @@ apiVersion: apps/v1
 kind: DaemonSet
 `,
 		},
-
+		// PrePuller has to pull image before node can upgrade
 		{
-			expectNode:   true,
-			expectMaster: true,
+			expectNode:    false,
+			expectMaster:  true,
+			expectPrePull: true,
 			node: `
 apiVersion: apps/v1
 kind: DaemonSet
@@ -622,6 +626,11 @@ kind: DaemonSet
 		{
 			expectNode:   true,
 			expectMaster: true,
+			// Note: For reducing testing complexity, prepuller is set to false
+			// because it hits the condition where the node's version (null) is same
+			// as release version (null). In reality if node's version is differnt
+			// from expected, prePull will be true.
+			expectPrePull: false,
 			master: `
 apiVersion: apps/v1
 kind: DaemonSet
@@ -637,11 +646,12 @@ kind: DaemonSet
 `,
 		},
 
-		// steady state
+		// steady state, no prepuller
 		{
-			expectNode:   true,
-			expectMaster: true,
-			rv:           "2.0.0",
+			expectNode:    true,
+			expectMaster:  true,
+			expectPrePull: false,
+			rv:            "2.0.0",
 			master: `
 apiVersion: apps/v1
 kind: DaemonSet
@@ -657,16 +667,17 @@ kind: DaemonSet
 metadata:
   annotations:
     release.openshift.io/version: 2.0.0
-  namespace: openshift-ovn-kubernetes
-  name: ovnkube-node
+namespace: openshift-ovn-kubernetes
+name: ovnkube-node
 `,
 		},
 
-		// upgrade not yet applied
+		// upgrade not yet applied, expecting prepuller to get created
 		{
-			expectNode:   true,
-			expectMaster: false,
-			rv:           "2.0.0",
+			expectNode:    false,
+			expectMaster:  false,
+			expectPrePull: true,
+			rv:            "2.0.0",
 			master: `
 apiVersion: apps/v1
 kind: DaemonSet
@@ -687,11 +698,91 @@ metadata:
 `,
 		},
 
-		// node upgrade applied, upgrade not yet rolled out
+		// upgrade not yet applied, prepuller rolling out
 		{
-			expectNode:   true,
-			expectMaster: false,
-			rv:           "2.0.0",
+			expectNode:    false,
+			expectMaster:  false,
+			expectPrePull: true,
+			rv:            "2.0.0",
+			master: `
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    release.openshift.io/version: 1.9.9
+  namespace: openshift-ovn-kubernetes
+  name: ovnkube-master
+`,
+			node: `
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    release.openshift.io/version: 1.9.9
+  namespace: openshift-ovn-kubernetes
+  name: ovnkube-node
+`,
+			prepull: `
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    release.openshift.io/version: 2.0.0
+  namespace: openshift-ovn-kubernetes
+  name: ovnkube-upgrades-prepuller
+  generation: 2
+status:
+  currentNumberScheduled: 6
+  desiredNumberScheduled: 6
+  numberAvailable: 6
+  numberMisscheduled: 0
+  numberReady: 6
+  observedGeneration: 1
+  updatedNumberScheduled: 6
+`,
+		},
+
+		// upgrade not yet applied, prepuller having wrong image version
+		{
+			expectNode:    false,
+			expectMaster:  false,
+			expectPrePull: true,
+			rv:            "2.0.0",
+			master: `
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    release.openshift.io/version: 1.9.9
+  namespace: openshift-ovn-kubernetes
+  name: ovnkube-master
+`,
+			node: `
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    release.openshift.io/version: 1.9.9
+  namespace: openshift-ovn-kubernetes
+  name: ovnkube-node
+`,
+			prepull: `
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    release.openshift.io/version: 2.0.1
+  namespace: openshift-ovn-kubernetes
+  name: ovnkube-upgrades-prepuller
+`,
+		},
+
+		// node upgrade applied, upgrade not yet rolled out, prepuller has done its work.
+		{
+			expectNode:    true,
+			expectMaster:  false,
+			expectPrePull: false,
+			rv:            "2.0.0",
 			master: `
 apiVersion: apps/v1
 kind: DaemonSet
@@ -723,8 +814,9 @@ status:
 
 		// node upgrade rolling out
 		{
-			expectNode:   true,
-			expectMaster: false,
+			expectNode:    true,
+			expectMaster:  false,
+			expectPrePull: false,
 
 			rv: "2.0.0",
 			master: `
@@ -756,11 +848,13 @@ status:
   updatedNumberScheduled: 5
 `,
 		},
+
 		// node upgrade hung but not made progress
 		{
-			expectNode:   true,
-			expectMaster: false,
-			rv:           "2.0.0",
+			expectNode:    true,
+			expectMaster:  false,
+			expectPrePull: false,
+			rv:            "2.0.0",
 			master: `
 apiVersion: apps/v1
 kind: DaemonSet
@@ -794,9 +888,10 @@ status:
 
 		// node upgrade hung but made enough progress
 		{
-			expectNode:   true,
-			expectMaster: true,
-			rv:           "2.0.0",
+			expectNode:    true,
+			expectMaster:  true,
+			expectPrePull: false,
+			rv:            "2.0.0",
 			master: `
 apiVersion: apps/v1
 kind: DaemonSet
@@ -827,11 +922,13 @@ status:
   updatedNumberScheduled: 5
 `,
 		},
+
 		// Upgrade rolled out, everything is good
 		{
-			expectNode:   true,
-			expectMaster: true,
-			rv:           "2.0.0",
+			expectNode:    true,
+			expectMaster:  true,
+			expectPrePull: false,
+			rv:            "2.0.0",
 			master: `
 apiVersion: apps/v1
 kind: DaemonSet
@@ -863,9 +960,10 @@ status:
 
 		// downgrade not yet applied
 		{
-			expectNode:   false,
-			expectMaster: true,
-			rv:           "1.8.9",
+			expectNode:    false,
+			expectMaster:  true,
+			expectPrePull: false,
+			rv:            "1.8.9",
 			master: `
 apiVersion: apps/v1
 kind: DaemonSet
@@ -888,9 +986,10 @@ metadata:
 
 		// master downgrade applied, not yet rolled out
 		{
-			expectNode:   false,
-			expectMaster: true,
-			rv:           "1.8.9",
+			expectNode:    false,
+			expectMaster:  true,
+			expectPrePull: false,
+			rv:            "1.8.9",
 			master: `
 apiVersion: apps/v1
 kind: DaemonSet
@@ -922,10 +1021,10 @@ metadata:
 
 		// downgrade rolling out
 		{
-			expectNode:   false,
-			expectMaster: true,
-
-			rv: "1.8.9",
+			expectNode:    false,
+			expectMaster:  true,
+			expectPrePull: false,
+			rv:            "1.8.9",
 			master: `
 apiVersion: apps/v1
 kind: DaemonSet
@@ -950,7 +1049,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    release.openshift.io/version: 1.9.9 
+    release.openshift.io/version: 1.9.9
   namespace: openshift-ovn-kubernetes
   name: ovnkube-node
 `,
@@ -958,9 +1057,10 @@ metadata:
 
 		// downgrade hung but not made progress
 		{
-			expectNode:   false,
-			expectMaster: true,
-			rv:           "1.8.9",
+			expectNode:    false,
+			expectMaster:  true,
+			expectPrePull: false,
+			rv:            "1.8.9",
 			master: `
 apiVersion: apps/v1
 kind: DaemonSet
@@ -986,7 +1086,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    release.openshift.io/version: 1.9.9 
+    release.openshift.io/version: 1.9.9
   namespace: openshift-ovn-kubernetes
   name: ovnkube-node
 `,
@@ -995,9 +1095,10 @@ metadata:
 		// downgrade hung but made enough progress
 		// except we always wait for 100% master.
 		{
-			expectNode:   false,
-			expectMaster: true,
-			rv:           "1.8.9",
+			expectNode:    false,
+			expectMaster:  true,
+			expectPrePull: false,
+			rv:            "1.8.9",
 			master: `
 apiVersion: apps/v1
 kind: DaemonSet
@@ -1023,7 +1124,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    release.openshift.io/version: 1.9.9 
+    release.openshift.io/version: 1.9.9
   namespace: openshift-ovn-kubernetes
   name: ovnkube-node
 `,
@@ -1034,6 +1135,7 @@ metadata:
 
 			var node *appsv1.DaemonSet
 			var master *appsv1.DaemonSet
+			var prepuller *appsv1.DaemonSet
 			crd := OVNKubernetesConfig.DeepCopy()
 			config := &crd.Spec
 			os.Setenv("RELEASE_VERSION", tc.rv)
@@ -1063,6 +1165,22 @@ metadata:
 				t.Errorf("Unexpected error: %v", err)
 			}
 
+			var usPrePuller *uns.Unstructured
+			if tc.prepull != "" {
+				prepuller = &appsv1.DaemonSet{}
+				err = yaml.Unmarshal([]byte(tc.prepull), prepuller)
+				if err != nil {
+					t.Fatal(err)
+				}
+				usPrePuller, err = k8s.ToUnstructured(prepuller)
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			} else {
+				prepuller = nil
+				usPrePuller = nil
+			}
+
 			bootstrapResult := &bootstrap.BootstrapResult{
 				OVN: bootstrap.OVNBootstrapResult{
 					MasterIPs:               []string{"1.2.3.4", "5.6.7.8", "9.10.11.12"},
@@ -1073,6 +1191,7 @@ metadata:
 						EnableEgressIP:         true,
 						DisableSNATMutlipleGWs: false,
 					},
+					PrePullerDaemonset: prepuller,
 				},
 			}
 
@@ -1081,15 +1200,23 @@ metadata:
 
 			renderedNode := findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
 			renderedMaster := findInObjs("apps", "DaemonSet", "ovnkube-master", "openshift-ovn-kubernetes", objs)
+			renderedPrePuller := findInObjs("apps", "DaemonSet", "ovnkube-upgrades-prepuller", "openshift-ovn-kubernetes", objs)
 
 			// if we expect a node update, the original node and the rendered one must be different
 			g.Expect(tc.expectNode).To(Equal(!reflect.DeepEqual(renderedNode, usNode)), "Check node rendering")
 			// if we expect a master update, the original master and the rendered one must be different
 			g.Expect(tc.expectMaster).To(Equal(!reflect.DeepEqual(renderedMaster, usMaster)), "Check master rendering")
+			// if we expect a prepuller update, the original prepuller and the rendered one must be different
+			g.Expect(tc.expectPrePull).To(Equal(!reflect.DeepEqual(renderedPrePuller, usPrePuller)), "Check prepuller rendering")
 
 			updateNode, updateMaster := shouldUpdateOVNKonUpgrade(node, master, tc.rv)
-			g.Expect(updateNode).To(Equal(tc.expectNode), "Check node")
 			g.Expect(updateMaster).To(Equal(tc.expectMaster), "Check master")
+			if updateNode {
+				var updatePrePuller bool
+				updateNode, updatePrePuller = shouldUpdateOVNKonPrepull(node, prepuller, tc.rv)
+				g.Expect(updatePrePuller).To(Equal(tc.expectPrePull), "Check prepuller")
+			}
+			g.Expect(updateNode).To(Equal(tc.expectNode), "Check node")
 		})
 	}
 }


### PR DESCRIPTION
According to https://bugzilla.redhat.com/show_bug.cgi?id=1943334#c0 it takes roughly a minute during upgrades for old pods to get killed and new pods to get created.

It is predicted that a major chunk of this time is spent in pulling the new image into the node. (@squeed : do we have data to back up this claim that I can point to?)

This PR adds a new prepuller daemonset that is basically a no-op which simply assists in pulling the new image onto the nodes before the new pods get created so that it cuts down on the downtime.

Idea, Co-Authored By: https://github.com/squeed/openshift-cluster-network-operator/commit/42c0d1db5576a2e4e6b16b115e657477dbc33073