### PR TITLE
Revert "ovn: reduce SB<->ovn-controller inactivity probe to 30 seconds"

### DIFF
--- a/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
@@ -79,7 +79,7 @@ spec:
         - name: OVN_NORTHD_PROBE_INTERVAL
           value: "5000"
         - name: OVN_CONTROLLER_INACTIVITY_PROBE
-          value: "30000"
+          value: "180000"
         - name: OVN_NB_INACTIVITY_PROBE
           value: "60000"
         - name: EGRESS_ROUTER_CNI_IMAGE

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -90,7 +90,7 @@ spec:
         - name: OVN_NORTHD_PROBE_INTERVAL
           value: "5000"
         - name: OVN_CONTROLLER_INACTIVITY_PROBE
-          value: "30000"
+          value: "180000"
         - name: OVN_NB_INACTIVITY_PROBE
           value: "60000"
         - name: EGRESS_ROUTER_CNI_IMAGE


### PR DESCRIPTION
This reverts commit ee7269e37286af8cdc4e0f6670036d4d32924e71.

While this makes sense for an isolated ovn-controller, it doesn't make
sense for some common cluster recovery cases where many controllers
connect to the SB around the same time:

1) If the OVN databases get wiped (sometimes done to reset clusters during
customer cases) then the database index resets to zero. ovn-controllers
stop intentionally ignore updates with old indexes to ensure cluster
consistency. When they are told to reset their index (because the wipe was
intentional) they will request the full DB from the SB.

2) if a large number of	nodes reboot, or part of the cluster was offline
and then came online again, a large number of controllers will attempt
to connect to the SB at the same time.

In these cases the controllers will request the entire database since
they have no cached in-memory copy. The SB may take more than the probe
interval sending the database to all the controllers, causing those that
haven't yet received the DB to disconnect and reconnect, proloning the
cluster recovery.

Instead of attempting to work around a problem where the controller
cannot talk to the SB after a successful TCP handshake the first time
after upgrade (which should be root-caused and fixed by itself) revert
the inactivity probe change so we don't make some common cluster recovery
scenarios worse.

@flavio-fernandes @trozet @jcaamano @tssurya 