### PR TITLE
Bug 2035093: Cloud network config controller: Fix for Hypershift

### DIFF
--- a/bindata/cloud-network-config-controller/controller.yaml
+++ b/bindata/cloud-network-config-controller/controller.yaml
@@ -55,8 +55,10 @@ spec:
           mountPath: "/etc/secret/cloudprovider"
           readOnly: true
         terminationMessagePolicy: FallbackToLogsOnError
+{{- if not .ExternalControlPlane }}
       nodeSelector:
         node-role.kubernetes.io/master: ""
+{{- end }}
       tolerations:
       - key: "node-role.kubernetes.io/master"
         operator: "Exists"

--- a/bindata/cloud-network-config-controller/controller.yaml
+++ b/bindata/cloud-network-config-controller/controller.yaml
@@ -54,6 +54,9 @@ spec:
         - name: cloud-provider-secret
           mountPath: "/etc/secret/cloudprovider"
           readOnly: true
+        - name: bound-sa-token
+          mountPath: /var/run/secrets/openshift/serviceaccount
+          readOnly: true
         terminationMessagePolicy: FallbackToLogsOnError
 {{- if not .ExternalControlPlane }}
       nodeSelector:
@@ -70,3 +73,11 @@ spec:
       - name: cloud-provider-secret
         secret:
           secretName: cloud-credentials
+      # This service account token can be used to provide identity outside the cluster.
+      # For example, this token can be used with AssumeRoleWithWebIdentity to authenticate with AWS using IAM OIDC provider and STS.
+      - name: bound-sa-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: token
+              audience: openshift

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -666,6 +666,7 @@ func renderCloudNetworkConfigController(conf *operv1.NetworkSpec, cloudBootstrap
 	data.Data["CloudNetworkConfigControllerImage"] = os.Getenv("CLOUD_NETWORK_CONFIG_CONTROLLER_IMAGE")
 	data.Data["KubernetesServiceHost"] = os.Getenv("KUBERNETES_SERVICE_HOST")
 	data.Data["KubernetesServicePort"] = os.Getenv("KUBERNETES_SERVICE_PORT")
+	data.Data["ExternalControlPlane"] = cloudBootstrapResult.ExternalControlPlane
 
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "cloud-network-config-controller"), &data)
 	if err != nil {


### PR DESCRIPTION
Two changes are needed:
* Hypershift doesn't have master nodes, so the node selector must be absent
* Hypershift uses STS to auth with AWS, so a SA token with an `openshift` audience needs to be mounted. This also requires https://github.com/openshift/cloud-network-config-controller/pull/13 to work

/assign @alexanderConstantinescu 