### PR TITLE
Plug proxying through the networking stack for Hypershift

### DIFF
--- a/bindata/cloud-network-config-controller/controller.yaml
+++ b/bindata/cloud-network-config-controller/controller.yaml
@@ -51,6 +51,18 @@ spec:
           value: "{{.KubernetesServicePort}}"
         - name: KUBERNETES_SERVICE_HOST
           value: "{{.KubernetesServiceHost}}"
+{{ if .HTTP_PROXY }}
+        - name: "HTTP_PROXY"
+          value: "{{ .HTTP_PROXY}}"
+{{ end }}
+{{ if .HTTPS_PROXY }}
+        - name: "HTTPS_PROXY"
+          value: "{{ .HTTPS_PROXY}}"
+{{ end }}
+{{ if .NO_PROXY }}
+        - name: "NO_PROXY"
+          value: "{{ .NO_PROXY}}"
+{{ end }}
         resources:
           requests:
             cpu: 10m

--- a/bindata/network/mtu-prober/02-job.yaml
+++ b/bindata/network/mtu-prober/02-job.yaml
@@ -23,6 +23,18 @@ spec:
           value: "{{.KUBERNETES_SERVICE_PORT}}"
         - name: KUBERNETES_SERVICE_HOST
           value: "{{.KUBERNETES_SERVICE_HOST}}"
+{{ if .HTTP_PROXY }}
+        - name: "HTTP_PROXY"
+          value: "{{ .HTTP_PROXY}}"
+{{ end }}
+{{ if .HTTPS_PROXY }}
+        - name: "HTTPS_PROXY"
+          value: "{{ .HTTPS_PROXY}}"
+{{ end }}
+{{ if .NO_PROXY }}
+        - name: "NO_PROXY"
+          value: "{{ .NO_PROXY}}"
+{{ end }}
         resources:
           requests:
             cpu: 10m

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -180,6 +180,18 @@ spec:
           value: "{{.KUBERNETES_SERVICE_PORT}}"
         - name: KUBERNETES_SERVICE_HOST
           value: "{{.KUBERNETES_SERVICE_HOST}}"
+{{ if .HTTP_PROXY }}
+        - name: "HTTP_PROXY"
+          value: "{{ .HTTP_PROXY}}"
+{{ end }}
+{{ if .HTTPS_PROXY }}
+        - name: "HTTPS_PROXY"
+          value: "{{ .HTTPS_PROXY}}"
+{{ end }}
+{{ if .NO_PROXY }}
+        - name: "NO_PROXY"
+          value: "{{ .NO_PROXY}}"
+{{ end }}
       terminationGracePeriodSeconds: 10
       volumes:
         - name: system-cni-dir

--- a/bindata/network/openshift-sdn/controller.yaml
+++ b/bindata/network/openshift-sdn/controller.yaml
@@ -46,6 +46,18 @@ spec:
           value: "{{.KUBERNETES_SERVICE_PORT}}"
         - name: KUBERNETES_SERVICE_HOST
           value: "{{.KUBERNETES_SERVICE_HOST}}"
+{{ if .HTTP_PROXY }}
+        - name: "HTTP_PROXY"
+          value: "{{ .HTTP_PROXY}}"
+{{ end }}
+{{ if .HTTPS_PROXY }}
+        - name: "HTTPS_PROXY"
+          value: "{{ .HTTPS_PROXY}}"
+{{ end }}
+{{ if .NO_PROXY }}
+        - name: "NO_PROXY"
+          value: "{{ .NO_PROXY}}"
+{{ end }}
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /env

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -186,6 +186,18 @@ spec:
           value: "{{.KUBERNETES_SERVICE_HOST}}"
         - name: OPENSHIFT_DNS_DOMAIN
           value: cluster.local
