### PR TITLE
Re-reconcile network on configmap, stop watching all configmaps in proxy controllers

### DIFF
--- a/pkg/client/fake/fake_client.go
+++ b/pkg/client/fake/fake_client.go
@@ -11,6 +11,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 
@@ -155,4 +157,8 @@ func (fc *FakeClusterClient) OperatorHelperClient() operatorv1helpers.OperatorCl
 
 func (fc *FakeClusterClient) HostPort() (string, string) {
 	return "testing", "9999"
+}
+
+func (fc *FakeClusterClient) AddCustomInformer(inf cache.SharedInformer) {
+	klog.Warningf("the fake Kubernetes client doesn't support informers!")
 }

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -57,4 +58,6 @@ type ClusterClient interface {
 
 	// HostPort returns the host and port, as a string, of this connection
 	HostPort() (string, string)
+
+	AddCustomInformer(inf cache.SharedInformer)
 }


### PR DESCRIPTION
This PR encompasses three separate changes that take the same shape:

1. Trigger a re-reconcile of the network when a Node is added or a ConfigMap changes in the CNO's namespace. This is because we saw HyperShift hang when no Nodes existed, and thus we couldn't run the MTU prober.
2. Switch the configmap-ca-injector to use a label-scoped watch, rather than watching all configmaps in the entire world.
3. Switch the ProxyConfig controller to use a namespace-scoped watch 