### PR TITLE
Bug 1992507: Use prometheus rule annotations comply with the OpenShift alerting guidelines

### DIFF
--- a/bindata/network/kuryr/alert-rules.yaml
+++ b/bindata/network/kuryr/alert-rules.yaml
@@ -14,8 +14,7 @@ spec:
     rules:
     - alert: NoRunningKuryrKubernetes
       annotations:
-        message: |
-          There is no running kuryr controller
+        summary: There is no running kuryr controller
       expr: |
         absent(up{job="kuryr-controller",namespace="openshift-kuryr"} ==1)
       for: 10m
@@ -23,8 +22,7 @@ spec:
         severity: warning
     - alert: NodeWithoutKuryrCNIPodRunning
       annotations:
-        message: |
-          All nodes should be running a kuryr-cni pod, {{"{{"}} $labels.node {{"}}"}} is not.
+        summary: All nodes should be running a kuryr-cni pod, {{"{{"}} $labels.node {{"}}"}} is not.
       expr: |
         (kube_node_info unless on(node) kube_pod_info{namespace="openshift-kuryr",  pod=~"kuryr-cni.*"}) > 0
       for: 20m
@@ -32,7 +30,7 @@ spec:
         severity: warning
     - alert: KuryrPodsCrashLooping
       annotations:
