### PR TITLE
ensures type: Directory for multus host paths

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -185,12 +185,15 @@ spec:
         - name: system-cni-dir
           hostPath:
             path: {{ .SystemCNIConfDir }}
+            type: Directory
         - name: multus-cni-dir
           hostPath:
             path: {{ .MultusCNIConfDir }}
+            type: Directory
         - name: cnibin
           hostPath:
             path: {{ .CNIBinDir }}
+            type: Directory
         - name: os-release
           hostPath:
             path: /etc/os-release


### PR DESCRIPTION
In case there's a possible timing conflict with the MCO creating these paths, this will wait for the paths.