### PR TITLE
Bug 1998508: Fix the install-time "waiting for other operators" statuses

### DIFF
--- a/pkg/controller/statusmanager/pod_status.go
+++ b/pkg/controller/statusmanager/pod_status.go
@@ -84,7 +84,7 @@ func (status *StatusManager) SetFromPods() {
 
 		dsProgressing := false
 
-		if isNonCritical(ds) && ds.Status.NumberReady == 0 && !status.everAvailable {
+		if isNonCritical(ds) && ds.Status.NumberReady == 0 && !status.installComplete {
 			progressing = append(progressing, fmt.Sprintf("DaemonSet %q is waiting for other operators to become ready", dsName.String()))
 			dsProgressing = true
 		} else if ds.Status.UpdatedNumberScheduled < ds.Status.DesiredNumberScheduled {
@@ -148,7 +148,7 @@ func (status *StatusManager) SetFromPods() {
 
 		depProgressing := false
 
-		if isNonCritical(dep) && dep.Status.UnavailableReplicas > 0 && !status.everAvailable {
+		if isNonCritical(dep) && dep.Status.UnavailableReplicas > 0 && !status.installComplete {
 			progressing = append(progressing, fmt.Sprintf("Deployment %q is waiting for other operators to become ready", depName.String()))
 			depProgressing = true
 		} else if dep.Status.UnavailableReplicas > 0 {
@@ -226,7 +226,10 @@ func (status *StatusManager) SetFromPods() {
 				Status: operv1.ConditionTrue,
 			},
 		)
-		status.everAvailable = true
+	}
+
+	if reachedAvailableLevel && len(progressing) == 0 {
+		status.installComplete = true
 	}
 
 	status.set(reachedAvailableLevel, conditions...)

--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -52,8 +52,8 @@ type StatusManager struct {
 	mapper meta.RESTMapper
 	name   string
 
-	failing       [maxStatusLevel]*operv1.OperatorCondition
-	everAvailable bool
+	failing         [maxStatusLevel]*operv1.OperatorCondition
+	installComplete bool
 
 	daemonSets     []types.NamespacedName
 	deployments    []types.NamespacedName


### PR DESCRIPTION
We specially handle the statuses of "non-critical" components (ie,
things that are not expected to become available until late in the
initial install), but we were ending that special handling as soon as
we reached "Available" for the first time... which intentionally
happens *before* the "non-critical" components finish deploying,
meaning that if the masters fully deploy but the workers don't, we
will erroneously report a status that makes it look like there is a
problem with the network components, rather than a problem with the
cluster.