### PR TITLE
Add missing node name into KuryrSDNPodNotReady Alert

### DIFF
--- a/bindata/network/kuryr/alert-rules.yaml
+++ b/bindata/network/kuryr/alert-rules.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         message: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node {{"}}"}} is not ready.
       expr: |
-        kube_pod_status_ready{namespace='openshift-kuryr', condition='true'} == 0
+        sum by(pod, namespace) (kube_pod_status_ready{condition="true",namespace="openshift-kuryr"}) * on(pod, namespace) group_right() kube_pod_info == 0
       for: 10m
       labels:
         severity: warning


### PR DESCRIPTION

## Reproducer Environment

- OCP 4.6.0-0.nightly-2020-10-20-101225
- This version is no longer available. Reproduced with latest nightly.
- OSP 16.1.5 (RHOS-16.1-RHEL-8-20210323.n.0) with ovn octavia provider

```bash
oc get clusterversion
NAME      VERSION                             AVAILABLE   PROGRESSING   SINCE   STATUS
version   4.6.0-0.nightly-2021-07-30-013820   True        False         3s      Cluster version is 4.6.0-0.nightly-2021-07-30-013820
```

Run rsh to the Kuryr controller pod and remove `/tmp/pools_loaded` file (to make it not ready)
```bash
oc -n openshift-kuryr rsh kuryr-controller-56578b95d8-lkkz6
rm /tmp/pools_loaded
```
- Check the `KuryrSDNPodNotReady` alert is raised.

```bash
token=`oc sa get-token prometheus-k8s -n openshift-monitoring`
curl -sk -H "Authorization: Bearer $token" 'https://prometheus-k8s-openshift-monitoring.apps.ostest.shiftstack.com/api/v1/alerts' | jq '.data.alerts[] | select(.labels.alertname == "KuryrSDNPodNotReady")'
{
  "labels": {
    "alertname": "KuryrSDNPodNotReady",
    "condition": "true",
    "container": "kube-rbac-proxy-main",
    "endpoint": "https-main",
    "job": "kube-state-metrics",
    "namespace": "openshift-kuryr",
    "pod": "kuryr-controller-56578b95d8-lkkz6",
    "service": "kube-state-metrics",
    "severity": "warning"
  },
  "annotations": {
    "message": "SDN pod kuryr-controller-56578b95d8-lkkz6 on node  is not ready."
  },
  "state": "pending",
  "activeAt": "2021-08-04T03:54:49.939162962Z",
  "value": "0e+00"
}
```

## Problem Analysis

