### PR TITLE
Bug 2087135: Fixing Hypershift nodeport flow

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/005-service.yaml
+++ b/bindata/network/ovn-kubernetes/managed/005-service.yaml
@@ -27,8 +27,10 @@ spec:
 {{ if .OVN_SB_NODE_PORT }}
     nodePort: {{.OVN_SB_NODE_PORT}}
 {{ end }}
-  sessionAffinity: None
+{{ if ne .OVNDbServiceType "NodePort" }}
   clusterIP: None
+{{ end }}
+  sessionAffinity: None
   type: {{.OVNDbServiceType}}
 
 ---


### PR DESCRIPTION
    Bug 2087135: Fixing Hypershift nodeport flow:
    1. In case of NodePort ClusterIp should not be set
    2. Using the right client(management) to get NodePort service from
       management cluster
    3. Using right variable to set ovnsdb nodeport for ovnkube-node
