### PR TITLE
Bug 2032559: Block DualStack migration for unsupported cluster types

### DIFF
--- a/pkg/controller/clusterconfig/clusterconfig_controller.go
+++ b/pkg/controller/clusterconfig/clusterconfig_controller.go
@@ -88,7 +88,7 @@ func (r *ReconcileClusterConfig) Reconcile(ctx context.Context, request reconcil
 	}
 
 	// Validate the cluster config
-	if err := network.ValidateClusterConfig(clusterConfig.Spec); err != nil {
+	if err := network.ValidateClusterConfig(clusterConfig.Spec, r.client); err != nil {
 		log.Printf("Failed to validate Network.Spec: %v", err)
 		r.status.SetDegraded(statusmanager.ClusterConfig, "InvalidClusterConfig",
 			fmt.Sprintf("The cluster configuration is invalid (%v). Use 'oc edit network.config.openshift.io cluster' to fix.", err))

--- a/pkg/controller/operconfig/cluster.go
+++ b/pkg/controller/operconfig/cluster.go
@@ -34,7 +34,7 @@ func (r *ReconcileOperConfig) MergeClusterConfig(ctx context.Context, operConfig
 
 	// Validate cluster config
 	// If invalid just warn and proceed.
-	if err := network.ValidateClusterConfig(clusterConfig.Spec); err != nil {
+	if err := network.ValidateClusterConfig(clusterConfig.Spec, r.client); err != nil {
 		log.Printf("WARNING: ignoring Network.config.openshift.io/v1/cluster - failed validation: %v", err)
 		return nil
 	}

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -188,7 +188,7 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 	if prev != nil {
 		// We may need to fill defaults here -- sort of as a poor-man's
 		// upconversion scheme -- if we add additional fields to the config.
-		err = network.IsChangeSafe(prev, &operConfig.Spec)
+		err = network.IsChangeSafe(prev, &operConfig.Spec, r.client)
 		if err != nil {
 			log.Printf("Not applying unsafe change: %v", err)
 			r.status.SetDegraded(statusmanager.OperatorConfig, "InvalidOperatorConfig",

--- a/pkg/network/render_test.go
+++ b/pkg/network/render_test.go
@@ -14,18 +14,24 @@ func TestIsChangeSafe(t *testing.T) {
 	// NOTE: IsChangeSafe() requires you to have called Validate() beforehand, so we
 	// don't have to check that invalid configs are considered unsafe to change to.
 
+	// OpenShiftSDN validation
+	// =================================
+
 	prev := OpenShiftSDNConfig.Spec.DeepCopy()
 	FillDefaults(prev, nil)
 	next := OpenShiftSDNConfig.Spec.DeepCopy()
 	FillDefaults(next, nil)
 
+	// No error should occur when prev equals next.
 	err := IsChangeSafe(prev, next)
 	g.Expect(err).NotTo(HaveOccurred())
 
+	// Changes to the cluster network's prefix are not supported.
 	next.ClusterNetwork[0].HostPrefix = 31
 	err = IsChangeSafe(prev, next)
-	g.Expect(err).To(MatchError(ContainSubstring("cannot change ClusterNetwork")))
+	g.Expect(err).To(MatchError(ContainSubstring("unsupported change to ClusterNetwork")))
 
+	// It is not supported to append another cluster network of the same type.
 	next = OpenShiftSDNConfig.Spec.DeepCopy()
 	FillDefaults(next, nil)
 	next.ClusterNetwork = append(next.ClusterNetwork, operv1.ClusterNetworkEntry{
@@ -33,23 +39,79 @@ func TestIsChangeSafe(t *testing.T) {
 		HostPrefix: 24,
 	})
 	err = IsChangeSafe(prev, next)
-	g.Expect(err).To(MatchError(ContainSubstring("cannot change ClusterNetwork")))
+	g.Expect(err).To(MatchError(ContainSubstring("unsupported change to ClusterNetwork")))
 
+	// It is not supported to change the ServiceNetwork.
 	next = OpenShiftSDNConfig.Spec.DeepCopy()
 	FillDefaults(next, nil)
 	next.ServiceNetwork = []string{"1.2.3.0/24"}
 	err = IsChangeSafe(prev, next)
-	g.Expect(err).To(MatchError(ContainSubstring("cannot change ServiceNetwork")))
+	g.Expect(err).To(MatchError(ContainSubstring("unsupported change to ServiceNetwork")))
 
-	next = OpenShiftSDNConfig.Spec.DeepCopy()
+	// Migration from OpenShiftSDN to OVNKubernetes validation
+	// =================================
+
+	prev = OpenShiftSDNConfig.Spec.DeepCopy()
+	FillDefaults(prev, nil)
+	prev.Migration = &operv1.NetworkMigration{NetworkType: "OVNKubernetes"}
+	next = OVNKubernetesConfig.Spec.DeepCopy()
 	FillDefaults(next, nil)
+
+	// You can change cluster network during migration.
+	next.ClusterNetwork = append(next.ClusterNetwork,
+		operv1.ClusterNetworkEntry{
+			CIDR:       "1.2.0.0/16",
+			HostPrefix: 24,
+		},
+	)
+	err = IsChangeSafe(prev, next)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// You can't change service network during migration.
+	next = OVNKubernetesConfig.Spec.DeepCopy()
+	FillDefaults(next, nil)
+	next.ServiceNetwork = []string{"1.2.3.0/24"}
+	err = IsChangeSafe(prev, next)
+	g.Expect(err).To(MatchError(ContainSubstring("cannot change ServiceNetwork during migration")))
+
+	// Invalid miscellaneous migration validation
+	// =================================
+
+	prev = OpenShiftSDNConfig.Spec.DeepCopy()
+	FillDefaults(prev, nil)
+	next = OpenShiftSDNConfig.Spec.DeepCopy()
+	FillDefaults(prev, nil)
+
+	// You can't change default network type when not doing migration.
 	next.DefaultNetwork.Type = "Kuryr"
 	err = IsChangeSafe(prev, next)
 	g.Expect(err).To(MatchError(ContainSubstring("cannot change default network type when not doing migration")))
 
-	// You can change a single-stack config to dual-stack
+	// You can't change default network type to non-target migration network type.
 	next = OpenShiftSDNConfig.Spec.DeepCopy()
 	FillDefaults(next, nil)
+	prev.Migration = &operv1.NetworkMigration{NetworkType: "OVNKubernetes"}
+	next.DefaultNetwork.Type = "Kuryr"
+	err = IsChangeSafe(prev, next)
+	g.Expect(err).To(MatchError(ContainSubstring("can only change default network type to the target migration network type")))
+
+	// You can't change the migration network type when it is not null.
+	next = OpenShiftSDNConfig.Spec.DeepCopy()
+	FillDefaults(next, nil)
+	next.Migration = &operv1.NetworkMigration{NetworkType: "OVNKubernetes"}
+	prev.Migration = &operv1.NetworkMigration{NetworkType: "Kuryr"}
+	err = IsChangeSafe(prev, next)
+	g.Expect(err).To(MatchError(ContainSubstring("cannot change migration network type after migration has started")))
+
+	// OVNKubernetes DualStack validation
+	// =================================
+
+	prev = OVNKubernetesConfig.Spec.DeepCopy()
+	FillDefaults(prev, nil)
+	next = OVNKubernetesConfig.Spec.DeepCopy()
+	FillDefaults(next, nil)
+
+	// You can change a single-stack config to dual-stack ...
 	next.ServiceNetwork = append(next.ServiceNetwork, "fd02::/112")
 	next.ClusterNetwork = append(next.ClusterNetwork, operv1.ClusterNetworkEntry{
 		CIDR:       "fd01::/48",
@@ -57,12 +119,12 @@ func TestIsChangeSafe(t *testing.T) {
 	})
 	err = IsChangeSafe(prev, next)
 	g.Expect(err).NotTo(HaveOccurred())
-	// ...and vice-versa
+	// ... and vice-versa.
 	err = IsChangeSafe(next, prev)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	// But you can't go from single-stack IPv4 to dual-stack IPv6-primary
-	next = OpenShiftSDNConfig.Spec.DeepCopy()
+	// But you can't change the ServiceNetwork from single-stack IPv4 to dual-stack IPv6-primary ...
+	next = OVNKubernetesConfig.Spec.DeepCopy()
 	FillDefaults(next, nil)
 	next.ServiceNetwork = append([]string{"fd02::/112"}, prev.ServiceNetwork...)
 	next.ClusterNetwork = append([]operv1.ClusterNetworkEntry{{
@@ -70,13 +132,27 @@ func TestIsChangeSafe(t *testing.T) {
 		HostPrefix: 64,
 	}}, prev.ClusterNetwork...)
 	err = IsChangeSafe(prev, next)
-	g.Expect(err).To(MatchError(ContainSubstring("cannot change ServiceNetwork")))
-	// ...or vice-versa
+	g.Expect(err).To(MatchError(ContainSubstring("cannot change primary ServiceNetwork when migrating to/from dual-stack")))
+	// ... or vice-versa.
 	err = IsChangeSafe(next, prev)
-	g.Expect(err).To(MatchError(ContainSubstring("cannot change ServiceNetwork")))
+	g.Expect(err).To(MatchError(ContainSubstring("cannot change primary ServiceNetwork when migrating to/from dual-stack")))
 
-	// You can add multiple ClusterNetworks of the new IP family
-	next = OpenShiftSDNConfig.Spec.DeepCopy()
+	// You also cannot change the ClusterNetwork from single-stack IPv4 to dual-stack IPv6-primary ...
+	next = OVNKubernetesConfig.Spec.DeepCopy()
+	FillDefaults(next, nil)
+	next.ServiceNetwork = append(next.ServiceNetwork, "fd02::/112")
+	next.ClusterNetwork = append([]operv1.ClusterNetworkEntry{{
+		CIDR:       "fd01::/48",
+		HostPrefix: 64,
+	}}, prev.ClusterNetwork...)
+	err = IsChangeSafe(prev, next)
+	g.Expect(err).To(MatchError(ContainSubstring("cannot change primary ClusterNetwork when migrating to/from dual-stack")))
+	// ... or vice-versa.
+	err = IsChangeSafe(next, prev)
+	g.Expect(err).To(MatchError(ContainSubstring("cannot change primary ClusterNetwork when migrating to/from dual-stack")))
+
+	// You can add multiple ClusterNetworks of the new IP family ...
+	next = OVNKubernetesConfig.Spec.DeepCopy()
 	FillDefaults(next, nil)
 	next.ServiceNetwork = append(next.ServiceNetwork, "fd02::/112")
 	next.ClusterNetwork = append(next.ClusterNetwork,
@@ -91,12 +167,12 @@ func TestIsChangeSafe(t *testing.T) {
 	)
 	err = IsChangeSafe(prev, next)
 	g.Expect(err).NotTo(HaveOccurred())
-	// ...and vice-versa
+	// ... and vice-versa.
 	err = IsChangeSafe(next, prev)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	// You can't add any new ClusterNetworks of the old IP family
-	next = OpenShiftSDNConfig.Spec.DeepCopy()
+	// You can't add any new ClusterNetworks of the old IP family.
+	next = OVNKubernetesConfig.Spec.DeepCopy()
 	FillDefaults(next, nil)
 	next.ServiceNetwork = append(next.ServiceNetwork, "fd02::/112")
 	next.ClusterNetwork = append(next.ClusterNetwork,
@@ -110,46 +186,7 @@ func TestIsChangeSafe(t *testing.T) {
 		},
 	)
 	err = IsChangeSafe(prev, next)
-	g.Expect(err).To(MatchError(ContainSubstring("cannot change ClusterNetwork")))
-
-	// You can change cluster network during migration
-	next = OpenShiftSDNConfig.Spec.DeepCopy()
-	FillDefaults(next, nil)
-	prev.Migration = &operv1.NetworkMigration{NetworkType: "OVNKubernetes"}
-	next.DefaultNetwork.Type = "OVNKubernetes"
-	next.ClusterNetwork = append(next.ClusterNetwork,
-		operv1.ClusterNetworkEntry{
-			CIDR:       "1.2.0.0/16",
-			HostPrefix: 24,
-		},
-	)
-	err = IsChangeSafe(prev, next)
-	g.Expect(err).NotTo(HaveOccurred())
-
-	// You can't change service network during migration
-	next = OpenShiftSDNConfig.Spec.DeepCopy()
-	FillDefaults(next, nil)
-	prev.Migration = &operv1.NetworkMigration{NetworkType: "OVNKubernetes"}
-	next.DefaultNetwork.Type = "OVNKubernetes"
-	next.ServiceNetwork = []string{"1.2.3.0/24"}
-	err = IsChangeSafe(prev, next)
-	g.Expect(err).To(MatchError(ContainSubstring("cannot change ServiceNetwork during migration")))
-
-	// You can't change default network type to non-target migration network type
-	next = OpenShiftSDNConfig.Spec.DeepCopy()
-	FillDefaults(next, nil)
-	prev.Migration = &operv1.NetworkMigration{NetworkType: "OVNKubernetes"}
-	next.DefaultNetwork.Type = "Kuryr"
-	err = IsChangeSafe(prev, next)
-	g.Expect(err).To(MatchError(ContainSubstring("can only change default network type to the target migration network type")))
-
-	// You can't change the migration network type when it is not null.
-	next = OpenShiftSDNConfig.Spec.DeepCopy()
-	FillDefaults(next, nil)
-	next.Migration = &operv1.NetworkMigration{NetworkType: "OVNKubernetes"}
-	prev.Migration = &operv1.NetworkMigration{NetworkType: "Kuryr"}
-	err = IsChangeSafe(prev, next)
-	g.Expect(err).To(MatchError(ContainSubstring("cannot change migration network type after migration is start")))
+	g.Expect(err).To(MatchError(ContainSubstring("cannot add additional ClusterNetwork values of original IP family when migrating to dual stack")))
 }
 
 func TestRenderUnknownNetwork(t *testing.T) {


### PR DESCRIPTION
Only allow DualStack migration for BareMetal and None type clusters.

Additionally, update error messages for DualStack migrations.
Now that we are not hiding the existence of DualStack any more, give
clearer error messages for unsupported configurations.