### PR TITLE
Bug 1991551: allow sdn (and others) to use new events.k8s.io API

### DIFF
--- a/bindata/kube-proxy/001-rbac.yaml
+++ b/bindata/kube-proxy/001-rbac.yaml
@@ -31,7 +31,7 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
-- apiGroups: [""]
+- apiGroups: ["", "events.k8s.io"]
   resources:
   - events
   verbs:

--- a/bindata/network-diagnostics/001-rbac.yaml
+++ b/bindata/network-diagnostics/001-rbac.yaml
@@ -53,7 +53,7 @@ rules:
   - get
   - list
   - watch
-- apiGroups: [""]
+- apiGroups: ["", "events.k8s.io"]
   resources:
   - events
   verbs:

--- a/bindata/network/multus/002-rbac.yaml
+++ b/bindata/network/multus/002-rbac.yaml
@@ -35,7 +35,7 @@ rules:
   - watch
   - patch
   - update
-- apiGroups: [""]
+- apiGroups: ["", "events.k8s.io"]
   resources:
   - events
   verbs:

--- a/bindata/network/openshift-sdn/002-rbac.yaml
+++ b/bindata/network/openshift-sdn/002-rbac.yaml
@@ -39,13 +39,6 @@ rules:
   - list
   - watch
   - patch
-- apiGroups: ["extensions"]
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
 - apiGroups: ["networking.k8s.io"]
   resources:
   - networkpolicies

--- a/bindata/network/openshift-sdn/002-rbac.yaml
+++ b/bindata/network/openshift-sdn/002-rbac.yaml
@@ -53,7 +53,7 @@ rules:
   - get
   - list
   - watch
-- apiGroups: [""]
+- apiGroups: ["", "events.k8s.io"]
   resources:
   - events
   verbs:

--- a/bindata/network/openshift-sdn/003-rbac-controller.yaml
+++ b/bindata/network/openshift-sdn/003-rbac-controller.yaml
@@ -78,7 +78,7 @@ rules:
   - get
   - list
   - watch
-- apiGroups: [""]
+- apiGroups: ["", "events.k8s.io"]
   resources:
   - events
   verbs:

--- a/bindata/network/ovn-kubernetes/002-rbac.yaml
+++ b/bindata/network/ovn-kubernetes/002-rbac.yaml
@@ -36,7 +36,7 @@ rules:
   - get
   - list
   - watch
-- apiGroups: [""]
+- apiGroups: ["", "events.k8s.io"]
   resources:
   - events
   verbs:

--- a/bindata/network/ovn-kubernetes/002-rbac.yaml
+++ b/bindata/network/ovn-kubernetes/002-rbac.yaml
@@ -29,7 +29,7 @@ rules:
   verbs:
   - list
   - watch
-- apiGroups: ["extensions", "networking.k8s.io"]
+- apiGroups: ["networking.k8s.io"]
   resources:
   - networkpolicies
   verbs:

--- a/bindata/network/ovn-kubernetes/003-rbac-controller.yaml
+++ b/bindata/network/ovn-kubernetes/003-rbac-controller.yaml
@@ -52,7 +52,7 @@ rules:
   verbs:
   - list
   - watch
-- apiGroups: ["extensions", "networking.k8s.io"]
+- apiGroups: ["networking.k8s.io"]
   resources:
   - networkpolicies
   verbs:

--- a/bindata/network/ovn-kubernetes/003-rbac-controller.yaml
+++ b/bindata/network/ovn-kubernetes/003-rbac-controller.yaml
@@ -59,7 +59,7 @@ rules:
   - get
   - list
   - watch
-- apiGroups: [""]
+- apiGroups: ["", "events.k8s.io"]
   resources:
   - events
   verbs:


### PR DESCRIPTION
Events are slowly being moved from `core/v1` to `events.k8s.io/v1`, so update everything to be able to use both namespaces for now.

Also, while we're here, drop the rules for the old `extensions/v1beta1` NetworkPolicy API.

/hold
need to test manually as the bug is not currently caught by CI
