### PR TITLE
Bug 2063123: Drop Node update permission for sdn-node

### DIFF
--- a/bindata/network/openshift-sdn/002-rbac.yaml
+++ b/bindata/network/openshift-sdn/002-rbac.yaml
@@ -31,14 +31,6 @@ rules:
   verbs:
   - list
   - watch
-- apiGroups: [""]
-  resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - patch
 - apiGroups: ["networking.k8s.io"]
   resources:
   - networkpolicies


### PR DESCRIPTION
https://github.com/openshift/sdn/pull/417 makes openshift-sdn-node no longer make use of its Node modifying permissions, so this drops it from its service account.

/hold