### PR TITLE
Bug 2044227: Add rolling update strategy for Kuryr-CNI.

### DIFF
--- a/bindata/network/kuryr/005-daemon.yaml
+++ b/bindata/network/kuryr/005-daemon.yaml
@@ -11,6 +11,10 @@ spec:
   selector:
     matchLabels:
       app: kuryr-cni
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       name: kuryr-cni


### PR DESCRIPTION
In daemonset for kuryr-cni there was no upgrade strategy defined, which
means that during upgrade maxUnavailable field will have value of 1,
while it is expected of value of 10% or 33%. And since Kuryr daemon is
an entity which do have impact on other workloads in the cluster, the
appropriate value for maxUnavailable would be 10%.