### PR TITLE
BUG 2034413: cncc: create Cloud CredentialsRequest in /manifests

### DIFF
--- a/bindata/cloud-network-config-controller/002-rbac.yaml
+++ b/bindata/cloud-network-config-controller/002-rbac.yaml
@@ -31,6 +31,14 @@ rules:
   - list
   - watch
   - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cloud-network-config-controller
+  namespace: openshift-cloud-network-config-controller
+rules:
 - apiGroups: 
   - ""
   resources:
@@ -39,6 +47,7 @@ rules:
   - get
   - create
   - update
+  - patch
 - apiGroups:
   - ""
   resources:
@@ -55,6 +64,20 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
+  name: cloud-network-config-controller
+subjects:
+- kind: ServiceAccount
+  name: cloud-network-config-controller
+  namespace: openshift-cloud-network-config-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: openshift-cloud-network-config-controller
+  name: cloud-network-config-controller-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
   name: cloud-network-config-controller
 subjects:
 - kind: ServiceAccount

--- a/bindata/cloud-network-config-controller/controller.yaml
+++ b/bindata/cloud-network-config-controller/controller.yaml
@@ -77,9 +77,6 @@ spec:
       - key: "node-role.kubernetes.io/master"
         operator: "Exists"
         effect: "NoSchedule"
-      - key: "node.kubernetes.io/not-ready"
-        operator: "Exists"
-        effect: "NoSchedule"
       volumes:
       - name: cloud-provider-secret
         secret:

--- a/manifests/01-cncc-namespace.yaml
+++ b/manifests/01-cncc-namespace.yaml
@@ -1,11 +1,16 @@
+# This is the namespace for the Cloud Network Controller
+# Although this is really an operand of the CNO, we create this now
+# because CredentialsRequests must be created at install time.
 apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-cloud-network-config-controller
   labels:
-    openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
     openshift.io/description: "OpenShift cloud network config controller namespace - a controller used to manage cloud-level network configuration"
     workload.openshift.io/allowed: "management"

--- a/manifests/02-cncc-credentials.yaml
+++ b/manifests/02-cncc-credentials.yaml
@@ -1,9 +1,17 @@
-{{if eq .PlatformType .PlatformTypeGCP }}
+# These are the CredentialsRequests for the cloud-network-config-controller,
+# NOT the CNO directly. Rather, CredentialsRequests need to be part of the
+# install payload (in /manifests), so that administrators can manually
+# provision them - see
+# https://github.com/openshift/enhancements/blob/master/enhancements/installer/credentials-management-outside-openshift-cluster.md
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest
 metadata:
-  name: openshift-cloud-network-config-controller
+  name: openshift-cloud-network-config-controller-gcp
   namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   secretRef:
     name: cloud-credentials
@@ -13,12 +21,16 @@ spec:
     kind: GCPProviderSpec
     predefinedRoles:
     - roles/compute.admin 
-{{else if eq .PlatformType .PlatformTypeAWS }}
+---
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest
 metadata:
-  name: openshift-cloud-network-config-controller
+  name: openshift-cloud-network-config-controller-aws
   namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   secretRef:
     name: cloud-credentials
@@ -39,12 +51,16 @@ spec:
       - ec2:DescribeSubnets
       - ec2:DescribeNetworkInterfaces
       resource: "*"
-{{else if eq .PlatformType .PlatformTypeAzure }}
+---
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest
 metadata:
-  name: openshift-cloud-network-config-controller
+  name: openshift-cloud-network-config-controller-azure
   namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   secretRef:
     name: cloud-credentials
@@ -53,5 +69,4 @@ spec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: AzureProviderSpec
     roleBindings:
-      - role: Contributor 
-{{end}}
+      - role: Contributor

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -291,6 +291,12 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 		Resource: "CloudPrivateIPConfig",
 	})
 
+	// This Namespace is rendered by the CVO, but it's really our operand.
+	relatedObjects = append(relatedObjects, configv1.ObjectReference{
+		Resource: "namespaces",
+		Name:     "openshift-cloud-network-config-controller",
+	})
+
 	r.status.SetDaemonSets(daemonSets)
 	r.status.SetDeployments(deployments)
 	r.status.SetRelatedObjects(relatedObjects)


### PR DESCRIPTION
It turns out, that thanks to https://github.com/openshift/enhancements/blob/master/enhancements/installer/credentials-management-outside-openshift-cluster.md, we need to be embedding all CredentialsRequests in `manifests` instead of dynamically in the CNO itself. So, do that. It's a bit awkward but doesn't actually break anything.

Also,
- tighten up RBAC for the CNCC. We accidentally added access to all Secrets, oops.
- don't blanket tolerate NotReady -- we're not critical to startup, and this keeps us from getting Pod creation errors