### PR TITLE
Fix bond cni source directory path

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -274,11 +274,11 @@ spec:
           readOnly: true
         env:
         - name: RHEL7_SOURCE_DIRECTORY
-          value: "/bondcni/rhel7"
+          value: "/bondcni/rhel7/"
         - name: RHEL8_SOURCE_DIRECTORY
-          value: "/bondcni/rhel8"
+          value: "/bondcni/rhel8/"
         - name: DEFAULT_SOURCE_DIRECTORY
-          value: "/bondcni"          
+          value: "/bondcni/"
       - name: routeoverride-cni
         image: {{.RouteOverrideImage}}
         command: ["/entrypoint/cnibincopy.sh"]


### PR DESCRIPTION
The bond cni source directory path is incorrect. It is missing a trailing
directory separator. Without the separator the cnicopy.sh command will not
copy the contents of the directory.

BZ: [https://bugzilla.redhat.com/show_bug.cgi?id=2048413](https://bugzilla.redhat.com/2048413)

Verified using cluster bot (launch `openshift/cluster-network-operator#1205`)