### PR TITLE
Remove ObjectMeta.ClusterName usage

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/004-config.yaml
@@ -67,7 +67,8 @@ apiVersion: v1
 metadata:
   name: ovnkube-config
   namespace: {{.HostedClusterNamespace}}
-  clusterName: {{.ManagementClusterName}}
+  annotations:
+    network.operator.openshift.io/cluster-name:  {{.ManagementClusterName}}
 data:
   ovnkube.conf:   |-
     [default]

--- a/bindata/network/ovn-kubernetes/managed/005-service.yaml
+++ b/bindata/network/ovn-kubernetes/managed/005-service.yaml
@@ -8,7 +8,8 @@ kind: Service
 metadata:
   name: ovnkube-master-external
   namespace: {{.HostedClusterNamespace}}
-  clusterName: {{.ManagementClusterName}}
+  annotations:
+    network.operator.openshift.io/cluster-name:  {{.ManagementClusterName}}
   labels:
     app: ovnkube-master
 spec:
@@ -36,8 +37,8 @@ kind: Service
 metadata:
   name: ovnkube-master-internal
   namespace: {{.HostedClusterNamespace}}
-  clusterName: {{.ManagementClusterName}}
   annotations:
+    network.operator.openshift.io/cluster-name:  {{.ManagementClusterName}}
     service.beta.openshift.io/serving-cert-secret-name: ovn-master-metrics-cert
   labels:
     app: ovnkube-master

--- a/bindata/network/ovn-kubernetes/managed/007-certificate.yaml
+++ b/bindata/network/ovn-kubernetes/managed/007-certificate.yaml
@@ -5,8 +5,8 @@ kind: Secret
 metadata:
   name: ovn-cert
   namespace: {{.HostedClusterNamespace}}
-  clusterName: {{.ManagementClusterName}}
   annotations:
+    network.operator.openshift.io/cluster-name:  {{.ManagementClusterName}}
     network.operator.openshift.io/copy-from: "default/openshift-ovn-kubernetes/ovn-cert"
 data: {}
 
@@ -17,7 +17,7 @@ apiVersion: v1
 metadata:
   name: ovn-ca
   namespace: {{.HostedClusterNamespace}}
-  clusterName: {{.ManagementClusterName}}
   annotations:
+    network.operator.openshift.io/cluster-name:  {{.ManagementClusterName}}
     network.operator.openshift.io/copy-from: "default/openshift-ovn-kubernetes/ovn-ca"
 data: {}

--- a/bindata/network/ovn-kubernetes/managed/008-route.yaml
+++ b/bindata/network/ovn-kubernetes/managed/008-route.yaml
@@ -6,7 +6,8 @@ kind: Route
 metadata:
   name: ovnkube-sbdb
   namespace: {{.HostedClusterNamespace}}
-  clusterName: {{.ManagementClusterName}}
+  annotations:
+    network.operator.openshift.io/cluster-name:  {{.ManagementClusterName}}
 spec:
   port:
     targetPort: {{.OVN_SB_PORT}}

--- a/bindata/network/ovn-kubernetes/managed/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/alert-rules-control-plane.yaml
@@ -6,9 +6,9 @@ metadata:
     role: alert-rules
   annotations:
     networkoperator.openshift.io/ignore-errors: ""
+    network.operator.openshift.io/cluster-name:  {{.ManagementClusterName}}
   name: master-rules
   namespace: {{.HostedClusterNamespace}}
-  clusterName: {{.ManagementClusterName}}
 spec:
   groups:
   - name: cluster-network-operator-master.rules

--- a/bindata/network/ovn-kubernetes/managed/monitor-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/monitor-master.yaml
@@ -6,9 +6,9 @@ metadata:
     app: ovnkube-master
   annotations:
     networkoperator.openshift.io/ignore-errors: ""
+    network.operator.openshift.io/cluster-name:  {{.ManagementClusterName}}
   name: monitor-ovn-master-metrics
   namespace: {{.HostedClusterNamespace}}
-  clusterName: {{.ManagementClusterName}}
 spec:
   endpoints:
   - interval: 30s

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -7,7 +7,8 @@ kind: PodDisruptionBudget
 metadata:
   name: ovn-raft-quorum-guard
   namespace: {{.HostedClusterNamespace}}
-  clusterName: {{.ManagementClusterName}}
+  annotations:
+    network.operator.openshift.io/cluster-name:  {{.ManagementClusterName}}
 spec:
   minAvailable: {{.OVN_MIN_AVAILABLE}}
   selector:
@@ -20,8 +21,8 @@ apiVersion: apps/v1
 metadata:
   name: ovnkube-master
   namespace: {{.HostedClusterNamespace}}
