### PR TITLE
Bug 2058368: move enable memory trimming to readiness prob

### DIFF
--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
@@ -356,18 +356,6 @@ spec:
                 {{ if .EnableIPsec }}
                 ${OVN_NB_CTL} set nb_global . ipsec=true
                 {{ end }}
-                OVNNBDB_CTL="/var/run/ovn/ovnnb_db.ctl"
-                if [[ -f $OVNNBDB_CTL ]]; then
-                  # Enable NBDB memory trimming on DB compaction, Every 10mins DBs are compacted
-                  # memory on the heap is freed, when enable memory trimmming freed memory will go back to OS.
-                  /usr/bin/ovn-appctl -t $OVNNBDB_CTL --timeout=5 ovsdb-server/memory-trim-on-compaction on
-                  if [[ $? -eq 0 ]]; then
-                    echo "Successfully enabled NBDB memory trimming on compaction"
-                  else
-                    echo "Couldn't enable NBDB memory trimming on compaction"
-                    exit 1
-                  fi
-                fi
           preStop:
             exec:
               command:
@@ -393,6 +381,8 @@ spec:
               if [[ ! -z "${leader_status}" ]]; then
                 echo "NB DB Raft leader is unknown to the cluster node."
                 exit 1
+              else
+                /usr/bin/ovn-appctl -t /var/run/ovn/ovnnb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on 2>/dev/null
               fi
 
         env:
@@ -679,18 +669,6 @@ spec:
                       ovsdb-client -t 30 convert "$DB_SERVER" "$DB_SCHEMA"
                   fi
                 fi
-                OVNSBDB_CTL="/var/run/ovn/ovnsb_db.ctl"
-                if [[ -f $OVNSBDB_CTL ]]; then
-                  # Enable SBDB memory trimming on DB compaction, Every 10mins DBs are compacted
-                  # memory on the heap is freed, when enable memory trimmming freed memory will go back to OS.
-                  /usr/bin/ovn-appctl -t $OVNSBDB_CTL --timeout=5 ovsdb-server/memory-trim-on-compaction on
-                  if [[ $? -eq 0 ]]; then
-                    echo "Successfully enabled SBDB memory trimming on compaction"
-                  else
-                    echo "Couldn't enable SBDB memory trimming on compaction"
-                    exit 1
-                  fi
-                fi
           preStop:
             exec:
               command:
@@ -716,6 +694,8 @@ spec:
               if [[ ! -z "${leader_status}" ]]; then
                 echo "SB DB Raft leader is unknown to the cluster node."
                 exit 1
+              else
+                /usr/bin/ovn-appctl -t /var/run/ovn/ovnsb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on 2>/dev/null
               fi
         env:
         - name: OVN_LOG_LEVEL


### PR DESCRIPTION
by the time nbdb and sbdb run the readiness prob the db ctl file should already be present

Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>