`KuryrSDNPodNotReady` is defined in `cluster-network-operator` in
[https://github.com/openshift/cluster-network-operator/blob/18c4ad6453fe4e247d1af6326dfcbdb8ccfdfbca/bindata/network/kuryr/alert-rules.yaml#L42-L49](https://github.com/openshift/cluster-network-operator/blob/18c4ad6453fe4e247d1af6326dfcbdb8ccfdfbca/bindata/network/kuryr/alert-rules.yaml#L42-L49)

The variable that is missing is `$labels.node`.

The reason is that we are using `kube_pod_status_ready` which doesn't expose node name.


We could add a `promql` query to the alert, that contains both `$labels.node` and `$labels.pod`.

```
sum(kube_pod_status_ready{namespace='openshift-kuryr', condition='true'}) by(pod,namespace) * on(pod, namespace) group_right() kube_pod_info == 0
```

We can edit the Prometheus alert:

```yaml
apiVersion: monitoring.coreos.com/v1
kind: PrometheusRule
metadata:
  name: test-alert
  namespace: openshift-kuryr
spec:
  groups:
  - name: MyTestRules
    rules:
    - alert: KuryrSDNPodNotReady-Test
      annotations:
        message: SDN pod {{ $labels.pod }} on node {{ $labels.node }} is not ready.
      expr: |
        sum(kube_pod_status_ready{namespace='openshift-kuryr', condition='true'}) by(pod,namespace) * on(pod, namespace) group_right() kube_pod_info == 0
      for: 10m
      labels:
        severity: warning
```

Create new Alert
```bash
oc apply -f myrule.yaml
prometheusrule.monitoring.coreos.com/test-alert created

oc get PrometheusRule -n openshift-kuryr
NAME          AGE
kuryr-rules   144m
test-alert    18s
```

You can see the new alert `KuryrSDNPodNotReady-Test (0 active)` in Prometheus after a while
```yaml
alert: KuryrSDNPodNotReady-Test
expr: sum by(pod, namespace) (kube_pod_status_ready{condition="true",namespace="openshift-kuryr"}) * on(pod, namespace) group_right() kube_pod_info == 0
for: 10m
labels:
  severity: warning
annotations:
  message: SDN pod {{ $labels.pod }} on node {{ $labels.node }} is not ready.
```

Try to trigger the Alert again:
```
oc -n openshift-kuryr rsh kuryr-controller-598bcb85c7-dcxgp
sh-4.4$ rm /tmp/pools_loaded
sh-4.4$
```

And verify the message is complete:

```bash
$ curl -sk -H "Authorization: Bearer $token" 'https://prometheus-k8s-openshift-monitoring.apps.ostest.shiftstack.com/api/v1/alerts' | jq '.data.alerts[] | select(.labels.alertname == "KuryrSDNPodNotReady-Test")'
{
  "labels": {
    "alertname": "KuryrSDNPodNotReady-Test",
    "container": "kube-rbac-proxy-main",
    "created_by_kind": "ReplicaSet",
    "created_by_name": "kuryr-controller-598bcb85c7",
    "endpoint": "https-main",
    "host_ip": "10.0.3.173",
    "job": "kube-state-metrics",
    "namespace": "openshift-kuryr",
    "node": "ostest-jx2kx-master-1",
    "pod": "kuryr-controller-598bcb85c7-dcxgp",
    "pod_ip": "10.0.3.173",
    "priority_class": "system-cluster-critical",
    "service": "kube-state-metrics",
    "severity": "warning",
    "uid": "5d5b6e6d-cb42-44dc-8741-6dd25cbed96b"
  },
  "annotations": {
    "message": "SDN pod kuryr-controller-598bcb85c7-dcxgp on node ostest-jx2kx-master-1 is not ready."
  },
  "state": "pending",
  "activeAt": "2021-08-06T01:47:42.423099803Z",
  "value": "0e+00"
}
```

With this we can see the annotation really works:

```json
  "annotations": {
    "message": "SDN pod kuryr-controller-598bcb85c7-dcxgp on node ostest-jx2kx-master-1 is not ready."
  },
```

And compare the node is indeed `ostest-jx2kx-master-1`
```bash
$ oc get pods -n openshift-kuryr -o wide
NAME                                READY   STATUS    RESTARTS   AGE    IP           NODE                          NOMINATED NODE   READINESS GATES
kuryr-cni-fjwss                     1/1     Running   0          168m   10.0.3.173   ostest-jx2kx-master-1         <none>           <none>
kuryr-cni-ghf8c                     1/1     Running   0          149m   10.0.2.164   ostest-jx2kx-worker-0-jd46w   <none>           <none>
kuryr-cni-jbvnr                     1/1     Running   0          168m   10.0.1.63    ostest-jx2kx-master-2         <none>           <none>
kuryr-cni-js74b                     1/1     Running   0          149m   10.0.0.43    ostest-jx2kx-worker-0-tz65q   <none>           <none>
kuryr-cni-pqpr8                     1/1     Running   0          149m   10.0.2.183   ostest-jx2kx-worker-0-84cjj   <none>           <none>
kuryr-cni-zjqd8                     1/1     Running   0          168m   10.0.1.113   ostest-jx2kx-master-0         <none>           <none>
kuryr-controller-598bcb85c7-dcxgp   0/1     Running   4          168m   10.0.3.173   ostest-jx2kx-master-1         <none>           <none>
```
