### PR TITLE
Make egress IP and ICNI mutually exclusive when bootstrapping OVN-Kub…

### DIFF
--- a/bindata/network/ovn-kubernetes/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/004-config.yaml
@@ -22,11 +22,13 @@ data:
 {{- end  }}
  
     [ovnkubernetesfeature]
+{{- if .OVN_ENABLE_EGRESS_IP}}
     enable-egress-ip=true
+{{- end}}
     enable-egress-firewall=true
 
     [gateway]
-    mode=local
+    mode={{.OVN_GATEWAY_MODE}}
     nodeport=true
 {{ if .OVNHybridOverlayEnable }}
     [hybridoverlay]

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -837,6 +837,9 @@ spec:
             --nbctl-daemon-mode \
             --nb-cert-common-name "{{.OVN_CERT_CN}}" \
             --enable-multicast \
+            {{- if .OVN_DISABLE_SNAT_MULTIPLE_GWS }}
+            --disable-snat-multiple-gws \
+            {{- end }}
             --acl-logging-rate-limit "{{.OVNPolicyAuditRateLimit}}"
         lifecycle:
           preStop:

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -269,6 +269,9 @@ spec:
             ${gateway_mode_flags} \
             --metrics-bind-address "127.0.0.1:29103" \
             --metrics-enable-pprof \
+            {{- if .OVN_DISABLE_SNAT_MULTIPLE_GWS }}
+            --disable-snat-multiple-gws \
+            {{- end }}
             ${export_network_flows_flags}
         env:
         # for kubectl

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -27,13 +27,19 @@ type KuryrBootstrapResult struct {
 	UserCACert               string
 }
 
+type OVNConfigBoostrapResult struct {
+	GatewayMode            string
+	EnableEgressIP         bool
+	DisableSNATMutlipleGWs bool
+}
+
 type OVNBootstrapResult struct {
 	MasterIPs               []string
 	ClusterInitiator        string
 	ExistingMasterDaemonset *appsv1.DaemonSet
 	ExistingNodeDaemonset   *appsv1.DaemonSet
-	GatewayMode             string
 	Platform                configv1.PlatformType
+	OVNKubernetesConfig     *OVNConfigBoostrapResult
 }
 
 type BootstrapResult struct {

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -61,6 +61,11 @@ func TestRenderOVNKubernetes(t *testing.T) {
 	bootstrapResult := &bootstrap.BootstrapResult{
 		OVN: bootstrap.OVNBootstrapResult{
 			MasterIPs: []string{"1.2.3.4", "5.6.7.8", "9.10.11.12"},
+			OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
+				GatewayMode:            "shared",
+				EnableEgressIP:         true,
+				DisableSNATMutlipleGWs: false,
+			},
 		},
 	}
 
@@ -124,6 +129,11 @@ func TestRenderOVNKubernetesIPv6(t *testing.T) {
 	bootstrapResult := &bootstrap.BootstrapResult{
 		OVN: bootstrap.OVNBootstrapResult{
 			MasterIPs: []string{"1.2.3.4", "5.6.7.8", "9.10.11.12"},
+			OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
+				GatewayMode:            "shared",
+				EnableEgressIP:         true,
+				DisableSNATMutlipleGWs: false,
+			},
 		},
 	}
 	objs, err := renderOVNKubernetes(config, bootstrapResult, manifestDirOvn)
@@ -137,6 +147,11 @@ func TestRenderOVNKubernetesIPv6(t *testing.T) {
 	bootstrapResult = &bootstrap.BootstrapResult{
 		OVN: bootstrap.OVNBootstrapResult{
 			MasterIPs: []string{"fd01::1", "fd01::2", "fd01::3"},
+			OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
+				GatewayMode:            "shared",
+				EnableEgressIP:         true,
+				DisableSNATMutlipleGWs: false,
+			},
 		},
 	}
 	objs, err = renderOVNKubernetes(config, bootstrapResult, manifestDirOvn)
@@ -174,7 +189,7 @@ enable-egress-ip=true
 enable-egress-firewall=true
 
 [gateway]
-mode=local
+mode=shared
 nodeport=true`,
 		},
 
@@ -198,7 +213,7 @@ enable-egress-ip=true
 enable-egress-firewall=true
 
 [gateway]
-mode=local
+mode=shared
 nodeport=true
 
 [hybridoverlay]
@@ -230,7 +245,7 @@ enable-egress-ip=true
 enable-egress-firewall=true
 
 [gateway]
-mode=local
+mode=shared
 nodeport=true
 
 [hybridoverlay]
@@ -265,7 +280,7 @@ enable-egress-ip=true
 enable-egress-firewall=true
 
 [gateway]
-mode=local
+mode=shared
 nodeport=true
 
 [hybridoverlay]
@@ -298,6 +313,11 @@ enabled=true`,
 			bootstrapResult := &bootstrap.BootstrapResult{
 				OVN: bootstrap.OVNBootstrapResult{
 					MasterIPs: []string{"1.2.3.4", "5.6.7.8", "9.10.11.12"},
+					OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
+						GatewayMode:            "shared",
+						EnableEgressIP:         true,
+						DisableSNATMutlipleGWs: false,
+					},
 				},
 			}
 			objs, err := renderOVNKubernetes(config, bootstrapResult, manifestDirOvn)
@@ -1048,6 +1068,11 @@ metadata:
 					MasterIPs:               []string{"1.2.3.4", "5.6.7.8", "9.10.11.12"},
 					ExistingMasterDaemonset: master,
 					ExistingNodeDaemonset:   node,
+					OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
+						GatewayMode:            "shared",
+						EnableEgressIP:         true,
+						DisableSNATMutlipleGWs: false,
+					},
 				},
 			}
 
@@ -1335,6 +1360,11 @@ func TestRenderOVNKubernetesDualStackPrecedenceOverUpgrade(t *testing.T) {
 						"release.openshift.io/version":      "1.9.9",
 					},
 				},
+			},
+			OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
+				GatewayMode:            "shared",
+				EnableEgressIP:         true,
+				DisableSNATMutlipleGWs: false,
 			},
 		},
 	}


### PR DESCRIPTION
Gateway mode was always being set to local gw in 4.8...

Signed-off-by: Alexander Constantinescu <aconstan@redhat.com>
(cherry picked from commit 8c6d59abfca1a9cc5b40ce0d76fd399ceec51cad)
