### PR TITLE
Bug 2034153: Fix MTU migration verification for OpenShiftSDN

### DIFF
--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -173,7 +173,7 @@ func isOpenShiftSDNChangeSafe(prev, next *operv1.NetworkSpec) []error {
 	nn := next.DefaultNetwork.OpenShiftSDNConfig
 	errs := []error{}
 
-	if reflect.DeepEqual(pn, nn) {
+	if reflect.DeepEqual(pn, nn) && reflect.DeepEqual(prev.Migration, next.Migration) {
 		return errs
 	}
 
@@ -201,7 +201,7 @@ func isOpenShiftSDNChangeSafe(prev, next *operv1.NetworkSpec) []error {
 		} else {
 			// Only check next.Migration.MTU.Network.From when it changes
 			checkPrevMTU := prev.Migration == nil || prev.Migration.MTU == nil || prev.Migration.MTU.Network == nil || !reflect.DeepEqual(prev.Migration.MTU.Network.From, next.Migration.MTU.Network.From)
-			if checkPrevMTU && *next.Migration.MTU.Network.From != *pn.MTU {
+			if checkPrevMTU && !reflect.DeepEqual(next.Migration.MTU.Network.From, pn.MTU) {
 				errs = append(errs, errors.Errorf("invalid Migration.MTU.Network.From(%d) not equal to the currently applied MTU(%d)", *next.Migration.MTU.Network.From, *pn.MTU))
 			}
 			if (*next.Migration.MTU.Network.To + sdnOverhead) > *next.Migration.MTU.Machine.To {

--- a/pkg/network/openshift_sdn_test.go
+++ b/pkg/network/openshift_sdn_test.go
@@ -333,9 +333,7 @@ func TestOpenShiftSDNIsSafe(t *testing.T) {
 	g.Expect(errs[1]).To(MatchError("cannot change openshift-sdn vxlanPort"))
 	g.Expect(errs[2]).To(MatchError("cannot change openshift-sdn mtu without migration"))
 
-	next.DefaultNetwork.OpenShiftSDNConfig.VXLANPort = prev.DefaultNetwork.OpenShiftSDNConfig.VXLANPort
-	next.DefaultNetwork.OpenShiftSDNConfig.Mode = prev.DefaultNetwork.OpenShiftSDNConfig.Mode
-	next.DefaultNetwork.OpenShiftSDNConfig.MTU = prev.DefaultNetwork.OpenShiftSDNConfig.MTU
+	next = prev.DeepCopy()
 	// mtu migration
 
 	// valid mtu migration

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -414,7 +414,7 @@ func isOVNKubernetesChangeSafe(prev, next *operv1.NetworkSpec) []error {
 		} else {
 			// Only check next.Migration.MTU.Network.From when it changes
 			checkPrevMTU := prev.Migration == nil || prev.Migration.MTU == nil || prev.Migration.MTU.Network == nil || !reflect.DeepEqual(prev.Migration.MTU.Network.From, next.Migration.MTU.Network.From)
-			if checkPrevMTU && *next.Migration.MTU.Network.From != *pn.MTU {
+			if checkPrevMTU && !reflect.DeepEqual(next.Migration.MTU.Network.From, pn.MTU) {
 				errs = append(errs, errors.Errorf("invalid Migration.MTU.Network.From(%d) not equal to the currently applied MTU(%d)", *next.Migration.MTU.Network.From, *pn.MTU))
 			}
 			if (*next.Migration.MTU.Network.To + getOVNEncapOverhead(next)) > *next.Migration.MTU.Machine.To {


### PR DESCRIPTION
Previously the checks in `isOpenShiftSDNChangeSafe` were not run if there was no changes to `DefaultNetwork.OpenShiftSDNConfig`, which resulted in MTU migration not being verified.
With this commit `Migration` is also checked to make sure that the MTU migration changes are verified.

/cc @jcaamano @ricky-rav 
Signed-off-by: Patryk Diak <pdiak@redhat.com>