### PR TITLE
Bug 2037721: Do not apply OVN-Kubernetes `PodDisruptionBudget` on single-node clusters

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -1,5 +1,6 @@
 # The ovnkube control-plane components
 
+{{ if not .IsSNO }}
 # The pod disruption budget ensures that we keep a raft quorum
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
@@ -11,9 +12,8 @@ spec:
   selector:
     matchLabels:
       app: ovnkube-master
-
 ---
-
+{{ end }}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:


### PR DESCRIPTION
This is to avoid the `PodDisruptionBudgetAtLimit` alert defined as:

```json
{
  "alert": "PodDisruptionBudgetAtLimit",
  "annotations": {
    "description": "The pod disruption budget is at minimum disruptions allowed level. The number of current healthy pods is equal to desired healthy pods.",
    "summary": "The pod disruption budget is preventing further disruption to pods."
  },
  "expr": "max by(namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_current_healthy == kube_poddisruptionbudget_status_desired_healthy)\n",
  "for": "60m",
  "labels": {
    "severity": "warning"
  }
}
```