### PR TITLE
NETOBSERV-31: Expose CNI type features as a config-map

### DIFF
--- a/bindata/network/openshift-sdn/cni-features.yaml
+++ b/bindata/network/openshift-sdn/cni-features.yaml
@@ -1,0 +1,12 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: openshift-network-features
+  namespace: openshift-config-managed
+  annotations:
+    openshift.io/description: |
+      Exposes available network features as required by the Console in order to show or hide some form fields.
+      If the map or a given property is undefined, the Console won't throw error and will take a default action (show, hide, show with a warning message...).
+data:
+  policy_egress: "false"
+  policy_peer_ipblock_exceptions: "false"

--- a/bindata/network/ovn-kubernetes/cni-features.yaml
+++ b/bindata/network/ovn-kubernetes/cni-features.yaml
@@ -1,0 +1,12 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: openshift-network-features
+  namespace: openshift-config-managed
+  annotations:
+    openshift.io/description: |
+      Exposes available network features as required by the Console in order to show or hide some form fields.
+      If the map or a given property is undefined, the Console won't throw error and will take a default action (show, hide, show with a warning message...).
+data:
+  policy_egress: "true"
+  policy_peer_ipblock_exceptions: "true"

--- a/bindata/network/public/000-roles.yaml
+++ b/bindata/network/public/000-roles.yaml
@@ -1,0 +1,31 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openshift-network-public-role
+  namespace: openshift-config-managed
+  annotations:
+    openshift.io/description: "Can read the openshift-network-features ConfigMap values"
+rules:
+  - apiGroups: [ "" ]
+    resources:
+      - configmaps
+    resourceNames:
+      - openshift-network-features
+    verbs:
+      - get
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openshift-network-public-role-binding
+  namespace: openshift-config-managed
+  annotations:
+    openshift.io/description: "Grants access from any authenticated user to the openshift-network-features ConfigMap"
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:authenticated'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift-network-public-role

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -72,6 +72,12 @@ func Render(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapResult
 	}
 	objs = append(objs, o...)
 
+	o, err = renderNetworkPublic(manifestDir)
+	if err != nil {
+		return nil, err
+	}
+	objs = append(objs, o...)
+
 	log.Printf("Render phase done, rendered %d objects", len(objs))
 	return objs, nil
 }
@@ -613,5 +619,16 @@ func renderNetworkDiagnostics(conf *operv1.NetworkSpec, manifestDir string) ([]*
 		return nil, errors.Wrap(err, "failed to render network-diagnostics manifests")
 	}
 
+	return manifests, nil
+}
+
+// renderNetworkPublic renders the common objects related to the openshift-network-features configmap
+func renderNetworkPublic(manifestDir string) ([]*uns.Unstructured, error) {
+	data := render.MakeRenderData()
+
+	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network", "public"), &data)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to render network/public manifests")
+	}
 	return manifests, nil
 }

--- a/pkg/network/render_test.go
+++ b/pkg/network/render_test.go
@@ -197,5 +197,9 @@ func TestRenderUnknownNetwork(t *testing.T) {
 	// validate that Multus is still rendered
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "multus")))
 
+	// validate that the openshift-network-features namespace and role bindings are still rendered
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("Role", "openshift-config-managed", "openshift-network-public-role")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("RoleBinding", "openshift-config-managed", "openshift-network-public-role-binding")))
+
 	// TODO(cdc) validate that kube-proxy is rendered
 }


### PR DESCRIPTION
Related enhancement: [Expose Network features](https://github.com/openshift/enhancements/blob/master/enhancements/console/expose-network-features.md)

The console requires to know the network type capabilities to show/hide some Network Policy form fields.

As agreed in the linked enhancement document, the required network capabilities will be added to an `sdn-public` `ConfigMap`, created by the CNO, readable by any `system:authenticated` user.

This PR is also the placeholder to add future network capabilities, as long as our Console components require more knowledge about the underlying CNI.

We provide the known values to `OVNKubernetes` and `OpenShiftSDN` CNI types. If the CNI type is `Kuryr` or any other, we will take default actions (e.g. show the related form field with a warning message).

We restrict the access control for the new Role as much as possible. That means that a non-administrative user won't be able to read the configmap with the `oc describe configmap sdn-public` as long as  this command requires access to the `events` resource type and we don't grant it. Also, the created ConfigMap won't be listed in the non-admin user UI (but visible if you paste the URL in the browser bar)

Direct access by means of the REST API is possible, as it is the only required form of accessing this map.