### PR TITLE
Pod networking on DPU host in Infra and Tenant clusters

### DIFF
--- a/bindata/network-diagnostics/network-check-target.yaml
+++ b/bindata/network-diagnostics/network-check-target.yaml
@@ -56,6 +56,15 @@ spec:
       - operator: "Exists"
       nodeSelector:
         beta.kubernetes.io/os: "linux"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: network.operator.openshift.io/dpu-host
+                operator: DoesNotExist
+              - key: network.operator.openshift.io/dpu
+                operator: DoesNotExist
 
 ---
 apiVersion: v1

--- a/bindata/network/network-metrics/001-daemonset.yaml
+++ b/bindata/network/network-metrics/001-daemonset.yaml
@@ -29,6 +29,15 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: network.operator.openshift.io/dpu-host
+                operator: DoesNotExist
+              - key: network.operator.openshift.io/dpu
+                operator: DoesNotExist
       priorityClassName: "system-node-critical"
       tolerations:
         - operator: Exists


### PR DESCRIPTION
On DPU Deployments:
* Tenant Cluster (Cluster with x86 hosts that contain Ethernet Controller
  Cards with DPUs)  pods must either be host network backed or must request
  a VF from the SR-IOV Device Plugin.
* Infra Cluster (ARM Cluster that contain the DPUs) pods must be host
  network backed.

When OpenShift is deployed, some pods are deployed on all worker nodes.
Some of these pods are non-host network backed, so they need to handled
to meet the above criteria.

The following DaemonSets are marked as tolerating all taints, but are pod-networked:
* openshift-multus/network-metrics-daemon
* openshift-network-diagnostics/network-check-target

These DaemonSets are managed by CNO. This PR is setting affinity on
these DaemonSets so they won't be deployed on DPU or DPU-Host nodes.

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>