### PR TITLE
Bug 2002713: Add millisecond resolution to OVN logs

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -72,7 +72,7 @@ spec:
 
           echo "$(date -Iseconds) - starting ovn-northd"
           exec ovn-northd \
-            --no-chdir "-vconsole:${OVN_LOG_LEVEL}" -vfile:off \
+            --no-chdir "-vconsole:${OVN_LOG_LEVEL}" -vfile:off "-vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
             --ovnnb-db "{{.OVN_NB_DB_LIST}}" \
             --ovnsb-db "{{.OVN_SB_DB_LIST}}" \
             --pidfile /var/run/ovn/ovn-northd.pid \
@@ -212,13 +212,13 @@ spec:
               --db-nb-cluster-remote-port={{.OVN_NB_RAFT_PORT}} \
               --db-nb-cluster-remote-addr=${init_ip} \
               --db-nb-cluster-remote-proto=ssl \
-              --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
+              --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
               run_nb_ovsdb
             else
               # either we need to initialize a new cluster or wait for master to create it
               if [[ "${K8S_NODE_IP}" == "${CLUSTER_INITIATOR_IP}" ]]; then
                 exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
-                --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
+                --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
                 run_nb_ovsdb
               else
                 echo "Joining the nbdb cluster with init_ip=${init_ip}..."
@@ -226,13 +226,13 @@ spec:
                 --db-nb-cluster-remote-port={{.OVN_NB_RAFT_PORT}} \
                 --db-nb-cluster-remote-addr=${init_ip} \
                 --db-nb-cluster-remote-proto=ssl \
-                --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
+                --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
                 run_nb_ovsdb
               fi
             fi
           else
             exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
-              --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
+              --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
               run_nb_ovsdb
           fi
 
@@ -590,26 +590,26 @@ spec:
               --db-sb-cluster-remote-port={{.OVN_SB_RAFT_PORT}} \
               --db-sb-cluster-remote-addr=${init_ip} \
               --db-sb-cluster-remote-proto=ssl \
-              --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
+              --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
               run_sb_ovsdb
             else
               # either we need to initialize a new cluster or wait for master to create it
               if [[ "${K8S_NODE_IP}" == "${CLUSTER_INITIATOR_IP}" ]]; then
                 exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
-                --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
+                --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
                 run_sb_ovsdb
               else
                 exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
                 --db-sb-cluster-remote-port={{.OVN_SB_RAFT_PORT}} \
                 --db-sb-cluster-remote-addr=${init_ip} \
                 --db-sb-cluster-remote-proto=ssl \
-                --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
+                --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
                 run_sb_ovsdb
               fi
             fi
           else
             exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
-            --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
+            --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
             run_sb_ovsdb
           fi
         lifecycle:

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -60,6 +60,7 @@ spec:
             -vFACILITY:"{{.OVNPolicyAuditSyslogFacility}}" \
             -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt \
             -vconsole:"${OVN_LOG_LEVEL}" -vconsole:"acl_log:off" \
+            -vPATTERN:console:"{{.OVN_LOG_PATTERN_CONSOLE}}" \
             -vsyslog:"acl_log:info" \
             -vfile:"acl_log:info"
         securityContext:

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -43,6 +43,7 @@ const OVN_MASTER_DISCOVERY_POLL = 5
 const OVN_MASTER_DISCOVERY_BACKOFF = 120
 const OVN_LOCAL_GW_MODE = "local"
 const OVN_SHARED_GW_MODE = "shared"
+const OVN_LOG_PATTERN_CONSOLE = "%D{%Y-%m-%dT%H:%M:%S.###Z}|%05N|%c%T|%p|%m"
 
 var OVN_MASTER_DISCOVERY_TIMEOUT = 250
 
@@ -113,6 +114,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["OVNPolicyAuditMaxFileSize"] = c.PolicyAuditConfig.MaxFileSize
 	data.Data["OVNPolicyAuditDestination"] = c.PolicyAuditConfig.Destination
 	data.Data["OVNPolicyAuditSyslogFacility"] = c.PolicyAuditConfig.SyslogFacility
+	data.Data["OVN_LOG_PATTERN_CONSOLE"] = OVN_LOG_PATTERN_CONSOLE
 
 	var ippools string
 	for _, net := range conf.ClusterNetwork {


### PR DESCRIPTION
Currently OVN databases and ovn-northd are started with '-vconsole:${OVN_LOG_LEVEL} -vfile:off'.  This means that logs are going only to the console.  But console (unlike files) has no millisecond resolution by default.  This makes it hard to debug time-sensitive issues.

This PR adds the millisecond resolution to console logs of ovn components.

**How to verify:**
1. Start a cluster with this patch (e.g. via clusterbot: `launch openshift/cluster-network-operator#1196 ovn`)
2. Check the logs of ovn components, e.g. nbdb:
```
oc -n openshift-ovn-kubernetes logs ovnkube-master-n6gnc -c nbdb
...
+ exec /usr/share/ovn/scripts/ovn-ctl --db-nb-cluster-local-port=9643 --db-nb-cluster-local-addr=10.0.148.9 --no-monitor --db-nb-cluster-local-proto=ssl --ovn-nb-db-ssl-key=/ovn-cert/tls.key --ovn-nb-db-ssl-cert=/ovn-cert/tls.crt --ovn-nb-db-ssl-ca-cert=/ovn-ca/ca-bundle.crt '--ovn-nb-log=-vconsole:info -vfile:off -vPATTERN:console:%D{%Y-%m-%dT%H:%M:%S.###Z}|%05N|%c%T|%p|%m' run_nb_ovsdb
Creating cluster database /etc/ovn/ovnnb_db.db.
2021-09-15T10:59:33.684Z|00001|vlog|INFO|opened log file /var/log/ovn/ovsdb-server-nb.log
ovn-nbctl: unix:/var/run/ovn/ovnnb_db.sock: database connection failed (No such file or directory)
2021-09-15T10:59:33.685Z|00002|raft|INFO|term 1: 114062 ms timeout expired, starting election
2021-09-15T10:59:33.685Z|00003|raft|INFO|term 1: elected leader by 1+ of 1 servers
2021-09-15T10:59:33.685Z|00004|raft|INFO|local server ID is 625f
2021-09-15T10:59:33.688Z|00005|ovsdb_server|INFO|ovsdb-server (Open vSwitch) 2.16.1
2021-09-15T10:59:33Z|00001|reconnect|INFO|unix:/var/run/ovn/ovnnb_db.sock: connecting...
2021-09-15T10:59:33Z|00002|reconnect|INFO|unix:/var/run/ovn/ovnnb_db.sock: connected
Waiting for OVN_Northbound to come up.
2021-09-15T10:59:33.764Z|00006|raft|INFO|Election timer changed from 1000 to 2000
2021-09-15T10:59:33.767Z|00007|raft|INFO|Election timer changed from 2000 to 4000
2021-09-15T10:59:33.770Z|00008|raft|INFO|Election timer changed from 4000 to 8000
2021-09-15T10:59:33.773Z|00009|raft|INFO|Election timer changed from 8000 to 10000
```

**Hint for reviewers:**
* Descriptions of the parameters for the log pattern can be found [here](https://docs.openvswitch.org/en/latest/ref/ovs-appctl.8/#logging-commands) (these are for `ovs-appctl`, but commandline pattern is the same.