### PR TITLE
Bug 2010663: OVN-K alerts: conform to monitoring team style guide

### DIFF
--- a/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/alert-rules-control-plane.yaml
@@ -14,7 +14,10 @@ spec:
     rules:
     - alert: NoRunningOvnMaster
       annotations:
-        summary: There is no running ovn-kubernetes master
+        summary: There is no running ovn-kubernetes master.
+        description: |
+          Networking control plane is degraded. Networking configuration updates applied to the cluster will not be
+          implemented while there are no OVN Kubernetes pods.
       expr: |
         absent(up{job="ovnkube-master", namespace="openshift-ovn-kubernetes"} == 1)
       for: 10m
@@ -22,7 +25,11 @@ spec:
         severity: warning
     - alert: NoOvnMasterLeader
       annotations:
-        summary: There is no ovn-kubernetes master leader
+        summary: There is no ovn-kubernetes master leader.
+        description: |
+          Networking control plane is degraded. Networking configuration updates applied to the cluster will not be
+          implemented while there is no OVN Kubernetes leader. Existing workloads should continue to have connectivity.
+          OVN-Kubernetes control plane is not functional.
       expr: |
         max(ovnkube_master_leader) == 0
       for: 10m
@@ -30,7 +37,11 @@ spec:
         severity: warning
     - alert: NorthboundStale
       annotations:
-        summary: ovn-kubernetes has not written anything to the northbound database for too long
+        summary: ovn-kubernetes has not written anything to the northbound database for too long.
+        description: |
+          Networking control plane is degraded. Networking configuration updates applied to the cluster will not be
+          implemented. Existing workloads should continue to have connectivity. OVN-Kubernetes control plane and/or
+          OVN northbound database may not be functional.
       expr: |
          time() - max(ovn_nb_e2e_timestamp) > 300
       for: 10m
@@ -38,7 +49,11 @@ spec:
         severity: warning
     - alert: SouthboundStale
       annotations:
-        summary: ovn-northd has not successfully synced any changes to the southbound DB for too long
+        summary: ovn-northd has not successfully synced any changes to the southbound DB for too long.
+        description: |
+          Networking control plane is degraded. Networking configuration updates may not be applied to the cluster or
+          taking a long time to apply. This usually means there is a large load on OVN component 'northd' or it is not
+          functioning.
       expr: |
         max(ovn_nb_e2e_timestamp) - max(ovn_sb_e2e_timestamp) > 120
       for: 10m
@@ -46,7 +61,8 @@ spec:
         severity: warning
     - alert: V4SubnetAllocationThresholdExceeded
       annotations:
-        summary: More than 80% of v4 subnets available to assign to the nodes are allocated. Current v4 subnet allocation percentage is {{"{{"}} $value {{"}}"}}
+        summary: More than 80% of v4 subnets available to assign to the nodes are allocated. Current v4 subnet allocation percentage is {{"{{"}} $value {{"}}"}}.
+        description: More than 80% of IPv4 subnets are used. Insufficient IPv4 subnets could degrade provisioning of workloads.
       expr: |
         ovnkube_master_allocated_v4_host_subnets/ovnkube_master_num_v4_host_subnets * 100 > 80
       for: 10m
@@ -54,7 +70,8 @@ spec:
         severity: warning
     - alert: V6SubnetAllocationThresholdExceeded
       annotations:
-        summary: More than 80% of the v6 subnets available to assign to the nodes are allocated. Current v6 subnet allocation percentage is {{"{{"}} $value {{"}}"}}
+        summary: More than 80% of the v6 subnets available to assign to the nodes are allocated. Current v6 subnet allocation percentage is {{"{{"}} $value {{"}}"}}.
+        description: More than 80% of IPv6 subnets are used. Insufficient IPv6 subnets could degrade provisioning of workloads.
       expr: |
         ovnkube_master_allocated_v6_host_subnets/ovnkube_master_num_v6_host_subnets * 100 > 80
       for: 10m

--- a/bindata/network/ovn-kubernetes/alert-rules.yaml
+++ b/bindata/network/ovn-kubernetes/alert-rules.yaml
@@ -15,6 +15,10 @@ spec:
     - alert: NodeWithoutOVNKubeNodePodRunning
       annotations:
         summary: All Linux nodes should be running an ovnkube-node pod, {{"{{"}} $labels.node {{"}}"}} is not.
+        description: |
+          Networking is degraded on nodes that do not have a functioning ovnkube-node pod. Existing workloads on the
+          node may continue to have connectivity but any additional workloads will not be provisioned on the node. Any
+          network policy changes will not be implemented on existing workloads on the node.
       expr: |
         (kube_node_info unless on(node) (kube_pod_info{namespace="openshift-ovn-kubernetes",pod=~"ovnkube-node.*"}
         or kube_node_labels{label_kubernetes_io_os="windows"})) > 0


### PR DESCRIPTION
See "style guide" in alerting-consistency.md at repository
openshift/enhancements/monitoring.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>

/cc @npinaeva 

Waiting on clarification if I need to prefix metric name with component name.