### PR TITLE
Revert "Copying CNI binaries should be an atomic operation."

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -76,12 +76,7 @@ data:
       sourcedir=$DEFAULT_SOURCE_DIRECTORY
     fi
 
-    # Use a subdirectory called "upgrade" so we can atomically move fully copied files.
-    rm -Rf $DESTINATION_DIRECTORY/upgrade
-    mkdir -p $DESTINATION_DIRECTORY/upgrade
-    cp -rf ${sourcedir}* $DESTINATION_DIRECTORY/upgrade
-    mv $DESTINATION_DIRECTORY/upgrade/* $DESTINATION_DIRECTORY/
-    rm -Rf $DESTINATION_DIRECTORY/upgrade
+    cp -rf ${sourcedir}* $DESTINATION_DIRECTORY
 
     if [ $? -eq 0 ]; then
       echo "Successfully copied files in ${sourcedir} to $DESTINATION_DIRECTORY"


### PR DESCRIPTION
This reverts commit c0db22ad50e955cdfa0f41df777b049b6179619c.