### PR TITLE
Bug 2100079: Update sdn-controller perms for "configmapsleases" leaderelection

### DIFF
--- a/bindata/network/openshift-sdn/003-rbac-controller.yaml
+++ b/bindata/network/openshift-sdn/003-rbac-controller.yaml
@@ -95,6 +95,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups: ["coordination.k8s.io"]
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
 - apiGroups: ["", "events.k8s.io"]
   resources:
   - events


### PR DESCRIPTION
needed for 1.24 rebase (https://github.com/openshift/sdn/pull/440)