### PR TITLE
Remove NetworkPodsCrashLooping alert for ovn-kubernetes

### DIFF
--- a/bindata/network/ovn-kubernetes/alert-rules.yaml
+++ b/bindata/network/ovn-kubernetes/alert-rules.yaml
@@ -21,12 +21,3 @@ spec:
       for: 20m
       labels:
         severity: warning
-    - alert: NetworkPodsCrashLooping
-      annotations:
-        summary: Pod {{"{{"}} $labels.namespace{{"}}"}}/{{"{{"}} $labels.pod{{"}}"}} ({{"{{"}} $labels.container
-          {{"}}"}}) is restarting {{"{{"}} printf "%.2f" $value {{"}}"}} times / 5 minutes.
-      expr: |
-        rate(kube_pod_container_status_restarts_total{namespace="openshift-ovn-kubernetes"}[15m]) * 60 * 5 > 0
-      for: 1h
-      labels:
-        severity: warning


### PR DESCRIPTION
use existing KubePodCrashLooping (https://github.com/openshift/cluster-monitoring-operator/blob/master/assets/control-plane/prometheus-rule.yaml#L15) alert from cluster-network-operator instead.
NetworkPodsCrashLooping not only duplicates existing KubePodCrashLooping alert, but actually alerts on restarts instead of crashlooping events

Signed-off-by: Nadia Pinaeva <npinaeva@redhat.com>