+{{ if .HTTP_PROXY }}
+        - name: "HTTP_PROXY"
+          value: "{{ .HTTP_PROXY}}"
+{{ end }}
+{{ if .HTTPS_PROXY }}
+        - name: "HTTPS_PROXY"
+          value: "{{ .HTTPS_PROXY}}"
+{{ end }}
+{{ if .NO_PROXY }}
+        - name: "NO_PROXY"
+          value: "{{ .NO_PROXY}}"
+{{ end }}
         - name: K8S_NODE_NAME
           valueFrom:
             fieldRef:

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -411,6 +411,18 @@ spec:
           value: "{{.OVN_CONTROLLER_INACTIVITY_PROBE}}"
         - name: OVN_KUBE_LOG_LEVEL
           value: "4"
+{{ if .HTTP_PROXY }}
+        - name: "HTTP_PROXY"
+          value: "{{ .HTTP_PROXY}}"
+{{ end }}
+{{ if .HTTPS_PROXY }}
+        - name: "HTTPS_PROXY"
+          value: "{{ .HTTPS_PROXY}}"
+{{ end }}
+{{ if .NO_PROXY }}
+        - name: "NO_PROXY"
+          value: "{{ .NO_PROXY}}"
+{{ end }}
         {{ if .NetFlowCollectors }}
         - name: NETFLOW_COLLECTORS
           value: "{{.NetFlowCollectors}}"

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -67,6 +67,9 @@ type InfraStatus struct {
 
 	// URLs to the apiservers. This is because we can't use the default in-cluster one (they assume a running service network)
 	APIServers map[string]APIServer
+
+	// Proxy settings to use for all communication to the KAS
+	Proxy configv1.ProxyStatus
 }
 
 // APIServer is the hostname & port of a given APIServer. (This is the

--- a/pkg/controller/operconfig/mtu_probe.go
+++ b/pkg/controller/operconfig/mtu_probe.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
 	"github.com/openshift/cluster-network-operator/pkg/render"
 
