### PR TITLE
Bug 1970129: Add env variable OVS_SYS_LOG_LEVEL for ovn nodes to setup ovs syslog level

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ data:
   ip-10-0-135-96.us-east-2.compute.internal: |
     OVN_KUBE_LOG_LEVEL=5
     OVN_LOG_LEVEL=dbg
-    OVS_LOG_LEVEL=dbg
+    OVS_SYS_LOG_LEVEL=dbg
   # to adjust master log levels, use _master
   _master: |
     OVN_KUBE_LOG_LEVEL=5

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ data:
   ip-10-0-135-96.us-east-2.compute.internal: |
     OVN_KUBE_LOG_LEVEL=5
     OVN_LOG_LEVEL=dbg
+    OVS_LOG_LEVEL=dbg
   # to adjust master log levels, use _master
   _master: |
     OVN_KUBE_LOG_LEVEL=5

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -252,7 +252,7 @@ spec:
           if [[ -n "${IPFIX_COLLECTORS}" ]] ; then
             export_network_flows_flags="$export_network_flows_flags --ipfix-targets ${IPFIX_COLLECTORS}"
           fi
-          ovs-appctl vlog/set "syslog:${OVS_LOG_LEVEL}"
+          ovs-appctl vlog/set "syslog:${OVS_SYS_LOG_LEVEL}"
 
           exec /usr/bin/ovnkube --init-node "${K8S_NODE}" \
             --nb-address "{{.OVN_NB_DB_LIST}}" \
@@ -282,7 +282,7 @@ spec:
           value: "{{.OVN_CONTROLLER_INACTIVITY_PROBE}}"
         - name: OVN_KUBE_LOG_LEVEL
           value: "4"
-        - name: OVS_LOG_LEVEL
+        - name: OVS_SYS_LOG_LEVEL
           value: info
         {{ if .NetFlowCollectors }}
         - name: NETFLOW_COLLECTORS

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -252,6 +252,8 @@ spec:
           if [[ -n "${IPFIX_COLLECTORS}" ]] ; then
             export_network_flows_flags="$export_network_flows_flags --ipfix-targets ${IPFIX_COLLECTORS}"
           fi
+          ovs-appctl vlog/set "syslog:${OVS_LOG_LEVEL}"
+
           exec /usr/bin/ovnkube --init-node "${K8S_NODE}" \
             --nb-address "{{.OVN_NB_DB_LIST}}" \
             --sb-address "{{.OVN_SB_DB_LIST}}" \
@@ -280,6 +282,8 @@ spec:
           value: "{{.OVN_CONTROLLER_INACTIVITY_PROBE}}"
         - name: OVN_KUBE_LOG_LEVEL
           value: "4"
+        - name: OVS_LOG_LEVEL
+          value: info
         {{ if .NetFlowCollectors }}
         - name: NETFLOW_COLLECTORS
           value: "{{.NetFlowCollectors}}"


### PR DESCRIPTION
Since OVS is run on host, OVS logs are collected from systemd journal. Default value for ovs syslog level is err, set it to info to collect info level logs with must-gather.

How to test:
Run `ovs-appctl vlog/list` on a node, assure syslog level is set to requested level.
Run must-gather, check `host_service_logs/<node_name>/ovs-vswitchs_service.log` file. Previously it only contained ERR messages like this:

> Jun 28 07:35:19.248737 ci-ln-hxbr65t-f76d1-zw5kl-master-0 ovs-vswitchd[1234]: ovs|00040|stream_ssl|ERR|SSL_use_PrivateKey_file: error:20074002:BIO routines:file_ctrl:system lib
Jun 28 07:35:19.248780 ci-ln-hxbr65t-f76d1-zw5kl-master-0 ovs-vswitchd[1234]: ovs|00041|stream_ssl|ERR|failed to load client certificates from /ovn-ca/ca-bundle.crt: error:140AD002:SSL routines:SSL_CTX_use_certificate_file:system lib

After setting default level to INFO it should have INFO messages like this:
> Jun 28 08:54:14.080482 ci-ln-hxbr65t-f76d1-zw5kl-master-0 ovs-vswitchd[1234]: ovs|00507|connmgr|INFO|br-ex<->unix#1028: 2 flow_mods in the last 0 s (2 adds)
Jun 28 08:54:21.020662 ci-ln-hxbr65t-f76d1-zw5kl-master-0 ovs-vswitchd[1234]: ovs|00508|connmgr|INFO|br-int<->unix#1020: 5123 flow_mods 10 s ago (5122 adds, 1 deletes)

You can change default OVS_LOG_LEVEL value with ConfigMap:
```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: env-overrides
  namespace: openshift-ovn-kubernetes
  annotations:
data:
  # to set the node processes on a single node to verbose
  # replace this with the node's name (from oc get nodes)
  ip-10-0-135-96.us-east-2.compute.internal: |
    OVN_KUBE_LOG_LEVEL=5
    OVN_LOG_LEVEL=dbg
    OVS_LOG_LEVEL=dbg
  # to adjust master log levels, use _master
  _master: |
    OVN_KUBE_LOG_LEVEL=5
    OVN_LOG_LEVEL=dbg
```
