### PR TITLE
Bug 1961757: ovnkube: set ovn-controller lflow cache limit to 1GB

### DIFF
--- a/bindata/network/ovn-kubernetes/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/004-config.yaml
@@ -11,6 +11,8 @@ data:
     mtu="{{.MTU}}"
     cluster-subnets="{{.OVN_cidr}}"
     encap-port="{{.GenevePort}}"
+    enable-lflow-cache=true
+    lflow-cache-limit-kb=1048576
 
     [kubernetes]
     service-cidrs="{{.OVN_service_cidr}}"

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -177,6 +177,8 @@ func TestRenderedOVNKubernetesConfig(t *testing.T) {
 mtu="1500"
 cluster-subnets="10.128.0.0/15/23,10.0.0.0/14/24"
 encap-port="8061"
+enable-lflow-cache=true
+lflow-cache-limit-kb=1048576
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -200,6 +202,8 @@ nodeport=true`,
 mtu="1500"
 cluster-subnets="10.128.0.0/15/23,10.0.0.0/14/24"
 encap-port="8061"
+enable-lflow-cache=true
+lflow-cache-limit-kb=1048576
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -232,6 +236,8 @@ cluster-subnets="10.132.0.0/14"`,
 mtu="1500"
 cluster-subnets="10.128.0.0/15/23,10.0.0.0/14/24"
 encap-port="8061"
+enable-lflow-cache=true
+lflow-cache-limit-kb=1048576
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -267,6 +273,8 @@ hybrid-overlay-vxlan-port="9000"`,
 mtu="1500"
 cluster-subnets="10.128.0.0/15/23,10.0.0.0/14/24"
 encap-port="8061"
+enable-lflow-cache=true
+lflow-cache-limit-kb=1048576
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"


### PR DESCRIPTION
    By default the lflow cache is unlimited, but at scale this
    makes ovn-controller consume large amounts of RSS and cause OOM
    situations. Limit the cache size to prevent unbounded memory
    usage while still providing enough for most setups.
    
    The lflow cache is a tradeoff between CPU and memory, but we'd
    rather use a bit more CPU than OOM a box.
    
    Pick a 1GB limit based on data gathered from various scale runs,
    which seems to be the upper-limit (for now) for 120-node
    density runs.

@trozet @jcaamano 