### PR TITLE
Bug 2072710: Make northd probe interval default to 10 seconds

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -346,7 +346,7 @@ spec:
                 OVN_NB_CTL="ovn-nbctl -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt \
                 --db {{.OVN_NB_DB_LIST}}"
 
-                northd_probe_interval=${OVN_NORTHD_PROBE_INTERVAL:-5000}
+                northd_probe_interval=${OVN_NORTHD_PROBE_INTERVAL:-10000}
                 echo "Setting northd probe interval to ${northd_probe_interval} ms"
                 retries=0
                 current_probe_interval=0

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
@@ -323,7 +323,7 @@ spec:
                 #configure northd_probe_interval
                 OVN_NB_CTL="ovn-nbctl -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt \
                 --db "{{.OVN_NB_DB_LIST}}""
-                northd_probe_interval=${OVN_NORTHD_PROBE_INTERVAL:-5000}
+                northd_probe_interval=${OVN_NORTHD_PROBE_INTERVAL:-10000}
                 echo "Setting northd probe interval to ${northd_probe_interval} ms"
                 retries=0
                 current_probe_interval=0


### PR DESCRIPTION
Current probe interval for northd is set to 5 seconds.
The raft election timer is 16 seconds; which is the time
within which leader needs to hear from half its followers.
It doesn't make sense to have northd probe timeout set
less than half the raft election timer. Let's bump it to
10 seconds which is > than 8 seconds.

We had a bug where SBDB polls were 11 seconds and northd
was connecting with an old last-txn-id which was forcing
sbdb to reply with whole db causing the long loops and all
3 northd instances were dropping connection due to timeout
inactivity since sbdb was taking long to respond, as their
probes were set to 5 seconds.