### PR TITLE
bindata/network-diagnostics, cloud-network-config-controller: comply to restricted pod security level

### DIFF
--- a/bindata/cloud-network-config-controller/controller.yaml
+++ b/bindata/cloud-network-config-controller/controller.yaml
@@ -25,10 +25,19 @@ spec:
         type: infra
         openshift.io/component: network
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: cloud-network-config-controller
       priorityClassName: system-cluster-critical
       containers:
       - name: controller
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         image: {{.CloudNetworkConfigControllerImage}}
         imagePullPolicy: IfNotPresent
         command: ["/usr/bin/cloud-network-config-controller"]

--- a/bindata/network-diagnostics/network-check-source.yaml
+++ b/bindata/network-diagnostics/network-check-source.yaml
@@ -24,10 +24,19 @@ spec:
         app: network-check-source
         kubernetes.io/os: "linux"
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       priorityClassName: openshift-user-critical
       serviceAccountName: network-diagnostics
       containers:
       - name: check-endpoints
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         image: "{{.NetworkCheckSourceImage}}"
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError

--- a/bindata/network-diagnostics/network-check-target.yaml
+++ b/bindata/network-diagnostics/network-check-target.yaml
@@ -25,11 +25,20 @@ spec:
         app: network-check-target
         kubernetes.io/os: "linux"
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       priorityClassName: openshift-user-critical
       containers:
       - image: "{{.NetworkCheckTargetImage}}"
         imagePullPolicy: IfNotPresent
         name: network-check-target-container
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         command:
           - cluster-network-check-target
         ports:


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

```
{
  "objectRef": "openshift-network-diagnostics/daemonsets/network-check-target",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"network-check-target-container\" must set securityContext.allowPrivilegeEscalation=false), unrestri
cted capabilities (container \"network-check-target-container\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"network-check-target-container\" must set securityContext.runAsNonRoot=true), seccomp
Profile (pod or container \"network-check-target-container\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
}
```

```
{
  "objectRef": "openshift-network-diagnostics/deployments/network-check-source",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"check-endpoints\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabiliti
es (container \"check-endpoints\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"check-endpoints\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container \"check-endpoints\"
 must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
}
```

```
{
  "objectRef": "openshift-cloud-network-config-controller/deployments/cloud-network-config-controller",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"controller\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (c
ontainer \"controller\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"controller\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container \"controller\" must set securityCo
ntext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
}
```

Note: This is blocked until https://github.com/openshift/cluster-kube-apiserver-operator/pull/1338 merges.

/cc @soltysh @stlaz 