### PR TITLE
Bug 1983056: Kuryr: Update CRD from upstream

### DIFF
--- a/bindata/network/kuryr/002-crds.yaml
+++ b/bindata/network/kuryr/002-crds.yaml
@@ -89,6 +89,8 @@ spec:
                 type: string
               podNodeName:
                 type: string
+              podStatic:
+                type: boolean
           status:
             type: object
             required:


### PR DESCRIPTION
This is based on [1] and required by openshift/kuryr-kubernetes#645.

[1] https://opendev.org/openstack/kuryr-kubernetes/commit/d5f5db7005028f9ba88ed9dcc0b5d09d0bbd8bda
