### PR TITLE
openshift-sdn/daemonset: Mount /host/opt/cni/bin at /host-cni-bin

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -85,7 +85,7 @@ spec:
 
           # Take over network functions on the node
           rm -f /etc/cni/net.d/80-openshift-network.conf
-          cp -f /opt/cni/bin/openshift-sdn /host/opt/cni/bin/
+          cp -f /opt/cni/bin/openshift-sdn /host-cni-bin/
 
           # Launch the network process
           exec /usr/bin/openshift-sdn-node \
@@ -131,7 +131,7 @@ spec:
           readOnly: true
           mountPropagation: HostToContainer
         # CNI related mounts which we take over
-        - mountPath: /host/opt/cni/bin
+        - mountPath: /host-cni-bin
           name: host-cni-bin
         - mountPath: /etc/cni/net.d
           name: host-cni-conf
@@ -171,7 +171,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["rm","-f","/etc/cni/net.d/80-openshift-network.conf", "/host/opt/cni/bin/openshift-sdn"]
+              command: ["rm","-f","/etc/cni/net.d/80-openshift-network.conf", "/host-cni-bin/openshift-sdn"]
         readinessProbe:
           exec:
             # openshift-sdn writes this file when it is ready to handle pod requests.


### PR DESCRIPTION
For some as yet undebugged reason, the theory is this mount setup seems to
not work with the CentOS 9 Stream kernel at least.
https://bugzilla.redhat.com/show_bug.cgi?id=1988520

Here we're avoiding "overmounting" on `/host` inside the container;
instead create `/host-cni-bin` which contains the in-container
view of the host's `/opt/cni/bin` (which is `/var/opt/cni/bin` on ostree
systems).