+	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -94,7 +95,11 @@ func (r *ReconcileOperConfig) readMTUConfigMap(ctx context.Context) (int, error)
 }
 
 func (r *ReconcileOperConfig) deployMTUProber(ctx context.Context, owner metav1.Object, infra *bootstrap.InfraStatus) error {
-	objs, err := renderMTUProber(infra)
+	var proxy configv1.Proxy
+	if err := r.client.Default().CRClient().Get(ctx, crclient.ObjectKey{Name: "cluster"}, &proxy); err != nil {
+		return fmt.Errorf("failed to get proxy: %w", err)
+	}
+	objs, err := renderMTUProber(infra, proxy.Status)
 	if err != nil {
 		return err
 	}
@@ -116,7 +121,12 @@ func (r *ReconcileOperConfig) deleteMTUProber(ctx context.Context, infra *bootst
 	if r.mtuProberCleanedUp {
 		return nil
 	}
-	objs, err := renderMTUProber(infra)
+
+	var proxy configv1.Proxy
+	if err := r.client.Default().CRClient().Get(ctx, crclient.ObjectKey{Name: "cluster"}, &proxy); err != nil {
+		return fmt.Errorf("failed to get proxy: %w", err)
+	}
+	objs, err := renderMTUProber(infra, proxy.Status)
 	if err != nil {
 		return err
 	}
@@ -134,13 +144,16 @@ func (r *ReconcileOperConfig) deleteMTUProber(ctx context.Context, infra *bootst
 	return nil
 }
 
-func renderMTUProber(infra *bootstrap.InfraStatus) ([]*uns.Unstructured, error) {
+func renderMTUProber(infra *bootstrap.InfraStatus, proxyStatus configv1.ProxyStatus) ([]*uns.Unstructured, error) {
 	data := render.MakeRenderData()
 	data.Data["CNOImage"] = os.Getenv("NETWORK_CHECK_TARGET_IMAGE")
 	data.Data["KUBERNETES_SERVICE_HOST"] = infra.APIServers[bootstrap.APIServerDefault].Host
 	data.Data["KUBERNETES_SERVICE_PORT"] = infra.APIServers[bootstrap.APIServerDefault].Port
 	data.Data["DestNS"] = cmNamespace
 	data.Data["DestName"] = cmName
+	data.Data["HTTP_PROXY"] = proxyStatus.HTTPProxy
+	data.Data["HTTPS_PROXY"] = proxyStatus.HTTPSProxy
+	data.Data["NO_PROXY"] = proxyStatus.NoProxy
 
 	objs, err := render.RenderDir("bindata/network/mtu-prober", &data)
 	if err != nil {

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"log"
 	"reflect"
-	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"strings"
 	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	"github.com/pkg/errors"
 

--- a/pkg/network/cloud_network.go
+++ b/pkg/network/cloud_network.go
@@ -36,6 +36,9 @@ func renderCloudNetworkConfigController(conf *operv1.NetworkSpec, cloudBootstrap
 	data.Data["ExternalControlPlane"] = cloudBootstrapResult.ExternalControlPlane
 	data.Data["PlatformAzureEnvironment"] = ""
 	data.Data["PlatformAWSCAPath"] = ""
+	data.Data["HTTP_PROXY"] = cloudBootstrapResult.Proxy.HTTPProxy
+	data.Data["HTTPS_PROXY"] = cloudBootstrapResult.Proxy.HTTPSProxy
+	data.Data["NO_PROXY"] = cloudBootstrapResult.Proxy.NoProxy
 
 	// AWS and azure allow for funky endpoint overriding.
 	// in different ways, of course.

--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -45,6 +45,9 @@ func renderOpenShiftSDN(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Boo
 	data.Data["CNIConfDir"] = pluginCNIConfDir(conf)
 	data.Data["CNIBinDir"] = CNIBinDir
 	data.Data["PlatformType"] = bootstrapResult.Infra.PlatformType
+	data.Data["HTTP_PROXY"] = bootstrapResult.Infra.Proxy.HTTPProxy
+	data.Data["HTTPS_PROXY"] = bootstrapResult.Infra.Proxy.HTTPSProxy
+	data.Data["NO_PROXY"] = bootstrapResult.Infra.Proxy.NoProxy
 	if bootstrapResult.Infra.PlatformType == configv1.AzurePlatformType {
 		data.Data["SDNPlatformAzure"] = true
 	} else {

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -97,6 +97,9 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["KUBERNETES_SERVICE_PORT"] = apiServer.Port
 	data.Data["K8S_APISERVER"] = fmt.Sprintf("https://%s:%s", apiServer.Host, apiServer.Port)
 	data.Data["K8S_LOCAL_APISERVER"] = fmt.Sprintf("https://%s:%s", localAPIServer.Host, localAPIServer.Port)
+	data.Data["HTTP_PROXY"] = bootstrapResult.Infra.Proxy.HTTPProxy
+	data.Data["HTTPS_PROXY"] = bootstrapResult.Infra.Proxy.HTTPSProxy
+	data.Data["NO_PROXY"] = bootstrapResult.Infra.Proxy.NoProxy
 
 	data.Data["TokenMinterImage"] = os.Getenv("TOKEN_MINTER_IMAGE")
 	// TOKEN_AUDIENCE is used by token-minter to identify the audience for the service account token which is verified by the apiserver

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -1170,7 +1170,7 @@ status:
   numberMisscheduled: 0
   numberReady: 5
   observedGeneration: 2
-  updatedNumberScheduled: 
+  updatedNumberScheduled:
 `,
 			node: `
 apiVersion: apps/v1

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -45,7 +45,7 @@ func TestTopologyModeDetection(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			client := fake.NewFakeClient(tc.infrastructure)
+			client := fake.NewFakeClient(tc.infrastructure, &configv1.Proxy{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}})
 
 			bootstrapResult, err := InfraStatus(client)
 			if err != nil {


### PR DESCRIPTION
Currently, the deployed networking components never have a proxy
configured because it is never needed as it is always possible to reach
the KAS and OVN SBDB directly.

With Hypershift, the above assumption might be broken. This PR plugs
through proxy settings to the MTU prober, SDN, multus and into ovn-k.
In ovn-k it doesn't currently use these settings, because contrary to
all other components it is not enough to just set HTTP{,S}_PROXY and
NO_PROXY env vars as ovn-k doesn't use http but a custom protocol over
TLS and thus doesn't respect these vars.