### PR TITLE
podsecurity: enforce privileged for network namespaces

### DIFF
--- a/bindata/kube-proxy/000-ns.yaml
+++ b/bindata/kube-proxy/000-ns.yaml
@@ -6,6 +6,9 @@ metadata:
     name: openshift-kube-proxy
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
   annotations:
     openshift.io/node-selector: "" #override default node selector
     openshift.io/description: "kubernetes service proxy"

--- a/bindata/network/kuryr/000-ns.yaml
+++ b/bindata/network/kuryr/000-ns.yaml
@@ -6,6 +6,9 @@ metadata:
     name: openshift-kuryr
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
   annotations:
     openshift.io/node-selector: "" #override default node selector
     openshift.io/description: "Kuryr-Kubernetes components"

--- a/bindata/network/multus/000-ns.yaml
+++ b/bindata/network/multus/000-ns.yaml
@@ -10,3 +10,6 @@ metadata:
     openshift.io/node-selector: "" #override default node selector
     openshift.io/description: "Multus network plugin components"
     workload.openshift.io/allowed: "management"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/bindata/network/openshift-sdn/000-ns.yaml
+++ b/bindata/network/openshift-sdn/000-ns.yaml
@@ -10,3 +10,6 @@ metadata:
     openshift.io/node-selector: "" #override default node selector
     openshift.io/description: "OpenShift SDN components"
     workload.openshift.io/allowed: "management"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/bindata/network/ovn-kubernetes/000-ns.yaml
+++ b/bindata/network/ovn-kubernetes/000-ns.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
   annotations:
     openshift.io/node-selector: ""
     openshift.io/description: "OVN Kubernetes components"

--- a/manifests/0000_70_cluster-network-operator_00_namespace.yaml
+++ b/manifests/0000_70_cluster-network-operator_00_namespace.yaml
@@ -11,3 +11,6 @@ metadata:
   labels:
     name: openshift-network-operator
     openshift.io/run-level: "0"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
Starting with OpenShift 4.10 we are introducing PodSecurity admission (https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/2579-psp-replacement).

Currently, all pods are marked as privileged, however, over time we want to enforce at least baseline, admirably restricted as default. In order not to break control plane workloads this allows workloads in `openshift-multus`/`openshift-network-operator`/`openshift-sdn` namespace to run privileged pods.

See https://github.com/openshift/enhancements/pull/899 for more details (and excuse the eventual consistency of updates).

/cc @stlaz 