### PR TITLE
Bug 2034322: Move infrastructure bootstrap to its own package

### DIFF
--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -47,12 +47,11 @@ type OVNBootstrapResult struct {
 type BootstrapResult struct {
 	Kuryr KuryrBootstrapResult
 	OVN   OVNBootstrapResult
-
-	ExternalControlPlane bool
-	Cloud                CloudBootstrapResult
+	Infra InfraBootstrapResult
 }
 
-type CloudBootstrapResult struct {
-	PlatformType   configv1.PlatformType
-	PlatformRegion string
+type InfraBootstrapResult struct {
+	PlatformType         configv1.PlatformType
+	PlatformRegion       string
+	ExternalControlPlane bool
 }

--- a/pkg/network/kuryr.go
+++ b/pkg/network/kuryr.go
@@ -44,7 +44,7 @@ func renderKuryr(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapR
 	data.Data["UserCACertificate"] = b.UserCACert
 
 	// ExternalControlPlane
-	data.Data["ExternalControlPlane"] = bootstrapResult.ExternalControlPlane
+	data.Data["ExternalControlPlane"] = bootstrapResult.Infra.ExternalControlPlane
 
 	data.Data["HttpsProxy"] = b.HttpsProxy
 	data.Data["HttpProxy"] = b.HttpProxy

--- a/pkg/network/openshift_sdn_test.go
+++ b/pkg/network/openshift_sdn_test.go
@@ -47,7 +47,7 @@ func TestRenderOpenShiftSDN(t *testing.T) {
 	config := &crd.Spec
 
 	bootstrapResult := &bootstrap.BootstrapResult{
-		Cloud: bootstrap.CloudBootstrapResult{},
+		Infra: bootstrap.InfraBootstrapResult{},
 	}
 
 	errs := validateOpenShiftSDN(config)
@@ -196,7 +196,7 @@ func TestProxyArgs(t *testing.T) {
 	FillDefaults(config, nil)
 
 	bootstrapResult := &bootstrap.BootstrapResult{
-		Cloud: bootstrap.CloudBootstrapResult{},
+		Infra: bootstrap.InfraBootstrapResult{},
 	}
 
 	// iter through all objects, finding the kube-proxy config map
@@ -383,7 +383,7 @@ func TestOpenShiftSDNMultitenant(t *testing.T) {
 	config.DefaultNetwork.OpenShiftSDNConfig.Mode = "Multitenant"
 
 	bootstrapResult := &bootstrap.BootstrapResult{
-		Cloud: bootstrap.CloudBootstrapResult{},
+		Infra: bootstrap.InfraBootstrapResult{},
 	}
 
 	objs, err := renderOpenShiftSDN(config, bootstrapResult, manifestDir)
@@ -462,7 +462,7 @@ func TestOpenshiftSDNProxyConfig(t *testing.T) {
 	}
 
 	bootstrapResult := &bootstrap.BootstrapResult{
-		Cloud: bootstrap.CloudBootstrapResult{},
+		Infra: bootstrap.InfraBootstrapResult{},
 	}
 
 	// test default rendering

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -24,13 +24,13 @@ func Render(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapResult
 	log.Printf("Starting render phase")
 	objs := []*uns.Unstructured{}
 
-	if bootstrapResult.Cloud.PlatformType == v1.AWSPlatformType ||
-		bootstrapResult.Cloud.PlatformType == v1.AzurePlatformType ||
-		bootstrapResult.Cloud.PlatformType == v1.GCPPlatformType {
+	if bootstrapResult.Infra.PlatformType == v1.AWSPlatformType ||
+		bootstrapResult.Infra.PlatformType == v1.AzurePlatformType ||
+		bootstrapResult.Infra.PlatformType == v1.GCPPlatformType {
 		// render cloud network config controller **before** the network plugin.
 		// the network plugin is dependent upon having the cloud network CRD
 		// defined as to initialize its watcher, otherwise it will error and crash
-		o, err := renderCloudNetworkConfigController(conf, bootstrapResult.Cloud, manifestDir)
+		o, err := renderCloudNetworkConfigController(conf, bootstrapResult.Infra, manifestDir)
 		if err != nil {
 			return nil, err
 		}
@@ -45,7 +45,7 @@ func Render(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapResult
 	objs = append(objs, o...)
 
 	// render MultusAdmissionController
-	o, err = renderMultusAdmissionController(conf, manifestDir, bootstrapResult.ExternalControlPlane)
+	o, err = renderMultusAdmissionController(conf, manifestDir, bootstrapResult.Infra.ExternalControlPlane)
 	if err != nil {
 		return nil, err
 	}
@@ -655,7 +655,7 @@ func renderNetworkPublic(manifestDir string) ([]*uns.Unstructured, error) {
 }
 
 // renderCloudNetworkConfigController renders the cloud network config controller
-func renderCloudNetworkConfigController(conf *operv1.NetworkSpec, cloudBootstrapResult bootstrap.CloudBootstrapResult, manifestDir string) ([]*uns.Unstructured, error) {
+func renderCloudNetworkConfigController(conf *operv1.NetworkSpec, cloudBootstrapResult bootstrap.InfraBootstrapResult, manifestDir string) ([]*uns.Unstructured, error) {
 	data := render.MakeRenderData()
 	data.Data["ReleaseVersion"] = os.Getenv("RELEASE_VERSION")
 	data.Data["PlatformType"] = cloudBootstrapResult.PlatformType

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1,23 +1,22 @@
-package network
+package platform
 
 import (
 	"context"
 	"fmt"
 
 	configv1 "github.com/openshift/api/config/v1"
-	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
 	types "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func bootstrapCloud(conf *operv1.Network, kubeClient client.Client) (*bootstrap.CloudBootstrapResult, error) {
+func BootstrapInfra(kubeClient client.Client) (*bootstrap.InfraBootstrapResult, error) {
 	var platformType configv1.PlatformType
 	var platformRegion string
 
 	infraConfig := &configv1.Infrastructure{}
 	if err := kubeClient.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, infraConfig); err != nil {
-		return nil, fmt.Errorf("failed to get infrastructure 'config': %v", err)
+		return nil, fmt.Errorf("failed to get infrastructure 'cluster': %v", err)
 	}
 
 	if infraConfig.Status.PlatformStatus.Type != "" {
@@ -29,9 +28,10 @@ func bootstrapCloud(conf *operv1.Network, kubeClient client.Client) (*bootstrap.
 		platformRegion = infraConfig.Status.PlatformStatus.GCP.Region
 	}
 
-	res := &bootstrap.CloudBootstrapResult{
-		PlatformType:   platformType,
-		PlatformRegion: platformRegion,
+	res := &bootstrap.InfraBootstrapResult{
+		PlatformType:         platformType,
+		PlatformRegion:       platformRegion,
+		ExternalControlPlane: infraConfig.Status.ControlPlaneTopology == configv1.ExternalTopologyMode,
 	}
 	return res, nil
 }

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -1,0 +1,60 @@
+package platform
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestTopologyModeDetection(t *testing.T) {
+	testCases := []struct {
+		name                       string
+		infrastructure             *configv1.Infrastructure
+		expectExternalControlplane bool
+	}{
+		{
+			name: "External controlplane toplogy",
+			infrastructure: &configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status: configv1.InfrastructureStatus{
+					PlatformStatus:       &configv1.PlatformStatus{},
+					ControlPlaneTopology: configv1.ExternalTopologyMode,
+				},
+			},
+			expectExternalControlplane: true,
+		},
+		{
+			name: "Not expectExternalControlplane",
+			infrastructure: &configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status: configv1.InfrastructureStatus{
+					PlatformStatus:       &configv1.PlatformStatus{},
+					ControlPlaneTopology: configv1.HighlyAvailableTopologyMode,
+				},
+			},
+			expectExternalControlplane: false,
+		},
+	}
+
+	if err := configv1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatalf("failed to add configv1 to scheme: %v", err)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewClientBuilder().WithObjects(tc.infrastructure).Build()
+
+			bootstrapResult, err := BootstrapInfra(client)
+			if err != nil {
+				t.Fatalf("BootstrapInfra failed: %v", err)
+			}
+
+			if bootstrapResult.ExternalControlPlane != tc.expectExternalControlplane {
+				t.Errorf("expected externalControlPlane to be %t, was %t", tc.expectExternalControlplane, bootstrapResult.ExternalControlPlane)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This supersedes #1260. 

This PR implements the following changes:

- Renames and refactors `bootstrapCloud` to `bootstrapInfrastructure` and moves that to the `platform` package 
- Moves `BootstrapResult.ExternalControlPlane` to `InfraBootstrapResult`

subsequently fixing the initialization issues for hypershift, when bootstrapping with openshift-sdn. 

/assign @abhat @trozet 