### PR TITLE
Add an option to define the client name for in-cluster config

### DIFF
--- a/cmd/cluster-network-operator/main.go
+++ b/cmd/cluster-network-operator/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 	"log"
 	"math/rand"
 	"net/url"
@@ -80,14 +81,16 @@ which is a kubeconfig from which to take just the URL to the apiserver`,
 		},
 	}
 	var extraClusters *map[string]string
+	var inClusterClientName *string
 	cmdcfg := controllercmd.NewControllerCommandConfig("network-operator", version.Get(), func(ctx context.Context, controllerConfig *controllercmd.ControllerContext) error {
-		return operator.RunOperator(ctx, controllerConfig, *extraClusters)
+		return operator.RunOperator(ctx, controllerConfig, *inClusterClientName, *extraClusters)
 	})
 
 	cmd2 := cmdcfg.NewCommand()
 	cmd2.Use = "start"
 	cmd2.Short = "Start the cluster network operator"
 	extraClusters = cmd2.Flags().StringToString("extra-clusters", nil, "extra clusters, pairs of cluster name and kubeconfig path")
+	inClusterClientName = cmd2.Flags().String("in-cluster-client-name", cnoclient.DefaultClusterName, "client name for in-cluster config(service account or kubeconfig)")
 	cmd.AddCommand(cmd2)
 
 	cmd.AddCommand(newMTUProberCommand())

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -82,16 +82,16 @@ type OperatorClusterClient struct {
 // enforce that OperatorClusterClient implements the ClusterClient interface
 var _ ClusterClient = &OperatorClusterClient{}
 
-func NewClient(cfg, protocfg *rest.Config, extraClusters map[string]string) (*OperatorClient, error) {
+func NewClient(cfg, protocfg *rest.Config, inClusterClientName string, extraClusters map[string]string) (*OperatorClient, error) {
 	cli := &OperatorClient{
 		clusterClients: make(map[string]*OperatorClusterClient),
 	}
 
-	defaultClient, err := NewClusterClient(cfg, protocfg)
+	inClusterClient, err := NewClusterClient(cfg, protocfg)
 	if err != nil {
 		return nil, err
 	}
-	cli.clusterClients[DefaultClusterName] = defaultClient
+	cli.clusterClients[inClusterClientName] = inClusterClient
 
 	for name, kubeConfig := range extraClusters {
 		clientConfig, err := clientConfig.GetClientConfig(kubeConfig, nil)
@@ -208,6 +208,10 @@ func (c *OperatorClusterClient) RESTMapper() meta.RESTMapper {
 
 func (c *OperatorClusterClient) Scheme() *runtime.Scheme {
 	return scheme.Scheme
+}
+
+func (c *OperatorClusterClient) Config() *rest.Config {
+	return c.cfg
 }
 
 func (c *OperatorClusterClient) Start(ctx context.Context) error {

--- a/pkg/client/fake/fake_client.go
+++ b/pkg/client/fake/fake_client.go
@@ -2,13 +2,13 @@ package fake
 
 import (
 	"context"
-
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	fakedynamic "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 
@@ -87,6 +87,10 @@ func (fc *FakeClusterClient) Kubernetes() kubernetes.Interface {
 
 func (fc *FakeClusterClient) OpenshiftOperatorClient() *osoperclient.Clientset {
 	panic("not implemented!")
+}
+
+func (fc *FakeClusterClient) Config() *rest.Config {
+	return nil
 }
 
 func (fc *FakeClusterClient) Dynamic() dynamic.Interface {

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -3,13 +3,13 @@ package client
 import (
 	"context"
 
+	osoperclient "github.com/openshift/client-go/operator/clientset/versioned"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-
-	osoperclient "github.com/openshift/client-go/operator/clientset/versioned"
-	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+	"k8s.io/client-go/rest"
 
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -37,6 +37,9 @@ type ClusterClient interface {
 
 	// OpenshiftOperatorClient returns the clientset for operator.openshift.io
 	OpenshiftOperatorClient() *osoperclient.Clientset
+
+	// Config returns the clients rest config
+	Config() *rest.Config
 
 	// Dynamic returns an untyped, dynamic client.
 	Dynamic() dynamic.Interface


### PR DESCRIPTION
For usual deployments the in-cluster config is the one for the `default` clusterClient, in hypershift the in-cluster config will be for the `management` clusterClient instead.
This change allows us to define which client is tied to the in-cluster config.

I initially tried to create an additional kubeconfig from the ServiceAccount token but it seems that it is not the best idea since the token can expire: https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/1205-bound-service-account-tokens/README.md#safe-rollout-of-time-bound-token.
Currently it is not a huge deal since the expiration is set to 1year, but we do get the following audit log in kube-apiserver:
```
{"kind":"Event",...,"annotations":{"authentication.k8s.io/stale-token":"subject: system:serviceaccount:clusters-ovn-hypershift:cluster-network-operator, seconds after warning threshold: 3234","authorization.k8s.io/decision":"allow","authorization.k8s.io/reason":"RBAC: allowed by RoleBinding \"cluster-network-operator/clusters-ovn-hypershift\" of Role \"cluster-network-operator\" to ServiceAccount \"cluster-network-operator/clusters-ovn-hypershift\""}}
```

Signed-off-by: Patryk Diak <pdiak@redhat.com>