### PR TITLE
Bug 2092495: ovn: use up to 4 northd threads in non-SNO clusters

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -117,6 +117,7 @@ spec:
             --ovnnb-db "{{.OVN_NB_DB_LIST}}" \
             --ovnsb-db "{{.OVN_SB_DB_LIST}}" \
             --pidfile /var/run/ovn/ovn-northd.pid \
+            --n-threads={{.NorthdThreads}} \
             -p /ovn-cert/tls.key \
             -c /ovn-cert/tls.crt \
             -C /ovn-ca/ca-bundle.crt &

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
@@ -87,6 +87,7 @@ spec:
             --ovnnb-db "{{.OVN_NB_DB_LIST}}" \
             --ovnsb-db "{{.OVN_SB_DB_LIST}}" \
             --pidfile /var/run/ovn/ovn-northd.pid \
+            --n-threads={{.NorthdThreads}} \
             -p /ovn-cert/tls.key \
             -c /ovn-cert/tls.crt \
             -C /ovn-ca/ca-bundle.crt &

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -315,8 +315,14 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	renderOVNFlowsConfig(bootstrapResult, &data)
 	if len(bootstrapResult.OVN.MasterAddresses) == 1 {
 		data.Data["IsSNO"] = true
+		data.Data["NorthdThreads"] = 1
 	} else {
 		data.Data["IsSNO"] = false
+		// OVN 22.06 and later support multiple northd threads.
+		// Less resource constrained clusters can use multiple threads
+		// in northd to improve network operation latency at the cost
+		// of a bit of CPU.
+		data.Data["NorthdThreads"] = 4
 	}
 
 	var manifestSubDir string


### PR DESCRIPTION
OVN 22.06 and later support the --n-threads northd option.
Less resource constrained clusters can use up to 4 northd
threads for better network operation latency at the cost
of a bit of extra CPU usage.

@trozet @jcaamano @tssurya @flavio-fernandes 