### PR TITLE
Bug 2093399: Drop Node update permission for ovnkube-node

### DIFF
--- a/bindata/network/ovn-kubernetes/common/002-rbac.yaml
+++ b/bindata/network/ovn-kubernetes/common/002-rbac.yaml
@@ -52,6 +52,7 @@ rules:
 - apiGroups: [""]
   resources:
   - namespaces
+  - nodes
   - endpoints
   - services
   verbs:
@@ -77,15 +78,6 @@ rules:
   - events
   verbs:
   - create
-  - patch
-  - update
-- apiGroups: [""]
-  resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
   - patch
   - update
 - apiGroups: ["k8s.ovn.org"]


### PR DESCRIPTION
[PR#1127](https://github.com/openshift/ovn-kubernetes/pull/1127) remove node tainting used when MTU is too small then we don't need to update/patch node resource
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>