### PR TITLE
Bug 1986061: Monitor openshift-network-diagnostics namespace

### DIFF
--- a/bindata/network-diagnostics/000-ns.yaml
+++ b/bindata/network-diagnostics/000-ns.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-network-diagnostics
+  labels:
+    openshift.io/cluster-monitoring: "true"
   annotations:
     openshift.io/node-selector: "" #override default node selector
     workload.openshift.io/allowed: "management"

--- a/bindata/network-diagnostics/001-rbac.yaml
+++ b/bindata/network-diagnostics/001-rbac.yaml
@@ -84,7 +84,17 @@ rules:
 - apiGroups: ['controlplane.operator.openshift.io']
   resources: ['podnetworkconnectivitychecks/status']
   verbs: ['update']
-
+- apiGroups: ["authorization.k8s.io"]
+  resources:
+  - subjectaccessreviews
+  verbs: 
+  - create
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+  
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/bindata/network-diagnostics/network-check-source.yaml
+++ b/bindata/network-diagnostics/network-check-source.yaml
@@ -66,6 +66,8 @@ metadata:
   namespace: openshift-network-diagnostics
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    app: network-check-source
 spec:
   clusterIP: None
   ports:

--- a/bindata/network-diagnostics/network-check-source.yaml
+++ b/bindata/network-diagnostics/network-check-source.yaml
@@ -101,3 +101,36 @@ spec:
   selector:
     matchLabels:
       app: network-check-source
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-network-diagnostics
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-network-diagnostics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring


### PR DESCRIPTION
CNO deploys a service monitor named "network-check-source" which is never picked up by prometheus.

This PR adds the `openshift.io/cluster-monitoring="true"` label to the `openshift-network-diagnostics` namespace and fixes some RBAC so the service is picked up for monitoring.

**How to verify:**
1. Spin up a cluster with this patch
2. Login to the cluster dashboard, go to Observe -> Metrics and query for one of the metrics of the `checkendpoints` pod, e.g. `pod_network_connectivity_check_count`
    https://github.com/openshift/cluster-network-operator/blob/425a698d0459339878e34b2d580633c4eeba3ead/pkg/cmd/checkendpoints/controller/metrics.go#L22-L35 