### PR TITLE
ovn: reduce SB<->ovn-controller inactivity probe to 30 seconds

### DIFF
--- a/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
@@ -64,7 +64,7 @@ spec:
         - name: OVN_NORTHD_PROBE_INTERVAL
           value: "5000"
         - name: OVN_CONTROLLER_INACTIVITY_PROBE
-          value: "180000"
+          value: "30000"
         - name: OVN_NB_INACTIVITY_PROBE
           value: "60000"
         - name: EGRESS_ROUTER_CNI_IMAGE

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -75,7 +75,7 @@ spec:
         - name: OVN_NORTHD_PROBE_INTERVAL
           value: "5000"
         - name: OVN_CONTROLLER_INACTIVITY_PROBE
-          value: "180000"
+          value: "30000"
         - name: OVN_NB_INACTIVITY_PROBE
           value: "60000"
         - name: EGRESS_ROUTER_CNI_IMAGE


### PR DESCRIPTION
The inactivity probe ensures that a client eventually disconnects
from a peer when no traffic has been received, even if the TCP
connection is supposedly still up. It attempts to detect hung
peers and uncleanly terminated TCP connections and allow quicker
recovery from these situations.

Node reboots do not cleanly terminate TCP connections and appear
to clients like the the peer has hung. The MCO reboot procedure
doesn't appear to allow the container scripts or preStop hooks
to run:

```
Apr 29 21:49:39.739350 ip-10-0-157-135 root[130737]: machine-config-daemon[121493]: Rebooting node
Apr 29 21:49:39.741203 ip-10-0-157-135 root[130738]: machine-config-daemon[121493]: initiating reboot: Node will reboot into config rendered-master-b296a1ff04aa28db1b1a172a2f8ff6da
Apr 29 21:49:39.749501 ip-10-0-157-135 systemd[1]: Started machine-config-daemon: Node will reboot into config rendered-master-b296a1ff04aa28db1b1a172a2f8ff6da.
Apr 29 21:49:39.756707 ip-10-0-157-135 systemd[1]: Stopping Kubernetes Kubelet...
Apr 29 21:49:39.784065 ip-10-0-157-135 systemd[1]: kubelet.service: Succeeded.
Apr 29 21:49:39.784593 ip-10-0-157-135 systemd[1]: Stopped Kubernetes Kubelet.
Apr 29 21:49:39.784707 ip-10-0-157-135 systemd[1]: kubelet.service: Consumed 7min 46.727s CPU time
Apr 29 21:49:39.790959 ip-10-0-157-135 systemd-logind[1136]: System is rebooting.
Apr 29 21:49:39.800602 ip-10-0-157-135 systemd[1]: Stopping libcontainer container e426381bcb5e175844019f9d9e0dafe0fd6fc03dffe73962fe521e4c004a1bf3.
Apr 29 21:49:39.801013 ip-10-0-157-135 systemd[1]: Stopping libcontainer container c9ef52bd6f6322f1a427027dd6dc34472f640f1c15fae56a9234e804c9aedb1e.
Apr 29 21:49:39.801435 ip-10-0-157-135 systemd[1]: Stopping libcontainer container 0e402391ccaff19de091a9060fcd1c11df34eefea20f5efc5d52c47d9269ae64.
```

Thus our SBDB doesn't terminate ovn-controller connections on
reboot and the controllers connected to it don't notice that
it's gone for 180 seconds. That's pretty unhelpful.

In fact, there shouldn't be any reason to wait 180 seconds to
figure out the peer has gone away. We need to be careful not to
pick too small a value, as there are some cases where the SB or
ovn-controller will take a couple seconds to process, but
definitely not minutes.

With a 30s probe interval, we should see ovn-controllers
recovering much more quickly when the SB they are connected to
goes down for node reboot during upgrade.

@trozet @flavio-fernandes 