### PR TITLE
Revert: Add env variable OVS_SYS_LOG_LEVEL for ovn nodes to setup ovs syslog level

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,6 @@ data:
   ip-10-0-135-96.us-east-2.compute.internal: |
     OVN_KUBE_LOG_LEVEL=5
     OVN_LOG_LEVEL=dbg
-    OVS_SYS_LOG_LEVEL=dbg
   # to adjust master log levels, use _master
   _master: |
     OVN_KUBE_LOG_LEVEL=5

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -252,8 +252,6 @@ spec:
           if [[ -n "${IPFIX_COLLECTORS}" ]] ; then
             export_network_flows_flags="$export_network_flows_flags --ipfix-targets ${IPFIX_COLLECTORS}"
           fi
-          ovs-appctl vlog/set "syslog:${OVS_SYS_LOG_LEVEL}"
-
           gw_interface_flag=
           # if br-ex1 is configured on the node, we want to use it for external gateway traffic
           if [ -d /sys/class/net/br-ex1 ]; then
@@ -292,8 +290,6 @@ spec:
           value: "{{.OVN_CONTROLLER_INACTIVITY_PROBE}}"
         - name: OVN_KUBE_LOG_LEVEL
           value: "4"
-        - name: OVS_SYS_LOG_LEVEL
-          value: info
         {{ if .NetFlowCollectors }}
         - name: NETFLOW_COLLECTORS
           value: "{{.NetFlowCollectors}}"


### PR DESCRIPTION
Move setting ovs log level to machine-config-operator because:
- it should be set in the same place where ovs start to capture all the logs between ovs startup and CNO startup
- we don't need to reset this log level, therefore no need for ConfigMap variable
- log level settings should be alive after service restart, cluster upgrades

New PR for the same feature: https://github.com/openshift/machine-config-operator/pull/2690
