### PR TITLE
Bug 2038732: Add egress* patch credentials for ovnkube-master

### DIFF
--- a/bindata/network/ovn-kubernetes/003-rbac-controller.yaml
+++ b/bindata/network/ovn-kubernetes/003-rbac-controller.yaml
@@ -88,6 +88,7 @@ rules:
   - list
   - watch
   - update
+  - patch
 - apiGroups: ["cloud.network.openshift.io"]
   resources:
   - cloudprivateipconfigs


### PR DESCRIPTION
With PR https://github.com/ovn-org/ovn-kubernetes/pull/2734 we will need to patch the `EgressIP` objects. This gives our ovnkube-master service account, that capability

/assign @trozet 