### PR TITLE
Don't return err with empty relatedClusterObject annotation

### DIFF
--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -114,7 +114,7 @@ func (status *StatusManager) getClusterOperAnnotation(obj *configv1.ClusterOpera
 	objs := []network.RelatedObject{}
 
 	value, set := anno[names.RelatedClusterObjectsAnnotation]
-	if !set {
+	if !set || value == "" {
 		return objs, nil
 	}
 	items := strings.Split(value, ",")


### PR DESCRIPTION
Signed-off-by: Zenghui Shi <zshi@redhat.com>