### PR TITLE
Bug 2036861: multitenant - Add openshift-kube-apiserver-operator to global namespaces

### DIFF
--- a/bindata/network/openshift-sdn/004-multitenant.yaml
+++ b/bindata/network/openshift-sdn/004-multitenant.yaml
@@ -4,6 +4,7 @@
 # - openshift-ingress
 # - openshift-monitoring
 # - openshift-kube-apiserver
+# - openshift-kube-apiserver-operator
 # - openshift-operator-lifecycle-manager
 # - openshift-image-registry
 # - openshift-user-workload-monitoring
@@ -37,6 +38,14 @@ metadata:
   name: openshift-kube-apiserver
 netid: 0
 netname: openshift-kube-apiserver
+
+---
+apiVersion: network.openshift.io/v1
+kind: NetNamespace
+metadata:
+  name: openshift-kube-apiserver-operator
+netid: 0
+netname: openshift-kube-apiserver-operator
 
 ---
 apiVersion: network.openshift.io/v1

--- a/pkg/network/openshift_sdn_test.go
+++ b/pkg/network/openshift_sdn_test.go
@@ -395,10 +395,20 @@ func TestOpenShiftSDNMultitenant(t *testing.T) {
 		"openshift-ingress",
 		"openshift-monitoring",
 		"openshift-kube-apiserver",
+		"openshift-kube-apiserver-operator",
 		"openshift-apiserver",
 		"kube-system",
 		"openshift-operator-lifecycle-manager",
 		"openshift-image-registry",
+		"openshift-user-workload-monitoring",
+		"openshift-etcd",
+		"openshift-etcd-operator",
+		"openshift-service-catalog-apiserver",
+		"openshift-service-catalog-controller-manager",
+		"openshift-template-service-broker",
+		"openshift-ansible-service-broker",
+		"openshift-authentication",
+		"openshift-authentication-operator",
 	}
 
 	for _, ns := range netNS {


### PR DESCRIPTION
Since cluster-kube-apiserver-operator merged commit with number
77a0351146dbe38cba216b4a2036638524b27d41, that operator accesses all
service's webhook endpoints to verify if those are up. Therefore, open
all projects to/from namespace openshift-kube-apiserver-operator.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>