### PR TITLE
Add CNI to DPU and enable Kube-Proxy on DPU

### DIFF
--- a/bindata/kube-proxy/kube-proxy.yaml
+++ b/bindata/kube-proxy/kube-proxy.yaml
@@ -163,6 +163,9 @@ spec:
       - operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
+{{- if .KUBE_PROXY_NODE_SELECTOR }}
+        {{ .KUBE_PROXY_NODE_SELECTOR }}
+{{- end }}
       volumes:
       - name: host-slash
         hostPath:

--- a/bindata/network/ovn-kubernetes/error-cni.yaml
+++ b/bindata/network/ovn-kubernetes/error-cni.yaml
@@ -1,0 +1,154 @@
+{{- if eq .OVN_NODE_MODE "dpu" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: error-cni-script
+  namespace: openshift-ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This is a script that serves as the CNI on DPU. Only host network supported, so returns error to cmdAdd() calls.
+    release.openshift.io/version: "{{.ReleaseVersion}}"
+data:
+  error-cni.sh: |-
+    #!/bin/bash
+    set -e
+
+    cniVersionStr="0.4.0"
+    addErrorStr="Only host backed pods supported on DPU in Infra Cluster."
+    unknownErrorStr="Unknown cni command: $CNI_COMMAND"
+
+    case $CNI_COMMAND in
+    ADD)
+    echo "{
+      \"cniVersion\": \"${cniVersionStr}\",
+      \"code\": 7,
+      \"msg\": \"Not Supported\",
+      \"details\": \"${addErrorStr}\"
+    }"
+        exit 1 
+    ;;
+
+    DEL)
+    ;;
+
+    GET)
+    ;;
+
+    VERSION)
+    echo "{
+      \"cniVersion\": \"${cniVersionStr}\", 
+      \"supportedVersions\": [ \"0.3.0\", \"0.3.1\", \"0.4.0\" ] 
+    }"
+    ;;
+
+    *)
+    echo "{
+      \"cniVersion\": \"${cniVersionStr}\",
+      \"code\": 4,
+      \"msg\": \"Invalid Configuration\",
+      \"details\": \"${unknownErrorStr}\"
+    }"
+        exit 1 
+    ;;
+
+    esac
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: error-cni-conf
+  namespace: openshift-ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This is the Error-CNI Readiness Indicator File to let Multus know CNI is ready.
+    release.openshift.io/version: "{{.ReleaseVersion}}"
+data:
+  08-error-cni.conf: |-
+    {"cniVersion":"0.4.0","name":"error-cni","type":"error-cni"}
+
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: error-cni-plugin
+  namespace: openshift-ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This daemon installs the Error-CNI on DPU worker nodes in the Infra-Cluster.
+    release.openshift.io/version: "{{.ReleaseVersion}}"
+spec:
+  selector:
+    matchLabels:
+      app: error-cni-plugin
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
+  template:
+    metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        app: error-cni-plugin
+        component: network
+        type: infra
+        openshift.io/component: network
+        kubernetes.io/os: "linux"
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+        network.operator.openshift.io/dpu: ''
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: network.operator.openshift.io/dpu
+                operator: Exists
+      priorityClassName: "system-node-critical"
+      tolerations:
+      - operator: Exists
+      containers:
+      - name: error-cni-init
+        image: {{.OvnImage}}
+        command:
+          - /bin/sh
+          - -c
+          - |
+            #!/bin/sh
+            set -u -e
+            # Copy files stored in ConfigMap to mounted host directories 
+            cp -f /script-dir/error-cni.sh /cni-bin-dir/error-cni
+            cp -f /conf-dir/08-error-cni.conf /etc/cni/net.d/.
+            # Overwrite the OVN-Kubernetes conf file until Multus is updated
+            # to use a directory as the readiness-indicator-file
+            cp -f /conf-dir/08-error-cni.conf /etc/cni/net.d/10-ovn-kubernetes.conf
+            # RestartPolicy for pods in DaemonSets must be always, so sleep forever
+            trap : TERM INT; sleep infinity & wait
+        volumeMounts:
+        - mountPath: /script-dir
+          name: error-cni-script-config-map
+        - mountPath: /conf-dir
+          name: error-cni-conf-config-map
+        - mountPath: /cni-bin-dir
+          name: host-cni-bin
+        - mountPath: /etc/cni/net.d
+          name: host-cni-netd
+      volumes:
+        - name: error-cni-script-config-map
+          configMap:
+            name: error-cni-script
+            defaultMode: 0755
+        - name: error-cni-conf-config-map
+          configMap:
+            name: error-cni-conf
+            defaultMode: 0644
+        - name: host-cni-bin
+          hostPath:
+            path: "{{.CNIBinDir}}"
+        - name: host-cni-netd
+          hostPath:
+            path: "{{.CNIConfDir}}"
+{{- end }}

