### PR TITLE
Bug 2048575: The Whereabouts ip-reconciler should use api-int load balancer

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -494,6 +494,7 @@ spec:
         spec:
           priorityClassName: "system-cluster-critical"
           serviceAccountName: multus
+          hostNetwork: true
           containers:
             - name: whereabouts
               image: {{.WhereaboutsImage}}
@@ -507,6 +508,11 @@ spec:
               volumeMounts:
                 - name: cni-net-dir
                   mountPath: /host/etc/cni/net.d
+              env:
+              - name: KUBERNETES_SERVICE_PORT
+                value: "{{.KUBERNETES_SERVICE_PORT}}"
+              - name: KUBERNETES_SERVICE_HOST
+                value: "{{.KUBERNETES_SERVICE_HOST}}"
           volumes:
             - name: cni-net-dir
               hostPath:


### PR DESCRIPTION
It should also use the internal load balancer.

This gives it connectivity during cluster lifecycle events where the SDN is in a transitioning state.