### PR TITLE
ovn: fix northd preStop command handling

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -120,9 +120,9 @@ spec:
           preStop:
             exec:
               command:
-                - OVN_MANAGE_OVSDB=no
-                - /usr/share/ovn/scripts/ovn-ctl
-                - stop_northd
+                - /bin/bash
+                - -c
+                - OVN_MANAGE_OVSDB=no /usr/share/ovn/scripts/ovn-ctl stop_northd
         env:
         - name: OVN_LOG_LEVEL
           value: info

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
@@ -95,9 +95,9 @@ spec:
           preStop:
             exec:
               command:
-                - OVN_MANAGE_OVSDB=no
-                - /usr/share/ovn/scripts/ovn-ctl
-                - stop_northd
+                - /bin/bash
+                - -c
+                - OVN_MANAGE_OVSDB=no /usr/share/ovn/scripts/ovn-ctl stop_northd
         env:
         - name: OVN_LOG_LEVEL
           value: info 


### PR DESCRIPTION
Need to exec a shell so we can set the environment variable
we need that tells ovn-ctl not to touch the databases when
stopping northd.

@trozet 