### PR TITLE
Bug 2089805: Enable config duration for OVN-Kubernetes

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -743,6 +743,7 @@ spec:
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
             --metrics-bind-address "0.0.0.0:9102" \
             --metrics-enable-pprof \
+            --metrics-enable-config-duration \
             ${gateway_mode_flags} \
             --sb-address "{{.OVN_SB_DB_LIST}}" \
             --sb-client-privkey /ovn-cert/tls.key \

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
@@ -766,6 +766,7 @@ spec:
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
             --metrics-bind-address "127.0.0.1:29102" \
             --metrics-enable-pprof \
+            --metrics-enable-config-duration \
             ${gateway_mode_flags} \
             --sb-address "{{.OVN_SB_DB_LIST}}" \
             --sb-client-privkey /ovn-cert/tls.key \


### PR DESCRIPTION
This will enable the following bucket metrics:
ovnkube_master_network_programming_ovn_duration_seconds_*
ovnkube_master_network_programming_duration_seconds_*

We have carried out initial testing at scale with ~5k pods to show the perf 
regression is minimal.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>

/cc @npinaeva @bmeng 