### PR TITLE
[release-4.8] Bug 2021221: ovnkube: set ovn-controller lflow cache limit to 1GB

### DIFF
--- a/bindata/network/ovn-kubernetes/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/004-config.yaml
@@ -11,6 +11,8 @@ data:
     mtu="{{.MTU}}"
     cluster-subnets="{{.OVN_cidr}}"
     encap-port="{{.GenevePort}}"
+    enable-lflow-cache=true
+    lflow-cache-limit-kb=1048576
 
     [kubernetes]
     service-cidrs="{{.OVN_service_cidr}}"

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -163,6 +163,8 @@ func TestRenderedOVNKubernetesConfig(t *testing.T) {
 mtu="1500"
 cluster-subnets="10.128.0.0/15/23,10.0.0.0/14/24"
 encap-port="8061"
+enable-lflow-cache=true
+lflow-cache-limit-kb=1048576
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -186,6 +188,8 @@ nodeport=true`,
 mtu="1500"
 cluster-subnets="10.128.0.0/15/23,10.0.0.0/14/24"
 encap-port="8061"
+enable-lflow-cache=true
+lflow-cache-limit-kb=1048576
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -219,6 +223,8 @@ cluster-subnets="10.132.0.0/14"`,
 mtu="1500"
 cluster-subnets="10.128.0.0/15/23,10.0.0.0/14/24"
 encap-port="8061"
+enable-lflow-cache=true
+lflow-cache-limit-kb=1048576
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -255,6 +261,8 @@ hybrid-overlay-vxlan-port="9000"`,
 mtu="1500"
 cluster-subnets="10.128.0.0/15/23,10.0.0.0/14/24"
 encap-port="8061"
+enable-lflow-cache=true
+lflow-cache-limit-kb=1048576
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -284,6 +292,8 @@ enabled=true`,
 mtu="1500"
 cluster-subnets="10.128.0.0/15/23,10.0.0.0/14/24"
 encap-port="8061"
+enable-lflow-cache=true
+lflow-cache-limit-kb=1048576
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"


### PR DESCRIPTION
By default the lflow cache is unlimited, but at scale this
makes ovn-controller consume large amounts of RSS and cause OOM
situations. Limit the cache size to prevent unbounded memory
usage while still providing enough for most setups.

The lflow cache is a tradeoff between CPU and memory, but we'd
rather use a bit more CPU than OOM a box.

Pick a 1GB limit based on data gathered from various scale runs,
which seems to be the upper-limit (for now) for 120-node
density runs.

(cherry picked from commit 4d1056a590678ddacd1a884242a0f606bbac93c2)
Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>