### PR TITLE
Add ibm-cloud-managed annotations to 02-cncc-credentials.yaml, this is required in HyperShift

### DIFF
--- a/manifests/02-cncc-credentials.yaml
+++ b/manifests/02-cncc-credentials.yaml
@@ -10,6 +10,7 @@ metadata:
   namespace: openshift-cloud-credential-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:
   serviceAccountNames:
@@ -30,6 +31,7 @@ metadata:
   namespace: openshift-cloud-credential-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:
   serviceAccountNames:
@@ -61,6 +63,7 @@ metadata:
   namespace: openshift-cloud-credential-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:
   serviceAccountNames:


### PR DESCRIPTION
Hypershift uses `ibm-cloud-managed` cluster profile.
Without this change CVO does not render credentials requests in 02-cncc-credentials.yaml

/cc @squeed @zshi-redhat 

Signed-off-by: Patryk Diak <pdiak@redhat.com>