### PR TITLE
Bug 2070047: Bump max value of hist quantile for kuryr_cni_request_duration

### DIFF
--- a/bindata/network/kuryr/alert-rules.yaml
+++ b/bindata/network/kuryr/alert-rules.yaml
@@ -84,7 +84,7 @@ spec:
       annotations:
         summary: Kuryr CNI pod {{"{{"}} $labels.pod {{"}}"}} is taking too long, on average, to perform CNI {{"{{"}} $labels.command {{"}}"}} requests.
       expr: |
-        histogram_quantile(0.95, rate(kuryr_cni_request_duration_seconds_bucket[10m])) > 30
+        histogram_quantile(0.95, rate(kuryr_cni_request_duration_seconds_bucket[10m])) > 60
       labels:
         severity: warning
     - alert: KuryrLoadBalancerWithError


### PR DESCRIPTION
With Kuryr the CNI requests can take a considerable
time given that it has to wait for a VIF from Neutron.
We've seen warnings being raised for KuryrCNISlow, so let's
increase it's max acceptable value to 60 which is the value
hit in most of the observations.