### PR TITLE
Bug 2086461: Hypershift: Also add default for Azure mtu

### DIFF
--- a/pkg/controller/operconfig/mtu_probe.go
+++ b/pkg/controller/operconfig/mtu_probe.go
@@ -30,6 +30,7 @@ const (
 	cmNamespace = "openshift-network-operator"
 	cmName      = "mtu"
 	awsMTU      = 9001
+	azureMTU    = 1500
 )
 
 // probeMTU executes the MTU prober job, if the result configmap
@@ -38,9 +39,15 @@ const (
 // If, for whatever reason, it takes longer for the MTU to be detected,
 // it will adopt an existing job.
 func (r *ReconcileOperConfig) probeMTU(ctx context.Context, oc *operv1.Network, infra *bootstrap.InfraStatus) (int, error) {
-	if infra.ExternalControlPlane && infra.PlatformType == configv1.AWSPlatformType {
-		klog.Infof("AWS cluster, omitting MTU probing and using default of %d", awsMTU)
-		return awsMTU, nil
+	if infra.ExternalControlPlane {
+		if infra.PlatformType == configv1.AWSPlatformType {
+			klog.Infof("AWS cluster, omitting MTU probing and using default of %d", awsMTU)
+			return awsMTU, nil
+		}
+		if infra.PlatformType == configv1.AzurePlatformType {
+			klog.Infof("AWS cluster, omitting MTU probing and using default of %d", azureMTU)
+			return azureMTU, nil
+		}
 	}
 	mtu, err := r.readMTUConfigMap(ctx)
 	if err == nil {

--- a/pkg/controller/operconfig/mtu_probe_test.go
+++ b/pkg/controller/operconfig/mtu_probe_test.go
@@ -36,9 +36,22 @@ func TestProbeMTU(t *testing.T) {
 			}},
 			expectedMTU: 5000,
 		},
-
 		{
-			name:  "Not aws on Hypershift, value from configmap is used",
+			name:        "Azure on hypershift, hardcoded value is used",
+			infra:       &bootstrap.InfraStatus{PlatformType: configv1.AzurePlatformType, ExternalControlPlane: true},
+			expectedMTU: 1500,
+		},
+		{
+			name:  "Azure selfhosted, value from configmap is used",
+			infra: &bootstrap.InfraStatus{PlatformType: configv1.AzurePlatformType},
+			objects: []crclient.Object{&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Namespace: cmNamespace, Name: cmName},
+				Data:       map[string]string{"mtu": "5000"},
+			}},
+			expectedMTU: 5000,
+		},
+		{
+			name:  "Unknown platform on Hypershift, value from configmap is used",
 			infra: &bootstrap.InfraStatus{ExternalControlPlane: true},
 			objects: []crclient.Object{&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Namespace: cmNamespace, Name: cmName},
@@ -47,7 +60,7 @@ func TestProbeMTU(t *testing.T) {
 			expectedMTU: 5000,
 		},
 		{
-			name:  "Not aws, value from configmap is used",
+			name:  "Unknown platform, value from configmap is used",
 			infra: &bootstrap.InfraStatus{},
 			objects: []crclient.Object{&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Namespace: cmNamespace, Name: cmName},


### PR DESCRIPTION
This change adds a default for the Azure mtu to speed up cluster
creation, similiar like what already exists for AWS.

Ref:
https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-tcpip-performance-tuning

/assign @squeed 