### PR TITLE
Bug 2060079: Enhance sensitivity of SDN alert NodeProxyApplySlow

### DIFF
--- a/bindata/network/openshift-sdn/alert-rules.yaml
+++ b/bindata/network/openshift-sdn/alert-rules.yaml
@@ -40,7 +40,7 @@ spec:
         summary: OpenShift SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node {{"}}"}} is taking too long to update proxy rules for services.
         description: Configuration of proxy rules for Kubernetes services in the node is taking too long and stale endpoints may exist.
       expr: |
-        histogram_quantile(.95, kubeproxy_sync_proxy_rules_duration_seconds_bucket)
+        histogram_quantile(.95, sum(rate(kubeproxy_sync_proxy_rules_duration_seconds_bucket[5m])) by (le, namespace, pod))
         * on(namespace, pod) group_right topk by (namespace, pod) (1, kube_pod_info{namespace="openshift-sdn",  pod=~"sdn-[^-]*"}) > 15
       labels:
         severity: warning


### PR DESCRIPTION
Before this patch, alert NodeProxyApplySlow calculates the 95th
percentile of the _total_ time series
kubeproxy_sync_proxy_rules_duration_seconds and alerts if it is
above 15 seconds.

Because it looks at the total time series, it lacks the ability
to be sensitive to periodic spikes in proxy rules sync latency.

This should merge after code freeze so I do not blow up alerting for 4.11 and it has sufficient soak test time.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>
/cc @danwinship 