### PR TITLE
[release-4.10] Bug 2092193: Bump PodDisruptionBudget to v1

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -2,7 +2,7 @@
 
 {{ if not .IsSNO }}
 # The pod disruption budget ensures that we keep a raft quorum
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: ovn-raft-quorum-guard


### PR DESCRIPTION
similar to https://github.com/openshift/cluster-network-operator/pull/1427
Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>