### PR TITLE
Bug 1962206: DHCP daemon should have maxunavailable for upgrade strategy

### DIFF
--- a/bindata/network/multus/003-dhcp-daemon.yaml
+++ b/bindata/network/multus/003-dhcp-daemon.yaml
@@ -14,6 +14,8 @@ spec:
       app: dhcp-daemon
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 33%
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Set to 33% as it's not as critical as say, Multus (which uses 10%)