### PR TITLE
Bug 2072766: Reserve port TCP/9104 for cluster-network-operator

### DIFF
--- a/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
@@ -89,6 +89,11 @@ spec:
               fieldPath: metadata.name
         image: quay.io/openshift/origin-cluster-network-operator:latest
         name: network-operator
+        ports:
+        - containerPort: 9104
+          hostPort: 9104
+          name: cno
+          protocol: TCP
         resources:
           requests:
             cpu: 10m

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -21,6 +21,11 @@ spec:
     spec:
       containers:
       - name: network-operator
+        ports:
+          - containerPort: 9104
+            hostPort: 9104
+            name: cno
+            protocol: TCP
         image: quay.io/openshift/origin-cluster-network-operator:latest
         command:
         - /bin/bash


### PR DESCRIPTION
Cluster network operator is a host networked pod. Reserve port
TCP/9104 to make the kubernetes scheduler aware of that port
requirement.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>