### PR TITLE
Bug 2091167: incorrectly setting rbac role for certificatesigningrequests

### DIFF
--- a/bindata/network/ovn-kubernetes/common/002-rbac.yaml
+++ b/bindata/network/ovn-kubernetes/common/002-rbac.yaml
@@ -19,14 +19,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups: [certificates.k8s.io]
-  resources: ['certificatesigningrequests']
-  verbs:
-    - create
-    - get
-    - delete
-    - update
-    - list
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -116,6 +108,14 @@ rules:
 - apiGroups: ['authorization.k8s.io']
   resources: ['subjectaccessreviews']
   verbs: ['create']
+- apiGroups: [certificates.k8s.io]
+  resources: ['certificatesigningrequests']
+  verbs:
+    - create
+    - get
+    - delete
+    - update
+    - list
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Bug 2076776 incorrectly changed role for certificatesigningrequests
resource from cluster scoped to namespace which isn't correct

Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>