### PR TITLE
Bug 1989122: let openshift-sdn use EndpointSliceProxying

### DIFF
--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -71,8 +71,7 @@ func renderOpenShiftSDN(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Boo
 	// the insecure metrics port exposed by kube-proxy itself. So just override
 	// the value from conf (which we know is either "9101" or unspecified).
 	kpcOverrides := map[string]operv1.ProxyArgumentList{
-		"metrics-port":  {"29101"},
-		"feature-gates": {"EndpointSliceProxying=false"},
+		"metrics-port": {"29101"},
 	}
 	if *c.EnableUnidling {
 		// We already validated that proxy-mode was either unset or iptables.

--- a/pkg/network/openshift_sdn_test.go
+++ b/pkg/network/openshift_sdn_test.go
@@ -293,7 +293,7 @@ func TestProxyArgs(t *testing.T) {
 	g.Expect(errs).To(HaveLen(0))
 	// Validate that we don't allow the feature-gates to be set via user config
 	config.KubeProxyConfig.ProxyArguments = map[string]operv1.ProxyArgumentList{
-		"feature-gates": {"FGBar=baz"},
+		"feature-gates": {"FGBar=true"},
 	}
 	errs = validateKubeProxy(config)
 	g.Expect(errs).To(HaveLen(1))

--- a/pkg/network/openshift_sdn_test.go
+++ b/pkg/network/openshift_sdn_test.go
@@ -446,8 +446,6 @@ conntrack:
   tcpEstablishedTimeout: null
 detectLocalMode: ""
 enableProfiling: true
-featureGates:
-  EndpointSliceProxying: false
 healthzBindAddress: 0.0.0.0:10256
 hostnameOverride: ""
 iptables:
@@ -502,8 +500,6 @@ conntrack:
   tcpEstablishedTimeout: null
 detectLocalMode: ""
 enableProfiling: true
-featureGates:
-  EndpointSliceProxying: false
 healthzBindAddress: 0.0.0.0:10256
 hostnameOverride: ""
 iptables:


### PR DESCRIPTION
https://github.com/openshift/sdn/pull/296 added support for `EndpointSliceProxying` to openshift-sdn, so we no longer have to forcibly disable it.

Then once we rebase sdn to kube 1.22 we can use the endpoint termination stuff

/cc @abhat @Miciah 
