### PR TITLE
[release-4.10] Bug 2095111: ovn: fix northd preStop command handling

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -95,9 +95,9 @@ spec:
           preStop:
             exec:
               command:
-                - OVN_MANAGE_OVSDB=no
-                - /usr/share/ovn/scripts/ovn-ctl
-                - stop_northd
+                - /bin/bash
+                - -c
+                - OVN_MANAGE_OVSDB=no /usr/share/ovn/scripts/ovn-ctl stop_northd
         env:
         - name: OVN_LOG_LEVEL
           value: info 


### PR DESCRIPTION
Need to exec a shell so we can set the environment variable
we need that tells ovn-ctl not to touch the databases when
stopping northd.

(cherry picked from commit 599a9d5060e3e5bb79f93e2f321bc4592dfa7a22)
Backport of https://github.com/openshift/cluster-network-operator/pull/1414