### PR TITLE
Remove empty selector from the mtu prober job.

### DIFF
--- a/bindata/network/mtu-prober/02-job.yaml
+++ b/bindata/network/mtu-prober/02-job.yaml
@@ -8,7 +8,6 @@ metadata:
       This job is run early in the network installation process. It determines the MTU
       of the default route of a node on the cluster.
 spec:
-  selector: {} #need this to make the apiserver happy :/
   template:
     spec:
       containers:


### PR DESCRIPTION
Update of mtu prober job fails because spec.selector is immutable and this doesn't work with the recently introduced server side apply.

```
Could not apply mtu-prober object: failed to apply / update (batch/v1, Kind=Job) openshift-network-operator/mtu-prober: Job.batch "mtu-prober" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string(nil), MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
```

Signed-off-by: Patryk Diak <pdiak@redhat.com>