-  clusterName: {{.ManagementClusterName}}
   annotations:
+    network.operator.openshift.io/cluster-name:  {{.ManagementClusterName}}
     kubernetes.io/description: |
       This daemonset launches the ovn-kubernetes controller (master) networking components.
     release.openshift.io/version: "{{.ReleaseVersion}}"

--- a/pkg/controller/statusmanager/pod_status.go
+++ b/pkg/controller/statusmanager/pod_status.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/openshift/cluster-network-operator/pkg/apply"
 	"log"
 	"os"
 	"reflect"
@@ -442,7 +443,7 @@ func (status *StatusManager) setDSAnnotation(obj *appsv1.DaemonSet, key string, 
 		delete(anno, key)
 	}
 	new.SetAnnotations(anno)
-	return status.client.ClientFor(obj.GetClusterName()).CRClient().Patch(context.TODO(), new, crclient.MergeFrom(obj))
+	return status.client.ClientFor(apply.GetClusterName(obj)).CRClient().Patch(context.TODO(), new, crclient.MergeFrom(obj))
 }
 
 // setSSAnnotation sets an annotation on a statefulset; or unsets it if value is nil
@@ -467,7 +468,7 @@ func (status *StatusManager) setSSAnnotation(obj *appsv1.StatefulSet, key string
 		delete(anno, key)
 	}
 	new.SetAnnotations(anno)
-	return status.client.ClientFor(obj.GetClusterName()).CRClient().Patch(context.TODO(), new, crclient.MergeFrom(obj))
+	return status.client.ClientFor(apply.GetClusterName(obj)).CRClient().Patch(context.TODO(), new, crclient.MergeFrom(obj))
 }
 
 // setDepAnnotation sets an annotation on a Deployment. If value is nil,
@@ -493,5 +494,5 @@ func (status *StatusManager) setDepAnnotation(obj *appsv1.Deployment, key string
 		delete(anno, key)
 	}
 	new.SetAnnotations(anno)
-	return status.client.ClientFor(obj.GetClusterName()).CRClient().Patch(context.TODO(), new, crclient.MergeFrom(obj))
+	return status.client.ClientFor(apply.GetClusterName(obj)).CRClient().Patch(context.TODO(), new, crclient.MergeFrom(obj))
 }

--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -3,6 +3,7 @@ package statusmanager
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/cluster-network-operator/pkg/apply"
 	"log"
 	"os"
 	"reflect"
@@ -104,7 +105,7 @@ func (status *StatusManager) setClusterOperAnnotation(obj *configv1.ClusterOpera
 	}
 	anno[names.RelatedClusterObjectsAnnotation] = strings.Join(value, ",")
 	new.SetAnnotations(anno)
-	return status.client.ClientFor(obj.GetClusterName()).CRClient().Patch(context.TODO(), new, crclient.MergeFrom(obj))
+	return status.client.ClientFor(apply.GetClusterName(obj)).CRClient().Patch(context.TODO(), new, crclient.MergeFrom(obj))
 }
 
 // getClusterOperAnnotation gets an annotation from the clusterOperator network object
@@ -222,7 +223,6 @@ func (status *StatusManager) deleteRelatedObjectsNotRendered(co *configv1.Cluste
 			objToDelete := &uns.Unstructured{}
 			objToDelete.SetName(currentObj.Name)
 			objToDelete.SetNamespace(currentObj.Namespace)
-			objToDelete.SetClusterName(currentObj.ClusterName)
 			objToDelete.SetGroupVersionKind(gvk)
 			err = status.client.ClientFor(currentObj.ClusterName).CRClient().Delete(context.TODO(), objToDelete, crclient.PropagationPolicy("Background"))
 			if err != nil {

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -68,6 +68,9 @@ const KuryrOctaviaVersionAnnotation = "networkoperator.openshift.io/kuryr-octavi
 // value format: cluster/namespace/name
 const CopyFromAnnotation = "network.operator.openshift.io/copy-from"
 
+// ClusterNameAnnotation is an annotation that specifies the cluster an object belongs to
+const ClusterNameAnnotation = "network.operator.openshift.io/cluster-name"
+
 // RelatedClusterObjectsAnnotation is an annotation that allows deleting resources for specified clusters
 // value format: cluster/group/resource/namespace/name
 const RelatedClusterObjectsAnnotation = "network.operator.openshift.io/relatedClusterObjects"


### PR DESCRIPTION
Instead of using the deprecated `ObjectMeta.ClusterName` field, use an annotation that serves the same purpose

https://github.com/kubernetes/kubernetes/pull/108717

/cc @squeed @zshi-redhat 
Signed-off-by: Patryk Diak <pdiak@redhat.com>