### PR TITLE
Bug 2078501: [release-4.10] Drop Node update permission for sdn-node

### DIFF
--- a/bindata/network/openshift-sdn/002-rbac.yaml
+++ b/bindata/network/openshift-sdn/002-rbac.yaml
@@ -20,6 +20,7 @@ rules:
   - endpoints
   - services
   - pods
+  - nodes
   verbs:
   - get
   - list
@@ -31,14 +32,6 @@ rules:
   verbs:
   - list
   - watch
-- apiGroups: [""]
-  resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - patch
 - apiGroups: ["networking.k8s.io"]
   resources:
   - networkpolicies


### PR DESCRIPTION
Backport of #1350, incorporating #1409

depends on https://github.com/openshift/sdn/pull/422

/assign @andreaskaris 