### PR TITLE
[release-4.8] Bug 2023426: Add ip6tables NOTRACK rules for udp/6081

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -215,6 +215,8 @@ spec:
           echo "I$(date "+%m%d %H:%M:%S.%N") - disable conntrack on geneve port"
           iptables -t raw -A PREROUTING -p udp --dport {{.GenevePort}} -j NOTRACK
           iptables -t raw -A OUTPUT -p udp --dport {{.GenevePort}} -j NOTRACK
+          ip6tables -t raw -A PREROUTING -p udp --dport {{.GenevePort}} -j NOTRACK
+          ip6tables -t raw -A OUTPUT -p udp --dport {{.GenevePort}} -j NOTRACK
           retries=0
           while true; do
             # TODO: change to use '--request-timeout=30s', if https://github.com/kubernetes/kubernetes/issues/49343 is fixed. 


### PR DESCRIPTION
Add ip6tables NOTRACK rules for udp/6081

Signed-off-by: Michael Cambria <mcambria@redhat.com>

(cherry picked from commit 7d4d093844b0e614826c9d09ae34efb68ad9270c)