### PR TITLE
Bug 2092047: cncc: add RBAC coordination.k8s.io leases

### DIFF
--- a/bindata/cloud-network-config-controller/002-rbac.yaml
+++ b/bindata/cloud-network-config-controller/002-rbac.yaml
@@ -56,6 +56,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Requirement for https://github.com/openshift/cloud-network-config-controller/pull/44
so it can rebase to use k8s.io/api v0.24.0

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>
