### PR TITLE
Bug 2034517: watch and apply changes of the ovs-flows-config configmap

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -334,6 +334,15 @@ spec:
           if [[ -n "${IPFIX_COLLECTORS}" ]] ; then
             export_network_flows_flags="$export_network_flows_flags --ipfix-targets ${IPFIX_COLLECTORS}"
           fi
+          if [[ -n "${IPFIX_CACHE_MAX_FLOWS}" ]] ; then
+            export_network_flows_flags="$export_network_flows_flags --ipfix-cache-max-flows ${IPFIX_CACHE_MAX_FLOWS}"
+          fi
+          if [[ -n "${IPFIX_CACHE_ACTIVE_TIMEOUT}" ]] ; then
+            export_network_flows_flags="$export_network_flows_flags --ipfix-cache-active-timeout ${IPFIX_CACHE_ACTIVE_TIMEOUT}"
+          fi
+          if [[ -n "${IPFIX_SAMPLING}" ]] ; then
+            export_network_flows_flags="$export_network_flows_flags --ipfix-sampling ${IPFIX_SAMPLING}"
+          fi
           gw_interface_flag=
           # if br-ex1 is configured on the node, we want to use it for external gateway traffic
           if [ -d /sys/class/net/br-ex1 ]; then
@@ -390,6 +399,18 @@ spec:
         {{ if .IPFIXCollectors }}
         - name: IPFIX_COLLECTORS
           value: "{{.IPFIXCollectors}}"
+        {{ end }}
+        {{ if .IPFIXCacheMaxFlows }}
+        - name: IPFIX_CACHE_MAX_FLOWS
+          value: "{{.IPFIXCacheMaxFlows}}"
+        {{ end }}
+        {{ if .IPFIXCacheActiveTimeout }}
+        - name: IPFIX_CACHE_ACTIVE_TIMEOUT
+          value: "{{.IPFIXCacheActiveTimeout}}"
+        {{ end }}
+        {{ if .IPFIXSampling }}
+        - name: IPFIX_SAMPLING
+          value: "{{.IPFIXSampling}}"
         {{ end }}
         - name: K8S_NODE
           valueFrom:

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -2,7 +2,6 @@ package bootstrap
 
 import (
 	"github.com/gophercloud/utils/openstack/clientconfig"
-
 	configv1 "github.com/openshift/api/config/v1"
 	appsv1 "k8s.io/api/apps/v1"
 )
@@ -42,6 +41,7 @@ type OVNBootstrapResult struct {
 	ExistingNodeDaemonset   *appsv1.DaemonSet
 	OVNKubernetesConfig     *OVNConfigBoostrapResult
 	PrePullerDaemonset      *appsv1.DaemonSet
+	FlowsConfig             *FlowsConfig
 }
 
 type BootstrapResult struct {
@@ -55,4 +55,18 @@ type BootstrapResult struct {
 type CloudBootstrapResult struct {
 	PlatformType   configv1.PlatformType
 	PlatformRegion string
+}
+
+type FlowsConfig struct {
+	// Target IP:port of the flow collector
+	Target string
+
+	// CacheActiveTimeout is the max period, in seconds, during which the reporter will aggregate flows before sending
+	CacheActiveTimeout *uint
+
+	// CacheMaxFlows is the max number of flows in an aggregate; when reached, the reporter sends the flows
+	CacheMaxFlows *uint
+
+	// Sampling is the sampling rate on the reporter. 100 means one flow on 100 is sent. 0 means disabled.
+	Sampling *uint
 }

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -51,6 +51,11 @@ const OVN_NODE_SELECTOR_DPU = "network.operator.openshift.io/dpu: ''"
 
 var OVN_MASTER_DISCOVERY_TIMEOUT = 250
 
+const (
+	OVSFlowsConfigMapName   = "ovs-flows-config"
+	OVSFlowsConfigNamespace = names.APPLIED_NAMESPACE
+)
+
 // renderOVNKubernetes returns the manifests for the ovn-kubernetes.
 // This creates
 // - the openshift-ovn-kubernetes namespace
@@ -130,6 +135,9 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["NetFlowCollectors"] = ""
 	data.Data["SFlowCollectors"] = ""
 	data.Data["IPFIXCollectors"] = ""
+	data.Data["IPFIXCacheMaxFlows"] = ""
+	data.Data["IPFIXCacheActiveTimeout"] = ""
+	data.Data["IPFIXSampling"] = ""
 	data.Data["OVNPolicyAuditRateLimit"] = c.PolicyAuditConfig.RateLimit
 	data.Data["OVNPolicyAuditMaxFileSize"] = c.PolicyAuditConfig.MaxFileSize
 	data.Data["OVNPolicyAuditDestination"] = c.PolicyAuditConfig.Destination
@@ -207,7 +215,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 			data.Data["IPFIXCollectors"] = strings.TrimSuffix(collectors.String(), ",")
 		}
 	}
-
+	renderOVNFlowsConfig(bootstrapResult, &data)
 	if len(bootstrapResult.OVN.MasterIPs) == 1 {
 		data.Data["IsSNO"] = true
 	} else {
@@ -299,6 +307,34 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	}
 
 	return objs, nil
