### PR TITLE
Specific SDN controller alert

### DIFF
--- a/bindata/network/openshift-sdn/alert-rules.yaml
+++ b/bindata/network/openshift-sdn/alert-rules.yaml
@@ -15,6 +15,14 @@ spec:
     # note: all joins on kube_pod_* need a a "topk by (key) (1, <metric> )"
     # otherwise you will generate query errors when kube_state_metrics is being
     # upgraded and there are duplicate rows on the "right" side of the join.
+    - alert: NodeWithoutSDNController
+      annotations:
+        summary: All control plane nodes should be running a sdn controller pod, {{"{{"}} $labels.node {{"}}"}} is not.
+      expr: |
+          count(kube_node_role{role="master"} == 1) != count(kube_pod_info{namespace="openshift-sdn",  pod=~"sdn-controller.*"})
+      for: 10m
+      labels:
+        severity: warning
     - alert: NodeWithoutSDNPod
       annotations:
         summary: All nodes should be running an sdn pod, {{"{{"}} $labels.node {{"}}"}} is not.

--- a/bindata/network/openshift-sdn/alert-rules.yaml
+++ b/bindata/network/openshift-sdn/alert-rules.yaml
@@ -19,7 +19,7 @@ spec:
       annotations:
         summary: All nodes should be running an sdn pod, {{"{{"}} $labels.node {{"}}"}} is not.
       expr: |
-        (kube_node_info unless on(node) topk by (node) (1, kube_pod_info{namespace="openshift-sdn",  pod=~"sdn.*"})) > 0
+        (kube_node_info unless on(node) topk by (node) (1, kube_pod_info{namespace="openshift-sdn",  pod=~"sdn-[^-]*"})) > 0
       for: 10m
       labels:
         severity: warning
@@ -27,7 +27,7 @@ spec:
       annotations:
         summary: SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node {{"}}"}} is taking too long, on average, to apply kubernetes service rules to iptables.
       expr: |
-        histogram_quantile(.95, kubeproxy_sync_proxy_rules_duration_seconds_bucket) 
+        histogram_quantile(.95, kubeproxy_sync_proxy_rules_duration_seconds_bucket)
         * on(namespace, pod) group_right topk by (namespace, pod) (1, kube_pod_info{namespace="openshift-sdn",  pod=~"sdn-[^-]*"}) > 15
       labels:
         severity: warning


### PR DESCRIPTION
Previous to this change, we are overloading the meaning of "SDN pod" to include SDN controller. This PR removes SDN controller and adds a separate alert for SDN controller.

~~Looking for a better metric than ```cluster:master_nodes``` to get the total number of control plane nodes. It comes from container ```kube-rbac-proxy-main```..~~

edit: Got advice from monitoring team to use kube_node_role metric.

