### PR TITLE
Bug 2058673: ip-reconciler cronjob specification requires hostnetwork, api-int lb usage & proper backoff [backport 4.9]

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -476,6 +476,7 @@ spec:
         spec:
           priorityClassName: "system-cluster-critical"
           serviceAccountName: multus
+          hostNetwork: true
           containers:
             - name: whereabouts
               image: {{.WhereaboutsImage}}
@@ -489,6 +490,11 @@ spec:
               volumeMounts:
                 - name: cni-net-dir
                   mountPath: /host/etc/cni/net.d
+              env:
+              - name: KUBERNETES_SERVICE_PORT
+                value: "{{.KUBERNETES_SERVICE_PORT}}"
+              - name: KUBERNETES_SERVICE_HOST
+                value: "{{.KUBERNETES_SERVICE_HOST}}"
           volumes:
             - name: cni-net-dir
               hostPath:

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -471,9 +471,9 @@ spec:
   successfulJobsHistoryLimit: 0
   jobTemplate:
     spec:
+      backoffLimit: 0
       template:
         spec:
-          backoffLimit: 0
           priorityClassName: "system-cluster-critical"
           serviceAccountName: multus
           containers:

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -472,6 +472,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 0
+      ttlSecondsAfterFinished: 900
       template:
         spec:
           priorityClassName: "system-cluster-critical"


### PR DESCRIPTION
Fixes to include in this (and subsequent backports) include:

* auto clean failed jobs (https://github.com/openshift/cluster-network-operator/pull/1318)
* Use host network and api-int (https://github.com/openshift/cluster-network-operator/pull/1302)
* Disable retries on failure (https://github.com/openshift/cluster-network-operator/pull/1290)
