### PR TITLE
Bug 2090336: Multus should log at a verbose log level (without a logfile)

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -161,8 +161,7 @@ spec:
 {{- end}}
             --cleanup-config-on-exit=true
             --namespace-isolation=true
-            --multus-log-level=debug
-            --multus-log-file=/var/run/multus/cni/net.d/multus.log
+            --multus-log-level=verbose
             --cni-version=0.3.1
             --additional-bin-dir=/opt/multus/bin
             --skip-multus-binary-copy=true


### PR DESCRIPTION
Revert of PR used for debugging purposes.