### PR TITLE
Bug 2023295: Cleanup CNO relatedObjects

### DIFF
--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -345,27 +345,6 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 		Name:     "cluster",
 	})
 
-	// Add NetworkPolicy, EgressFirewall, EgressIP, CloudPrivateIPConfig for must-gather
-	relatedObjects = append(relatedObjects, configv1.ObjectReference{
-		Group:    "networking.k8s.io",
-		Resource: "NetworkPolicy",
-	})
-
-	relatedObjects = append(relatedObjects, configv1.ObjectReference{
-		Group:    "k8s.ovn.org",
-		Resource: "EgressFirewall",
-	})
-
-	relatedObjects = append(relatedObjects, configv1.ObjectReference{
-		Group:    "k8s.ovn.org",
-		Resource: "EgressIP",
-	})
-
-	relatedObjects = append(relatedObjects, configv1.ObjectReference{
-		Group:    "cloud.network.openshift.io",
-		Resource: "CloudPrivateIPConfig",
-	})
-
 	// This Namespace is rendered by the CVO, but it's really our operand.
 	relatedObjects = append(relatedObjects, configv1.ObjectReference{
 		Resource: "namespaces",

--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -179,6 +179,12 @@ func (status *StatusManager) deleteRelatedObjectsNotRendered(co *configv1.Cluste
 				log.Printf("Object Kind is network.operator.openshift.io, skip")
 				continue
 			}
+			// @npinaeva objects without a name shouldn't be listed as relatedObjects in the first place,
+			// and we should never try to delete them
+			if currentObj.Name == "" {
+				log.Printf("Object without a name GVK %+v, skip", gvk)
+				continue
+			}
 			log.Printf("Detected related object with GVK %+v, namespace %v and name %v not rendered by manifests, deleting...", gvk, currentObj.Namespace, currentObj.Name)
 			objToDelete := &uns.Unstructured{}
 			objToDelete.SetName(currentObj.Name)


### PR DESCRIPTION
Remove NetworkPolicy, EgressFirewall, EgressIP and CloudPrivateIPConfig from CNO relatedObjects, since
1. it doesn't match relatedObjects definition ("Common uses are: 1. the detailed resource driving the operator 2. operator namespaces 3. operand namespaces")
2. it makes must-gather collect instances of these resource for all namespaces, and must-gather shouldn't collect resources from custom namespaces

egressips and cloudprivateipconfigs will be collected as cluster-scoped resources https://github.com/openshift/must-gather/pull/300 and egressfirewalls and networkpolicies will be collected as namespaced resources. https://github.com/openshift/oc/pull/1128

Signed-off-by: Nadia Pinaeva <npinaeva@redhat.com>