### PR TITLE
Bug 2034398: Whereabouts CRD should include a "podref" field.

### DIFF
--- a/bindata/network/additional-networks/crd/001-crd.yaml
+++ b/bindata/network/additional-networks/crd/001-crd.yaml
@@ -66,12 +66,12 @@ spec:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -85,16 +85,18 @@ spec:
                   properties:
                     id:
                       type: string
+                    podref:
+                      type: string
                   required:
                   - id
                   type: object
-                description: Allocations is the set of allocated IPs for the given range.
-                  Its indices are a direct mapping to the IP with the same index/offset
-                  for the pool's range.
+                description: Allocations is the set of allocated IPs for the given
+                  range. Its indices are a direct mapping to the IP with the same
+                  index/offset for the pool's range.
                 type: object
               range:
-                description: Range is a RFC 4632/4291-style string that represents an
-                  IP address and prefix length in CIDR notation
+                description: Range is a RFC 4632/4291-style string that represents
+                  an IP address and prefix length in CIDR notation
                 type: string
             required:
             - allocations


### PR DESCRIPTION
This field is required for use in the IP reconciliation process for Whereabouts which uses the pod reference (podref) to calculate stranded IP addresses.