### PR TITLE
Bug 2084062: Make northd probe interval default to 10 seconds

### DIFF
--- a/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
@@ -77,7 +77,7 @@ spec:
         - name: OVN_SB_RAFT_ELECTION_TIMER
           value: "16"
         - name: OVN_NORTHD_PROBE_INTERVAL
-          value: "5000"
+          value: "10000"
         - name: OVN_CONTROLLER_INACTIVITY_PROBE
           value: "180000"
         - name: OVN_NB_INACTIVITY_PROBE

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -88,7 +88,7 @@ spec:
         - name: OVN_SB_RAFT_ELECTION_TIMER
           value: "16"
         - name: OVN_NORTHD_PROBE_INTERVAL
-          value: "5000"
+          value: "10000"
         - name: OVN_CONTROLLER_INACTIVITY_PROBE
           value: "180000"
         - name: OVN_NB_INACTIVITY_PROBE


### PR DESCRIPTION
Current probe interval for northd is set to 5 seconds.
The raft election timer is 16 seconds; which is the time
within which leader needs to hear from half its followers.
It doesn't make sense to have northd probe timeout set
less than half the raft election timer. Let's bump it to
10 seconds which is > than 8 seconds.

We had a bug where SBDB polls were 11 seconds and northd
was connecting with an old last-txn-id which was forcing
sbdb to reply with whole db causing the long loops and all
3 northd instances were dropping connection due to timeout
inactivity since sbdb was taking long to respond, as their
probes were set to 5 seconds.

NOTE: Seems like
https://github.com/openshift/cluster-network-operator/pull/1386 didn't
fix anything actually, so doing it correctly this time.