### PR TITLE
Bug 2022144: sbdb and nbdb containers leave pid around if they restarted or crashed

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -245,6 +245,7 @@ spec:
               - |
                 set -x
                 CLUSTER_INITIATOR_IP="{{.OVN_DB_CLUSTER_INITIATOR}}"
+                rm -f /var/run/ovn/ovnnb_db.pid
                 if [[ "${K8S_NODE_IP}" == "${CLUSTER_INITIATOR_IP}" ]]; then
                   echo "$(date -Iseconds) - nbdb - postStart - waiting for master to be selected"
 
@@ -563,6 +564,7 @@ spec:
               - |
                 set -x
                 CLUSTER_INITIATOR_IP="{{.OVN_DB_CLUSTER_INITIATOR}}"
+                rm -f /var/run/ovn/ovnsb_db.pid
                 if [[ "${K8S_NODE_IP}" == "${CLUSTER_INITIATOR_IP}" ]]; then
                   echo "$(date -Iseconds) - sdb - postStart - waiting for master to be selected"
 


### PR DESCRIPTION
This PR remove pidfile on postStart hook to avoid run_n/sb_ovsdb from an early return.

Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>