### PR TITLE
Bug 2049590: Limit reconcile loop for cm controller

### DIFF
--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -85,6 +85,11 @@ const TRUSTED_CA_BUNDLE_CONFIGMAP_NS = "openshift-config-managed"
 // determines whether or not to inject the combined ca certificate
 const TRUSTED_CA_BUNDLE_CONFIGMAP_LABEL = "config.openshift.io/inject-trusted-cabundle"
 
+// INJECT_CA_BUNDLE_CONFIGMAP_ANNOTATION is the name of the annotation that
+// determines whether or not to inject a services CA bundle to the configmap
+// This annotation is owned by service CA operator
+const INJECT_CA_BUNDLE_CONFIGMAP_ANNOTATION = "service.beta.openshift.io/inject-cabundle"
+
 // SYSTEM_TRUST_BUNDLE is the full path to the file containing
 // the system trust bundle.
 const SYSTEM_TRUST_BUNDLE = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"


### PR DESCRIPTION
If a user erroneously applies label
config.openshift.io/inject-trusted-cabundle=true and
annotation service.beta.openshift.io/inject-cabundle=true to
a config map, it causes the reconcile loop to be called
at a regular short interval due to updates to the configmap
from the service CA operator which owns the annotation.
This causes repeated requests to the API server and
doesn't inform the user of the issue.
This change will limit the API requests and inform the admin of
the issue via operator degraded status message.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>