--- a/bindata/network/ovn-kubernetes/ipsec.yaml
+++ b/bindata/network/ovn-kubernetes/ipsec.yaml
@@ -27,6 +27,13 @@ spec:
         openshift.io/component: network
         kubernetes.io/os: "linux"
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: network.operator.openshift.io/dpu-host
+                operator: DoesNotExist
       serviceAccountName: ovn-kubernetes-node
       hostNetwork: true
       priorityClassName: "system-node-critical"

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -50,6 +50,8 @@ spec:
                 {{ else }}
                 operator: DoesNotExist
                 {{ end }}
+              - key: network.operator.openshift.io/dpu
+                operator: DoesNotExist
       serviceAccountName: ovn-kubernetes-node
       hostNetwork: true
       hostPID: true

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -2,7 +2,11 @@
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
+  {{ if eq .OVN_NODE_MODE "dpu-host" }}
+  name: ovnkube-node-dpu-host
+  {{ else }}
   name: ovnkube-node
+  {{ end }}
   namespace: openshift-ovn-kubernetes
   annotations:
     kubernetes.io/description: |
@@ -11,7 +15,11 @@ metadata:
 spec:
   selector:
     matchLabels:
+      {{ if eq .OVN_NODE_MODE "dpu-host" }}
+      app: ovnkube-node-dpu-host
+      {{ else }}
       app: ovnkube-node
+      {{ end }}
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -21,12 +29,27 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
+        {{ if eq .OVN_NODE_MODE "dpu-host" }}
+        app: ovnkube-node-dpu-host
+        {{ else }}
         app: ovnkube-node
+        {{ end }}
         component: network
         type: infra
         openshift.io/component: network
         kubernetes.io/os: "linux"
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: network.operator.openshift.io/dpu-host
+                {{ if eq .OVN_NODE_MODE "dpu-host" }}
+                operator: Exists
+                {{ else }}
+                operator: DoesNotExist
+                {{ end }}
       serviceAccountName: ovn-kubernetes-node
       hostNetwork: true
       hostPID: true
@@ -38,6 +61,7 @@ spec:
       # /run/openvswitch -> tmpfs - ovsdb sockets
       # /env -> configmap env-overrides - debug overrides
       containers:
+      {{ if eq .OVN_NODE_MODE "full" }}
       # ovn-controller: programs the vswitch with flows from the sbdb
       - name: ovn-controller
         image: "{{.OvnImage}}"
@@ -145,6 +169,7 @@ spec:
           name: node-log
         - mountPath: /run/ovn/
           name: run-ovn
+      {{ end }}
       - name: kube-rbac-proxy
         image: {{.KubeRBACProxyImage}}
         command:
@@ -261,6 +286,11 @@ spec:
             gw_interface_flag="--exgw-interface=br-ex1"
           fi
 
+          node_mgmt_port_netdev_flags=
+          if [[ -n "${OVNKUBE_NODE_MGMT_PORT_NETDEV}" ]] ; then
+            node_mgmt_port_netdev_flags="--ovnkube-node-mgmt-port-netdev ${OVNKUBE_NODE_MGMT_PORT_NETDEV}"
+          fi
+
           exec /usr/bin/ovnkube --init-node "${K8S_NODE}" \
             --nb-address "{{.OVN_NB_DB_LIST}}" \
             --sb-address "{{.OVN_SB_DB_LIST}}" \
