### PR TITLE
Bug 1961509: DHCP Daemon should have memory and CPU limits set

### DIFF
--- a/bindata/network/multus/003-dhcp-daemon.yaml
+++ b/bindata/network/multus/003-dhcp-daemon.yaml
@@ -47,6 +47,10 @@ spec:
         - "daemon"
         - "-hostprefix"
         - "/host"
+        resources:
+          requests:
+            cpu: 10m
+            memory: 65Mi
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
Sets a modest memory and CPU limit for DHCP daemon