### PR TITLE
Bug 2048793: Kuryr: Decrease vif_annotation_timeout

### DIFF
--- a/bindata/network/kuryr/003-config.yaml
+++ b/bindata/network/kuryr/003-config.yaml
@@ -18,7 +18,7 @@ data:
     daemon_enabled = true
     docker_mode = true
     netns_proc_dir = /host_proc
-    vif_annotation_timeout = 500
+    vif_annotation_timeout = 200
 
     [ingress]
     #l7_router_uuid = <None>


### PR DESCRIPTION
A timeout during which kuryr-cni is waiting for the kuryr-controller to
create and populate KuryrPort for a Pod was set to 500 seconds, so
little over 8 minutes. The problem with that is that kubelet's timeout
to create PodSandbox is set to 4 minutes, after which kubelet will raise
mysterious "context deadline exceeded" error, effectively hiding the
real error from Kuryr.

This commit decreases the timeout in Kuryr to 200 seconds, so that we
will time out before kubelet and be able to raise real error.