### PR TITLE
Bug 2038295: Backport 4.8 OVN drop icmp frag from other nodes on Azure cluster

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -360,6 +360,74 @@ spec:
             command: ["test", "-f", "/etc/cni/net.d/10-ovn-kubernetes.conf"]
           initialDelaySeconds: 5
           periodSeconds: 5
+      {{- if .OVNPlatformAzure}}
+      - name: drop-icmp
+        image: "{{.OvnImage}}"
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -xe
+
+          touch /var/run/ovn/add_iptables.sh
+          chmod 0755 /var/run/ovn/add_iptables.sh
+          cat <<'EOF' > /var/run/ovn/add_iptables.sh
+          #!/bin/sh
+          if [ -z "$3" ]
+          then
+               echo "Called with host address missing, ignore"
+               exit 0
+          fi
+          echo "Adding ICMP drop rule for '$3' "
+          if iptables -C CHECK_ICMP_SOURCE -p icmp -s $3 -j ICMP_ACTION
+          then
+               echo "iptables already set for $3"
+          else
+               iptables -A CHECK_ICMP_SOURCE -p icmp -s $3 -j ICMP_ACTION
+          fi
+          EOF
+
+          echo "I$(date "+%m%d %H:%M:%S.%N") - drop-icmp - start drop-icmp ${K8S_NODE}"
+          iptables -X CHECK_ICMP_SOURCE || true
+          iptables -N CHECK_ICMP_SOURCE || true
+          iptables -F CHECK_ICMP_SOURCE
+          iptables -D INPUT -p icmp --icmp-type fragmentation-needed -j CHECK_ICMP_SOURCE || true
+          iptables -I INPUT -p icmp --icmp-type fragmentation-needed -j CHECK_ICMP_SOURCE
+          iptables -N ICMP_ACTION || true
+          iptables -F ICMP_ACTION
+          iptables -A ICMP_ACTION -j LOG
+          iptables -A ICMP_ACTION -j DROP
+          #
+          ip addr show
+          ip route show
+          iptables -nvL
+          iptables -nvL -t nat
+          oc observe pods -n openshift-ovn-kubernetes -l app=ovnkube-node -a '{ .status.hostIP }' -- /var/run/ovn/add_iptables.sh
+          #systemd-run -qPG -- oc observe pods -n openshift-ovn-kubernetes -l app=ovnkube-node -a '{ .status.hostIP }' -- /var/run/ovn/add_iptables.sh
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/bash", "-c", "echo drop-icmp done"]
+        securityContext:
+          privileged: true
+        volumeMounts:
+        # for the iptables wrapper
+        - mountPath: /host
+          name: host-slash
+          readOnly: true
+          mountPropagation: HostToContainer
+        - mountPath: /run/ovn/
+          name: run-ovn
+        resources:
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        env:
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+      {{- end}}
       nodeSelector:
         beta.kubernetes.io/os: "linux"
       volumes:


### PR DESCRIPTION

    Add logic to OVN-Kubernetes to determine what platform we are running on
    Only use drop icmp frag needed daemonset when on Azure platform
    drop icmp frag needed received from other nodes in the cluster

Signed-off-by: Michael Cambria <mcambria@redhat.com>
(cherry picked from commit 7a05ada8774081d8a7f8be2b45d517bd02b54acb)