### PR TITLE
Bug 2041989: no CredentialsRequests in ibm-cloud-managed

### DIFF
--- a/manifests/0000_70_cluster-network-operator_01_credentialsrequest.yaml
+++ b/manifests/0000_70_cluster-network-operator_01_credentialsrequest.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: openshift-cloud-credential-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:
   providerSpec:

--- a/manifests/02-cncc-credentials.yaml
+++ b/manifests/02-cncc-credentials.yaml
@@ -10,7 +10,6 @@ metadata:
   namespace: openshift-cloud-credential-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:
   secretRef:
@@ -29,7 +28,6 @@ metadata:
   namespace: openshift-cloud-credential-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:
   secretRef:
@@ -59,7 +57,6 @@ metadata:
   namespace: openshift-cloud-credential-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:
   secretRef:


### PR DESCRIPTION
The ibm-cloud-managed profile doesn't use the cloud-credential-operator.
The CredentialsRequest CRs should not be installed in that environment.

Unmark the existing CredentialsRequests so they are no longer installed
in ibm-cloud-managed.

Create a list of previously-installed CredentialsRequests so that they
are cleaned up by the CVO only on the ibm-cloud-managed profile.

xref: https://issues.redhat.com/browse/CCO-177