### PR TITLE
[CFE-465] As a developer I want to support wildcard character for noProxy

### DIFF
--- a/pkg/controller/proxyconfig/validation.go
+++ b/pkg/controller/proxyconfig/validation.go
@@ -36,7 +36,9 @@ const (
 // noProxy fields of proxyConfig are valid.
 func (r *ReconcileProxyConfig) ValidateProxyConfig(proxyConfig *configv1.ProxySpec) error {
 	if !isSpecHTTPProxySet(proxyConfig) && !isSpecHTTPSProxySet(proxyConfig) {
-		return fmt.Errorf("httpProxy or httpsProxy must be set when using proxy")
+		if proxyConfig.NoProxy != noProxyWildcard {
+			return fmt.Errorf("httpProxy or httpsProxy must be set when using proxy")
+		}
 	}
 
 	if isSpecHTTPProxySet(proxyConfig) {


### PR DESCRIPTION
Added wildcard '*' validation support to signify transparent proxy when there is no proxy set for http/https config.