### PR TITLE
Bug 2049613: Use a separate configmap for mtu migration config to avoid pod restart

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -6,7 +6,14 @@ metadata:
 data:
   kube-proxy-config.yaml: |-
 {{.KubeProxyConfig | indent 4}}
+---
 {{- if or .MTU .RoutableMTU }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  namespace: openshift-sdn
+  name: sdn-config-mtu-migration
+data:
   mtu.yaml: |-
   {{- if .MTU }}
     mtu: {{.MTU}}
@@ -101,8 +108,8 @@ spec:
           cp -f /opt/cni/bin/openshift-sdn /host-cni-bin/
 
           mtu_override_flag=
-          if [[ -f /config/mtu.yaml ]]; then
-            mtu_override_flag="--mtu-override /config/mtu.yaml"
+          if [[ -f /config-mtu-migration/mtu.yaml ]]; then
+            mtu_override_flag="--mtu-override /config-mtu-migration/mtu.yaml"
           fi
 
           # Launch the network process
@@ -117,6 +124,9 @@ spec:
         volumeMounts:
         - mountPath: /config
           name: config
+          readOnly: true
+        - mountPath: /config-mtu-migration
+          name: config-mtu-migration
           readOnly: true
         - mountPath: /env
           name: env-overrides
@@ -314,6 +324,10 @@ spec:
       - name: config
         configMap:
           name: sdn-config
+      - name: config-mtu-migration
+        configMap:
+          name: sdn-config-mtu-migration
+          optional: true
       - name: env-overrides
         configMap:
           name: env-overrides


### PR DESCRIPTION
SDN pods get restarted once `sdn-config` configmap changes, this caused transient issues with pods being deployed with wrong MTU during MTU migration.

Use a separate, optional config map that is used for mtu migration.

Signed-off-by: Patryk Diak <pdiak@redhat.com>