### PR TITLE
Bug 2039345: Verify against mininimal IPv6 MTU value for clusters with IPv6 networks

### DIFF
--- a/pkg/network/mtu.go
+++ b/pkg/network/mtu.go
@@ -8,6 +8,12 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+const (
+	MinMTUIPv4 uint32 = 576  // RFC 791
+	MinMTUIPv6 uint32 = 1280 // RFC 8200
+	MaxMTU     uint32 = 65536
+)
+
 // getDefaultMTU gets the mtu of the default route.
 func getDefaultMTU() (int, error) {
 	// Get the interface with the default route

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -408,7 +408,11 @@ func validateOVNKubernetes(conf *operv1.NetworkSpec) []error {
 
 	oc := conf.DefaultNetwork.OVNKubernetesConfig
 	if oc != nil {
-		if oc.MTU != nil && (*oc.MTU < 576 || *oc.MTU > 65536) {
+		minMTU := MinMTUIPv4
+		if cnHasIPv6 {
+			minMTU = MinMTUIPv6
+		}
+		if oc.MTU != nil && (*oc.MTU < minMTU || *oc.MTU > MaxMTU) {
 			out = append(out, errors.Errorf("invalid MTU %d", *oc.MTU))
 		}
 		if oc.GenevePort != nil && (*oc.GenevePort < 1 || *oc.GenevePort > 65535) {
@@ -453,6 +457,20 @@ func isOVNKubernetesChangeSafe(prev, next *operv1.NetworkSpec) []error {
 			checkPrevMTU := prev.Migration == nil || prev.Migration.MTU == nil || prev.Migration.MTU.Network == nil || !reflect.DeepEqual(prev.Migration.MTU.Network.From, next.Migration.MTU.Network.From)
 			if checkPrevMTU && *next.Migration.MTU.Network.From != *pn.MTU {
 				errs = append(errs, errors.Errorf("invalid Migration.MTU.Network.From(%d) not equal to the currently applied MTU(%d)", *next.Migration.MTU.Network.From, *pn.MTU))
+			}
+
+			minMTU := MinMTUIPv4
+			for _, cn := range next.ClusterNetwork {
+				if utilnet.IsIPv6CIDRString(cn.CIDR) {
+					minMTU = MinMTUIPv6
+					break
+				}
+			}
+			if *next.Migration.MTU.Network.To < minMTU || *next.Migration.MTU.Network.To > MaxMTU {
+				errs = append(errs, errors.Errorf("invalid Migration.MTU.Network.To(%d), has to be in range: %d-%d", *next.Migration.MTU.Network.To, minMTU, MaxMTU))
+			}
+			if *next.Migration.MTU.Machine.To < minMTU || *next.Migration.MTU.Machine.To > MaxMTU {
+				errs = append(errs, errors.Errorf("invalid Migration.MTU.Machine.To(%d), has to be in range: %d-%d", *next.Migration.MTU.Machine.To, minMTU, MaxMTU))
 			}
 			if (*next.Migration.MTU.Network.To + getOVNEncapOverhead(next)) > *next.Migration.MTU.Machine.To {
 				errs = append(errs, errors.Errorf("invalid Migration.MTU.Machine.To(%d), has to be at least %d", *next.Migration.MTU.Machine.To, *next.Migration.MTU.Network.To+getOVNEncapOverhead(next)))

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -540,6 +540,14 @@ func TestValidateOVNKubernetes(t *testing.T) {
 	ovnConfig.GenevePort = ptrToUint32(70001)
 	errExpect("invalid GenevePort 70001")
 
+	// invalid ipv6 mtu
+	config.ServiceNetwork = []string{"fd02::/112"}
+	config.ClusterNetwork = []operv1.ClusterNetworkEntry{{
+		CIDR: "fd01::/48", HostPrefix: 64,
+	}}
+	ovnConfig.MTU = ptrToUint32(576)
+	errExpect("invalid MTU 576")
+
 	config.ClusterNetwork = nil
 	errExpect("ClusterNetwork cannot be empty")
 }
@@ -669,11 +677,44 @@ func TestOVNKubernetesIsSafe(t *testing.T) {
 
 	next.Migration.MTU.Network.From = prev.DefaultNetwork.OVNKubernetesConfig.MTU
 
-	// invalid Migration.MTU.Host.To, not big enough to accommodate next.Migration.MTU.Network.To with encap overhead
+	// invalid Migration.MTU.Network.To, lower than minimum MTU for IPv4
+	next.Migration.MTU.Network.To = ptrToUint32(100)
+	errs = isOVNKubernetesChangeSafe(prev, next)
+	g.Expect(errs).To(HaveLen(1))
+	g.Expect(errs[0]).To(MatchError(fmt.Sprintf("invalid Migration.MTU.Network.To(%d), has to be in range: %d-%d", *next.Migration.MTU.Network.To, MinMTUIPv4, MaxMTU)))
+
+	// invalid Migration.MTU.Network.To, higher than maximum MTU for IPv4
+	next.Migration.MTU.Network.To = ptrToUint32(MaxMTU + 1)
+	errs = isOVNKubernetesChangeSafe(prev, next)
+	g.Expect(errs).To(HaveLen(2))
+	g.Expect(errs[0]).To(MatchError(fmt.Sprintf("invalid Migration.MTU.Network.To(%d), has to be in range: %d-%d", *next.Migration.MTU.Network.To, MinMTUIPv4, MaxMTU)))
+
+	next.Migration.MTU.Network.To = ptrToUint32(1300)
+
+	// invalid Migration.MTU.Machine.To, not big enough to accommodate next.Migration.MTU.Network.To with encap overhead
 	next.Migration.MTU.Network.To = ptrToUint32(1500)
 	errs = isOVNKubernetesChangeSafe(prev, next)
 	g.Expect(errs).To(HaveLen(1))
 	g.Expect(errs[0]).To(MatchError(fmt.Sprintf("invalid Migration.MTU.Machine.To(%d), has to be at least %d", *next.Migration.MTU.Machine.To, *next.Migration.MTU.Network.To+getOVNEncapOverhead(next))))
+
+	// invalid Migration.MTU.Network.To, lower than minimum MTU for IPv6
+	next.Migration.MTU.Network.To = ptrToUint32(1200)
+	next.ClusterNetwork = []operv1.ClusterNetworkEntry{
+		{
+			CIDR:       "fd00:1:2:3::/64",
+			HostPrefix: 56,
+		},
+	}
+	errs = isOVNKubernetesChangeSafe(prev, next)
+	g.Expect(errs).To(HaveLen(1))
+	g.Expect(errs[0]).To(MatchError(fmt.Sprintf("invalid Migration.MTU.Network.To(%d), has to be in range: %d-%d", *next.Migration.MTU.Network.To, MinMTUIPv6, MaxMTU)))
+
+	// invalid Migration.MTU.Machine.To, higher than max MTU
+	next.Migration.MTU.Network.To = ptrToUint32(MaxMTU)
+	next.Migration.MTU.Machine.To = ptrToUint32(*next.Migration.MTU.Network.To + getOVNEncapOverhead(next))
+	errs = isOVNKubernetesChangeSafe(prev, next)
+	g.Expect(errs).To(HaveLen(1))
+	g.Expect(errs[0]).To(MatchError(fmt.Sprintf("invalid Migration.MTU.Machine.To(%d), has to be in range: %d-%d", *next.Migration.MTU.Machine.To, MinMTUIPv6, MaxMTU)))
 }
 
 // TestOVNKubernetesShouldUpdateMasterOnUpgrade checks to see that


### PR DESCRIPTION
Additionally added verification of migration MTU values.

/cc @ricky-rav @jcaamano 


Signed-off-by: Patryk Diak <pdiak@redhat.com>