### PR TITLE
Bug 2076776: remove patch permissions from ovnkube-node service account

### DIFF
--- a/bindata/network/ovn-kubernetes/common/002-rbac.yaml
+++ b/bindata/network/ovn-kubernetes/common/002-rbac.yaml
@@ -7,22 +7,65 @@ metadata:
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openshift-ovn-kubernetes-node
+  namespace: openshift-ovn-kubernetes
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: [certificates.k8s.io]
+  resources: ['certificatesigningrequests']
+  verbs:
+    - create
+    - get
+    - delete
+    - update
+    - list
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift-ovn-kubernetes-node
+  namespace: openshift-ovn-kubernetes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift-ovn-kubernetes-node
+subjects:
+- kind: ServiceAccount
+  name: ovn-kubernetes-node
+  namespace: openshift-ovn-kubernetes
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: openshift-ovn-kubernetes-node
 rules:
 - apiGroups: [""]
   resources:
-  - endpoints
-  - namespaces
   - pods
-  - services
-  - configmaps
   verbs:
   - get
   - list
   - watch
   - patch
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - endpoints
+  - services
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - discovery.k8s.io
   resources:
@@ -73,14 +116,6 @@ rules:
 - apiGroups: ['authorization.k8s.io']
   resources: ['subjectaccessreviews']
   verbs: ['create']
-- apiGroups: [certificates.k8s.io]
-  resources: ['certificatesigningrequests']
-  verbs:
-  - create
-  - get
-  - delete
-  - update
-  - list
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
remove patch permission for ovnkube-node service for the following resources
- namespaces
- endpoints
- services
- configmaps

Kept same resource permissions for :-
- pods because its in use by `SetAnnotationsOnPod` used by ovn `addLogicalPort`
- nodes because its in use by `SetTaintOnNode` and `RemoveTaintFromNode`
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>