### PR TITLE
Add tuning cni sysctl allowlist to nodes

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cni-binary-copy-script
+  name: cni-copy-resources
   namespace: openshift-multus
   annotations:
     kubernetes.io/description: |
@@ -84,6 +84,16 @@ data:
       echo "Failed to copy files in ${sourcedir} to $DESTINATION_DIRECTORY"
       exit 1
     fi
+  allowlist.conf: |-
+    ^net.ipv4.conf.IFNAME.accept_redirects$
+    ^net.ipv4.conf.IFNAME.accept_source_route$
+    ^net.ipv4.conf.IFNAME.disable_policy$
+    ^net.ipv4.conf.IFNAME.secure_redirects$
+    ^net.ipv4.conf.IFNAME.send_redirects$
+    ^net.ipv6.conf.IFNAME.accept_redirects$
+    ^net.ipv6.conf.IFNAME.accept_source_route$
+    ^net.ipv6.neigh.IFNAME.base_reachable_time_ms$
+    ^net.ipv6.neigh.IFNAME.retrans_time_ms$
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -187,7 +197,7 @@ spec:
             type: File
         - name: cni-binary-copy
           configMap:
-            name: cni-binary-copy-script
+            name: cni-copy-resources
             defaultMode: 0744
 ---
 kind: DaemonSet
@@ -245,7 +255,7 @@ spec:
           value: "/usr/src/egress-router-cni/bin/"
       - name: cni-plugins
         image: {{.CNIPluginsImage}}
-        command: ["/entrypoint/cnibincopy.sh"]
+        command: ["/bin/bash", "-c", "/entrypoint/cnibincopy.sh && cp /entrypoint/allowlist.conf /host/etc/cni/tuning/"]
         volumeMounts:
         - mountPath: /entrypoint
           name: cni-binary-copy
@@ -254,6 +264,9 @@ spec:
         - mountPath: /host/etc/os-release
           name: os-release
           readOnly: true
+        - mountPath: /host/etc/cni/tuning/
+          name: tuning-conf-dir
+          readOnly: false
         env:
         - name: RHEL7_SOURCE_DIRECTORY
           value: "/usr/src/plugins/rhel7/bin/"
@@ -471,8 +484,12 @@ spec:
             type: File
         - name: cni-binary-copy
           configMap:
-            name: cni-binary-copy-script
+            name: cni-copy-resources
             defaultMode: 0744
+        - hostPath:
+            path: /etc/cni/tuning/
+            type: DirectoryOrCreate
+          name: tuning-conf-dir
 ---
 apiVersion: batch/v1
 kind: CronJob


### PR DESCRIPTION
The tuning cni currently allows to set any sysctl in the system, instead of just the sysctls for the specific interface on which it is run. In fact, until now it was not even possible to set the interface level sysctl, only global sysctls.
This poses security risks. It also makes the feature of limited pod level sysctls ([here](https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/#enabling-unsafe-sysctls)) void, as it can be easily circumvented with an appropriate tuning-cni nad.

For this reason two new features were added to the tuning-cni:
- interface level sysctls - allowing to set a sysctl for the interface on which the cni is chained
- sysctl whitelist - allowing to limit the sysctls that can be set by the tuning-cni.

The sysctl whitelist requires a file (/etc/cni/tuning/allowlist.conf) to be placed on each node.
This PR creates such a file with a predefined list of safe sysctls (RFE-2038). The list of the sysctl is a minimal list, additional sysctl's will be added when approved.

