### PR TITLE
[release-4.9] Bug 2040530: ovn: try to gracefully terminate ovn-northd and ovsdb

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -243,6 +243,7 @@ spec:
               --db-nb-cluster-remote-proto=ssl \
               --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
               run_nb_ovsdb &
+
               wait $!
             else
               # either we need to initialize a new cluster or wait for master to create it
@@ -250,6 +251,7 @@ spec:
                 exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
                 --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
                 run_nb_ovsdb &
+
                 wait $!
               else
                 echo "Joining the nbdb cluster with init_ip=${init_ip}..."
@@ -259,6 +261,7 @@ spec:
                 --db-nb-cluster-remote-proto=ssl \
                 --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
                 run_nb_ovsdb &
+
                 wait $!
               fi
             fi
@@ -266,6 +269,7 @@ spec:
             exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
               --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
               run_nb_ovsdb &
+
               wait $!
           fi
 
@@ -636,6 +640,7 @@ spec:
               --db-sb-cluster-remote-proto=ssl \
               --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
               run_sb_ovsdb &
+
               wait $!
             else
               # either we need to initialize a new cluster or wait for master to create it
@@ -643,6 +648,7 @@ spec:
                 exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
                 --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
                 run_sb_ovsdb &
+
                 wait $!
               else
                 exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
@@ -651,6 +657,7 @@ spec:
                 --db-sb-cluster-remote-proto=ssl \
                 --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
                 run_sb_ovsdb &
+
                 wait $!
               fi
             fi
@@ -658,6 +665,7 @@ spec:
             exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
             --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off" \
             run_sb_ovsdb &
+
             wait $!
           fi
         lifecycle:


### PR DESCRIPTION
OpenShift and kube don't yet gracefully terminate pods in all cases,
especially when taking a node down for reboot. Attempt to handle that
better by asking northd to stop gracefully in the preStop hook and
the container script.

Conflicts:
  bindata/network/ovn-kubernetes/ovnkube-master.yaml

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>
Co-Authored-By: Dan Williams <dcbw@redhat.com>
(cherry picked from commit 4eb76c54ee3ffd62d8244d3f5bf2c412bb149629)