### PR TITLE
Bug 2034460: cncc: handle advanced AWS and Azure configurations 

### DIFF
--- a/bindata/cloud-network-config-controller/003-configmaps.yaml
+++ b/bindata/cloud-network-config-controller/003-configmaps.yaml
@@ -1,0 +1,18 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  namespace: openshift-cloud-network-config-controller
+  name: kube-cloud-config
+# placeholder; will be replaced in render.go
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  namespace: openshift-cloud-network-config-controller
+  name: trusted-ca
+  annotations:
+    networkoperator.openshift.io/create-only: "true"
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+# will have CA-bundle injected by the CNO

--- a/bindata/cloud-network-config-controller/controller.yaml
+++ b/bindata/cloud-network-config-controller/controller.yaml
@@ -32,7 +32,12 @@ spec:
         image: {{.CloudNetworkConfigControllerImage}}
         imagePullPolicy: IfNotPresent
         command: ["/usr/bin/cloud-network-config-controller"]
-        args: ["-platform-type", "{{.PlatformType}}", "-platform-region", "{{.PlatformRegion}}", "-secret-name", "cloud-credentials"]
+        args: [ "-platform-type", "{{.PlatformType}}",
+                "-platform-region={{.PlatformRegion}}",
+                "-platform-api-url={{.PlatformAPIURL}}",
+                "-platform-aws-ca-override={{.PlatformAWSCAPath}}",
+                "-platform-azure-environment={{.PlatformAzureEnvironment}}",
+                "-secret-name", "cloud-credentials"]
         env:
         - name: CONTROLLER_NAMESPACE
           valueFrom:
@@ -54,6 +59,12 @@ spec:
         - name: cloud-provider-secret
           mountPath: "/etc/secret/cloudprovider"
           readOnly: true
+        - name: kube-cloud-config
+          mountPath: "/kube-cloud-config"
+          readOnly: true
+        - name: trusted-ca
+          mountPath: /etc/pki/ca-trust/extracted/pem
+          readOnly: true
         - name: bound-sa-token
           mountPath: /var/run/secrets/openshift/serviceaccount
           readOnly: true
@@ -73,6 +84,15 @@ spec:
       - name: cloud-provider-secret
         secret:
           secretName: cloud-credentials
