### PR TITLE
Bug 1944264: ovnkube: gracefully terminate databases from preStop

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -359,10 +359,13 @@ spec:
           preStop:
             exec:
               command:
-                - /usr/bin/ovn-appctl
-                - -t
-                - /var/run/ovn/ovnnb_db.ctl
-                - exit
+              - /bin/bash
+              - -c
+              - |
+                echo "$(date -Iseconds) - stopping nbdb"
+                /usr/share/ovn/scripts/ovn-ctl stop_nb_ovsdb
+                echo "$(date -Iseconds) - nbdb stopped"
+                rm -f /var/run/ovn/ovnnb_db.pid
         readinessProbe:
 {{ if not .IsSNO }}
           initialDelaySeconds: 90
@@ -667,10 +670,13 @@ spec:
           preStop:
             exec:
               command:
-                - /usr/bin/ovn-appctl
-                - -t
-                - /var/run/ovn/ovnsb_db.ctl
-                - exit
+              - /bin/bash
+              - -c
+              - |
+                echo "$(date -Iseconds) - stopping sbdb"
+                /usr/share/ovn/scripts/ovn-ctl stop_sb_ovsdb
+                echo "$(date -Iseconds) - sbdb stopped"
+                rm -f /var/run/ovn/ovnsb_db.pid
         readinessProbe:
 {{ if not .IsSNO }}
           initialDelaySeconds: 90


### PR DESCRIPTION
"ovn-appctl exit" just tells the DB to exit, it doesn't wait. But
"ovn-ctl stop" actually waits for the DBs to exit.

We should do the same things in preStop as in the TERM hook since
there are cases in which neither preStop or TERM is executed so
having both increases the chances we'll terminate gracefully.