-        message: Pod {{"{{"}} $labels.namespace{{"}}"}}/{{"{{"}} $labels.pod{{"}}"}} ({{"{{"}} $labels.container
+        summary: Pod {{"{{"}} $labels.namespace{{"}}"}}/{{"{{"}} $labels.pod{{"}}"}} ({{"{{"}} $labels.container
           {{"}}"}}) is restarting {{"{{"}} printf "%.2f" $value {{"}}"}} times / 5 minutes.
       expr: |
         rate(kube_pod_container_status_restarts_total{namespace="openshift-kuryr"}[15m]) * 60 * 5 > 0
@@ -41,7 +39,7 @@ spec:
         severity: warning
     - alert: KuryrSDNPodNotReady
       annotations:
-        message: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node {{"}}"}} is not ready.
+        summary: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node {{"}}"}} is not ready.
       expr: |
         sum by(pod, namespace) (kube_pod_status_ready{condition="true",namespace="openshift-kuryr"}) * on(pod, namespace) group_right() kube_pod_info == 0
       for: 10m
@@ -49,49 +47,49 @@ spec:
         severity: warning
     - alert: LimitedPortsOnNetwork
       annotations:
-        message: Subnet {{"{{"}} $labels.subnet_name {{"}}"}} is getting out of ports.
+        summary: Subnet {{"{{"}} $labels.subnet_name {{"}}"}} is getting out of ports.
       expr: |
         kuryr_port_quota_per_subnet > 0 and kuryr_port_quota_per_subnet < 10
       labels:
         severity: warning
     - alert: InsuficientPortsOnNetwork
       annotations:
-        message: Subnet {{"{{"}} $labels.subnet_name {{"}}"}} does not have available ports.
+        summary: Subnet {{"{{"}} $labels.subnet_name {{"}}"}} does not have available ports.
       expr: |
         kuryr_port_quota_per_subnet == 0
       labels:
         severity: critical
     - alert: LimitedResourceQuota
       annotations:
-        message: Running out of quota for {{"{{"}} $labels.resource {{"}}"}}.
+        summary: Running out of quota for {{"{{"}} $labels.resource {{"}}"}}.
       expr: |
         kuryr_quota_free_count > 0 and kuryr_quota_free_count < 10
       labels:
         severity: warning
     - alert: InsuficientResourceQuota
       annotations:
-        message: There is no quota for {{"{{"}} $labels.resource {{"}}"}}.
+        summary: There is no quota for {{"{{"}} $labels.resource {{"}}"}}.
       expr: |
         kuryr_quota_free_count == 0
       labels:
         severity: critical
     - alert: PodCreationSlow
       annotations:
-        message: The cluster is taking too long, on average, to make pods to running status.
+        summary: The cluster is taking too long, on average, to make pods to running status.
       expr: |
         histogram_quantile(0.95, sum(rate(kuryr_pod_creation_latency_bucket[10m])) by (le)) > 120
       labels:
         severity: warning
     - alert: KuryrCNISlow
       annotations:
-        message: Kuryr CNI pod {{"{{"}} $labels.pod {{"}}"}} is taking too long, on average, to perform CNI {{"{{"}} $labels.command {{"}}"}} requests.
+        summary: Kuryr CNI pod {{"{{"}} $labels.pod {{"}}"}} is taking too long, on average, to perform CNI {{"{{"}} $labels.command {{"}}"}} requests.
       expr: |
         histogram_quantile(0.95, rate(kuryr_cni_request_duration_seconds_bucket[10m])) > 30
       labels:
         severity: warning
     - alert: KuryrLoadBalancerWithError
       annotations:
-        message: Load Balancer {{"{{"}} $labels.lb_name {{"}}"}} is with {{"{{"}} $labels.kuryr_critical_lb_state {{"}}"}} state for more then 5m.
+        summary: Load Balancer {{"{{"}} $labels.lb_name {{"}}"}} is with {{"{{"}} $labels.kuryr_critical_lb_state {{"}}"}} state for more then 5m.
       expr: |
         kuryr_critical_lb_state{kuryr_critical_lb_state='ERROR'} == 1
       for: 5m
@@ -99,7 +97,7 @@ spec:
         severity: critical
     - alert: KuryrLoadBalancerDeleted
       annotations:
-        message: Load Balancer {{"{{"}} $labels.lb_name {{"}}"}} is not present for more then 5m.
+        summary: Load Balancer {{"{{"}} $labels.lb_name {{"}}"}} is not present for more then 5m.
       expr: |
         kuryr_critical_lb_state{kuryr_critical_lb_state='DELETED'} == 1
       for: 5m
@@ -107,7 +105,7 @@ spec:
         severity: critical
     - alert: LimitedLoadBalancerMembers
       annotations:
-        message: Low number of Members on Load Balancer {{"{{"}} $labels.lb_name {{"}}"}} with pool {{"{{"}} $labels.lb_pool_name {{"}}"}} for more then 5 min.
+        summary: Low number of Members on Load Balancer {{"{{"}} $labels.lb_name {{"}}"}} with pool {{"{{"}} $labels.lb_pool_name {{"}}"}} for more then 5 min.
       expr: |
         kuryr_critical_lb_members_count == 1
       for: 5m
@@ -115,7 +113,7 @@ spec:
         severity: warning
     - alert: InsuficientLoadBalancerMembers
       annotations:
-        message: No Members on Load Balancer {{"{{"}} $labels.lb_name {{"}}"}} with pool {{"{{"}} $labels.lb_pool_name {{"}}"}} for more then 5 min.
+        summary: No Members on Load Balancer {{"{{"}} $labels.lb_name {{"}}"}} with pool {{"{{"}} $labels.lb_pool_name {{"}}"}} for more then 5 min.
       expr: |
         kuryr_critical_lb_members_count == 0
       for: 5m
@@ -123,14 +121,14 @@ spec:
         severity: critical
     - alert: KuryrLoadBalancerNotReady
       annotations:
-        message: Kuryr noticed an Octavia load balancer unexpectedly stuck in PENDING_* state in the last 20 minutes. Most likely this indicates an issue with OpenStack Octavia.
+        summary: Kuryr noticed an Octavia load balancer unexpectedly stuck in PENDING_* state in the last 20 minutes. Most likely this indicates an issue with OpenStack Octavia.
       expr: |
         changes(kuryr_load_balancer_readiness_total[20m]) > 0
       labels:
         severity: critical
     - alert: KuryrPortNotReady
       annotations:
-        message: Kuryr noticed that a Neutron port was in unexpected DOWN state in the last 20 minutes. Most likely this indicates an issue with OpenStack Neutron.
+        summary: Kuryr noticed that a Neutron port was in unexpected DOWN state in the last 20 minutes. Most likely this indicates an issue with OpenStack Neutron.
       expr: |
         changes(kuryr_port_readiness_total[20m]) > 0
       labels:

--- a/bindata/network/openshift-sdn/alert-rules.yaml
+++ b/bindata/network/openshift-sdn/alert-rules.yaml
@@ -17,8 +17,7 @@ spec:
     # upgraded and there are duplicate rows on the "right" side of the join.
     - alert: NodeWithoutSDNPod
       annotations:
-        message: |
-          All nodes should be running an sdn pod, {{"{{"}} $labels.node {{"}}"}} is not.
+        summary: All nodes should be running an sdn pod, {{"{{"}} $labels.node {{"}}"}} is not.
       expr: |
         (kube_node_info unless on(node) topk by (node) (1, kube_pod_info{namespace="openshift-sdn",  pod=~"sdn.*"})) > 0
       for: 10m
@@ -26,7 +25,7 @@ spec:
         severity: warning
     - alert: NodeProxyApplySlow
       annotations:
-        message: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node {{"}}"}} is taking too long, on average, to apply kubernetes service rules to iptables.
+        summary: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node {{"}}"}} is taking too long, on average, to apply kubernetes service rules to iptables.
       expr: |
         histogram_quantile(.95, kubeproxy_sync_proxy_rules_duration_seconds_bucket) 
         * on(namespace, pod) group_right topk by (namespace, pod) (1, kube_pod_info{namespace="openshift-sdn",  pod=~"sdn-[^-]*"}) > 15
@@ -34,14 +33,14 @@ spec:
         severity: warning
     - alert: ClusterProxyApplySlow
       annotations:
-        message: The cluster is taking too long, on average, to apply kubernetes service rules to iptables.
+        summary: The cluster is taking too long, on average, to apply kubernetes service rules to iptables.
       expr: |
         histogram_quantile(0.95, sum(rate(kubeproxy_sync_proxy_rules_duration_seconds_bucket[5m])) by (le)) > 10
       labels:
         severity: warning
     - alert: NodeProxyApplyStale
       annotations:
-        message: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node {{"}}"}} has stale kubernetes service rules in iptables.
+        summary: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node {{"}}"}} has stale kubernetes service rules in iptables.
       # Query: find pods where
       #  - the queued-timestamp is at least 30 seconds after the applied-timestamp
       #  - the pod (still) exists
@@ -54,7 +53,7 @@ spec:
         severity: warning
     - alert: SDNPodNotReady
       annotations:
-        message: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node {{"}}"}} is not ready.
+        summary: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node {{"}}"}} is not ready.
       expr: |
         kube_pod_status_ready{namespace='openshift-sdn', condition='true'} == 0
       for: 10m

--- a/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
@@ -14,8 +14,7 @@ spec:
     rules:
     - alert: NoRunningOvnMaster
       annotations:
-        message: |
-          There is no running ovn-kubernetes master
+        summary: There is no running ovn-kubernetes master
       expr: |
         absent(up{job="ovnkube-master", namespace="openshift-ovn-kubernetes"} == 1)
       for: 10m
@@ -23,8 +22,7 @@ spec:
         severity: warning
     - alert: NoOvnMasterLeader
       annotations:
-        message: |
-          There is no ovn-kubernetes master leader
+        summary: There is no ovn-kubernetes master leader
       expr: |
         max(ovnkube_master_leader) == 0
       for: 10m
@@ -32,8 +30,7 @@ spec:
         severity: warning
     - alert: NorthboundStale
       annotations:
-        message: |
-          ovn-kubernetes has not written anything to the northbound database for too long
+        summary: ovn-kubernetes has not written anything to the northbound database for too long
       expr: |
          time() - max(ovn_nb_e2e_timestamp) > 300
       for: 10m
@@ -41,8 +38,7 @@ spec:
         severity: warning
     - alert: SouthboundStale
       annotations:
-        message: |
-          ovn-northd has not successfully synced any changes to the southbound DB for too long
+        summary: ovn-northd has not successfully synced any changes to the southbound DB for too long
       expr: |
         max(ovn_nb_e2e_timestamp) - max(ovn_sb_e2e_timestamp) > 120
       for: 10m
@@ -50,8 +46,7 @@ spec:
         severity: warning
     - alert: V4SubnetAllocationThresholdExceeded
       annotations:
-        message: |
-          More than 80% of v4 subnets available to assign to the nodes are allocated. Current v4 subnet allocation percentage is {{"{{"}} $value {{"}}"}}
+        summary: More than 80% of v4 subnets available to assign to the nodes are allocated. Current v4 subnet allocation percentage is {{"{{"}} $value {{"}}"}}
       expr: |
         ovnkube_master_allocated_v4_host_subnets/ovnkube_master_num_v4_host_subnets * 100 > 80
       for: 10m
@@ -59,8 +54,7 @@ spec:
         severity: warning
     - alert: V6SubnetAllocationThresholdExceeded
       annotations:
-        message: |
-          More than 80% of the v6 subnets available to assign to the nodes are allocated. Current v6 subnet allocation percentage is {{"{{"}} $value {{"}}"}}
+        summary: More than 80% of the v6 subnets available to assign to the nodes are allocated. Current v6 subnet allocation percentage is {{"{{"}} $value {{"}}"}}
       expr: |
         ovnkube_master_allocated_v6_host_subnets/ovnkube_master_num_v6_host_subnets * 100 > 80
       for: 10m

--- a/bindata/network/ovn-kubernetes/alert-rules.yaml
+++ b/bindata/network/ovn-kubernetes/alert-rules.yaml
@@ -14,8 +14,7 @@ spec:
     rules:
     - alert: NodeWithoutOVNKubeNodePodRunning
       annotations:
-        message: |
-          All Linux nodes should be running an ovnkube-node pod, {{"{{"}} $labels.node {{"}}"}} is not.
+        summary: All Linux nodes should be running an ovnkube-node pod, {{"{{"}} $labels.node {{"}}"}} is not.
       expr: |
         (kube_node_info unless on(node) (kube_pod_info{namespace="openshift-ovn-kubernetes",pod=~"ovnkube-node.*"}
         or kube_node_labels{label_kubernetes_io_os="windows"})) > 0
@@ -24,7 +23,7 @@ spec:
         severity: warning
     - alert: NetworkPodsCrashLooping
       annotations:
-        message: Pod {{"{{"}} $labels.namespace{{"}}"}}/{{"{{"}} $labels.pod{{"}}"}} ({{"{{"}} $labels.container
+        summary: Pod {{"{{"}} $labels.namespace{{"}}"}}/{{"{{"}} $labels.pod{{"}}"}} ({{"{{"}} $labels.container
           {{"}}"}}) is restarting {{"{{"}} printf "%.2f" $value {{"}}"}} times / 5 minutes.
       expr: |
         rate(kube_pod_container_status_restarts_total{namespace="openshift-ovn-kubernetes"}[15m]) * 60 * 5 > 0


### PR DESCRIPTION
This PR switches to the OpenShift comply annotations for PrometheusRules:
The guidelines can be found at https://github.com/openshift/enhancements/blob/master/enhancements/monitoring/alerting-consistency.md#documentation-required

**How to validate:**
* start a cluster with this patch
* check the prometheus rules (e.g. for openshift-sdn): `k -n openshift-sdn get prometheusrules -o yaml`. e.g.:
```
$ k -n openshift-sdn get prometheusrules -o yaml
apiVersion: v1
items:
- apiVersion: monitoring.coreos.com/v1
  kind: PrometheusRule
  metadata:
    annotations:
      networkoperator.openshift.io/ignore-errors: ""
    creationTimestamp: "2021-08-12T09:05:57Z"
    generation: 1
    labels:
      prometheus: k8s
      role: alert-rules
    name: networking-rules
    namespace: openshift-sdn
    ownerReferences:
    - apiVersion: operator.openshift.io/v1
      blockOwnerDeletion: true
      controller: true
      kind: Network
      name: cluster
      uid: 29b2fb5e-e6d3-4b94-86d0-1ee64c104f16
    resourceVersion: "3441"
    uid: 56d32d96-c2a7-46df-9c29-2e325c343bc1
  spec:
    groups:
    - name: cluster-network-operator-sdn.rules
      rules:
      - alert: NodeWithoutSDNPod
        annotations:
          summary: All nodes should be running an sdn pod, {{ $labels.node }} is not.
        expr: |
          (kube_node_info unless on(node) topk by (node) (1, kube_pod_info{namespace="openshift-sdn",  pod=~"sdn.*"})) > 0
        for: 10m
        labels:
          severity: warning
      - alert: NodeProxyApplySlow
        annotations:
          summary: SDN pod {{ $labels.pod }} on node {{ $labels.node }} is taking
            too long, on average, to apply kubernetes service rules to iptables.
        expr: "histogram_quantile(.95, kubeproxy_sync_proxy_rules_duration_seconds_bucket)
          \n* on(namespace, pod) group_right topk by (namespace, pod) (1, kube_pod_info{namespace=\"openshift-sdn\",
          \ pod=~\"sdn-[^-]*\"}) > 15\n"
        labels:
          severity: warning
      - alert: ClusterProxyApplySlow
        annotations:
          summary: The cluster is taking too long, on average, to apply kubernetes
            service rules to iptables.
        expr: |
          histogram_quantile(0.95, sum(rate(kubeproxy_sync_proxy_rules_duration_seconds_bucket[5m])) by (le)) > 10
        labels:
          severity: warning
      - alert: NodeProxyApplyStale
        annotations:
          summary: SDN pod {{ $labels.pod }} on node {{ $labels.node }} has stale
            kubernetes service rules in iptables.
        expr: |
          (kubeproxy_sync_proxy_rules_last_queued_timestamp_seconds - kubeproxy_sync_proxy_rules_last_timestamp_seconds)
          * on(namespace, pod) group_right() topk by (namespace, pod) (1, kube_pod_info{namespace="openshift-sdn",pod=~"sdn-[^-]*"})
          > 30
        for: 5m
        labels:
          severity: warning
      - alert: SDNPodNotReady
        annotations:
          summary: SDN pod {{ $labels.pod }} on node {{ $labels.node }} is not ready.
        expr: |
          kube_pod_status_ready{namespace='openshift-sdn', condition='true'} == 0
        for: 10m
        labels:
          severity: warning
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```

**Notes for reviewers:**
* [BZ 1992507](https://bugzilla.redhat.com/show_bug.cgi?id=1992507) only complains about openshift-sdn. This bug adjusts the annotations for ovn & kuryr as well