### PR TITLE
OVNKube: check if br-ex1 is available and pass it as a parameter

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -254,6 +254,12 @@ spec:
           fi
           ovs-appctl vlog/set "syslog:${OVS_SYS_LOG_LEVEL}"
 
+          gw_interface_flag=
+          # if br-ex1 is configured on the node, we want to use it for external gateway traffic
+          if [ -d /sys/class/net/br-ex1 ]; then
+            gw_interface_flag="--exgw-interface=br-ex1"
+          fi
+
           exec /usr/bin/ovnkube --init-node "${K8S_NODE}" \
             --nb-address "{{.OVN_NB_DB_LIST}}" \
             --sb-address "{{.OVN_SB_DB_LIST}}" \
@@ -274,7 +280,8 @@ spec:
             {{- if .OVN_DISABLE_SNAT_MULTIPLE_GWS }}
             --disable-snat-multiple-gws \
             {{- end }}
-            ${export_network_flows_flags}
+            ${export_network_flows_flags} \
+            ${gw_interface_flag}
         env:
         # for kubectl
         - name: KUBERNETES_SERVICE_PORT


### PR DESCRIPTION
If br-ex1 is available on the host, it means that the user wants to use
it as the ovs bridge for external gateway traffic, so we set the related
parameter in ovnkube-node
