### PR TITLE
Bug 1997050: Fix panic with unknown networks

### DIFF
--- a/pkg/network/bootstrap.go
+++ b/pkg/network/bootstrap.go
@@ -19,5 +19,5 @@ func Bootstrap(conf *operv1.Network, client client.Client) (*bootstrap.Bootstrap
 		return bootstrapOVN(conf, client)
 	}
 
-	return nil, nil
+	return &bootstrap.BootstrapResult{}, nil
 }

--- a/pkg/network/render_test.go
+++ b/pkg/network/render_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	operv1 "github.com/openshift/api/operator/v1"
-	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
 )
 
 func TestIsChangeSafe(t *testing.T) {
@@ -186,7 +185,10 @@ func TestRenderUnknownNetwork(t *testing.T) {
 	err = IsChangeSafe(prev, next)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	objs, err := Render(prev, &bootstrap.BootstrapResult{}, manifestDir)
+	bootstrapResult, err := Bootstrap(&config, nil)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	objs, err := Render(prev, bootstrapResult, manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// Validate that openshift-sdn isn't rendered


### PR DESCRIPTION
Make sure `Bootstrap()` returns an empty struct instead of a nil, and the unit test matches reality. Breakage was introduced in 403c4ff06400be0879c81d310da4600b497159fb.