### PR TITLE
Bug 2083266: Limit Kuryr pods permissions

### DIFF
--- a/bindata/network/kuryr/001-rbac.yaml
+++ b/bindata/network/kuryr/001-rbac.yaml
@@ -2,15 +2,16 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kuryr
+  name: kuryr-controller
 rules:
 - apiGroups: [""]
   resources:
-  - namespaces
   - nodes
-  - endpoints
-  - services
-  - services/status
+  verbs:
+  - get
+  - list
+- apiGroups: [""]
+  resources:
   - pods
   verbs:
   - get
@@ -19,13 +20,18 @@ rules:
   - update
   - patch
   - delete
-- apiGroups: ["extensions"]
+- apiGroups: [""]
   resources:
-  - networkpolicies
+  - endpoints
+  - services
+  - services/status
+  - namespaces
   verbs:
   - get
-  - list
   - watch
+  - list
+  - update
+  - patch
 - apiGroups: ["networking.k8s.io"]
   resources:
   - networkpolicies
@@ -35,21 +41,12 @@ rules:
   - watch
   - update
   - patch
-- apiGroups: ["k8s.cni.cncf.io"]
-  resources:
-  - network-attachment-definitions
-  verbs:
-  - get
 - apiGroups: ["openstack.org"]
   resources:
   - kuryrnetworks
   - kuryrnetworkpolicies
   - kuryrports
   - kuryrloadbalancers
-  verbs: ["*"]
-- apiGroups: ["route.openshift.io"]
-  resources:
-  - routes
   verbs: ["*"]
 - apiGroups: ["security.openshift.io"]
   resources:
@@ -69,22 +66,70 @@ rules:
   verbs:
   - create
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kuryr-daemon
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups: ["openstack.org"]
+  resources:
+  - kuryrports
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups: ["security.openshift.io"]
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups: ["", "events.k8s.io"]
+  resources:
+  - events
+  verbs:
+  - create
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kuryr
+  name: kuryr-controller
   namespace: openshift-kuryr
-
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kuryr-daemon
+  namespace: openshift-kuryr
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kuryr
+  name: kuryr-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kuryr
+  name: kuryr-controller
 subjects:
 - kind: ServiceAccount
-  name: kuryr
+  name: kuryr-controller
+  namespace: openshift-kuryr
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kuryr-daemon
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kuryr-daemon
+subjects:
+- kind: ServiceAccount
+  name: kuryr-daemon
   namespace: openshift-kuryr

--- a/bindata/network/kuryr/005-daemon.yaml
+++ b/bindata/network/kuryr/005-daemon.yaml
@@ -24,7 +24,7 @@ spec:
         configuration-hash: {{ .ConfigMapHash }}
     spec:
       hostNetwork: true
-      serviceAccountName: kuryr
+      serviceAccountName: kuryr-daemon
       priorityClassName: system-node-critical
       initContainers:
         - name: block-mcs

--- a/bindata/network/kuryr/006-controller.yaml
+++ b/bindata/network/kuryr/006-controller.yaml
@@ -26,7 +26,7 @@ spec:
         openshift.io/component: network
         configuration-hash: {{ .ConfigMapHash }}
     spec:
-      serviceAccountName: kuryr
+      serviceAccountName: kuryr-controller
       hostNetwork: true
       priorityClassName: system-cluster-critical
       containers:

--- a/bindata/network/kuryr/010-admission-controller.yaml
+++ b/bindata/network/kuryr/010-admission-controller.yaml
@@ -27,7 +27,7 @@ spec:
         type: infra
         openshift.io/component: network
     spec:
-      serviceAccountName: kuryr
+      serviceAccountName: kuryr-controller
       containers:
       - name: kuryr-dns-admission-controller
         image: {{ .ControllerImage }}

--- a/pkg/network/kuryr_test.go
+++ b/pkg/network/kuryr_test.go
@@ -61,9 +61,12 @@ func TestRenderKuryr(t *testing.T) {
 	// the ClusterNetwork.
 	g.Expect(objs[0]).To(HaveKubernetesID("Namespace", "", "openshift-kuryr"))
 
-	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "kuryr")))
-	g.Expect(objs).To(ContainElement(HaveKubernetesID("ServiceAccount", "openshift-kuryr", "kuryr")))
-	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRoleBinding", "", "kuryr")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "kuryr-controller")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "kuryr-daemon")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ServiceAccount", "openshift-kuryr", "kuryr-controller")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ServiceAccount", "openshift-kuryr", "kuryr-daemon")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRoleBinding", "", "kuryr-controller")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRoleBinding", "", "kuryr-daemon")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("Deployment", "openshift-kuryr", "kuryr-controller")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-kuryr", "kuryr-cni")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ConfigMap", "openshift-kuryr", "kuryr-config")))


### PR DESCRIPTION
This splits the Kuryr RBAC into separate ClusterRoles for controller nad
daemon and makes sure we don't keep unnecessary permissions. I also
dropped the ones related to sriov and dpdk support as we don't configure
them in OpenShift.