@@ -276,6 +306,10 @@ spec:
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
             --inactivity-probe="${OVN_CONTROLLER_INACTIVITY_PROBE}" \
             ${gateway_mode_flags} \
+            {{- if eq .OVN_NODE_MODE "dpu-host" }}
+            --ovnkube-node-mode dpu-host \
+            ${node_mgmt_port_netdev_flags} \
+            {{- end }}
             --metrics-bind-address "127.0.0.1:29103" \
             --metrics-enable-pprof \
             {{- if .OVN_DISABLE_SNAT_MULTIPLE_GWS }}
@@ -467,6 +501,7 @@ spec:
       - name: run-ovn
         hostPath:
           path: /var/run/ovn
+      {{ if eq .OVN_NODE_MODE "full" }}
       # Used for placement of ACL audit logs 
       - name: node-log
         hostPath: 
@@ -474,6 +509,7 @@ spec:
       - name: log-socket
         hostPath: 
           path: /dev/log
+      {{ end }}
       # For CNI server
       - name: host-run-ovn-kubernetes
         hostPath:

--- a/hack/dpu-mode.yaml
+++ b/hack/dpu-mode.yaml
@@ -1,0 +1,9 @@
+# Example ConfigMap to enable dpu-host mode with OVNKubernetes
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: dpu-mode-config
+    namespace: openshift-network-operator
+data:
+    mode: "dpu-host"
+immutable: true

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -32,6 +32,7 @@ type KuryrBootstrapResult struct {
 
 type OVNConfigBoostrapResult struct {
 	GatewayMode            string
+	NodeMode               string
 	EnableEgressIP         bool
 	DisableSNATMultipleGWs bool
 }

--- a/pkg/network/kube_proxy_test.go
+++ b/pkg/network/kube_proxy_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	operv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	. "github.com/onsi/gomega"
@@ -342,6 +343,14 @@ func TestFillKubeProxyDefaults(t *testing.T) {
 	}
 }
 
