### PR TITLE
OVN-K alerts: Fix incorrect metric name reference

### DIFF
--- a/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         summary: ovn-kubernetes has not written anything to the northbound database for too long
       expr: |
-         time() - max(ovn_nb_e2e_timestamp) > 300
+         time() - max(ovnkube_master_nb_e2e_timestamp) > 120
       for: 10m
       labels:
         severity: warning
@@ -40,7 +40,7 @@ spec:
       annotations:
         summary: ovn-northd has not successfully synced any changes to the southbound DB for too long
       expr: |
-        max(ovn_nb_e2e_timestamp) - max(ovn_sb_e2e_timestamp) > 120
+        max(ovnkube_master_nb_e2e_timestamp) - max(ovnkube_master_sb_e2e_timestamp) > 120
       for: 10m
       labels:
         severity: warning


### PR DESCRIPTION
Fix incorrect metric name reference. 
As you can see upstream [1], we register with the default register, and this means the metric starts with "ovnkube_master".

[1] https://github.com/ovn-org/ovn-kubernetes/blob/b1b54eddff1490d6c93a5aceba6bd2029b6b31cf/go-controller/pkg/metrics/master.go#L201
