### PR TITLE
Bug 2082235: manifests: Add in service, service-cert, and ServiceMonitor

### DIFF
--- a/manifests/0000_70_cluster-network-operator_00_namespace.yaml
+++ b/manifests/0000_70_cluster-network-operator_00_namespace.yaml
@@ -14,3 +14,4 @@ metadata:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/warn: privileged
+    openshift.io/cluster-monitoring: "true"

--- a/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
@@ -118,6 +118,8 @@ spec:
         - mountPath: /etc/kubernetes
           name: host-etc-kube
           readOnly: true
+        - mountPath: /var/run/secrets/serving-cert
+          name: metrics-tls
       hostNetwork: true
       priorityClassName: system-cluster-critical
       restartPolicy: Always
@@ -139,3 +141,7 @@ spec:
           path: /etc/kubernetes
           type: Directory
         name: host-etc-kube
+      - name: metrics-tls
+        secret:
+          optional: true
+          secretName: metrics-tls

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -118,6 +118,8 @@ spec:
         - mountPath: /etc/kubernetes
           name: host-etc-kube
           readOnly: true
+        - mountPath: /var/run/secrets/serving-cert
+          name: metrics-tls
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
@@ -127,6 +129,10 @@ spec:
           hostPath:
             path: /etc/kubernetes
             type: Directory
+        - name: metrics-tls
+          secret:
+            secretName: metrics-tls
+            optional: true
       restartPolicy: Always
       securityContext:
         runAsNonRoot: true

--- a/manifests/03-metrics-service.yaml
+++ b/manifests/03-metrics-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    service.beta.openshift.io/serving-cert-secret-name: metrics-tls
+  name: metrics
+  namespace: openshift-network-operator
+  labels:
+    name: network-operator
+spec:
+  ports:
+  - name: metrics
+    port: 9104
+    targetPort: cno
+  selector:
+    name: network-operator
+  type: ClusterIP
+  clusterIP: None

--- a/manifests/04-monitoring-role.yaml
+++ b/manifests/04-monitoring-role.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-network-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/05-prometheus-binding.yaml
+++ b/manifests/05-prometheus-binding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-network-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/manifests/06-servicemonitor.yaml
+++ b/manifests/06-servicemonitor.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: network-operator
+  namespace: openshift-network-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    port: metrics
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: metrics.openshift-network-operator.svc
+  jobLabel: component
+  selector:
+    matchLabels:
+      name: network-operator


### PR DESCRIPTION
That way we actually use a securely generated certificate for the CNO.