+var FakeKubeProxyBootstrapResult = bootstrap.BootstrapResult{
+	OVN: bootstrap.OVNBootstrapResult{
+		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
+			NodeMode: "full",
+		},
+	},
+}
+
 func TestRenderKubeProxy(t *testing.T) {
 	g := NewGomegaWithT(t)
 
@@ -360,7 +369,7 @@ func TestRenderKubeProxy(t *testing.T) {
 
 	fillKubeProxyDefaults(c, nil)
 
-	objs, err := renderStandaloneKubeProxy(c, manifestDir)
+	objs, err := renderStandaloneKubeProxy(c, &FakeKubeProxyBootstrapResult, manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	g.Expect(objs).To(HaveLen(10))

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -44,6 +44,8 @@ const OVN_MASTER_DISCOVERY_BACKOFF = 120
 const OVN_LOCAL_GW_MODE = "local"
 const OVN_SHARED_GW_MODE = "shared"
 const OVN_LOG_PATTERN_CONSOLE = "%D{%Y-%m-%dT%H:%M:%S.###Z}|%05N|%c%T|%p|%m"
+const OVN_NODE_MODE_FULL = "full"
+const OVN_NODE_MODE_DPU_HOST = "dpu-host"
 
 var OVN_MASTER_DISCOVERY_TIMEOUT = 250
 
@@ -79,6 +81,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["CNIConfDir"] = pluginCNIConfDir(conf)
 	data.Data["CNIBinDir"] = CNIBinDir
 	data.Data["OVN_GATEWAY_MODE"] = bootstrapResult.OVN.OVNKubernetesConfig.GatewayMode
+	data.Data["OVN_NODE_MODE"] = OVN_NODE_MODE_FULL
 	data.Data["OVN_ENABLE_EGRESS_IP"] = bootstrapResult.OVN.OVNKubernetesConfig.EnableEgressIP
 	data.Data["OVN_DISABLE_SNAT_MULTIPLE_GWS"] = bootstrapResult.OVN.OVNKubernetesConfig.DisableSNATMultipleGWs
 	data.Data["OVN_NB_PORT"] = OVN_NB_PORT
@@ -193,6 +196,16 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	}
 	objs = append(objs, manifests...)
 
+	nodeMode := bootstrapResult.OVN.OVNKubernetesConfig.NodeMode
+	if nodeMode != OVN_NODE_MODE_FULL {
+		data.Data["OVN_NODE_MODE"] = nodeMode
+		manifests, err = render.RenderTemplate(filepath.Join(manifestDir, "network/ovn-kubernetes/ovnkube-node.yaml"), &data)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to render manifests")
+		}
+		objs = append(objs, manifests...)
+	}
+
 	// obtain the current IP family mode.
 	ipFamilyMode := names.IPFamilySingleStack
 	if len(conf.ServiceNetwork) == 2 {
@@ -246,6 +259,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 func bootstrapOVNConfig(kubeClient client.Client) (*bootstrap.OVNConfigBoostrapResult, error) {
 	ovnConfigResult := &bootstrap.OVNConfigBoostrapResult{
 		GatewayMode:            OVN_SHARED_GW_MODE,
+		NodeMode:               OVN_NODE_MODE_FULL,
 		EnableEgressIP:         true,
 		DisableSNATMultipleGWs: false,
 	}
@@ -256,24 +270,43 @@ func bootstrapOVNConfig(kubeClient client.Client) (*bootstrap.OVNConfigBoostrapR
 
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			klog.Infof("Did not find gateway-mode-config. Using default OVN configuration: %+v", ovnConfigResult)
-			return ovnConfigResult, nil
+			klog.Infof("Did not find gateway-mode-config")
 		} else {
 			return nil, fmt.Errorf("Could not determine gateway mode: %w", err)
 		}
+	} else {
+		modeOverride := cm.Data["mode"]
+		_, disableSNATMultipleGWsOverride := cm.Data["disable-snat-multiple-gws"]
+		if modeOverride != OVN_SHARED_GW_MODE && modeOverride != OVN_LOCAL_GW_MODE {
+			klog.Warningf("gateway-mode-config does not match %q or %q, is: %q. Using default OVN configuration: %+v", OVN_LOCAL_GW_MODE, OVN_SHARED_GW_MODE, modeOverride, ovnConfigResult)
+			return ovnConfigResult, nil
+		}
+		ovnConfigResult.GatewayMode = modeOverride
+		if disableSNATMultipleGWsOverride {
+			ovnConfigResult.EnableEgressIP = false
+			ovnConfigResult.DisableSNATMultipleGWs = true
+		}
+		klog.Infof("Overriding OVN configuration to %+v", ovnConfigResult)
 	}
-	modeOverride := cm.Data["mode"]
-	_, disableSNATMultipleGWsOverride := cm.Data["disable-snat-multiple-gws"]
-	if modeOverride != OVN_SHARED_GW_MODE && modeOverride != OVN_LOCAL_GW_MODE {
-		klog.Warningf("gateway-mode-config does not match %q or %q, is: %q. Using default OVN configuration: %+v", OVN_LOCAL_GW_MODE, OVN_SHARED_GW_MODE, modeOverride, ovnConfigResult)
-		return ovnConfigResult, nil
+
+	dmc := types.NamespacedName{Namespace: "openshift-network-operator", Name: "dpu-mode-config"}
+	err = kubeClient.Get(context.TODO(), dmc, cm)
+
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.Infof("Did not find dpu-mode-config")
+		} else {
+			return nil, fmt.Errorf("Could not determine Node Mode: %w", err)
+		}
+	} else {
+		nodeModeOverride := cm.Data["mode"]
+		if nodeModeOverride != OVN_NODE_MODE_DPU_HOST {
+			klog.Warningf("dpu-mode-config does not match %q, is: %q. Using OVN configuration: %+v", OVN_NODE_MODE_DPU_HOST, nodeModeOverride, ovnConfigResult)
+			return ovnConfigResult, nil
+		}
+		ovnConfigResult.NodeMode = nodeModeOverride
+		klog.Infof("Overriding OVN configuration to %+v", ovnConfigResult)
 	}
-	ovnConfigResult.GatewayMode = modeOverride
-	if disableSNATMultipleGWsOverride {
-		ovnConfigResult.EnableEgressIP = false
-		ovnConfigResult.DisableSNATMultipleGWs = true
-	}
-	klog.Infof("Overriding OVN configuration to %+v", ovnConfigResult)
 	return ovnConfigResult, nil
 }
 

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -63,6 +63,7 @@ func TestRenderOVNKubernetes(t *testing.T) {
 			MasterIPs: []string{"1.2.3.4", "5.6.7.8", "9.10.11.12"},
 			OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
 				GatewayMode:            "shared",
+				NodeMode:               "full",
 				EnableEgressIP:         true,
 				DisableSNATMultipleGWs: false,
 			},
