### PR TITLE
Use 10% for sdn maxUnavailable for rolling update

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -23,6 +23,8 @@ spec:
       app: sdn
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       labels:


### PR DESCRIPTION
default is 1 and can be inefficient with larger clusters

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>