### PR TITLE
Add ovnkube-node initContainer to make sure sbdb is up before running other containers

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -56,6 +56,42 @@ spec:
       hostNetwork: true
       hostPID: true
       priorityClassName: "system-node-critical"
+      initContainers:
+      # ovnkube-node-init: wait for sbdb ready
+      {{ if eq .OVN_NODE_MODE "full" }}
+      - name: ovnkube-node-init
+        image: "{{.OvnImage}}"
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -xe
+          if [[ -f "/env/${K8S_NODE}" ]]; then
+            set -o allexport
+            source "/env/${K8S_NODE}"
+            set +o allexport
+          fi
+          echo "$(date -Iseconds) - checking sbdb"
+          ovndb_ctl_ssl_opts="-p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt"
+          sbdb_ip="{{.OVN_SB_DB_ROUTE}}"
+          retries=0
+          while ! ovn-sbctl --no-leader-only --timeout=5 --db=${sbdb_ip} ${ovndb_ctl_ssl_opts} get-connection; do
+            (( retries += 1 ))
+            if [[ "${retries}" -gt 40 ]]; then
+              echo "$(date -Iseconds) - ERROR RESTARTING - sbdb - too many failed ovn-sbctl attempts, giving up"
+              exit 1
+            fi
+            sleep 2
+          done
+        volumeMounts:
+        - mountPath: /env
+          name: env-overrides
+        - mountPath: /ovn-cert
+          name: ovn-cert
+        - mountPath: /ovn-ca
+          name: ovn-ca
+      {{ end }}
+
       # volumes in all containers:
       # (container) -> (host)
       # /etc/openvswitch -> /etc/openvswitch - ovsdb system id

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -144,10 +144,9 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["HostedClusterNamespace"] = os.Getenv("HOSTED_CLUSTER_NAMESPACE")
 	data.Data["OvnkubeMasterReplicas"] = len(bootstrapResult.OVN.MasterAddresses)
 
-	// Sbdb route in the format of "ssl://ovnkube-sbdb-<hostedcluster namespace>.apps.<hostedcluster domain name>:443"
-	// TODO: get this from the route Status
-	data.Data["OVN_NB_DB_ROUTE"] = fmt.Sprintf("ssl://ovnkube-sbdb-%s.apps.%s:%s", os.Getenv("HOSTED_CLUSTER_NAMESPACE"), os.Getenv("MANAGEMENT_CLUSTER_DOMAIN"), OVN_SB_ROUTE_PORT)
-	data.Data["OVN_SB_DB_ROUTE"] = fmt.Sprintf("ssl://ovnkube-sbdb-%s.apps.%s:%s", os.Getenv("HOSTED_CLUSTER_NAMESPACE"), os.Getenv("MANAGEMENT_CLUSTER_DOMAIN"), OVN_SB_ROUTE_PORT)
+	// Sbdb route in the format of "ssl:dbAddress:dbPort"
+	data.Data["OVN_NB_DB_ROUTE"] = fmt.Sprintf("ssl:ovnkube-sbdb-%s.apps.%s:%s", os.Getenv("HOSTED_CLUSTER_NAMESPACE"), os.Getenv("MANAGEMENT_CLUSTER_DOMAIN"), OVN_SB_ROUTE_PORT)
+	data.Data["OVN_SB_DB_ROUTE"] = fmt.Sprintf("ssl:ovnkube-sbdb-%s.apps.%s:%s", os.Getenv("HOSTED_CLUSTER_NAMESPACE"), os.Getenv("MANAGEMENT_CLUSTER_DOMAIN"), OVN_SB_ROUTE_PORT)
 
 	data.Data["OVN_NB_INACTIVITY_PROBE"] = nb_inactivity_probe
 	data.Data["OVN_NB_DB_LIST"] = dbList(bootstrapResult.OVN.MasterAddresses, OVN_NB_PORT)


### PR DESCRIPTION
Adding initContainer in ovnkube-node pod to check sbdb avaliability before starting ovn-controller container
verified the changes on local cluster
```
+ [[ -f /env/ ]]
++ date -Iseconds
2022-03-29T12:57:57+00:00 - checking sbdb
+ echo '2022-03-29T12:57:57+00:00 - checking sbdb'
+ ovndb_ctl_ssl_opts='-p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt'
+ transport=ssl
+ db_port=9642
+ CLUSTER_INITIATOR_IP=10.0.0.3
+ retries=0
+ ovn-sbctl --no-leader-only --timeout=5 --db=ssl:10.0.0.3:9642 -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt get-connection
read-write role="" pssl:9642
```
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>