### PR TITLE
Set upgrade strategy on kube-proxy

### DIFF
--- a/bindata/kube-proxy/kube-proxy.yaml
+++ b/bindata/kube-proxy/kube-proxy.yaml
@@ -23,6 +23,8 @@ spec:
       app: kube-proxy
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 33%
   template:
     metadata:
       annotations:


### PR DESCRIPTION
All daemonsets in OCP must have a max unavailable value set to 10% or
33%. Fixed kube-proxy daemonset to be in accordance with this rule

Signed-off-by: Ben Pickard <bpickard@redhat.com>