+      - name: kube-cloud-config
+        configMap:
+          name: kube-cloud-config
+      - name: trusted-ca
+        configMap:
+          name: trusted-ca
+          items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
       # This service account token can be used to provide identity outside the cluster.
       # For example, this token can be used with AssumeRoleWithWebIdentity to authenticate with AWS using IAM OIDC provider and STS.
       - name: bound-sa-token

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/openshift/cluster-network-operator/pkg/names"
+
 	"github.com/pkg/errors"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -51,6 +53,11 @@ func ApplyObject(ctx context.Context, client k8sclient.Client, obj *uns.Unstruct
 		if err != nil {
 			log.Printf("could not retrieve %s", objDesc)
 			return err
+		}
+
+		// object exists - for create-only objects, stop here
+		if anno := existing.GetAnnotations()[names.CreateOnlyAnnotation]; anno == "true" {
+			return nil
 		}
 
 		// Merge the desired object with what actually exists

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -53,7 +53,11 @@ type BootstrapResult struct {
 type InfraBootstrapResult struct {
 	PlatformType         configv1.PlatformType
 	PlatformRegion       string
+	PlatformStatus       *configv1.PlatformStatus
 	ExternalControlPlane bool
+
+	// KubeCloudConfig is the contents of the openshift-config-managed/kube-cloud-config ConfigMap
+	KubeCloudConfig map[string]string
 }
 
 type FlowsConfig struct {

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -33,6 +33,10 @@ const IgnoreObjectErrorAnnotation = "networkoperator.openshift.io/ignore-errors"
 // that they are not critical to the functioning of the pod network
 const NonCriticalAnnotation = "networkoperator.openshift.io/non-critical"
 
+// CreateOnlyAnnotation is an annotation on all objects that
+// tells the CNO reconciliaton engine to ignore this object if it already exists.
+const CreateOnlyAnnotation = "networkoperator.openshift.io/create-only"
+
 // NetworkMigrationAnnotation is an annotation on the networks.operator.openshift.io CR to indicate
 // that executing network migration (switching the default network type of the cluster) is allowed.
 const NetworkMigrationAnnotation = "networkoperator.openshift.io/network-migration"

--- a/pkg/network/cloud_network.go
+++ b/pkg/network/cloud_network.go
@@ -1,0 +1,85 @@
+package network
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	v1 "github.com/openshift/api/config/v1"
+	operv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
+	"github.com/openshift/cluster-network-operator/pkg/render"
+	k8sutil "github.com/openshift/cluster-network-operator/pkg/util/k8s"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// renderCloudNetworkConfigController renders the cloud network config controller
+func renderCloudNetworkConfigController(conf *operv1.NetworkSpec, cloudBootstrapResult bootstrap.InfraBootstrapResult, manifestDir string) ([]*uns.Unstructured, error) {
+	pt := cloudBootstrapResult.PlatformType
+	if !(pt == v1.AWSPlatformType || pt == v1.AzurePlatformType || pt == v1.GCPPlatformType) {
+		return nil, nil
+	}
+	data := render.MakeRenderData()
+	data.Data["ReleaseVersion"] = os.Getenv("RELEASE_VERSION")
+	data.Data["PlatformType"] = cloudBootstrapResult.PlatformType
+	data.Data["PlatformRegion"] = cloudBootstrapResult.PlatformRegion
+	data.Data["PlatformTypeAWS"] = v1.AWSPlatformType
+	data.Data["PlatformTypeAzure"] = v1.AzurePlatformType
+	data.Data["PlatformTypeGCP"] = v1.GCPPlatformType
+	data.Data["CloudNetworkConfigControllerImage"] = os.Getenv("CLOUD_NETWORK_CONFIG_CONTROLLER_IMAGE")
+	data.Data["KubernetesServiceHost"] = os.Getenv("KUBERNETES_SERVICE_HOST")
+	data.Data["KubernetesServicePort"] = os.Getenv("KUBERNETES_SERVICE_PORT")
+	data.Data["ExternalControlPlane"] = cloudBootstrapResult.ExternalControlPlane
+	data.Data["PlatformAzureEnvironment"] = ""
+	data.Data["PlatformAWSCAPath"] = ""
+
+	// AWS and azure allow for funky endpoint overriding.
+	// in different ways, of course.
+	apiurl := ""
+	if cloudBootstrapResult.PlatformType == v1.AWSPlatformType {
+		for _, ep := range cloudBootstrapResult.PlatformStatus.AWS.ServiceEndpoints {
+			if ep.Name == "ec2" {
+				apiurl = ep.URL
+			}
+		}
+		if cloudBootstrapResult.KubeCloudConfig["ca-bundle.pem"] != "" {
+			data.Data["PlatformAWSCAPath"] = "/kube-cloud-config/ca-bundle.pem" // installed by ConfigMap
+		}
+	}
+
+	if cloudBootstrapResult.PlatformType == v1.AzurePlatformType {
+		apiurl = cloudBootstrapResult.PlatformStatus.Azure.ARMEndpoint
+		data.Data["PlatformAzureEnvironment"] = cloudBootstrapResult.PlatformStatus.Azure.CloudName
+	}
+
+	data.Data["PlatformAPIURL"] = apiurl
+
+	manifests, err := render.RenderDir(filepath.Join(manifestDir, "cloud-network-config-controller"), &data)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to render cloud-network-config-controller manifests")
+	}
+
+	// Generate the silly AWS CA override
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-cloud-network-config-controller",
+			Name:      "kube-cloud-config",
+		},
+		Data: cloudBootstrapResult.KubeCloudConfig,
+	}
+	obj, err := k8sutil.ToUnstructured(cm)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to transmute")
+	}
+	manifests = k8sutil.ReplaceObj(manifests, obj)
+
+	return manifests, nil
+}

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	v1 "github.com/openshift/api/config/v1"
 	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
 	"github.com/openshift/cluster-network-operator/pkg/render"
