### PR TITLE
WIP: [RFE-2181] To support transparent proxy configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -153,3 +153,5 @@ replace (
 	sigs.k8s.io/cluster-api-provider-kubevirt => github.com/openshift/cluster-api-provider-kubevirt v0.0.0-20211223062810-ef64d5ff1cde
 	sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.0.0-20220209101310-a384cbe0dfa0
 )
+
+replace github.com/openshift/api => github.com/TrilokGeer/api v0.0.2

--- a/go.mod
+++ b/go.mod
@@ -154,4 +154,4 @@ replace (
 	sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.0.0-20220209101310-a384cbe0dfa0
 )
 
-replace github.com/openshift/api => github.com/TrilokGeer/api v0.0.2
+replace github.com/openshift/api => github.com/TrilokGeer/api v0.0.5

--- a/pkg/controller/proxyconfig/status.go
+++ b/pkg/controller/proxyconfig/status.go
@@ -28,9 +28,18 @@ func (r *ReconcileProxyConfig) syncProxyStatus(proxy *configv1.Proxy, infra *con
 		}
 	}
 
-	updated.Status.HTTPProxy = proxy.Spec.HTTPProxy
-	updated.Status.HTTPSProxy = proxy.Spec.HTTPSProxy
-	updated.Status.NoProxy = noProxy
+	updated.Status.ConfigType = proxy.Spec.ConfigType
+	if proxy.Spec.ConfigType == configv1.ExplicitProxy {
+		updated.Status.HTTPProxy = proxy.Spec.HTTPProxy
+		updated.Status.HTTPSProxy = proxy.Spec.HTTPSProxy
+		updated.Status.NoProxy = noProxy
+	}
+
+	if proxy.Spec.ConfigType == configv1.TransparentProxy {
+		updated.Status.HTTPProxy = ""
+		updated.Status.HTTPSProxy = ""
+		updated.Status.NoProxy = ""
+	}
 
 	if !proxyStatusesEqual(proxy.Status, updated.Status) {
 		if err := r.client.Status().Update(context.TODO(), updated); err != nil {

--- a/pkg/controller/proxyconfig/validation.go
+++ b/pkg/controller/proxyconfig/validation.go
@@ -35,8 +35,10 @@ const (
 // ValidateProxyConfig ensures that httpProxy, httpsProxy and
 // noProxy fields of proxyConfig are valid.
 func (r *ReconcileProxyConfig) ValidateProxyConfig(proxyConfig *configv1.ProxySpec) error {
-	if !isSpecHTTPProxySet(proxyConfig) && !isSpecHTTPSProxySet(proxyConfig) {
-		return fmt.Errorf("httpProxy or httpsProxy must be set when using proxy")
+	if proxyConfig.ConfigType == configv1.ExplicitProxy {
+		if !isSpecHTTPProxySet(proxyConfig) && !isSpecHTTPSProxySet(proxyConfig) {
+			return fmt.Errorf("httpProxy or httpsProxy must be set when using proxy")
+		}
 	}
 
 	if isSpecHTTPProxySet(proxyConfig) {


### PR DESCRIPTION
Added configType support during installation to signify transparent or explicit proxy configuration to enable user-ca-bundle configured with cluster proxy and determine configuration type for cluster-wide proxy.