### PR TITLE
network, bootstrap: don't get apiserver from the environment

### DIFF
--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -3,10 +3,11 @@ package apply
 import (
 	"context"
 	"fmt"
-	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
-	"github.com/openshift/cluster-network-operator/pkg/names"
 	"log"
 	"strings"
+
+	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
+	"github.com/openshift/cluster-network-operator/pkg/names"
 
 	"github.com/pkg/errors"
 
@@ -27,7 +28,7 @@ type Object interface {
 // This causes fields we own to be updated, and fields we don't own to be preserved.
 // For more information, see https://kubernetes.io/docs/reference/using-api/server-side-apply/
 // The subcontroller, if set, is used to assign field ownership.
-func ApplyObject(ctx context.Context, client *cnoclient.Client, obj Object, subcontroller string) error {
+func ApplyObject(ctx context.Context, client cnoclient.Client, obj Object, subcontroller string) error {
 	name := obj.GetName()
 	namespace := obj.GetNamespace()
 	clusterClient := client.ClientFor(obj.GetClusterName())
@@ -115,7 +116,7 @@ func ApplyObject(ctx context.Context, client *cnoclient.Client, obj Object, subc
 //  ManagedFields
 //  Finalizers
 // Annotations are merged, when there is a conflict obj's annotation is used.
-func getCopySource(ctx context.Context, obj Object, client *cnoclient.Client) (Object, error) {
+func getCopySource(ctx context.Context, obj Object, client cnoclient.Client) (Object, error) {
 	anno, exists := obj.GetAnnotations()[names.CopyFromAnnotation]
 	if !exists {
 		return nil, fmt.Errorf("%s annotation not specified", names.CopyFromAnnotation)

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -47,10 +47,10 @@ type OVNBootstrapResult struct {
 type BootstrapResult struct {
 	Kuryr KuryrBootstrapResult
 	OVN   OVNBootstrapResult
-	Infra InfraBootstrapResult
+	Infra InfraStatus
 }
 
-type InfraBootstrapResult struct {
+type InfraStatus struct {
 	PlatformType         configv1.PlatformType
 	PlatformRegion       string
 	PlatformStatus       *configv1.PlatformStatus
@@ -58,7 +58,28 @@ type InfraBootstrapResult struct {
 
 	// KubeCloudConfig is the contents of the openshift-config-managed/kube-cloud-config ConfigMap
 	KubeCloudConfig map[string]string
+
+	// URLs to the apiservers. This is because we can't use the default in-cluster one (they assume a running service network)
+	APIServers map[string]APIServer
 }
+
+// APIServer is the hostname & port of a given APIServer. (This is the
+// load-balancer or other "real" address, not the ServiceIP).
+type APIServer struct {
+	Host string
+	Port string
+}
+
+// APIServerDefault is the key in to APIServers for the cluster's APIserver
+// This **always** declares how manifests inside the cluster should reference it
+// In other words, for Hypershift clusters, it is the url to the gateway / route / proxy
+// for standard clusters, it is the internal ALB. It is never a service IP
+const APIServerDefault = "default"
+
+// APIServerDefaultLocal is the key in to APIServer that is local to the CNO.
+// This describes how to talk to the apiserver in the same way the CNO does it. For hypershift,
+// this might be a ServiceIP that is only valid inside the management cluster.
+const APIServerDefaultLocal = "default-local"
 
 type FlowsConfig struct {
 	// Target IP:port of the flow collector

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -170,22 +170,7 @@ func NewClusterClient(cfg, protocfg *rest.Config) (*OperatorClusterClient, error
 		return nil, err
 	}
 
-	// Add types to the scheme.
-	if err := operv1.Install(c.Scheme()); err != nil {
-		log.Fatal(err)
-	}
-	if err := configv1.Install(c.Scheme()); err != nil {
-		log.Fatal(err)
-	}
-	if err := netopv1.Install(c.Scheme()); err != nil {
-		log.Fatal(err)
-	}
-	if err := machineapi.AddToScheme(c.Scheme()); err != nil {
-		log.Fatal(err)
-	}
-	if err := op_netopv1.Install(c.Scheme()); err != nil {
-		log.Fatal(err)
-	}
+	RegisterTypes(c.Scheme())
 
 	return &c, nil
 }
@@ -294,5 +279,24 @@ func (c *OperatorClusterClient) AddCustomInformer(inf cache.SharedInformer) {
 	c.informers = append(c.informers, inf)
 	if c.started {
 		go inf.Run(c.donech)
+	}
+}
+
+func RegisterTypes(s *runtime.Scheme) {
+	// Add types to the scheme.
+	if err := operv1.Install(s); err != nil {
+		log.Fatal(err)
+	}
+	if err := configv1.Install(s); err != nil {
+		log.Fatal(err)
+	}
+	if err := netopv1.Install(s); err != nil {
+		log.Fatal(err)
+	}
+	if err := machineapi.AddToScheme(s); err != nil {
+		log.Fatal(err)
+	}
+	if err := op_netopv1.Install(s); err != nil {
+		log.Fatal(err)
 	}
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -3,6 +3,9 @@ package client
 import (
 	"context"
 	"fmt"
+	"log"
+	"time"
+
 	"github.com/openshift/cluster-network-operator/pkg/util/k8s"
 	clientConfig "github.com/openshift/library-go/pkg/config/client"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -14,8 +17,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
-	"log"
-	"time"
 
 	osoperclient "github.com/openshift/client-go/operator/clientset/versioned"
 	osoperinformer "github.com/openshift/client-go/operator/informers/externalversions"
@@ -35,11 +36,11 @@ const (
 	DefaultClusterName  = "default"
 )
 
-// ClusterClient is a bag of holding for object clients & informers.
+// OperatorClusterClient is a bag of holding for object clients & informers.
 // It is generally responsible for managing informer lifecycle.
 //
 // int 5, wis 2, dex 10, cha 6
-type ClusterClient struct {
+type OperatorClusterClient struct {
 	cfg *rest.Config
 
 	// Same configuration, but with protobuf enabled
@@ -77,9 +78,12 @@ type ClusterClient struct {
 	donech  <-chan struct{}
 }
 
-func NewClient(cfg, protocfg *rest.Config, extraClusters map[string]string) (*Client, error) {
-	cli := &Client{
-		clusterClients: make(map[string]*ClusterClient),
+// enforce that OperatorClusterClient implements the ClusterClient interface
+var _ ClusterClient = &OperatorClusterClient{}
+
+func NewClient(cfg, protocfg *rest.Config, extraClusters map[string]string) (*OperatorClient, error) {
+	cli := &OperatorClient{
+		clusterClients: make(map[string]*OperatorClusterClient),
 	}
 
 	defaultClient, err := NewClusterClient(cfg, protocfg)
@@ -106,24 +110,37 @@ func NewClient(cfg, protocfg *rest.Config, extraClusters map[string]string) (*Cl
 	return cli, nil
 }
 
-type Client struct {
-	clusterClients map[string]*ClusterClient
+type OperatorClient struct {
+	clusterClients map[string]*OperatorClusterClient
 }
 
+// ensure OperatorClient implements Client
+var _ Client = &OperatorClient{}
+
 // ClientFor returns a ClusterClient reference based on the name provided, if name is empty returns the default ClusterClient
-func (c *Client) ClientFor(name string) *ClusterClient {
+func (c *OperatorClient) ClientFor(name string) ClusterClient {
 	if len(name) == 0 {
 		return c.Default()
 	}
 	return c.clusterClients[name]
 }
 
-func (c *Client) Default() *ClusterClient {
+func (c *OperatorClient) Default() ClusterClient {
 	return c.clusterClients[DefaultClusterName]
 }
 
-func NewClusterClient(cfg, protocfg *rest.Config) (*ClusterClient, error) {
-	c := ClusterClient{
+func (c *OperatorClient) Start(ctx context.Context) error {
+	for _, cc := range c.clusterClients {
+		if err := cc.Start(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func NewClusterClient(cfg, protocfg *rest.Config) (*OperatorClusterClient, error) {
+	c := OperatorClusterClient{
 		cfg:      cfg,
 		protocfg: protocfg,
 	}
@@ -173,33 +190,33 @@ func NewClusterClient(cfg, protocfg *rest.Config) (*ClusterClient, error) {
 	return &c, nil
 }
 
-func (c *ClusterClient) Kubernetes() kubernetes.Interface {
+func (c *OperatorClusterClient) Kubernetes() kubernetes.Interface {
 	return c.kClient
 }
 
 // OpenshiftOperatorClient returns the clientset for operator.openshift.io
-func (c *ClusterClient) OpenshiftOperatorClient() *osoperclient.Clientset {
+func (c *OperatorClusterClient) OpenshiftOperatorClient() *osoperclient.Clientset {
 	return c.osOperClient
 }
 
 // Dynamic returns an untyped, dynamic client.
-func (c *ClusterClient) Dynamic() dynamic.Interface {
+func (c *OperatorClusterClient) Dynamic() dynamic.Interface {
 	return c.dynclient
 }
 
-func (c *ClusterClient) CRClient() crclient.Client {
+func (c *OperatorClusterClient) CRClient() crclient.Client {
 	return c.crclient
 }
 
-func (c *ClusterClient) RESTMapper() meta.RESTMapper {
+func (c *OperatorClusterClient) RESTMapper() meta.RESTMapper {
 	return c.restMapper
 }
 
-func (c *ClusterClient) Scheme() *runtime.Scheme {
+func (c *OperatorClusterClient) Scheme() *runtime.Scheme {
 	return scheme.Scheme
 }
 
-func (c *ClusterClient) Start(ctx context.Context) error {
+func (c *OperatorClusterClient) Start(ctx context.Context) error {
 	if c.started {
 		return fmt.Errorf("Trying to start ClusterClient twice")
 	}
@@ -245,7 +262,7 @@ func (c *ClusterClient) Start(ctx context.Context) error {
 // OperatorHelperClient returns an implementation of the
 // v1helpers.OperatorClient interface for use by the library-go
 // controllers.
-func (c *ClusterClient) OperatorHelperClient() operatorv1helpers.OperatorClient {
+func (c *OperatorClusterClient) OperatorHelperClient() operatorv1helpers.OperatorClient {
 	if c.hc != nil {
 		return c.hc
 	}
@@ -273,7 +290,7 @@ func (c *ClusterClient) OperatorHelperClient() operatorv1helpers.OperatorClient 
 //				options.LabelSelector = "operator.example.dev/mylabel=myval"
 //			}))
 //
-func (c *ClusterClient) AddCustomInformer(inf cache.SharedInformer) {
+func (c *OperatorClusterClient) AddCustomInformer(inf cache.SharedInformer) {
 	c.informers = append(c.informers, inf)
 	if c.started {
 		go inf.Run(c.donech)

--- a/pkg/client/fake/fake_client.go
+++ b/pkg/client/fake/fake_client.go
@@ -1,0 +1,101 @@
+package fake
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	fakedynamic "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
+
+	osoperclient "github.com/openshift/client-go/operator/clientset/versioned"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type FakeClient struct {
+	clusterClients map[string]*FakeClusterClient
+}
+
+type FakeClusterClient struct {
+	// dynclient is an untyped, uncached client for making direct requests
+	// against the apiserver.
+	dynclient dynamic.Interface
+
+	// crclient is the controller-runtime ClusterClient, for controllers that have
+	// not yet been migrated.
+	crclient crclient.Client
+}
+
+func (fcc *FakeClient) ClientFor(name string) cnoclient.ClusterClient {
+	return fcc.clusterClients[name]
+}
+
+func (fcc *FakeClient) Default() cnoclient.ClusterClient {
+	return fcc.ClientFor(cnoclient.DefaultClusterName)
+}
+
+func (fcc *FakeClient) Start(context.Context) error {
+	return nil
+}
+
+// NewFakeClient creates a fake client with a backing store that contains the given objexts.
+//
+// Note that, due to limitations in the test infrastructure, each client has an independent store.
+// This means that changes made in, say, the crclient, won't show up in the Dynamic client or the typed
+// Kubernetes client
+// TODO: stop using the crclient entirely
+// TODO: Somehow convince upstream client-go to allow sharing the store between the dynamic and typed clients.
+//       (this is't that big a deal since we don't actually use the typed client that much).
+func NewFakeClient(objs ...crclient.Object) cnoclient.Client {
+	// silly go type conversion
+	oo := make([]runtime.Object, 0, len(objs))
+	for _, o := range objs {
+		oo = append(oo, o)
+	}
+	scheme := scheme.Scheme
+	cnoclient.RegisterTypes(scheme)
+	fc := FakeClusterClient{
+		// kClient:   faketyped.NewSimpleClientset(oo...), // TODO: fix this, it doesn't work for non-kubernetes objects
+		dynclient: fakedynamic.NewSimpleDynamicClient(scheme, oo...),
+		crclient:  crfake.NewClientBuilder().WithObjects(objs...).Build(),
+	}
+
+	return &FakeClient{
+		clusterClients: map[string]*FakeClusterClient{
+			cnoclient.DefaultClusterName: &fc,
+		},
+	}
+}
+
+func (fc *FakeClusterClient) Kubernetes() kubernetes.Interface {
+	panic("not implemented!")
+}
+
+func (fc *FakeClusterClient) OpenshiftOperatorClient() *osoperclient.Clientset {
+	panic("not implemented!")
+}
+
+func (fc *FakeClusterClient) Dynamic() dynamic.Interface {
+	return fc.dynclient
+}
+
+func (fc *FakeClusterClient) CRClient() crclient.Client {
+	return fc.crclient
+}
+
+func (fc *FakeClusterClient) RESTMapper() meta.RESTMapper {
+	panic("not implemented!")
+}
+
+func (fc *FakeClusterClient) Scheme() *runtime.Scheme {
+	panic("not implemented!")
+}
+func (fc *FakeClusterClient) OperatorHelperClient() operatorv1helpers.OperatorClient {
+	panic("not implemented!")
+}

--- a/pkg/client/fake/fake_client.go
+++ b/pkg/client/fake/fake_client.go
@@ -32,16 +32,24 @@ type FakeClusterClient struct {
 	crclient crclient.Client
 }
 
-func (fcc *FakeClient) ClientFor(name string) cnoclient.ClusterClient {
-	return fcc.clusterClients[name]
+func (fc *FakeClient) ClientFor(name string) cnoclient.ClusterClient {
+	return fc.clusterClients[name]
 }
 
-func (fcc *FakeClient) Default() cnoclient.ClusterClient {
-	return fcc.ClientFor(cnoclient.DefaultClusterName)
+func (fc *FakeClient) Default() cnoclient.ClusterClient {
+	return fc.ClientFor(cnoclient.DefaultClusterName)
 }
 
-func (fcc *FakeClient) Start(context.Context) error {
+func (fc *FakeClient) Start(context.Context) error {
 	return nil
+}
+
+func (fc *FakeClient) Clients() map[string]cnoclient.ClusterClient {
+	out := make(map[string]cnoclient.ClusterClient)
+	for k, v := range fc.clusterClients {
+		out[k] = v
+	}
+	return out
 }
 
 // NewFakeClient creates a fake client with a backing store that contains the given objexts.
@@ -98,4 +106,8 @@ func (fc *FakeClusterClient) Scheme() *runtime.Scheme {
 }
 func (fc *FakeClusterClient) OperatorHelperClient() operatorv1helpers.OperatorClient {
 	panic("not implemented!")
+}
+
+func (fc *FakeClusterClient) HostPort() (string, string) {
+	return "testing", "9999"
 }

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -1,0 +1,51 @@
+package client
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+
+	osoperclient "github.com/openshift/client-go/operator/clientset/versioned"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Client holds all apiserver connections.
+type Client interface {
+	// ClientFor returns the ClusterClient for a given named cluster.
+	ClientFor(name string) ClusterClient
+
+	// Default returns the "default" cluster's Client. This is probably what you want.
+	Default() ClusterClient
+
+	// Start may start all informers for all clients, if applicable.
+	Start(context.Context) error
+}
+
+// ClusterClient is the connection to a single cluster / apiserver. It exposes
+// various "clients" to this single apiserver.
+type ClusterClient interface {
+	// Kuberetes returns the typed Kubernetes client
+	Kubernetes() kubernetes.Interface
+
+	// OpenshiftOperatorClient returns the clientset for operator.openshift.io
+	OpenshiftOperatorClient() *osoperclient.Clientset
+
+	// Dynamic returns an untyped, dynamic client.
+	Dynamic() dynamic.Interface
+
+	// CRClient returns the controller-runtime client, another untyped client
+	CRClient() crclient.Client
+
+	// RESTMapper returns this cluster's RESTMapper, a mapping from type to api resource
+	RESTMapper() meta.RESTMapper
+
+	Scheme() *runtime.Scheme
+
+	// OpenshiftOperatorClient returns the clientset for operator.openshift.io
+	OperatorHelperClient() operatorv1helpers.OperatorClient
+}

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -16,6 +16,9 @@ import (
 
 // Client holds all apiserver connections.
 type Client interface {
+	// Clients returns all known cluster clietns.
+	Clients() map[string]ClusterClient
+
 	// ClientFor returns the ClusterClient for a given named cluster.
 	ClientFor(name string) ClusterClient
 
@@ -48,4 +51,7 @@ type ClusterClient interface {
 
 	// OpenshiftOperatorClient returns the clientset for operator.openshift.io
 	OperatorHelperClient() operatorv1helpers.OperatorClient
+
+	// HostPort returns the host and port, as a string, of this connection
+	HostPort() (string, string)
 }

--- a/pkg/controller/clusterconfig/clusterconfig_controller.go
+++ b/pkg/controller/clusterconfig/clusterconfig_controller.go
@@ -89,7 +89,7 @@ func (r *ReconcileClusterConfig) Reconcile(ctx context.Context, request reconcil
 	}
 
 	// Validate the cluster config
-	if err := network.ValidateClusterConfig(clusterConfig.Spec, r.client.Default().CRClient()); err != nil {
+	if err := network.ValidateClusterConfig(clusterConfig.Spec, r.client); err != nil {
 		log.Printf("Failed to validate Network.Spec: %v", err)
 		r.status.SetDegraded(statusmanager.ClusterConfig, "InvalidClusterConfig",
 			fmt.Sprintf("The cluster configuration is invalid (%v). Use 'oc edit network.config.openshift.io cluster' to fix.", err))

--- a/pkg/controller/clusterconfig/clusterconfig_controller.go
+++ b/pkg/controller/clusterconfig/clusterconfig_controller.go
@@ -25,12 +25,12 @@ import (
 )
 
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, status *statusmanager.StatusManager, c *cnoclient.Client) error {
+func Add(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client) error {
 	return add(mgr, newReconciler(mgr, status, c))
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, status *statusmanager.StatusManager, c *cnoclient.Client) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client) reconcile.Reconciler {
 	return &ReconcileClusterConfig{client: c, scheme: mgr.GetScheme(), status: status}
 }
 
@@ -55,7 +55,7 @@ var _ reconcile.Reconciler = &ReconcileClusterConfig{}
 
 // ReconcileClusterConfig reconciles a cluster Network object
 type ReconcileClusterConfig struct {
-	client *cnoclient.Client
+	client cnoclient.Client
 	scheme *runtime.Scheme
 	status *statusmanager.StatusManager
 }

--- a/pkg/controller/configmap_ca_injector/controller.go
+++ b/pkg/controller/configmap_ca_injector/controller.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-func Add(mgr manager.Manager, status *statusmanager.StatusManager, c *cnoclient.Client) error {
+func Add(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client) error {
 	reconciler := newReconciler(mgr, status, c)
 	if reconciler == nil {
 		return fmt.Errorf("failed to create reconciler")
@@ -38,7 +38,7 @@ func Add(mgr manager.Manager, status *statusmanager.StatusManager, c *cnoclient.
 	return add(mgr, reconciler)
 }
 
-func newReconciler(mgr manager.Manager, status *statusmanager.StatusManager, c *cnoclient.Client) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client) reconcile.Reconciler {
 	return &ReconcileConfigMapInjector{client: c, scheme: mgr.GetScheme(), status: status}
 }
 
@@ -77,7 +77,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 var _ reconcile.Reconciler = &ReconcileConfigMapInjector{}
 
 type ReconcileConfigMapInjector struct {
-	client *cnoclient.Client
+	client cnoclient.Client
 	scheme *runtime.Scheme
 	status *statusmanager.StatusManager
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -7,10 +7,10 @@ import (
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-var AddToManagerFuncs []func(manager.Manager, *statusmanager.StatusManager, *cnoclient.Client) error
+var AddToManagerFuncs []func(manager.Manager, *statusmanager.StatusManager, cnoclient.Client) error
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(m manager.Manager, sm *statusmanager.StatusManager, c *cnoclient.Client) error {
+func AddToManager(m manager.Manager, sm *statusmanager.StatusManager, c cnoclient.Client) error {
 	for _, f := range AddToManagerFuncs {
 		if err := f(m, sm, c); err != nil {
 			return err

--- a/pkg/controller/egress_router/egress_router_controller.go
+++ b/pkg/controller/egress_router/egress_router_controller.go
@@ -36,7 +36,7 @@ import (
 )
 
 // Attach control loop to the manager and watch for Egress Router objects
-func Add(mgr manager.Manager, status *statusmanager.StatusManager, cli *cnoclient.Client) error {
+func Add(mgr manager.Manager, status *statusmanager.StatusManager, cli cnoclient.Client) error {
 	r, err := newEgressRouterReconciler(mgr, status, cli)
 	if err != nil {
 		return err
@@ -66,7 +66,7 @@ type egressrouter struct {
 
 type EgressRouterReconciler struct {
 	mgr    manager.Manager
-	client *cnoclient.Client
+	client cnoclient.Client
 	status *statusmanager.StatusManager
 
 	egressrouters    map[types.NamespacedName]*egressrouter
@@ -75,7 +75,7 @@ type EgressRouterReconciler struct {
 
 var ResyncPeriod = 5 * time.Minute
 
-func newEgressRouterReconciler(mgr manager.Manager, status *statusmanager.StatusManager, c *cnoclient.Client) (reconcile.Reconciler, error) {
+func newEgressRouterReconciler(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client) (reconcile.Reconciler, error) {
 
 	return &EgressRouterReconciler{
 		mgr:    mgr,

--- a/pkg/controller/ingressconfig/ingressconfig_controller.go
+++ b/pkg/controller/ingressconfig/ingressconfig_controller.go
@@ -34,7 +34,7 @@ var ManifestPath = "./bindata"
 
 // Add creates a new ingressConfig controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, status *statusmanager.StatusManager, _ *cnoclient.Client) error {
+func Add(mgr manager.Manager, status *statusmanager.StatusManager, _ cnoclient.Client) error {
 
 	return add(mgr, newIngressConfigReconciler(mgr.GetClient()))
 }

--- a/pkg/controller/operconfig/cluster.go
+++ b/pkg/controller/operconfig/cluster.go
@@ -34,7 +34,7 @@ func (r *ReconcileOperConfig) MergeClusterConfig(ctx context.Context, operConfig
 
 	// Validate cluster config
 	// If invalid just warn and proceed.
-	if err := network.ValidateClusterConfig(clusterConfig.Spec, r.client.Default().CRClient()); err != nil {
+	if err := network.ValidateClusterConfig(clusterConfig.Spec, r.client); err != nil {
 		log.Printf("WARNING: ignoring Network.config.openshift.io/v1/cluster - failed validation: %v", err)
 		return nil
 	}

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -47,14 +47,14 @@ var ManifestPath = "./bindata"
 
 // Add creates a new OperConfig Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, status *statusmanager.StatusManager, c *cnoclient.Client) error {
+func Add(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client) error {
 	return add(mgr, newReconciler(mgr, status, c))
 }
 
 const ControllerName = "operconfig"
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, status *statusmanager.StatusManager, c *cnoclient.Client) *ReconcileOperConfig {
+func newReconciler(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client) *ReconcileOperConfig {
 	return &ReconcileOperConfig{
 		client:        c,
 		scheme:        mgr.GetScheme(),
@@ -107,7 +107,7 @@ var _ reconcile.Reconciler = &ReconcileOperConfig{}
 
 // ReconcileOperConfig reconciles a Network.operator.openshift.io object
 type ReconcileOperConfig struct {
-	client        *cnoclient.Client
+	client        cnoclient.Client
 	scheme        *runtime.Scheme
 	status        *statusmanager.StatusManager
 	mapper        meta.RESTMapper

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/controller/statusmanager"
 	"github.com/openshift/cluster-network-operator/pkg/names"
 	"github.com/openshift/cluster-network-operator/pkg/network"
+	"github.com/openshift/cluster-network-operator/pkg/platform"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -180,12 +181,19 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, err
 	}
 
+	// Gather the Infra status, we'll need it a few places
+	infraStatus, err := platform.InfraStatus(r.client)
+	if err != nil {
+		log.Printf("Failed to retrieve infrastructure status: %v", err)
+		return reconcile.Result{}, err
+	}
+
 	// If we need to, probe the host's MTU via a Job.
 	// It's okay if this is 0, since running clusters have no need of this
 	// and thus do not need to probe MTU
 	mtu := 0
 	if network.NeedMTUProbe(prev, &operConfig.Spec) {
-		mtu, err = r.probeMTU(ctx, operConfig)
+		mtu, err = r.probeMTU(ctx, operConfig, infraStatus)
 		if err != nil {
 			log.Printf("Failed to probe MTU: %v", err)
 			r.status.SetDegraded(statusmanager.OperatorConfig, "MTUProbeFailed",
@@ -208,7 +216,7 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 	if prev != nil {
 		// We may need to fill defaults here -- sort of as a poor-man's
 		// upconversion scheme -- if we add additional fields to the config.
-		err = network.IsChangeSafe(prev, &operConfig.Spec, r.client.Default().CRClient())
+		err = network.IsChangeSafe(prev, &operConfig.Spec, infraStatus)
 		if err != nil {
 			log.Printf("Not applying unsafe change: %v", err)
 			r.status.SetDegraded(statusmanager.OperatorConfig, "InvalidOperatorConfig",
@@ -220,7 +228,7 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 	newOperConfig := operConfig.DeepCopy()
 
 	// Bootstrap any resources
-	bootstrapResult, err := network.Bootstrap(newOperConfig, r.client.Default().CRClient())
+	bootstrapResult, err := network.Bootstrap(newOperConfig, r.client)
 	if err != nil {
 		log.Printf("Failed to reconcile platform networking resources: %v", err)
 		r.status.SetDegraded(statusmanager.OperatorConfig, "BootstrapError",

--- a/pkg/controller/pki/pki_controller.go
+++ b/pkg/controller/pki/pki_controller.go
@@ -41,7 +41,7 @@ const (
 )
 
 // Add attaches our control loop to the manager and watches for PKI objects
-func Add(mgr manager.Manager, status *statusmanager.StatusManager, _ *cnoclient.Client) error {
+func Add(mgr manager.Manager, status *statusmanager.StatusManager, _ cnoclient.Client) error {
 	r, err := newPKIReconciler(mgr, status)
 	if err != nil {
 		return err

--- a/pkg/controller/proxyconfig/controller.go
+++ b/pkg/controller/proxyconfig/controller.go
@@ -27,7 +27,7 @@ import (
 )
 
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, status *statusmanager.StatusManager, _ *cnoclient.Client) error {
+func Add(mgr manager.Manager, status *statusmanager.StatusManager, _ cnoclient.Client) error {
 	reconciler := newReconciler(mgr, status)
 	if reconciler == nil {
 		return fmt.Errorf("failed to create reconciler")

--- a/pkg/controller/signer/signer-controller.go
+++ b/pkg/controller/signer/signer-controller.go
@@ -29,7 +29,7 @@ import (
 const signerName = "network.openshift.io/signer"
 
 // Add controller and start it when the Manager is started.
-func Add(mgr manager.Manager, status *statusmanager.StatusManager, _ *cnoclient.Client) error {
+func Add(mgr manager.Manager, status *statusmanager.StatusManager, _ cnoclient.Client) error {
 	reconciler, err := newReconciler(mgr, status)
 	if err != nil {
 		return err

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -144,3 +144,8 @@ const IPFamilySingleStack = "single-stack"
 
 // dual stack IP family mode
 const IPFamilyDualStack = "dual-stack"
+
+// EnvApiOverrideHost is an environment variable that, if set, allows overriding the host / port
+// of the apiserver, but only for rendered manifests. CNO itself will not use it
+const EnvApiOverrideHost = "APISERVER_OVERRIDE_HOST"
+const EnvApiOverridePort = "APISERVER_OVERRIDE_PORT"

--- a/pkg/network/cloud_network.go
+++ b/pkg/network/cloud_network.go
@@ -18,7 +18,7 @@ import (
 )
 
 // renderCloudNetworkConfigController renders the cloud network config controller
-func renderCloudNetworkConfigController(conf *operv1.NetworkSpec, cloudBootstrapResult bootstrap.InfraBootstrapResult, manifestDir string) ([]*uns.Unstructured, error) {
+func renderCloudNetworkConfigController(conf *operv1.NetworkSpec, cloudBootstrapResult bootstrap.InfraStatus, manifestDir string) ([]*uns.Unstructured, error) {
 	pt := cloudBootstrapResult.PlatformType
 	if !(pt == v1.AWSPlatformType || pt == v1.AzurePlatformType || pt == v1.GCPPlatformType) {
 		return nil, nil
@@ -31,8 +31,8 @@ func renderCloudNetworkConfigController(conf *operv1.NetworkSpec, cloudBootstrap
 	data.Data["PlatformTypeAzure"] = v1.AzurePlatformType
 	data.Data["PlatformTypeGCP"] = v1.GCPPlatformType
 	data.Data["CloudNetworkConfigControllerImage"] = os.Getenv("CLOUD_NETWORK_CONFIG_CONTROLLER_IMAGE")
-	data.Data["KubernetesServiceHost"] = os.Getenv("KUBERNETES_SERVICE_HOST")
-	data.Data["KubernetesServicePort"] = os.Getenv("KUBERNETES_SERVICE_PORT")
+	data.Data["KubernetesServiceHost"] = cloudBootstrapResult.APIServers[bootstrap.APIServerDefault].Host
+	data.Data["KubernetesServicePort"] = cloudBootstrapResult.APIServers[bootstrap.APIServerDefault].Port
 	data.Data["ExternalControlPlane"] = cloudBootstrapResult.ExternalControlPlane
 	data.Data["PlatformAzureEnvironment"] = ""
 	data.Data["PlatformAWSCAPath"] = ""

--- a/pkg/network/cluster_config.go
+++ b/pkg/network/cluster_config.go
@@ -5,9 +5,9 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	operv1 "github.com/openshift/api/operator/v1"
+	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 	"github.com/openshift/cluster-network-operator/pkg/platform"
 	iputil "github.com/openshift/cluster-network-operator/pkg/util/ip"
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilnet "k8s.io/utils/net"
@@ -19,7 +19,7 @@ import (
 var pluginsUsingHostPrefix = sets.NewString(string(operv1.NetworkTypeOpenShiftSDN), string(operv1.NetworkTypeOVNKubernetes))
 
 // ValidateClusterConfig ensures the cluster config is valid.
-func ValidateClusterConfig(clusterConfig configv1.NetworkSpec, client crclient.Client) error {
+func ValidateClusterConfig(clusterConfig configv1.NetworkSpec, client cnoclient.Client) error {
 	// Check all networks for overlaps
 	pool := iputil.IPPool{}
 
@@ -95,7 +95,7 @@ func ValidateClusterConfig(clusterConfig configv1.NetworkSpec, client crclient.C
 	}
 
 	// If for whatever reason it is not possible to get the platform type, fail
-	infraRes, err := platform.BootstrapInfra(client)
+	infraRes, err := platform.InfraStatus(client)
 	if err != nil {
 		return err
 	}

--- a/pkg/network/cluster_config_test.go
+++ b/pkg/network/cluster_config_test.go
@@ -7,7 +7,8 @@ import (
 	operv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/openshift/cluster-network-operator/pkg/client/fake"
 
 	. "github.com/onsi/gomega"
 )
@@ -43,7 +44,7 @@ func TestValidateClusterConfig(t *testing.T) {
 			},
 		},
 	}
-	client := fake.NewClientBuilder().WithObjects(infrastructure).Build()
+	client := fake.NewFakeClient(infrastructure)
 
 	cc := *ClusterConfig.DeepCopy()
 	err := ValidateClusterConfig(cc, client)
@@ -111,7 +112,7 @@ func TestValidateClusterConfigDualStack(t *testing.T) {
 			},
 		},
 	}
-	client := fake.NewClientBuilder().WithObjects(infrastructure).Build()
+	client := fake.NewFakeClient(infrastructure)
 
 	cc := *ClusterConfig.DeepCopy()
 	err := ValidateClusterConfig(cc, client)
@@ -164,7 +165,7 @@ func TestValidateClusterConfigDualStack(t *testing.T) {
 
 	// You can't use dual-stack if this is anything else but BareMetal or NonePlatformType
 	infrastructure.Status.PlatformStatus.Type = configv1.AzurePlatformType
-	client = fake.NewClientBuilder().WithObjects(infrastructure).Build()
+	client = fake.NewFakeClient(infrastructure)
 	cc = *ClusterConfig.DeepCopy()
 	cc.ServiceNetwork = append(cc.ServiceNetwork, "fd02::/112")
 	cc.ClusterNetwork = append(cc.ClusterNetwork, configv1.ClusterNetworkEntry{

--- a/pkg/network/dhcp_daemon_test.go
+++ b/pkg/network/dhcp_daemon_test.go
@@ -171,7 +171,7 @@ func TestRenderWithDHCP(t *testing.T) {
 	config := &crd.Spec
 	fillDefaults(config, nil)
 
-	objs, err := renderMultus(config, manifestDir)
+	objs, err := renderMultus(config, fakeBootstrapResult(), manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "dhcp-daemon")))
 }
@@ -184,7 +184,7 @@ func TestRenderNoDHCP(t *testing.T) {
 	config := &crd.Spec
 	fillDefaults(config, nil)
 
-	objs, err := renderMultus(config, manifestDir)
+	objs, err := renderMultus(config, fakeBootstrapResult(), manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "dhcp-daemon")))
 }
@@ -197,7 +197,7 @@ func TestRenderInvalidDHCP(t *testing.T) {
 	config := &crd.Spec
 	fillDefaults(config, nil)
 
-	objs, err := renderMultus(config, manifestDir)
+	objs, err := renderMultus(config, fakeBootstrapResult(), manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "dhcp-daemon")))
 }
@@ -210,7 +210,7 @@ func TestRenderWithDHCPSimpleMacvlan(t *testing.T) {
 	config := &crd.Spec
 	fillDefaults(config, nil)
 
-	objs, err := renderMultus(config, manifestDir)
+	objs, err := renderMultus(config, fakeBootstrapResult(), manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "dhcp-daemon")))
 }
@@ -223,7 +223,7 @@ func TestRenderNoDHCPSimpleMacvlan(t *testing.T) {
 	config := &crd.Spec
 	fillDefaults(config, nil)
 
-	objs, err := renderMultus(config, manifestDir)
+	objs, err := renderMultus(config, fakeBootstrapResult(), manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "dhcp-daemon")))
 }

--- a/pkg/network/kube_proxy.go
+++ b/pkg/network/kube_proxy.go
@@ -210,8 +210,8 @@ func renderStandaloneKubeProxy(conf *operv1.NetworkSpec, bootstrapResult *bootst
 	data.Data["ReleaseVersion"] = os.Getenv("RELEASE_VERSION")
 	data.Data["KubeProxyImage"] = os.Getenv("KUBE_PROXY_IMAGE")
 	data.Data["KubeRBACProxyImage"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
-	data.Data["KUBERNETES_SERVICE_HOST"] = os.Getenv("KUBERNETES_SERVICE_HOST")
-	data.Data["KUBERNETES_SERVICE_PORT"] = os.Getenv("KUBERNETES_SERVICE_PORT")
+	data.Data["KUBERNETES_SERVICE_HOST"] = bootstrapResult.Infra.APIServers[bootstrap.APIServerDefault].Host
+	data.Data["KUBERNETES_SERVICE_PORT"] = bootstrapResult.Infra.APIServers[bootstrap.APIServerDefault].Port
 	data.Data["KubeProxyConfig"] = kpc
 	data.Data["MetricsPort"] = metricsPort
 	data.Data["HealthzPort"] = healthzPort

--- a/pkg/network/kuryr.go
+++ b/pkg/network/kuryr.go
@@ -98,8 +98,8 @@ func renderKuryr(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapR
 	data.Data["CNIPluginsImage"] = os.Getenv("CNI_PLUGINS_IMAGE")
 	data.Data["DaemonImage"] = os.Getenv("KURYR_DAEMON_IMAGE")
 	data.Data["ControllerImage"] = os.Getenv("KURYR_CONTROLLER_IMAGE")
-	data.Data["KUBERNETES_SERVICE_HOST"] = os.Getenv("KUBERNETES_SERVICE_HOST")
-	data.Data["KUBERNETES_SERVICE_PORT"] = os.Getenv("KUBERNETES_SERVICE_PORT")
+	data.Data["KUBERNETES_SERVICE_HOST"] = bootstrapResult.Infra.APIServers[bootstrap.APIServerDefault].Host
+	data.Data["KUBERNETES_SERVICE_PORT"] = bootstrapResult.Infra.APIServers[bootstrap.APIServerDefault].Port
 	data.Data["CNIConfDir"] = pluginCNIConfDir(conf)
 	data.Data["CNIBinDir"] = CNIBinDir
 

--- a/pkg/network/kuryr_test.go
+++ b/pkg/network/kuryr_test.go
@@ -26,7 +26,7 @@ var KuryrConfig = operv1.Network{
 	},
 }
 
-var FakeBootstrapResult = bootstrap.BootstrapResult{
+var fakeKuryrBootstrapResult = bootstrap.BootstrapResult{
 	Kuryr: bootstrap.KuryrBootstrapResult{
 		PodSubnetpool:     "pod-subnetpool-id",
 		ServiceSubnet:     "svc-subnet-id",
@@ -35,6 +35,14 @@ var FakeBootstrapResult = bootstrap.BootstrapResult{
 			AuthType: "password",
 			AuthInfo: &clientconfig.AuthInfo{
 				AuthURL: "https://foo.bar:8080",
+			},
+		},
+	},
+	Infra: bootstrap.InfraStatus{
+		APIServers: map[string]bootstrap.APIServer{
+			bootstrap.APIServerDefault: {
+				Host: "testing.test",
+				Port: "8443",
 			},
 		},
 	},
@@ -52,7 +60,7 @@ func TestRenderKuryr(t *testing.T) {
 
 	fillDefaults(config, nil)
 
-	objs, err := renderKuryr(config, &FakeBootstrapResult, manifestDir)
+	objs, err := renderKuryr(config, &fakeKuryrBootstrapResult, manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-kuryr", "kuryr-cni")))
 

--- a/pkg/network/multus_test.go
+++ b/pkg/network/multus_test.go
@@ -37,14 +37,14 @@ func TestRenderMultus(t *testing.T) {
 	fillDefaults(config, nil)
 
 	// disable Multus
-	objs, err := renderMultus(config, manifestDir)
+	objs, err := renderMultus(config, fakeBootstrapResult(), manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "multus")))
 
 	// enable Multus
 	enabled := false
 	config.DisableMultiNetwork = &enabled
-	objs, err = renderMultus(config, manifestDir)
+	objs, err = renderMultus(config, fakeBootstrapResult(), manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "multus")))
 

--- a/pkg/network/network_metrics_test.go
+++ b/pkg/network/network_metrics_test.go
@@ -36,14 +36,14 @@ func TestRenderNetworkMetricsDaemon(t *testing.T) {
 	fillDefaults(config, nil)
 
 	// disable MultusAdmissionController
-	objs, err := renderMultus(config, manifestDir)
+	objs, err := renderMultus(config, fakeBootstrapResult(), manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "network-metrics-daemon")))
 
 	// enable MultusAdmissionController
 	enabled := false
 	config.DisableMultiNetwork = &enabled
-	objs, err = renderMultus(config, manifestDir)
+	objs, err = renderMultus(config, fakeBootstrapResult(), manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "network-metrics-daemon")))
 

--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -11,8 +11,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
-	"github.com/openshift/cluster-network-operator/pkg/platform"
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -40,8 +38,8 @@ func renderOpenShiftSDN(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Boo
 	data.Data["SDNImage"] = os.Getenv("SDN_IMAGE")
 	data.Data["CNIPluginsImage"] = os.Getenv("CNI_PLUGINS_IMAGE")
 	data.Data["KubeRBACProxyImage"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
-	data.Data["KUBERNETES_SERVICE_HOST"] = os.Getenv("KUBERNETES_SERVICE_HOST")
-	data.Data["KUBERNETES_SERVICE_PORT"] = os.Getenv("KUBERNETES_SERVICE_PORT")
+	data.Data["KUBERNETES_SERVICE_HOST"] = bootstrapResult.Infra.APIServers[bootstrap.APIServerDefault].Host
+	data.Data["KUBERNETES_SERVICE_PORT"] = bootstrapResult.Infra.APIServers[bootstrap.APIServerDefault].Port
 	data.Data["Mode"] = c.Mode
 	data.Data["CNIConfDir"] = pluginCNIConfDir(conf)
 	data.Data["CNIBinDir"] = CNIBinDir
@@ -338,15 +336,4 @@ func clusterNetwork(conf *operv1.NetworkSpec) (string, error) {
 	}
 
 	return string(cnBuf), nil
-}
-
-func bootstrapSDN(conf *operv1.Network, kubeClient crclient.Client) (*bootstrap.BootstrapResult, error) {
-	infraRes, err := platform.BootstrapInfra(kubeClient)
-	if err != nil {
-		return nil, err
-	}
-	res := bootstrap.BootstrapResult{
-		Infra: *infraRes,
-	}
-	return &res, nil
 }

--- a/pkg/network/openshift_sdn_test.go
+++ b/pkg/network/openshift_sdn_test.go
@@ -46,7 +46,7 @@ func TestRenderOpenShiftSDN(t *testing.T) {
 	config := &crd.Spec
 
 	bootstrapResult := &bootstrap.BootstrapResult{
-		Infra: bootstrap.InfraBootstrapResult{},
+		Infra: bootstrap.InfraStatus{},
 	}
 
 	errs := validateOpenShiftSDN(config)
@@ -180,7 +180,7 @@ func TestProxyArgs(t *testing.T) {
 	fillDefaults(config, nil)
 
 	bootstrapResult := &bootstrap.BootstrapResult{
-		Infra: bootstrap.InfraBootstrapResult{},
+		Infra: bootstrap.InfraStatus{},
 	}
 
 	// iter through all objects, finding the kube-proxy config map
@@ -386,7 +386,7 @@ func TestOpenShiftSDNMultitenant(t *testing.T) {
 	config.DefaultNetwork.OpenShiftSDNConfig.Mode = "Multitenant"
 
 	bootstrapResult := &bootstrap.BootstrapResult{
-		Infra: bootstrap.InfraBootstrapResult{},
+		Infra: bootstrap.InfraStatus{},
 	}
 
 	objs, err := renderOpenShiftSDN(config, bootstrapResult, manifestDir)
@@ -475,7 +475,7 @@ func TestOpenshiftSDNProxyConfig(t *testing.T) {
 	}
 
 	bootstrapResult := &bootstrap.BootstrapResult{
-		Infra: bootstrap.InfraBootstrapResult{},
+		Infra: bootstrap.InfraStatus{},
 	}
 
 	// test default rendering

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -62,12 +62,11 @@ func TestRenderOVNKubernetes(t *testing.T) {
 	g.Expect(errs).To(HaveLen(0))
 	fillDefaults(config, nil)
 
-	bootstrapResult := &bootstrap.BootstrapResult{
-		OVN: bootstrap.OVNBootstrapResult{
-			MasterIPs: []string{"1.2.3.4", "5.6.7.8", "9.10.11.12"},
-			OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-				NodeMode: "full",
-			},
+	bootstrapResult := fakeBootstrapResult()
+	bootstrapResult.OVN = bootstrap.OVNBootstrapResult{
+		MasterIPs: []string{"1.2.3.4", "5.6.7.8", "9.10.11.12"},
+		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
+			NodeMode: "full",
 		},
 	}
 
@@ -113,12 +112,11 @@ func TestRenderOVNKubernetesIPv6(t *testing.T) {
 	g.Expect(errs).To(HaveLen(0))
 	fillDefaults(config, nil)
 
-	bootstrapResult := &bootstrap.BootstrapResult{
-		OVN: bootstrap.OVNBootstrapResult{
-			MasterIPs: []string{"1.2.3.4", "5.6.7.8", "9.10.11.12"},
-			OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-				NodeMode: "full",
-			},
+	bootstrapResult := fakeBootstrapResult()
+	bootstrapResult.OVN = bootstrap.OVNBootstrapResult{
+		MasterIPs: []string{"1.2.3.4", "5.6.7.8", "9.10.11.12"},
+		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
+			NodeMode: "full",
 		},
 	}
 	objs, err := renderOVNKubernetes(config, bootstrapResult, manifestDirOvn)
@@ -129,12 +127,11 @@ func TestRenderOVNKubernetesIPv6(t *testing.T) {
 
 	g.Expect(script).To(ContainSubstring("pssl:9641"))
 
-	bootstrapResult = &bootstrap.BootstrapResult{
-		OVN: bootstrap.OVNBootstrapResult{
-			MasterIPs: []string{"fd01::1", "fd01::2", "fd01::3"},
-			OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-				NodeMode: "full",
-			},
+	bootstrapResult = fakeBootstrapResult()
+	bootstrapResult.OVN = bootstrap.OVNBootstrapResult{
+		MasterIPs: []string{"fd01::1", "fd01::2", "fd01::3"},
+		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
+			NodeMode: "full",
 		},
 	}
 	objs, err = renderOVNKubernetes(config, bootstrapResult, manifestDirOvn)
@@ -168,9 +165,9 @@ lflow-cache-limit-kb=1048576
 [kubernetes]
 service-cidrs="172.30.0.0/16"
 ovn-config-namespace="openshift-ovn-kubernetes"
-apiserver="https://1.1.1.1:1111"
+apiserver="https://testing.test:8443"
 host-network-namespace="openshift-host-network"
-platform-type=""
+platform-type="GCP"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
@@ -194,10 +191,10 @@ lflow-cache-limit-kb=1048576
 [kubernetes]
 service-cidrs="172.30.0.0/16"
 ovn-config-namespace="openshift-ovn-kubernetes"
-apiserver="https://1.1.1.1:1111"
+apiserver="https://testing.test:8443"
 host-network-namespace="openshift-host-network"
 no-hostsubnet-nodes="kubernetes.io/os=windows"
-platform-type=""
+platform-type="GCP"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
@@ -233,10 +230,10 @@ lflow-cache-limit-kb=1048576
 [kubernetes]
 service-cidrs="172.30.0.0/16"
 ovn-config-namespace="openshift-ovn-kubernetes"
-apiserver="https://1.1.1.1:1111"
+apiserver="https://testing.test:8443"
 host-network-namespace="openshift-host-network"
 no-hostsubnet-nodes="kubernetes.io/os=windows"
-platform-type=""
+platform-type="GCP"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
@@ -275,10 +272,10 @@ lflow-cache-limit-kb=1048576
 [kubernetes]
 service-cidrs="172.30.0.0/16"
 ovn-config-namespace="openshift-ovn-kubernetes"
-apiserver="https://1.1.1.1:1111"
+apiserver="https://testing.test:8443"
 host-network-namespace="openshift-host-network"
 no-hostsubnet-nodes="kubernetes.io/os=windows"
-platform-type=""
+platform-type="GCP"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
@@ -307,9 +304,9 @@ lflow-cache-limit-kb=1048576
 [kubernetes]
 service-cidrs="172.30.0.0/16"
 ovn-config-namespace="openshift-ovn-kubernetes"
-apiserver="https://1.1.1.1:1111"
+apiserver="https://testing.test:8443"
 host-network-namespace="openshift-host-network"
-platform-type=""
+platform-type="GCP"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
@@ -331,9 +328,6 @@ election-retry-period=26`,
 	}
 	g := NewGomegaWithT(t)
 
-	os.Setenv("KUBERNETES_SERVICE_HOST", "1.1.1.1")
-	os.Setenv("KUBERNETES_SERVICE_PORT", "1111")
-
 	for i, tc := range testcases {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			OVNKubeConfig := OVNKubernetesConfig.DeepCopy()
@@ -354,12 +348,11 @@ election-retry-period=26`,
 			g.Expect(errs).To(HaveLen(0))
 			fillDefaults(config, nil)
 
-			bootstrapResult := &bootstrap.BootstrapResult{
-				OVN: bootstrap.OVNBootstrapResult{
-					MasterIPs: tc.masterIPs,
-					OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-						NodeMode: "full",
-					},
+			bootstrapResult := fakeBootstrapResult()
+			bootstrapResult.OVN = bootstrap.OVNBootstrapResult{
+				MasterIPs: tc.masterIPs,
+				OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
+					NodeMode: "full",
 				},
 			}
 			objs, err := renderOVNKubernetes(config, bootstrapResult, manifestDirOvn)
@@ -1287,16 +1280,15 @@ metadata:
 				}
 			}
 
-			bootstrapResult := &bootstrap.BootstrapResult{
-				OVN: bootstrap.OVNBootstrapResult{
-					MasterIPs:               []string{"1.2.3.4", "5.6.7.8", "9.10.11.12"},
-					ExistingMasterDaemonset: master,
-					ExistingNodeDaemonset:   node,
-					OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-						NodeMode: "full",
-					},
-					PrePullerDaemonset: prepuller,
+			bootstrapResult := fakeBootstrapResult()
+			bootstrapResult.OVN = bootstrap.OVNBootstrapResult{
+				MasterIPs:               []string{"1.2.3.4", "5.6.7.8", "9.10.11.12"},
+				ExistingMasterDaemonset: master,
+				ExistingNodeDaemonset:   node,
+				OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
+					NodeMode: "full",
 				},
+				PrePullerDaemonset: prepuller,
 			}
 
 			objs, err := renderOVNKubernetes(config, bootstrapResult, manifestDirOvn)
@@ -1563,40 +1555,39 @@ func TestRenderOVNKubernetesDualStackPrecedenceOverUpgrade(t *testing.T) {
 
 	// bootstrap also represents current status
 	// the current cluster is single-stack and has version 1.9.9
-	bootstrapResult := &bootstrap.BootstrapResult{
-		OVN: bootstrap.OVNBootstrapResult{
-			MasterIPs: []string{"1.2.3.4", "5.6.7.8", "9.10.11.12"},
-			ExistingMasterDaemonset: &appsv1.DaemonSet{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "apps/v1",
-					Kind:       "DaemonSet",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "ovnkube-master",
-					Namespace: "openshift-ovn-kubernetes",
-					Annotations: map[string]string{
-						names.NetworkIPFamilyModeAnnotation: names.IPFamilySingleStack,
-						"release.openshift.io/version":      "1.9.9",
-					},
+	bootstrapResult := fakeBootstrapResult()
+	bootstrapResult.OVN = bootstrap.OVNBootstrapResult{
+		MasterIPs: []string{"1.2.3.4", "5.6.7.8", "9.10.11.12"},
+		ExistingMasterDaemonset: &appsv1.DaemonSet{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "apps/v1",
+				Kind:       "DaemonSet",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ovnkube-master",
+				Namespace: "openshift-ovn-kubernetes",
+				Annotations: map[string]string{
+					names.NetworkIPFamilyModeAnnotation: names.IPFamilySingleStack,
+					"release.openshift.io/version":      "1.9.9",
 				},
 			},
-			ExistingNodeDaemonset: &appsv1.DaemonSet{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "apps/v1",
-					Kind:       "DaemonSet",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "ovnkube-node",
-					Namespace: "openshift-ovn-kubernetes",
-					Annotations: map[string]string{
-						names.NetworkIPFamilyModeAnnotation: names.IPFamilySingleStack,
-						"release.openshift.io/version":      "1.9.9",
-					},
+		},
+		ExistingNodeDaemonset: &appsv1.DaemonSet{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "apps/v1",
+				Kind:       "DaemonSet",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ovnkube-node",
+				Namespace: "openshift-ovn-kubernetes",
+				Annotations: map[string]string{
+					names.NetworkIPFamilyModeAnnotation: names.IPFamilySingleStack,
+					"release.openshift.io/version":      "1.9.9",
 				},
 			},
-			OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-				NodeMode: "full",
-			},
+		},
+		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
+			NodeMode: "full",
 		},
 	}
 
@@ -1684,14 +1675,13 @@ func TestRenderOVNKubernetesOVSFlowsConfigMap(t *testing.T) {
 		t.Run(tc.Description, func(t *testing.T) {
 			RegisterTestingT(t)
 			g := NewGomegaWithT(t)
-			bootstrapResult := &bootstrap.BootstrapResult{
-				OVN: bootstrap.OVNBootstrapResult{
-					MasterIPs: []string{"1.2.3.4"},
-					OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-						GatewayMode: "shared",
-					},
-					FlowsConfig: tc.FlowsConfig,
+			bootstrapResult := fakeBootstrapResult()
+			bootstrapResult.OVN = bootstrap.OVNBootstrapResult{
+				MasterIPs: []string{"1.2.3.4"},
+				OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
+					GatewayMode: "shared",
 				},
+				FlowsConfig: tc.FlowsConfig,
 			}
 			objs, err := renderOVNKubernetes(config, bootstrapResult, manifestDirOvn)
 			g.Expect(err).ToNot(HaveOccurred())

--- a/pkg/network/previous_test.go
+++ b/pkg/network/previous_test.go
@@ -4,12 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	configv1 "github.com/openshift/api/config/v1"
 	operv1 "github.com/openshift/api/operator/v1"
 
 	. "github.com/onsi/gomega"
@@ -40,18 +36,6 @@ func TestPreviousVersionsSafe(t *testing.T) {
 		},
 	}
 
-	// Bootstrap a client with an infrastructure object
-	if err := configv1.AddToScheme(scheme.Scheme); err != nil {
-		t.Fatalf("failed to add configv1 to scheme: %v", err)
-	}
-	infrastructure := &configv1.Infrastructure{
-		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-		Status: configv1.InfrastructureStatus{
-			PlatformStatus: &configv1.PlatformStatus{},
-		},
-	}
-	client := fake.NewClientBuilder().WithObjects(infrastructure).Build()
-
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
@@ -65,7 +49,7 @@ func TestPreviousVersionsSafe(t *testing.T) {
 			// This is the exact config transformation flow in the operator
 			g.Expect(Validate(input)).NotTo(HaveOccurred())
 			fillDefaults(input, applied)
-			g.Expect(IsChangeSafe(applied, input, client)).NotTo(HaveOccurred())
+			g.Expect(IsChangeSafe(applied, input, &fakeBootstrapResult().Infra)).NotTo(HaveOccurred())
 		})
 	}
 }

--- a/pkg/network/testutil_test.go
+++ b/pkg/network/testutil_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/onsi/gomega/types"
+	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -53,4 +54,20 @@ func (k *KubeObjectMatcher) NegatedFailureMessage(actual interface{}) string {
 		k.kind, k.namespace, k.name,
 		obj.GetKind(), obj.GetNamespace(), obj.GetName())
 
+}
+
+func fakeBootstrapResult() *bootstrap.BootstrapResult {
+	return &bootstrap.BootstrapResult{
+		Infra: bootstrap.InfraStatus{
+			PlatformType:         "GCP",
+			PlatformRegion:       "moon-2",
+			ExternalControlPlane: false,
+			APIServers: map[string]bootstrap.APIServer{
+				bootstrap.APIServerDefault: {
+					Host: "testing.test",
+					Port: "8443",
+				},
+			},
+		},
+	}
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -28,7 +28,7 @@ type Operator struct {
 	// general controller configuration / context
 	ccfg *controllercmd.ControllerContext
 
-	client  *cnoclient.Client
+	client  cnoclient.Client
 	manager ctmanager.Manager
 
 	StatusManager *statusmanager.StatusManager
@@ -81,7 +81,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	// https://github.com/openshift/library-go/issues/936 is resolved.
 
 	// Start informers
-	if err := o.client.Default().Start(ctx); err != nil {
+	if err := o.client.Start(ctx); err != nil {
 		return fmt.Errorf("Failed to start client: %w", err)
 	}
 

--- a/pkg/platform/openstack/kuryr_bootstrap.go
+++ b/pkg/platform/openstack/kuryr_bootstrap.go
@@ -26,7 +26,6 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
 	"github.com/openshift/cluster-network-operator/pkg/names"
-	"github.com/openshift/cluster-network-operator/pkg/platform"
 	"github.com/openshift/cluster-network-operator/pkg/platform/openstack/util/cert"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
@@ -297,7 +296,7 @@ func getWorkersSubnetFromMasters(client *gophercloud.ServiceClient, kubeClient c
 // between them and created subnets. Also SG rules are added to make sure pod
 // subnet can reach nodes and nodes can reach pods and services. The data is
 // returned to populate Kuryr's configuration.
-func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient crclient.Client) (*bootstrap.BootstrapResult, error) {
+func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient crclient.Client) (*bootstrap.KuryrBootstrapResult, error) {
 	log.Print("Kuryr bootstrap started")
 	kc := conf.DefaultNetwork.KuryrConfig
 
@@ -756,36 +755,29 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient crclient.Client) (*boot
 	}
 	octaviaVersion = maxOctaviaVersion.Original()
 
-	infraConfig, err := platform.BootstrapInfra(kubeClient)
-	if err != nil {
-		return nil, err
-	}
-
 	log.Print("Kuryr bootstrap finished")
 
-	res := bootstrap.BootstrapResult{
-		Infra: *infraConfig,
-		Kuryr: bootstrap.KuryrBootstrapResult{
-			ServiceSubnet:            svcSubnetId,
-			PodSubnetpool:            podSubnetpoolId,
-			WorkerNodesRouter:        routerId,
-			WorkerNodesSubnets:       []string{workerSubnet.ID},
-			PodsNetworkMTU:           mtu,
-			PodSecurityGroups:        []string{podSgId},
-			ExternalNetwork:          externalNetwork,
-			ClusterID:                clusterID,
-			OctaviaProvider:          octaviaProvider,
-			OctaviaMultipleListeners: octaviaMultipleListenersSupport,
-			OctaviaVersion:           octaviaVersion,
-			OpenStackCloud:           cloud,
-			WebhookCA:                b64.StdEncoding.EncodeToString(ca),
-			WebhookCAKey:             b64.StdEncoding.EncodeToString(key),
-			WebhookKey:               b64.StdEncoding.EncodeToString(webhookKey),
-			WebhookCert:              b64.StdEncoding.EncodeToString(webhookCert),
-			UserCACert:               userCACert,
-			HttpProxy:                httpProxy,
-			HttpsProxy:               httpsProxy,
-			NoProxy:                  noProxy,
-		}}
-	return &res, nil
+	res := &bootstrap.KuryrBootstrapResult{
+		ServiceSubnet:            svcSubnetId,
+		PodSubnetpool:            podSubnetpoolId,
+		WorkerNodesRouter:        routerId,
+		WorkerNodesSubnets:       []string{workerSubnet.ID},
+		PodsNetworkMTU:           mtu,
+		PodSecurityGroups:        []string{podSgId},
+		ExternalNetwork:          externalNetwork,
+		ClusterID:                clusterID,
+		OctaviaProvider:          octaviaProvider,
+		OctaviaMultipleListeners: octaviaMultipleListenersSupport,
+		OctaviaVersion:           octaviaVersion,
+		OpenStackCloud:           cloud,
+		WebhookCA:                b64.StdEncoding.EncodeToString(ca),
+		WebhookCAKey:             b64.StdEncoding.EncodeToString(key),
+		WebhookKey:               b64.StdEncoding.EncodeToString(webhookKey),
+		WebhookCert:              b64.StdEncoding.EncodeToString(webhookCert),
+		UserCACert:               userCACert,
+		HttpProxy:                httpProxy,
+		HttpsProxy:               httpsProxy,
+		NoProxy:                  noProxy,
+	}
+	return res, nil
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -3,14 +3,16 @@ package platform
 import (
 	"context"
 	"fmt"
+	"os"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
+	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
+	"github.com/openshift/cluster-network-operator/pkg/names"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	types "k8s.io/apimachinery/pkg/types"
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var cloudProviderConfig = types.NamespacedName{
@@ -18,16 +20,44 @@ var cloudProviderConfig = types.NamespacedName{
 	Name:      "kube-cloud-config",
 }
 
-func BootstrapInfra(kubeClient crclient.Client) (*bootstrap.InfraBootstrapResult, error) {
+func InfraStatus(client cnoclient.Client) (*bootstrap.InfraStatus, error) {
 	infraConfig := &configv1.Infrastructure{}
-	if err := kubeClient.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, infraConfig); err != nil {
+	if err := client.Default().CRClient().Get(context.TODO(), types.NamespacedName{Name: "cluster"}, infraConfig); err != nil {
 		return nil, fmt.Errorf("failed to get infrastructure 'cluster': %v", err)
 	}
 
-	res := &bootstrap.InfraBootstrapResult{
+	res := &bootstrap.InfraStatus{
 		PlatformType:         infraConfig.Status.PlatformStatus.Type,
 		PlatformStatus:       infraConfig.Status.PlatformStatus,
 		ExternalControlPlane: infraConfig.Status.ControlPlaneTopology == configv1.ExternalTopologyMode,
+		APIServers:           map[string]bootstrap.APIServer{},
+	}
+
+	// Extract apiserver URLs from the kubeconfig(s) passed to the CNO
+	for name, c := range client.Clients() {
+		h, p := c.HostPort()
+		res.APIServers[name] = bootstrap.APIServer{
+			Host: h,
+			Port: p,
+		}
+	}
+
+	// default-local defines how the CNO connects to the APIServer. So, just copy from Default
+	res.APIServers[bootstrap.APIServerDefaultLocal] = res.APIServers[bootstrap.APIServerDefault]
+
+	// Allow overriding the "default" apiserver via the environment var APISERVER_OVERRIDE_HOST / _PORT
+	// This is used by Hypershift, since the cno connects to a "local" ServiceIP, but rendered manifests
+	// that run on a hosted cluster need to talk to the external URL
+	if h := os.Getenv(names.EnvApiOverrideHost); h != "" {
+		p := os.Getenv(names.EnvApiOverridePort)
+		if p == "" {
+			p = "443"
+		}
+
+		res.APIServers[bootstrap.APIServerDefault] = bootstrap.APIServer{
+			Host: h,
+			Port: p,
+		}
 	}
 
 	if res.PlatformType == configv1.AWSPlatformType {
@@ -39,7 +69,7 @@ func BootstrapInfra(kubeClient crclient.Client) (*bootstrap.InfraBootstrapResult
 	// AWS specifies a CA bundle via a config map; retrieve it.
 	if res.PlatformType == configv1.AWSPlatformType {
 		cm := &corev1.ConfigMap{}
-		if err := kubeClient.Get(context.TODO(), cloudProviderConfig, cm); err != nil {
+		if err := client.Default().CRClient().Get(context.TODO(), cloudProviderConfig, cm); err != nil {
 			if !apierrors.IsNotFound(err) {
 				return nil, fmt.Errorf("failed to retrieve ConfigMap %s: %w", cloudProviderConfig, err)
 			}

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-network-operator/pkg/client/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestTopologyModeDetection(t *testing.T) {
@@ -45,9 +45,9 @@ func TestTopologyModeDetection(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			client := fake.NewClientBuilder().WithObjects(tc.infrastructure).Build()
+			client := fake.NewFakeClient(tc.infrastructure)
 
-			bootstrapResult, err := BootstrapInfra(client)
+			bootstrapResult, err := InfraStatus(client)
 			if err != nil {
 				t.Fatalf("BootstrapInfra failed: %v", err)
 			}

--- a/vendor/k8s.io/client-go/dynamic/fake/simple.go
+++ b/vendor/k8s.io/client-go/dynamic/fake/simple.go
@@ -1,0 +1,493 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/testing"
+)
+
+func NewSimpleDynamicClient(scheme *runtime.Scheme, objects ...runtime.Object) *FakeDynamicClient {
+	unstructuredScheme := runtime.NewScheme()
+	for gvk := range scheme.AllKnownTypes() {
+		if unstructuredScheme.Recognizes(gvk) {
+			continue
+		}
+		if strings.HasSuffix(gvk.Kind, "List") {
+			unstructuredScheme.AddKnownTypeWithName(gvk, &unstructured.UnstructuredList{})
+			continue
+		}
+		unstructuredScheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+	}
+
+	objects, err := convertObjectsToUnstructured(scheme, objects)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, obj := range objects {
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		if !unstructuredScheme.Recognizes(gvk) {
+			unstructuredScheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+		}
+		gvk.Kind += "List"
+		if !unstructuredScheme.Recognizes(gvk) {
+			unstructuredScheme.AddKnownTypeWithName(gvk, &unstructured.UnstructuredList{})
+		}
+	}
+
+	return NewSimpleDynamicClientWithCustomListKinds(unstructuredScheme, nil, objects...)
+}
+
+// NewSimpleDynamicClientWithCustomListKinds try not to use this.  In general you want to have the scheme have the List types registered
+// and allow the default guessing for resources match.  Sometimes that doesn't work, so you can specify a custom mapping here.
+func NewSimpleDynamicClientWithCustomListKinds(scheme *runtime.Scheme, gvrToListKind map[schema.GroupVersionResource]string, objects ...runtime.Object) *FakeDynamicClient {
+	// In order to use List with this client, you have to have your lists registered so that the object tracker will find them
+	// in the scheme to support the t.scheme.New(listGVK) call when it's building the return value.
+	// Since the base fake client needs the listGVK passed through the action (in cases where there are no instances, it
+	// cannot look up the actual hits), we need to know a mapping of GVR to listGVK here.  For GETs and other types of calls,
+	// there is no return value that contains a GVK, so it doesn't have to know the mapping in advance.
+
+	// first we attempt to invert known List types from the scheme to auto guess the resource with unsafe guesses
+	// this covers common usage of registering types in scheme and passing them
+	completeGVRToListKind := map[schema.GroupVersionResource]string{}
+	for listGVK := range scheme.AllKnownTypes() {
+		if !strings.HasSuffix(listGVK.Kind, "List") {
+			continue
+		}
+		nonListGVK := listGVK.GroupVersion().WithKind(listGVK.Kind[:len(listGVK.Kind)-4])
+		plural, _ := meta.UnsafeGuessKindToResource(nonListGVK)
+		completeGVRToListKind[plural] = listGVK.Kind
+	}
+
+	for gvr, listKind := range gvrToListKind {
+		if !strings.HasSuffix(listKind, "List") {
+			panic("coding error, listGVK must end in List or this fake client doesn't work right")
+		}
+		listGVK := gvr.GroupVersion().WithKind(listKind)
+
+		// if we already have this type registered, just skip it
+		if _, err := scheme.New(listGVK); err == nil {
+			completeGVRToListKind[gvr] = listKind
+			continue
+		}
+
+		scheme.AddKnownTypeWithName(listGVK, &unstructured.UnstructuredList{})
+		completeGVRToListKind[gvr] = listKind
+	}
+
+	codecs := serializer.NewCodecFactory(scheme)
+	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	cs := &FakeDynamicClient{scheme: scheme, gvrToListKind: completeGVRToListKind, tracker: o}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := o.Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		return true, watch, nil
+	})
+
+	return cs
+}
+
+// Clientset implements clientset.Interface. Meant to be embedded into a
+// struct to get a default implementation. This makes faking out just the method
+// you want to test easier.
+type FakeDynamicClient struct {
+	testing.Fake
+	scheme        *runtime.Scheme
+	gvrToListKind map[schema.GroupVersionResource]string
+	tracker       testing.ObjectTracker
+}
+
+type dynamicResourceClient struct {
+	client    *FakeDynamicClient
+	namespace string
+	resource  schema.GroupVersionResource
+	listKind  string
+}
+
+var (
+	_ dynamic.Interface  = &FakeDynamicClient{}
+	_ testing.FakeClient = &FakeDynamicClient{}
+)
+
+func (c *FakeDynamicClient) Tracker() testing.ObjectTracker {
+	return c.tracker
+}
+
+func (c *FakeDynamicClient) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return &dynamicResourceClient{client: c, resource: resource, listKind: c.gvrToListKind[resource]}
+}
+
+func (c *dynamicResourceClient) Namespace(ns string) dynamic.ResourceInterface {
+	ret := *c
+	ret.namespace = ns
+	return &ret
+}
+
+func (c *dynamicResourceClient) Create(ctx context.Context, obj *unstructured.Unstructured, opts metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootCreateAction(c.resource, obj), obj)
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		var accessor metav1.Object // avoid shadowing err
+		accessor, err = meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name := accessor.GetName()
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootCreateSubresourceAction(c.resource, name, strings.Join(subresources, "/"), obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewCreateAction(c.resource, c.namespace, obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		var accessor metav1.Object // avoid shadowing err
+		accessor, err = meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name := accessor.GetName()
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewCreateSubresourceAction(c.resource, name, strings.Join(subresources, "/"), c.namespace, obj), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) Update(ctx context.Context, obj *unstructured.Unstructured, opts metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateAction(c.resource, obj), obj)
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateSubresourceAction(c.resource, strings.Join(subresources, "/"), obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateAction(c.resource, c.namespace, obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateSubresourceAction(c.resource, strings.Join(subresources, "/"), c.namespace, obj), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, opts metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateSubresourceAction(c.resource, "status", obj), obj)
+
+	case len(c.namespace) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateSubresourceAction(c.resource, "status", c.namespace, obj), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) Delete(ctx context.Context, name string, opts metav1.DeleteOptions, subresources ...string) error {
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteAction(c.resource, name), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteSubresourceAction(c.resource, strings.Join(subresources, "/"), name), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewDeleteAction(c.resource, c.namespace, name), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewDeleteSubresourceAction(c.resource, strings.Join(subresources, "/"), c.namespace, name), &metav1.Status{Status: "dynamic delete fail"})
+	}
+
+	return err
+}
+
+func (c *dynamicResourceClient) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		action := testing.NewRootDeleteCollectionAction(c.resource, listOptions)
+		_, err = c.client.Fake.Invokes(action, &metav1.Status{Status: "dynamic deletecollection fail"})
+
+	case len(c.namespace) > 0:
+		action := testing.NewDeleteCollectionAction(c.resource, c.namespace, listOptions)
+		_, err = c.client.Fake.Invokes(action, &metav1.Status{Status: "dynamic deletecollection fail"})
+
+	}
+
+	return err
+}
+
+func (c *dynamicResourceClient) Get(ctx context.Context, name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootGetAction(c.resource, name), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootGetSubresourceAction(c.resource, strings.Join(subresources, "/"), name), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewGetAction(c.resource, c.namespace, name), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewGetSubresourceAction(c.resource, c.namespace, strings.Join(subresources, "/"), name), &metav1.Status{Status: "dynamic get fail"})
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	if len(c.listKind) == 0 {
+		panic(fmt.Sprintf("coding error: you must register resource to list kind for every resource you're going to LIST when creating the client.  See NewSimpleDynamicClientWithCustomListKinds or register the list into the scheme: %v out of %v", c.resource, c.client.gvrToListKind))
+	}
+	listGVK := c.resource.GroupVersion().WithKind(c.listKind)
+	listForFakeClientGVK := c.resource.GroupVersion().WithKind(c.listKind[:len(c.listKind)-4]) /*base library appends List*/
+
+	var obj runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		obj, err = c.client.Fake.
+			Invokes(testing.NewRootListAction(c.resource, listForFakeClientGVK, opts), &metav1.Status{Status: "dynamic list fail"})
+
+	case len(c.namespace) > 0:
+		obj, err = c.client.Fake.
+			Invokes(testing.NewListAction(c.resource, listForFakeClientGVK, c.namespace, opts), &metav1.Status{Status: "dynamic list fail"})
+
+	}
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+
+	retUnstructured := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(obj, retUnstructured, nil); err != nil {
+		return nil, err
+	}
+	entireList, err := retUnstructured.ToList()
+	if err != nil {
+		return nil, err
+	}
+
+	list := &unstructured.UnstructuredList{}
+	list.SetResourceVersion(entireList.GetResourceVersion())
+	list.GetObjectKind().SetGroupVersionKind(listGVK)
+	for i := range entireList.Items {
+		item := &entireList.Items[i]
+		metadata, err := meta.Accessor(item)
+		if err != nil {
+			return nil, err
+		}
+		if label.Matches(labels.Set(metadata.GetLabels())) {
+			list.Items = append(list.Items, *item)
+		}
+	}
+	return list, nil
+}
+
+func (c *dynamicResourceClient) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	switch {
+	case len(c.namespace) == 0:
+		return c.client.Fake.
+			InvokesWatch(testing.NewRootWatchAction(c.resource, opts))
+
+	case len(c.namespace) > 0:
+		return c.client.Fake.
+			InvokesWatch(testing.NewWatchAction(c.resource, c.namespace, opts))
+
+	}
+
+	panic("math broke")
+}
+
+// TODO: opts are currently ignored.
+func (c *dynamicResourceClient) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchAction(c.resource, name, pt, data), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchSubresourceAction(c.resource, name, pt, data, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchAction(c.resource, c.namespace, name, pt, data), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchSubresourceAction(c.resource, c.namespace, name, pt, data, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func convertObjectsToUnstructured(s *runtime.Scheme, objs []runtime.Object) ([]runtime.Object, error) {
+	ul := make([]runtime.Object, 0, len(objs))
+
+	for _, obj := range objs {
+		u, err := convertToUnstructured(s, obj)
+		if err != nil {
+			return nil, err
+		}
+
+		ul = append(ul, u)
+	}
+	return ul, nil
+}
+
+func convertToUnstructured(s *runtime.Scheme, obj runtime.Object) (runtime.Object, error) {
+	var (
+		err error
+		u   unstructured.Unstructured
+	)
+
+	u.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert to unstructured: %w", err)
+	}
+
+	gvk := u.GroupVersionKind()
+	if gvk.Group == "" || gvk.Kind == "" {
+		gvks, _, err := s.ObjectKinds(obj)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert to unstructured - unable to get GVK %w", err)
+		}
+		apiv, k := gvks[0].ToAPIVersionAndKind()
+		u.SetAPIVersion(apiv)
+		u.SetKind(k)
+	}
+	return &u, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -941,6 +941,7 @@ k8s.io/client-go/discovery
 k8s.io/client-go/dynamic
 k8s.io/client-go/dynamic/dynamicinformer
 k8s.io/client-go/dynamic/dynamiclister
+k8s.io/client-go/dynamic/fake
 k8s.io/client-go/informers
 k8s.io/client-go/informers/admissionregistration
 k8s.io/client-go/informers/admissionregistration/v1


### PR DESCRIPTION
Rather than relying on the environment to be correct, which may not be the case for Hypershift, explicitly determine the apiserver URL from the kubeconfig. Then, pass it down to all parts that depend on it.

This includes a minor refactor of the bootstrap process, since we rely on gathering "Infra" status in more places than just "bootstrapping".