### PR TITLE
OCPVE-106 Customize rollout strategy to fix SNO upgrade

### DIFF
--- a/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
@@ -9,9 +9,15 @@ metadata:
   name: network-operator
   namespace: openshift-network-operator
 spec:
+  replicas: 1
   selector:
     matchLabels:
       name: network-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       annotations:
@@ -19,6 +25,15 @@ spec:
       labels:
         name: network-operator
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  name: network-operator
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - command:
         - /bin/bash

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -9,9 +9,15 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:
+  replicas: 1
   selector:
     matchLabels:
       name: network-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       annotations:
@@ -19,6 +25,15 @@ spec:
       labels:
         name: network-operator
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  name: network-operator
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - name: network-operator
         ports:


### PR DESCRIPTION
- PR addresses issue recently occurring in SNO upgrade jobs where upgrade fails because network-operator Deployment fails to rollout new  ReplicaSet because of already used `hostPort`.
- PR borrows from https://github.com/openshift/gcp-pd-csi-driver-operator/pull/30 which fixed similar issue for cluster-storage-operator
- How fix works
	- `maxSurge: 0` results in first terminating old Pod, then starting new one (instead of both Pod existing at the same time, which cannot happen in SNO due to only one master and port being reserved)
	- affinity settings causes to schedule new Pod on another master in regular clusters
- How the issue manifests
	- network-operator Deployment fails to progress to a new ReplicaSet
	  ```
	  {
	      "lastTransitionTime": "2022-04-21T19:27:37Z",
	      "lastUpdateTime": "2022-04-21T19:27:37Z",
	      "message": "ReplicaSet \"network-operator-7bf4666c75\" has timed out progressing.",
	      "reason": "ProgressDeadlineExceeded",
	      "status": "False",
	      "type": "Progressing"
	  }
	  ```
	- new Pod of network-operator fails to be scheduled
	  ```
	  {
	      "lastProbeTime": null,
	      "lastTransitionTime": "2022-04-21T19:17:36Z",
	      "message": "0/1 nodes are available: 1 node(s) didn't have free ports for the requested pod ports.",
	      "reason": "Unschedulable",
	      "status": "False",
	      "type": "PodScheduled"
	  }
	  ```
- Failures
	- Apr 21 [1517206150934695936](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-aws-upgrade-single-node/1517206150934695936) (error visible in "Cluster should remain functional during upgrade") - [deployments.json](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-aws-upgrade-single-node/1517206150934695936/artifacts/e2e-aws-upgrade-single-node/gather-extra/artifacts/deployments.json) - [pods.json](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-aws-upgrade-single-node/1517206150934695936/artifacts/e2e-aws-upgrade-single-node/gather-extra/artifacts/pods.json)
	- Apr 22 upgrade didn't happen (issue didn't have a chance to occur)
	- Apr 23 job didn't fully run (issue didn't have a chance to occur)
	- Apr 24 [1518293588276940800](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-aws-upgrade-single-node/1518293588276940800) - [deployments.json](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-aws-upgrade-single-node/1518293588276940800/artifacts/e2e-aws-upgrade-single-node/gather-extra/artifacts/deployments.json) - [pods.json](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-aws-upgrade-single-node/1518293588276940800/artifacts/e2e-aws-upgrade-single-node/gather-extra/artifacts/pods.json)
	- Apr 25 [1518655980550754304](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-aws-upgrade-single-node/1518655980550754304) - [deployments.json](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-aws-upgrade-single-node/1518655980550754304/artifacts/e2e-aws-upgrade-single-node/gather-extra/artifacts/deployments.json) - [pods.json](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-aws-upgrade-single-node/1518655980550754304/artifacts/e2e-aws-upgrade-single-node/gather-extra/artifacts/pods.json)
	- Apr 26 [1519018546309369856](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-aws-upgrade-single-node/1519018546309369856) - [deployments.json](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-aws-upgrade-single-node/1519018546309369856/artifacts/e2e-aws-upgrade-single-node/gather-extra/artifacts/deployments.json) - [pods.json](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-aws-upgrade-single-node/1519018546309369856/artifacts/e2e-aws-upgrade-single-node/gather-extra/artifacts/pods.json)
		- ```
		  Cluster did not complete upgrade: timed out waiting for the condition: deployment openshift-network-operator/network-operator is Progressing=False: ProgressDeadlineExceeded: ReplicaSet "network-operator-7bcbf49b68" has timed out progressing.
	- Apr 27 [1519381178254102528](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-aws-upgrade-single-node/1519381178254102528) - [deployments.json](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-aws-upgrade-single-node/1519381178254102528/artifacts/e2e-aws-upgrade-single-node/gather-extra/artifacts/deployments.json) - [pods.json](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-aws-upgrade-single-node/1519381178254102528/artifacts/e2e-aws-upgrade-single-node/gather-extra/artifacts/pods.json)
		- ```
		  {Cluster did not complete upgrade: timed out waiting for the condition: deployment openshift-network-operator/network-operator is Progressing=False: ProgressDeadlineExceeded: ReplicaSet "network-operator-75cb6c999f" has timed out progressing.  Cluster did not complete upgrade: timed out waiting for the condition: deployment openshift-network-operator/network-operator is Progressing=False: ProgressDeadlineExceeded: ReplicaSet "network-operator-75cb6c999f" has timed out progressing.}
- Upgrade tests with the PR (note successful progression of ReplicaSet in deployments.json)
	- [test upgrade 4.11.0-0.ci-2022-04-25-025503 4.11.0-0.ci-2022-04-25-062459,https://github.com/openshift/cluster-network-operator/pull/1392 aws](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws-modern/1518879312235728896) - [deployments.json](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws-modern/1518879312235728896/artifacts/launch/gather-extra/artifacts/deployments.json) - [pods.json](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws-modern/1518879312235728896/artifacts/launch/gather-extra/artifacts/pods.json)
	- [test upgrade 4.11.0-0.ci-2022-04-25-025503 4.11.0-0.ci-2022-04-25-062459,https://github.com/openshift/cluster-network-operator/pull/1392 aws,single-node](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws/1518879375976566784) - [deployments.json](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws/1518879375976566784/artifacts/launch/deployments.json) - [pods.json](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws/1518879375976566784/artifacts/launch/pods.json)