### PR TITLE
Bug 1984049: Slow OVN Recovery on SNO

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -374,7 +374,9 @@ spec:
                 - /var/run/ovn/ovnnb_db.ctl
                 - exit
         readinessProbe:
+{{ if not .IsSNO }}
           initialDelaySeconds: 90
+{{ end }}
           timeoutSeconds: 5
           exec:
             command:
@@ -711,7 +713,9 @@ spec:
                 - /var/run/ovn/ovnsb_db.ctl
                 - exit
         readinessProbe:
+{{ if not .IsSNO }}
           initialDelaySeconds: 90
+{{ end }}
           timeoutSeconds: 5
           exec:
             command:


### PR DESCRIPTION
Adding template OVN_DB_PROBE_INITIAL_DELAY parameter, which will set to 0 when there is only one master node.

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>
