### PR TITLE
Hypershift: Fix ovnkube-master priority class and set resource requests on token-minter

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -63,7 +63,7 @@ spec:
               matchLabels:
                 app: ovnkube-master
             topologyKey: topology.kubernetes.io/zone
-      priorityClassName: "system-cluster-critical"
+      priorityClassName: hypershift-api-critical
       containers:
       # token-minter creates a token with the default service account path
       # The token is read by ovn-k containers to authenticate against the hosted cluster api server

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -76,6 +76,10 @@ spec:
         - --token-audience={{.TokenAudience}}
         - --token-file=/var/run/secrets/hosted_cluster/token
         - --kubeconfig=/etc/kubernetes/kubeconfig
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
         volumeMounts:
         - mountPath: /etc/kubernetes
           name: admin-kubeconfig


### PR DESCRIPTION
These two are needed before we can use ovnkube as default in CI, we have verifications for these that currently fail.

Ref  https://github.com/openshift/hypershift/pull/1331

/assign @squeed 