+}
+
+// renderOVNFlowsConfig renders the bootstrapped information from the ovs-flows-config ConfigMap
+func renderOVNFlowsConfig(bootstrapResult *bootstrap.BootstrapResult, data *render.RenderData) {
+	flows := bootstrapResult.OVN.FlowsConfig
+	if flows == nil {
+		return
+	}
+	if flows.Target == "" {
+		klog.Warningf("ovs-flows-config configmap 'target' field can't be empty. Ignoring configuration: %+v", flows)
+		return
+	}
+	// if IPFIX collectors are provided by means of both the operator configuration and the
+	// ovs-flows-config ConfigMap, we will merge both targets
+	if colls, ok := data.Data["IPFIXCollectors"].(string); !ok || colls == "" {
+		data.Data["IPFIXCollectors"] = flows.Target
+	} else {
+		data.Data["IPFIXCollectors"] = colls + "," + flows.Target
+	}
+	if flows.CacheMaxFlows != nil {
+		data.Data["IPFIXCacheMaxFlows"] = *flows.CacheMaxFlows
+	}
+	if flows.Sampling != nil {
+		data.Data["IPFIXSampling"] = *flows.Sampling
+	}
+	if flows.CacheActiveTimeout != nil {
+		data.Data["IPFIXCacheActiveTimeout"] = *flows.CacheActiveTimeout
+	}
 }
 
 // bootstrapOVNConfig returns the value of mode found in the openshift-ovn-kubernetes/dpu-mode-config configMap
@@ -675,9 +711,76 @@ func bootstrapOVN(conf *operv1.Network, kubeClient client.Client) (*bootstrap.Bo
 			ExistingNodeDaemonset:   nodeDS,
 			OVNKubernetesConfig:     ovnConfigResult,
 			PrePullerDaemonset:      prePullerDS,
+			FlowsConfig:             bootstrapFlowsConfig(kubeClient),
 		},
 	}
 	return &res, nil
+}
+
+// bootstrapFlowsConfig looks for the openshift-network-operator/ovs-flows-config configmap, and
+// returns it or returns nil if it does not exist (or can't be properly parsed).
+// Usually, the second argument will be net.LookupIP
+func bootstrapFlowsConfig(cl client.Reader) *bootstrap.FlowsConfig {
+	cm := corev1.ConfigMap{}
+	if err := cl.Get(context.TODO(), types.NamespacedName{
+		Name:      OVSFlowsConfigMapName,
+		Namespace: OVSFlowsConfigNamespace,
+	}, &cm); err != nil {
+		if !apierrors.IsNotFound(err) {
+			klog.Warningf("%s: error fetching configmap: %v", OVSFlowsConfigMapName, err)
+		}
+		// ovs-flows-config is not defined. Ignoring from bootstrap
+		return nil
+	}
+	fc := bootstrap.FlowsConfig{}
+	// fetching string fields and transforming them to OVS format
+	if st, ok := cm.Data["sharedTarget"]; ok {
+		fc.Target = st
+	} else if np, ok := cm.Data["nodePort"]; ok {
+		// empty host will be interpreted as Node IP by ovn-kubernetes
+		fc.Target = ":" + np
+	} else {
+		klog.Warningf("%s: wrong data section: either sharedTarget or nodePort sections are needed: %+v",
+			OVSFlowsConfigMapName, cm.Data)
+		return nil
+	}
+
+	if catStr, ok := cm.Data["cacheActiveTimeout"]; ok {
+		if catd, err := time.ParseDuration(catStr); err != nil {
+			klog.Warningf("%s: wrong cacheActiveTimeout value %s. Ignoring: %v",
+				OVSFlowsConfigMapName, catStr, err)
+		} else {
+			catf := catd.Seconds()
+			catu := uint(catf)
+			if catf != float64(catu) {
+				klog.Warningf("%s: cacheActiveTimeout %s will be truncated to %d seconds",
+					OVSFlowsConfigMapName, catStr, catu)
+			}
+			fc.CacheActiveTimeout = &catu
+		}
+	}
+
+	if cmfStr, ok := cm.Data["cacheMaxFlows"]; ok {
+		if cmf, err := strconv.ParseUint(cmfStr, 10, 32); err != nil {
+			klog.Warningf("%s: wrong cacheMaxFlows value %s. Ignoring: %v",
+				OVSFlowsConfigMapName, cmfStr, err)
+		} else {
+			cmfu := uint(cmf)
+			fc.CacheMaxFlows = &cmfu
+		}
+	}
+
+	if sStr, ok := cm.Data["sampling"]; ok {
+		if sampling, err := strconv.ParseUint(sStr, 10, 32); err != nil {
+			klog.Warningf("%s: wrong sampling value %s. Ignoring: %v",
+				OVSFlowsConfigMapName, sStr, err)
+		} else {
+			su := uint(sampling)
+			fc.Sampling = &su
+		}
+	}
+
+	return &fc
 }
 
 func currentInitiatorExists(ovnMasterIPs []string, configInitiator string) bool {


### PR DESCRIPTION
As described in the [Related RFE](https://github.com/openshift/enhancements/blob/master/enhancements/network/ovs-flow-export-configuration.md), the CNO needs to listen for any change in the `ovs-flows-config` ConfigMap that is created after a `FlowCollector` object, so the CNO can properly configure and tune the OVN-Kubernetes' OpenVSwitch instance to export IPFIX flows.

This PR adds the following functionalities:

1. Adds a watcher for the `ovs-flows-config` configmap and retriggers the `operconfig_controller` reconciliation process on any change in that map.
2. On reconciliation, bootstraps the `ovs-flows-config` configmap information and renders it into the `ovnkube-node.yaml` to properly reconfigure`ovn-kubernetes`.
3. Defines the RBAC assets according to the [CNO<->NOO RBAC configuration document](https://docs.google.com/document/d/1AeUgETCtsVsYPuvpu0HuDfeuhTaWGRd3Qpkf38bu81U)

The following PR for the `ovn-kubernetes` repository must be merged before this PR: https://github.com/ovn-org/ovn-kubernetes/pull/2649

Related bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2034517
