### PR TITLE
Add bare pods to status manager

### DIFF
--- a/pkg/controller/operconfig/pod_controller.go
+++ b/pkg/controller/operconfig/pod_controller.go
@@ -43,7 +43,7 @@ func (r *ReconcilePods) Reconcile(ctx context.Context, request reconcile.Request
 	}
 
 	log.Printf("Reconciling update to %s/%s\n", request.Namespace, request.Name)
-	r.status.SetFromPods()
+	r.status.SetFromRollout()
 
 	return reconcile.Result{RequeueAfter: ResyncPeriod}, nil
 }

--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -55,6 +55,7 @@ type StatusManager struct {
 	failing         [maxStatusLevel]*operv1.OperatorCondition
 	installComplete bool
 
+	pods           []types.NamespacedName
 	daemonSets     []types.NamespacedName
 	deployments    []types.NamespacedName
 	relatedObjects []configv1.ObjectReference
@@ -310,6 +311,12 @@ func (status *StatusManager) SetNotDegraded(statusLevel StatusLevel) {
 	status.Lock()
 	defer status.Unlock()
 	status.setNotDegraded(statusLevel)
+}
+
+func (status *StatusManager) SetPods(pods []types.NamespacedName) {
+	status.Lock()
+	defer status.Unlock()
+	status.pods = pods
 }
 
 func (status *StatusManager) SetDaemonSets(daemonSets []types.NamespacedName) {


### PR DESCRIPTION
As part of the ongoing effort to allow MTU changes which would include
jobs deployed as bare pods, add support in status manager to track their
status assuming that they run to completion

ref: https://github.com/openshift/cluster-network-operator/pull/1215

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>