### PR TITLE
Bug 2008589: [4.8z] Slow OVN Recovery on SNO

### DIFF
--- a/bindata/network/ovn-kubernetes/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/004-config.yaml
@@ -28,7 +28,8 @@ data:
     [gateway]
     mode=local
     nodeport=true
-{{ if .OVNHybridOverlayEnable }}
+{{- if .OVNHybridOverlayEnable }}
+
     [hybridoverlay]
     enabled=true
     {{- if .OVNHybridOverlayNetCIDR }}
@@ -37,4 +38,17 @@ data:
     {{- if .OVNHybridOverlayVXLANPort}}
     hybrid-overlay-vxlan-port="{{.OVNHybridOverlayVXLANPort}}"
     {{- end }}
+{{- end  }}
+{{- if .IsSNO }}
+
+    [masterha]
+    {{- /* 
+    Even in case of SNO there will be only one ovn-master, we set dedicated values for leader election 
+    durations in SNO, as disabling it can cause issues on scaling out SNO again. 
+    The whole discussion can be found at https://coreos.slack.com/archives/CDCP2LA9L/p1627402405090600. 
+    Recommended values at https://github.com/openshift/enhancements/blame/84e894ead7b188a1013556e0ba6973b8463995f1/CONVENTIONS.md#L183
+    */}}
+    election-lease-duration=137
+    election-renew-deadline=107
+    election-retry-period=26
 {{- end  }}

--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -383,7 +383,9 @@ spec:
                 - /var/run/ovn/ovnnb_db.ctl
                 - exit
         readinessProbe:
+{{ if not .IsSNO }}
           initialDelaySeconds: 90
+{{ end }}
           timeoutSeconds: 5
           exec:
             command:
@@ -729,7 +731,9 @@ spec:
                 - /var/run/ovn/ovnsb_db.ctl
                 - exit
         readinessProbe:
+{{ if not .IsSNO }}
           initialDelaySeconds: 90
+{{ end }}
           timeoutSeconds: 5
           exec:
             command:

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -150,6 +150,12 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 		}
 	}
 
+	if len(bootstrapResult.OVN.MasterIPs) == 1 {
+		data.Data["IsSNO"] = true
+	} else {
+		data.Data["IsSNO"] = false
+	}
+
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/ovn-kubernetes"), &data)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to render manifests")

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -153,6 +153,7 @@ func TestRenderedOVNKubernetesConfig(t *testing.T) {
 		desc                string
 		expected            string
 		hybridOverlayConfig *operv1.HybridOverlayConfig
+		masterIPs           []string
 	}
 	testcases := []testcase{
 		{
@@ -176,8 +177,8 @@ enable-egress-firewall=true
 [gateway]
 mode=local
 nodeport=true`,
+			masterIPs: []string{"1.2.3.4", "2.3.4.5"},
 		},
-
 		{
 			desc: "HybridOverlay",
 			expected: `
@@ -209,6 +210,7 @@ cluster-subnets="10.132.0.0/14"`,
 					{CIDR: "10.132.0.0/14", HostPrefix: 23},
 				},
 			},
+			masterIPs: []string{"1.2.3.4", "2.3.4.5"},
 		},
 		{
 			desc: "HybridOverlay with custom VXLAN port",
@@ -244,6 +246,7 @@ hybrid-overlay-vxlan-port="9000"`,
 				},
 				HybridOverlayVXLANPort: ptrToUint32(9000),
 			},
+			masterIPs: []string{"1.2.3.4", "2.3.4.5"},
 		},
 		{
 			desc: "HybridOverlay enabled with no ClusterNetworkEntry",
@@ -272,6 +275,37 @@ nodeport=true
 enabled=true`,
 
 			hybridOverlayConfig: &operv1.HybridOverlayConfig{},
+			masterIPs:           []string{"1.2.3.4", "2.3.4.5"},
+		},
+		{
+			desc: "Single Node OpenShift should contain SNO specific leader election settings",
+			expected: `
+[default]
+mtu="1500"
+cluster-subnets="10.128.0.0/15/23,10.0.0.0/14/24"
+encap-port="8061"
+enable-lflow-cache=true
+lflow-cache-limit-kb=1048576
+
+[kubernetes]
+service-cidrs="172.30.0.0/16"
+ovn-config-namespace="openshift-ovn-kubernetes"
+apiserver="https://1.1.1.1:1111"
+host-network-namespace="openshift-host-network"
+
+[ovnkubernetesfeature]
+enable-egress-ip=true
+enable-egress-firewall=true
+
+[gateway]
+mode=shared
+nodeport=true
+
+[masterha]
+election-lease-duration=137
+election-renew-deadline=107
+election-retry-period=26`,
+			masterIPs: []string{"1.2.3.4"},
 		},
 	}
 	g := NewGomegaWithT(t)
@@ -285,6 +319,7 @@ enabled=true`,
 			if tc.hybridOverlayConfig != nil {
 				OVNKubeConfig.Spec.DefaultNetwork.OVNKubernetesConfig.HybridOverlayConfig = tc.hybridOverlayConfig
 			}
+
 			//set a few inputs so that the tests are not machine dependant
 			OVNKubeConfig.Spec.DefaultNetwork.OVNKubernetesConfig.MTU = ptrToUint32(1500)
 
@@ -297,7 +332,7 @@ enabled=true`,
 
 			bootstrapResult := &bootstrap.BootstrapResult{
 				OVN: bootstrap.OVNBootstrapResult{
-					MasterIPs: []string{"1.2.3.4", "5.6.7.8", "9.10.11.12"},
+					MasterIPs: tc.masterIPs,
 				},
 			}
 			objs, err := renderOVNKubernetes(config, bootstrapResult, manifestDirOvn)

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -284,8 +284,6 @@ enabled=true`,
 mtu="1500"
 cluster-subnets="10.128.0.0/15/23,10.0.0.0/14/24"
 encap-port="8061"
-enable-lflow-cache=true
-lflow-cache-limit-kb=1048576
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -298,7 +296,7 @@ enable-egress-ip=true
 enable-egress-firewall=true
 
 [gateway]
-mode=shared
+mode=local
 nodeport=true
 
 [masterha]


### PR DESCRIPTION
This PR is a backport to release-4.8 from release-4.9 for Bug 2008589  (a clone of Bug 1984049)

It combines 2 PRs: 
- https://github.com/openshift/cluster-network-operator/pull/1154 - Bug 1981055
- https://github.com/openshift/cluster-network-operator/pull/1159  - Bug 1984049. Depends on PR 1154

Bug 1981055 To handle kube-apiserver disruptions, the recommended defaults are LeaseDuration=137s, RenewDealine=107s, RetryPeriod=26s according to
https://github.com/openshift/enhancements/blame/84e894ead7b188a1013556e0ba6973b8463995f1/CONVENTIONS.md#L183

Signed-off-by: Christoph Stäbler <cstabler@redhat.com>
(cherry picked from commit 4126e3c3c254f8c899eb72b6d56864292abbedc7)

Conflicts:
	pkg/network/ovn_kubernetes_test.go
	
---

 Bug 1984049: Slow OVN Recovery on SNO

Keep default initialDelaySeconds if Single Node Operator used.
Otherwise, specify initialDelaySeconds=90.

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>
(cherry picked from commit cb2bde784fc5922cacb1fb7791c4d89f21ebbc7a)

