### PR TITLE
Bug 1961811: Add a newline between user CAs and system CAs

### DIFF
--- a/pkg/controller/proxyconfig/controller.go
+++ b/pkg/controller/proxyconfig/controller.go
@@ -371,6 +371,8 @@ func (r *ReconcileProxyConfig) mergeTrustBundlesToConfigMap(additionalData, syst
 
 	combinedTrustData := []byte{}
 	combinedTrustData = append(combinedTrustData, additionalData...)
+	// add a newline here so that CVO can digest user and system certs correctly
+	combinedTrustData = append(combinedTrustData, []byte("\n")...)
 	combinedTrustData = append(combinedTrustData, systemData...)
 
 	mergedCfgMap := &corev1.ConfigMap{


### PR DESCRIPTION
Without the PR:

```
RJPkcV9aF5Oc08hytpBfeU/H8v+e2DQK258=
-----END CERTIFICATE-----# Red Hat IT Root CA
-----BEGIN CERTIFICATE-----
```

With the PR:

```
RJPkcV9aF5Oc08hytpBfeU/H8v+e2DQK258=
-----END CERTIFICATE-----
# Red Hat IT Root CA
-----BEGIN CERTIFICATE-----
```