### PR TITLE
Bug 2058672: ip-reconciler cronjob specification requires hostnetwork, api-int lb usage & proper backoff [backport 4.10]

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -490,6 +490,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 0
+      ttlSecondsAfterFinished: 900
       template:
         spec:
           priorityClassName: "system-cluster-critical"


### PR DESCRIPTION
This commit makes use of the `ttlSecondsAfterFinished` knob to auto clean
the failed jobs.

According to the Kubernetes API documentation - [0] - this property:
"""
limits the lifetime of a Job that has finished execution (either Complete or
Failed). If this field is set, ttlSecondsAfterFinished after the Job finishes,
it is eligible to be automatically deleted. When the Job is being deleted, its
lifecycle guarantees (e.g. finalizers) will be honored. If this field is unset,
the Job won't be automatically deleted. If this field is set to zero, the Job
becomes eligible to be deleted immediately after it finishes.
"""

We're leaving the failed job around for 15 minutes - which is the period
of the cron job.

[0] - https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/job-v1/#JobSpec

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>