### PR TITLE
Bug 2082611: Limit Kuryr pods permissions

### DIFF
--- a/bindata/network/kuryr/001-rbac.yaml
+++ b/bindata/network/kuryr/001-rbac.yaml
@@ -2,30 +2,27 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuryr
+  name: kuryr-controller
 rules:
 - apiGroups: [""]
   resources:
-  - namespaces
   - nodes
+  verbs:
+  - get
+  - list
+- apiGroups: [""]
+  resources:
   - endpoints
   - services
   - services/status
   - pods
+  - namespaces
   verbs:
   - get
   - watch
   - list
   - update
   - patch
-  - delete
-- apiGroups: ["extensions"]
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
 - apiGroups: ["networking.k8s.io"]
   resources:
   - networkpolicies
@@ -35,21 +32,12 @@ rules:
   - watch
   - update
   - patch
-- apiGroups: ["k8s.cni.cncf.io"]
-  resources:
-  - network-attachment-definitions
-  verbs:
-  - get
 - apiGroups: ["openstack.org"]
   resources:
   - kuryrnetworks
   - kuryrnetworkpolicies
   - kuryrports
   - kuryrloadbalancers
-  verbs: ["*"]
-- apiGroups: ["route.openshift.io"]
-  resources:
-  - routes
   verbs: ["*"]
 - apiGroups: ["security.openshift.io"]
   resources:
@@ -69,22 +57,70 @@ rules:
   verbs:
   - create
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kuryr-daemon
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups: ["openstack.org"]
+  resources:
+  - kuryrports
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups: ["security.openshift.io"]
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups: ["", "events.k8s.io"]
+  resources:
+  - events
+  verbs:
+  - create
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kuryr
+  name: kuryr-controller
   namespace: openshift-kuryr
-
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kuryr-daemon
+  namespace: openshift-kuryr
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuryr
+  name: kuryr-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuryr
+  name: kuryr-controller
 subjects:
 - kind: ServiceAccount
-  name: kuryr
+  name: kuryr-controller
+  namespace: openshift-kuryr
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kuryr-daemon
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kuryr-daemon
+subjects:
+- kind: ServiceAccount
+  name: kuryr-daemon
   namespace: openshift-kuryr

--- a/bindata/network/kuryr/005-daemon.yaml
+++ b/bindata/network/kuryr/005-daemon.yaml
@@ -28,7 +28,7 @@ spec:
         configuration-hash: {{ .ConfigMapHash }}
     spec:
       hostNetwork: true
-      serviceAccountName: kuryr
+      serviceAccountName: kuryr-daemon
       priorityClassName: system-node-critical
       initContainers:
         - name: block-mcs

--- a/bindata/network/kuryr/006-controller.yaml
+++ b/bindata/network/kuryr/006-controller.yaml
@@ -26,7 +26,7 @@ spec:
         openshift.io/component: network
         configuration-hash: {{ .ConfigMapHash }}
     spec:
-      serviceAccountName: kuryr
+      serviceAccountName: kuryr-controller
       hostNetwork: true
       priorityClassName: system-cluster-critical
       containers:

--- a/pkg/network/kuryr_test.go
+++ b/pkg/network/kuryr_test.go
@@ -69,9 +69,12 @@ func TestRenderKuryr(t *testing.T) {
 	// the ClusterNetwork.
 	g.Expect(objs[0]).To(HaveKubernetesID("Namespace", "", "openshift-kuryr"))
 
-	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "kuryr")))
-	g.Expect(objs).To(ContainElement(HaveKubernetesID("ServiceAccount", "openshift-kuryr", "kuryr")))
-	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRoleBinding", "", "kuryr")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "kuryr-controller")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "kuryr-daemon")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ServiceAccount", "openshift-kuryr", "kuryr-controller")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ServiceAccount", "openshift-kuryr", "kuryr-daemon")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRoleBinding", "", "kuryr-controller")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRoleBinding", "", "kuryr-daemon")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("Deployment", "openshift-kuryr", "kuryr-controller")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-kuryr", "kuryr-cni")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ConfigMap", "openshift-kuryr", "kuryr-config")))


### PR DESCRIPTION
This splits the Kuryr RBAC into separate ClusterRoles for controller nad
daemon and makes sure we don't keep unnecessary permissions. I also
dropped the ones related to sriov and dpdk support as we don't configure
them in OpenShift.