### PR TITLE
Bug 2035459: modify cluster-network-features for OpenshiftSDN

### DIFF
--- a/bindata/network/openshift-sdn/cni-features.yaml
+++ b/bindata/network/openshift-sdn/cni-features.yaml
@@ -8,5 +8,5 @@ metadata:
       Exposes available network features as required by the Console in order to show or hide some form fields.
       If the map or a given property is undefined, the Console won't throw error and will take a default action (show, hide, show with a warning message...).
 data:
-  policy_egress: "false"
-  policy_peer_ipblock_exceptions: "false"
+  policy_egress: "true"
+  policy_peer_ipblock_exceptions: "true"


### PR DESCRIPTION
According to the recent comment of Dan Winship in a recently merged
PR: https://github.com/openshift/cluster-network-operator/pull/1204#issuecomment-990201372

> openshift-sdn also implements both egress rules and ipBlock exceptions.

This PR updates the reported capabilities for OpenshiftSDN so the Console
will accordingly show the proper sections in the Network Policy forms.
