### PR TITLE
Bug 2041329: cncc: add serviceAccountNames to CredentialsRequests

### DIFF
--- a/manifests/02-cncc-credentials.yaml
+++ b/manifests/02-cncc-credentials.yaml
@@ -13,6 +13,8 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:
+  serviceAccountNames:
+    - cloud-network-config-controller
   secretRef:
     name: cloud-credentials
     namespace: openshift-cloud-network-config-controller
@@ -32,6 +34,8 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:
+  serviceAccountNames:
+    - cloud-network-config-controller
   secretRef:
     name: cloud-credentials
     namespace: openshift-cloud-network-config-controller
@@ -62,6 +66,8 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:
+  serviceAccountNames:
+    - cloud-network-config-controller
   secretRef:
     name: cloud-credentials
     namespace: openshift-cloud-network-config-controller


### PR DESCRIPTION
This is needed for more advanced cloud provider authentication scenarios
(e.g AWS STS).