### PR TITLE
Hypershift: enable TLS for ovnkube-master metrics

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/monitor-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/monitor-master.yaml
@@ -13,8 +13,22 @@ spec:
   endpoints:
   - interval: 30s
     port: metrics
-    scheme: http
-    path: /metrics
+    scheme: https
+    bearerTokenSecret:
+      key: ""
+    tlsConfig:
+      ca:
+        configMap:
+          key: service-ca.crt
+          name: openshift-service-ca.crt
+      cert:
+        secret:
+          key: tls.crt
+          name: ovn-master-metrics-cert
+      keySecret:
+        key: tls.key
+        name: ovn-master-metrics-cert
+      serverName: ovnkube-master-internal.{{.HostedClusterNamespace}}.svc
     metricRelabelings:
     - action: replace
       replacement: {{.ClusterID}}

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -742,8 +742,8 @@ spec:
             --nb-cert-common-name "{{.OVN_CERT_CN}}" \
             --enable-multicast \
             --disable-snat-multiple-gws \
-            --metrics-node-server-privkey ${TLS_PK} \
-            --metrics-node-server-cert ${TLS_CERT} \
+            --node-server-privkey ${TLS_PK} \
+            --node-server-cert ${TLS_CERT} \
             --acl-logging-rate-limit "{{.OVNPolicyAuditRateLimit}}"
         volumeMounts:
         - mountPath: /etc/ovn

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -742,6 +742,8 @@ spec:
             --nb-cert-common-name "{{.OVN_CERT_CN}}" \
             --enable-multicast \
             --disable-snat-multiple-gws \
+            --metrics-node-server-privkey ${TLS_PK} \
+            --metrics-node-server-cert ${TLS_CERT} \
             --acl-logging-rate-limit "{{.OVNPolicyAuditRateLimit}}"
         volumeMounts:
         - mountPath: /etc/ovn


### PR DESCRIPTION
TLS support for ovnk-master was backported in https://github.com/openshift/ovn-kubernetes/pull/1064