@@ -131,6 +132,7 @@ func TestRenderOVNKubernetesIPv6(t *testing.T) {
 			MasterIPs: []string{"1.2.3.4", "5.6.7.8", "9.10.11.12"},
 			OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
 				GatewayMode:            "shared",
+				NodeMode:               "full",
 				EnableEgressIP:         true,
 				DisableSNATMultipleGWs: false,
 			},
@@ -149,6 +151,7 @@ func TestRenderOVNKubernetesIPv6(t *testing.T) {
 			MasterIPs: []string{"fd01::1", "fd01::2", "fd01::3"},
 			OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
 				GatewayMode:            "shared",
+				NodeMode:               "full",
 				EnableEgressIP:         true,
 				DisableSNATMultipleGWs: false,
 			},
@@ -358,6 +361,7 @@ election-retry-period=26`,
 					MasterIPs: tc.masterIPs,
 					OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
 						GatewayMode:            "shared",
+						NodeMode:               "full",
 						EnableEgressIP:         true,
 						DisableSNATMultipleGWs: false,
 					},
@@ -1231,6 +1235,7 @@ metadata:
 					ExistingNodeDaemonset:   node,
 					OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
 						GatewayMode:            "shared",
+						NodeMode:               "full",
 						EnableEgressIP:         true,
 						DisableSNATMultipleGWs: false,
 					},
@@ -1533,6 +1538,7 @@ func TestRenderOVNKubernetesDualStackPrecedenceOverUpgrade(t *testing.T) {
 			},
 			OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
 				GatewayMode:            "shared",
+				NodeMode:               "full",
 				EnableEgressIP:         true,
 				DisableSNATMultipleGWs: false,
 			},

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -52,7 +52,14 @@ func Render(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapResult
 	objs = append(objs, o...)
 
 	// render kube-proxy
-	o, err = renderStandaloneKubeProxy(conf, manifestDir)
+	// DPU_DEV_PREVIEW
+	// There is currently a restriction that renderStandaloneKubeProxy() is
+	// called after renderDefaultNetwork(). The OVN-Kubernetes code is enabling
+	// KubeProxy in Node Mode of "dpu". Once out of DevPreview, CNO API will be
+	// expanded to include Node Mode and it will be stored in conf (operv1.NetworkSpec)
+	// and KubeProxy can read Node Mode and be enabled in KubeProxy code, removing this
+	// dependency.
+	o, err = renderStandaloneKubeProxy(conf, bootstrapResult, manifestDir)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In the Infra-Cluster (Cluster with DPUs), OVN-Kubernetes on DPU is managing the networking for the Tenant-Cluster (Cluster with x86-hosts). Currently, only host network based pods are supported on the DPU. This PR adds an Infra-DPU-CNI to the DPU, which is just a script that return an error to any CNI cmdAdd() calls. Multus requires a "readiness-indicator-file", which is a conf file with the CNI Plugin specifics. The presence of this file indicates to Multus that the CNI is ready. This PR also setups the "readiness-indicator-file".

Since OVN-Kubernetes running on the DPU is serving the Tenant-Cluster (x86 host), enable KubeProxy to run on the DPU to  enable networking on the DPUs in the Infra-Cluster.