### PR TITLE
hypershift: disable TLS for ovnk master metrics

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/monitor-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/monitor-master.yaml
@@ -13,22 +13,8 @@ spec:
   endpoints:
   - interval: 30s
     port: metrics
-    scheme: https
-    bearerTokenSecret:
-      key: ""
-    tlsConfig:
-      ca:
-        configMap:
-          key: service-ca.crt
-          name: openshift-service-ca.crt
-      cert:
-        secret:
-          key: tls.crt
-          name: ovn-master-metrics-cert
-      keySecret:
-        key: tls.key
-        name: ovn-master-metrics-cert
-      serverName: ovnkube-master-internal.{{.HostedClusterNamespace}}.svc
+    scheme: http
+    path: /metrics
     metricRelabelings:
     - action: replace
       replacement: {{.ClusterID}}

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -741,8 +741,6 @@ spec:
             --nb-cert-common-name "{{.OVN_CERT_CN}}" \
             --enable-multicast \
             --disable-snat-multiple-gws \
-            --metrics-node-server-privkey ${TLS_PK} \
-            --metrics-node-server-cert ${TLS_CERT} \
             --acl-logging-rate-limit "{{.OVNPolicyAuditRateLimit}}"
         volumeMounts:
         - mountPath: /etc/ovn


### PR DESCRIPTION
revert this change once ovnk metrics support tls
via: https://github.com/ovn-org/ovn-kubernetes/pull/2900

Signed-off-by: Zenghui Shi <zshi@redhat.com>