### PR TITLE
multi-networkpolicy: Enable on SR-IOV networks

### DIFF
--- a/bindata/network/multus-networkpolicy/multus-networkpolicy.yaml
+++ b/bindata/network/multus-networkpolicy/multus-networkpolicy.yaml
@@ -34,6 +34,7 @@ spec:
         - "--host-prefix=/host"
         - "--container-runtime-endpoint=/run/crio/crio.sock"
         - "--pod-iptables=/var/lib/multi-networkpolicy/iptables"
+        - "--network-plugins=macvlan,sriov"
         resources:
           requests:
             cpu: "100m"


### PR DESCRIPTION
Add `sriov` to the array of network plugins multus-networkpolicy-iptables should manage.
