### PR TITLE
Bug 1939435: proxyconfig - accept IPv6 address literals for noProxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.16 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.16 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-network-operator
 COPY . .
 RUN hack/build-go.sh
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder  /go/src/github.com/openshift/cluster-network-operator/cluster-network-operator /usr/bin/
 COPY --from=builder  /go/src/github.com/openshift/cluster-network-operator/cluster-network-check-endpoints /usr/bin/
 COPY --from=builder  /go/src/github.com/openshift/cluster-network-operator/cluster-network-check-target /usr/bin/

--- a/pkg/controller/proxyconfig/validation.go
+++ b/pkg/controller/proxyconfig/validation.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"k8s.io/apimachinery/pkg/types"
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -65,7 +64,7 @@ func (r *ReconcileProxyConfig) ValidateProxyConfig(proxyConfig *configv1.ProxySp
 			for _, v := range strings.Split(proxyConfig.NoProxy, ",") {
 				v = strings.TrimSpace(v)
 				errDomain := validation.DomainName(v, true)
-				_, _, errCIDR := net.ParseCIDR(v)
+				errCIDR := validation.IPAddressOrCIDR(v)
 				if errDomain != nil && errCIDR != nil {
 					return fmt.Errorf("invalid noProxy: %v", v)
 				}

--- a/pkg/util/validation/network.go
+++ b/pkg/util/validation/network.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"strconv"
 	"strings"
@@ -77,4 +78,15 @@ func URI(uri string) (string, error) {
 	}
 
 	return parsed.Scheme, nil
+}
+
+// IPAddressOrCIDR validates ip as being a valid IP or CIDR (IPv4/IPv6)
+func IPAddressOrCIDR(ip string) error {
+	if net.ParseIP(ip) == nil {
+		if _, _, err := net.ParseCIDR(ip); err != nil {
+			return fmt.Errorf("invalid IP/CIDR: %v", ip)
+		}
+	}
+
+	return nil
 }

--- a/pkg/util/validation/network_test.go
+++ b/pkg/util/validation/network_test.go
@@ -47,3 +47,33 @@ func TestURI(t *testing.T) {
 	}
 
 }
+
+func TestIPCIDR(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	validIPCIDRs := []string{
+		"fd2e:6f44:5dd8::1",
+		"fd02::/112",
+		"192.168.0.1",
+		"192.168.0.1/8",
+	}
+
+	invalidIPCIDRs := []string{
+		"redhat.com",
+		"123.10",
+		"2600:14a0::/256",
+		"fd01::/48,fd02::/112",
+	}
+
+	for _, ip := range validIPCIDRs {
+		t.Log("valid ip:", ip)
+		err := IPAddressOrCIDR(ip)
+		g.Expect(err).NotTo(HaveOccurred())
+	}
+
+	for _, ip := range invalidIPCIDRs {
+		t.Log("invalid ip:", ip)
+		err := IPAddressOrCIDR(ip)
+		g.Expect(err).To(HaveOccurred())
+	}
+}


### PR DESCRIPTION
ProxyConfig validation: check for valid IP addresses added.

Before:
```bash
$ oc -n openshift-network-operator logs network-operator-58d595444f-6rf4d | grep invalid
I0826 18:57:02.366450       1 log.go:184] Failed to validate proxy 'cluster': invalid noProxy: fd2e:6f44:5dd8::1
I0826 18:57:02.419354       1 log.go:184] Failed to validate proxy 'cluster': invalid noProxy: fd2e:6f44:5dd8::1
```

After, note `fd2e:6f44:5dd8::1` address:
```bash
$ oc version
Client Version: 4.8.4
Server Version: 4.8.4
Kubernetes Version: v1.21.1+38b3ecc

$ oc get proxy.config cluster --template '{{.status.noProxy}}' | tr ',' '\n' && echo
.cluster.local
.ocp-edge-cluster-0.qe.lab.redhat.com
.svc
10.0.0.0/16
10.128.0.0/14
127.0.0.1
169.254.169.254
172.30.0.0/16
api-int.ci-ln-5dffx6b-f76d1.origin-ci-int-gce.dev.openshift.com
fd01::/48
fd02::/112
fd2e:6f44:5dd8::1
localhost
metadata
metadata.google.internal
metadata.google.internal.
ocp-edge-cluster-0.qe.lab.redhat.com
registry.ocp-edge-cluster-0.qe.lab.redhat.com

```