### PR TITLE
Bug 1983056: Include info about static Pod to CRD

### DIFF
--- a/bindata/network/kuryr/002-crds.yaml
+++ b/bindata/network/kuryr/002-crds.yaml
@@ -89,6 +89,8 @@ spec:
                 type: string
               podNodeName:
                 type: string
+              podStatic:
+                type: boolean
           status:
             type: object
             required:


### PR DESCRIPTION
Kuryr is adding support to use the K8S_POD_UID passed
from CRI and it needs to skip its usage when the Pod is static
due to a know issue[1]. This commit adds a new field to
the KuryrPort CRD to easily identify if the Pod is static.

[1] https://github.com/k8snetworkplumbingwg/multus-cni/issues/773