### PR TITLE
Bug 1981055: ovnkube-master handle 60 seconds downtime of API server gracefully in SNO

### DIFF
--- a/bindata/network/ovn-kubernetes/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/004-config.yaml
@@ -32,7 +32,8 @@ data:
     [gateway]
     mode={{.OVN_GATEWAY_MODE}}
     nodeport=true
-{{ if .OVNHybridOverlayEnable }}
+{{- if .OVNHybridOverlayEnable }}
+
     [hybridoverlay]
     enabled=true
     {{- if .OVNHybridOverlayNetCIDR }}
@@ -41,4 +42,17 @@ data:
     {{- if .OVNHybridOverlayVXLANPort}}
     hybrid-overlay-vxlan-port="{{.OVNHybridOverlayVXLANPort}}"
     {{- end }}
+{{- end  }}
+{{- if .IsSNO }}
+
+    [masterha]
+    {{- /* 
+    Even in case of SNO there will be only one ovn-master, we set dedicated values for leader election 
+    durations in SNO, as disabling it can cause issues on scaling out SNO again. 
+    The whole discussion can be found at https://coreos.slack.com/archives/CDCP2LA9L/p1627402405090600. 
+    Recommended values at https://github.com/openshift/enhancements/blame/84e894ead7b188a1013556e0ba6973b8463995f1/CONVENTIONS.md#L183
+    */}}
+    election-lease-duration=137
+    election-renew-deadline=107
+    election-retry-period=26
 {{- end  }}

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -154,6 +154,12 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 		}
 	}
 
+	if len(bootstrapResult.OVN.MasterIPs) == 1 {
+		data.Data["IsSNO"] = true
+	} else {
+		data.Data["IsSNO"] = false
+	}
+
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/ovn-kubernetes"), &data)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to render manifests")


### PR DESCRIPTION
Currently ovnkube-master leader election has the following timers [(ovn-org/ovn-kubernetes config.go)](https://github.com/ovn-org/ovn-kubernetes/blob/f5ddbe324fc561c58629db649524cd4b44075255/go-controller/pkg/config/config.go#L119-L123):
* lease duration: 60 seconds
* renew deadline: 30 seconds
* retry period: 20 seconds
This causes it to go through leader election and restart during an kube-apiserver rollout in a SNO (as this currently takes longer than 60 seconds).

This PR increases the ovnkube-master leader election timers for SNO clusters to its [recommended](https://github.com/openshift/enhancements/pull/832/files#diff-2e28754e69aa417e5b6d89e99e42f05bfb6330800fa823753383db1d170fbc2fR183) values to handle a apiserver disruption:
* lease duration: 137 seconds
* renew deadline: 107 seconds
* retry period: 26 seconds

How to reproduce / validate:
1. Start a SNO cluster with this patch
2. Trigger a apiserver rollout (e.g. via `k patch kubeapiserver/cluster --type merge -p '{"spec":{"forceRedeploymentReason":"something"}}'`)
3. Check the logs from ovnkube-master pod (ovnkube-master container) during the update
4. Validate the pod did not get restarted cause it lost the lease (e.g. check no previous logs are available / don't contain something like the following:
```
$ k logs ovnkube-master-5wwhv -c ovnkube-master --previous
...
I0720 10:42:28.610244       1 leaderelection.go:278] failed to renew lease openshift-ovn-kubernetes/ovn-kubernetes-master: timed out waiting for the condition
E0720 10:42:28.610348       1 leaderelection.go:301] Failed to release lock: resource name may not be empty
I0720 10:42:28.610356       1 master.go:107] No longer leader; exiting
```