### PR TITLE
Add control-plane-component label to ovnkube-master for hypershift

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -54,6 +54,7 @@ spec:
         component: network
         type: infra
         openshift.io/component: network
+        hypershift.openshift.io/control-plane-component: onvkube-master
         kubernetes.io/os: "linux"
     spec:
       affinity:


### PR DESCRIPTION
Allows the onvkube-master to be included in hypershift metrics recording rules
https://github.com/openshift/hypershift/blob/main/cmd/install/assets/recordingrules/hypershift.yaml