### PR TITLE
Bug 2071859: Switch dnsPolicy to Default for OVN hostNetwork pods

### DIFF
--- a/bindata/network/ovn-kubernetes/common/error-cni.yaml
+++ b/bindata/network/ovn-kubernetes/common/error-cni.yaml
@@ -97,6 +97,7 @@ spec:
         kubernetes.io/os: "linux"
     spec:
       hostNetwork: true
+      dnsPolicy: Default
       nodeSelector:
         kubernetes.io/os: linux
         network.operator.openshift.io/dpu: ''

--- a/bindata/network/ovn-kubernetes/common/ipsec.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec.yaml
@@ -36,6 +36,7 @@ spec:
                 operator: DoesNotExist
       serviceAccountName: ovn-kubernetes-node
       hostNetwork: true
+      dnsPolicy: Default
       priorityClassName: "system-node-critical"
       initContainers:
       - name: ovn-keys

--- a/bindata/network/ovn-kubernetes/common/pre-puller.yaml
+++ b/bindata/network/ovn-kubernetes/common/pre-puller.yaml
@@ -22,6 +22,7 @@ spec:
     spec:
       serviceAccountName: ovn-kubernetes-node
       hostNetwork: true
+      dnsPolicy: Default
       priorityClassName: "system-node-critical"
       containers:
         # ovnkube-upgrades-prepuller: no-op container that simply pulls the new image during upgrades

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -54,6 +54,7 @@ spec:
                 operator: DoesNotExist
       serviceAccountName: ovn-kubernetes-node
       hostNetwork: true
+      dnsPolicy: Default
       hostPID: true
       priorityClassName: "system-node-critical"
       initContainers:

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
@@ -48,6 +48,7 @@ spec:
     spec:
       serviceAccountName: ovn-kubernetes-controller
       hostNetwork: true
+      dnsPolicy: Default
       priorityClassName: "system-cluster-critical"
       # volumes in all containers:
       # (container) -> (host)

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -54,6 +54,7 @@ spec:
                 operator: DoesNotExist
       serviceAccountName: ovn-kubernetes-node
       hostNetwork: true
+      dnsPolicy: Default
       hostPID: true
       priorityClassName: "system-node-critical"
       # volumes in all containers:


### PR DESCRIPTION
**- What this PR does and why is it needed**

This commit changes the spec.dnsPolicy to Default for OVN hostNetwork pods
so they use the hosts DNS. Even this is currently already the case for
pods having hostNetwork:true and spec.dnsPolicy DNSClusterFirst (which
is the default) this makes it more clear (https://github.com/kubernetes/kubernetes/blob/0424c7c74d926b4fe3193059e003e9056b429d28/pkg/kubelet/network/dns/dns.go#L303-L322)

**- How to verify it**
1. Deploy a cluster with this patch
2. Check that all of the ovn pods which use host network have the dnsPolicy `Default`:
    ```
    $ oc -n openshift-ovn-kubernetes get po -ojsonpath='{.items[?(@.spec.hostNetwork)].spec.dnsPolicy}' 
    Default Default Default Default Default Default Default Default Default%
    ```

**- Description for the changelog**
none