### PR TITLE
Bug 2075475: Add default-route field to egress-router k8s.v1.cni.cncf.io/networks

### DIFF
--- a/bindata/egress-router/001-deployment.yaml
+++ b/bindata/egress-router/001-deployment.yaml
@@ -19,7 +19,13 @@ spec:
         app: egress-router-cni
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        k8s.v1.cni.cncf.io/networks: egress-router-cni-nad
+        k8s.v1.cni.cncf.io/networks: |
+          [
+            {
+              "name":"egress-router-cni-nad",
+              "default-route": ["{{.Gateway}}"]
+            }
+          ]
     spec:
       containers:
         - name: egress-router-cni-pod


### PR DESCRIPTION
Add default-route field to egress-router additional networks def so
that multus/ovn-k inject the correct routes into the pod towards
the cluster. Currently, the egress-router-cni relies on the gateway
field of the CNI definition to delete the default route and inject
its own, so in the future we will have to fix egress-router-cni, too.
For the moment, both the correct annotation and egress-router-cni's
incorrect behavior can coexist.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>