### PR TITLE
Bug 2033422: bootstrapOVNGatewayConfig should only be called once

### DIFF
--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -288,7 +288,9 @@ func bootstrapOVNConfig(conf *operv1.Network, kubeClient client.Client) (*bootst
 	ovnConfigResult := &bootstrap.OVNConfigBoostrapResult{
 		NodeMode: OVN_NODE_MODE_FULL,
 	}
-	bootstrapOVNGatewayConfig(conf, kubeClient)
+	if conf.Spec.DefaultNetwork.OVNKubernetesConfig.GatewayConfig == nil {
+		bootstrapOVNGatewayConfig(conf, kubeClient)
+	}
 	cm := &corev1.ConfigMap{}
 	dmc := types.NamespacedName{Namespace: "openshift-network-operator", Name: "dpu-mode-config"}
 	err := kubeClient.Get(context.TODO(), dmc, cm)


### PR DESCRIPTION
bootstrapOVN is repeatedly called in CNO's render loop.
However we should be calling bootstrapOVNGatewayConfig
only once right at the starup scenario of CNO where
the gatewayConfig is nil. Once that field is set, we
should not have to worry about checking the config map
and setting the default value.

Currently this makes CNO always change the gatewaymode
to shared because bootstrap is seemed to be called every
time in the loop. Let's add the check where this
function is called only if gatewayConfig==nil