@@ -24,21 +23,17 @@ func Render(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapResult
 	log.Printf("Starting render phase")
 	objs := []*uns.Unstructured{}
 
-	if bootstrapResult.Infra.PlatformType == v1.AWSPlatformType ||
-		bootstrapResult.Infra.PlatformType == v1.AzurePlatformType ||
-		bootstrapResult.Infra.PlatformType == v1.GCPPlatformType {
-		// render cloud network config controller **before** the network plugin.
-		// the network plugin is dependent upon having the cloud network CRD
-		// defined as to initialize its watcher, otherwise it will error and crash
-		o, err := renderCloudNetworkConfigController(conf, bootstrapResult.Infra, manifestDir)
-		if err != nil {
-			return nil, err
-		}
-		objs = append(objs, o...)
+	// render cloud network config controller **before** the network plugin.
+	// the network plugin is dependent upon having the cloud network CRD
+	// defined as to initialize its watcher, otherwise it will error and crash
+	o, err := renderCloudNetworkConfigController(conf, bootstrapResult.Infra, manifestDir)
+	if err != nil {
+		return nil, err
 	}
+	objs = append(objs, o...)
 
 	// render Multus
-	o, err := renderMultus(conf, manifestDir)
+	o, err = renderMultus(conf, manifestDir)
 	if err != nil {
 		return nil, err
 	}
@@ -650,27 +645,6 @@ func renderNetworkPublic(manifestDir string) ([]*uns.Unstructured, error) {
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network", "public"), &data)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to render network/public manifests")
-	}
-	return manifests, nil
-}
-
-// renderCloudNetworkConfigController renders the cloud network config controller
-func renderCloudNetworkConfigController(conf *operv1.NetworkSpec, cloudBootstrapResult bootstrap.InfraBootstrapResult, manifestDir string) ([]*uns.Unstructured, error) {
-	data := render.MakeRenderData()
-	data.Data["ReleaseVersion"] = os.Getenv("RELEASE_VERSION")
-	data.Data["PlatformType"] = cloudBootstrapResult.PlatformType
-	data.Data["PlatformRegion"] = cloudBootstrapResult.PlatformRegion
-	data.Data["PlatformTypeAWS"] = v1.AWSPlatformType
-	data.Data["PlatformTypeAzure"] = v1.AzurePlatformType
-	data.Data["PlatformTypeGCP"] = v1.GCPPlatformType
-	data.Data["CloudNetworkConfigControllerImage"] = os.Getenv("CLOUD_NETWORK_CONFIG_CONTROLLER_IMAGE")
-	data.Data["KubernetesServiceHost"] = os.Getenv("KUBERNETES_SERVICE_HOST")
-	data.Data["KubernetesServicePort"] = os.Getenv("KUBERNETES_SERVICE_PORT")
-	data.Data["ExternalControlPlane"] = cloudBootstrapResult.ExternalControlPlane
-
-	manifests, err := render.RenderDir(filepath.Join(manifestDir, "cloud-network-config-controller"), &data)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to render cloud-network-config-controller manifests")
 	}
 	return manifests, nil
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -6,32 +6,47 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	types "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func BootstrapInfra(kubeClient client.Client) (*bootstrap.InfraBootstrapResult, error) {
-	var platformType configv1.PlatformType
-	var platformRegion string
+var cloudProviderConfig = types.NamespacedName{
+	Namespace: "openshift-config-managed",
+	Name:      "kube-cloud-config",
+}
 
+func BootstrapInfra(kubeClient client.Client) (*bootstrap.InfraBootstrapResult, error) {
 	infraConfig := &configv1.Infrastructure{}
 	if err := kubeClient.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, infraConfig); err != nil {
 		return nil, fmt.Errorf("failed to get infrastructure 'cluster': %v", err)
 	}
 
-	if infraConfig.Status.PlatformStatus.Type != "" {
-		platformType = infraConfig.Status.PlatformStatus.Type
-	}
-	if platformType == configv1.AWSPlatformType {
-		platformRegion = infraConfig.Status.PlatformStatus.AWS.Region
-	} else if platformType == configv1.GCPPlatformType {
-		platformRegion = infraConfig.Status.PlatformStatus.GCP.Region
-	}
-
 	res := &bootstrap.InfraBootstrapResult{
-		PlatformType:         platformType,
-		PlatformRegion:       platformRegion,
+		PlatformType:         infraConfig.Status.PlatformStatus.Type,
+		PlatformStatus:       infraConfig.Status.PlatformStatus,
 		ExternalControlPlane: infraConfig.Status.ControlPlaneTopology == configv1.ExternalTopologyMode,
 	}
+
+	if res.PlatformType == configv1.AWSPlatformType {
+		res.PlatformRegion = infraConfig.Status.PlatformStatus.AWS.Region
+	} else if res.PlatformType == configv1.GCPPlatformType {
+		res.PlatformRegion = infraConfig.Status.PlatformStatus.GCP.Region
+	}
+
+	// AWS specifies a CA bundle via a config map; retrieve it.
+	if res.PlatformType == configv1.AWSPlatformType {
+		cm := &corev1.ConfigMap{}
+		if err := kubeClient.Get(context.TODO(), cloudProviderConfig, cm); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return nil, fmt.Errorf("failed to retrieve ConfigMap %s: %w", cloudProviderConfig, err)
+			}
+		} else {
+			res.KubeCloudConfig = cm.Data
+		}
+	}
+
 	return res, nil
 }


### PR DESCRIPTION
It was noticed that there are cases that require special configuration
to authenticate to the AWS and Azure API endpoints:

- Azure has the notion of "Environments", which are named sets of API
  URLs. Anyone connecting to Azure needs to be aware of them.
- Customers can override AWS and Azure endpoints via the Infrastructure object
- There is a magic ConfigMap that may contain a CA bundle only to be
  used when connecting to AWS. This is needed for the AWS C2S platform
- We needed to include the proxy CA bundle.

So, add a lot of bootstrapping code to get all these configuration knobs.

Also, add a small commit that allows for create-only objects.