### PR TITLE
Bug 2101918: Make the use of the ip-reconciler cronjob opt-in [backport 4.8]

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -455,6 +455,7 @@ spec:
           configMap:
             name: cni-binary-copy-script
             defaultMode: 0744
+{{if .RenderIpReconciler}}
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -501,3 +502,4 @@ spec:
               hostPath:
                 path: {{ .SystemCNIConfDir }}
           restartPolicy: Never
+{{- end}}

--- a/pkg/network/multus.go
+++ b/pkg/network/multus.go
@@ -31,8 +31,9 @@ func renderMultus(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Unstruct
 	}
 	out = append(out, objs...)
 
-	usedhcp := useDHCP(conf)
-	objs, err = renderMultusConfig(manifestDir, string(conf.DefaultNetwork.Type), usedhcp)
+	usedhcp, usewhereabouts := detectAuxiliaryIPAM(conf)
+	objs, err = renderMultusConfig(manifestDir, string(conf.DefaultNetwork.Type), usedhcp, usewhereabouts)
+
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +49,7 @@ func renderMultus(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Unstruct
 }
 
 // renderMultusConfig returns the manifests of Multus
-func renderMultusConfig(manifestDir, defaultNetworkType string, useDHCP bool) ([]*uns.Unstructured, error) {
+func renderMultusConfig(manifestDir, defaultNetworkType string, useDHCP bool, useWhereabouts bool) ([]*uns.Unstructured, error) {
 	objs := []*uns.Unstructured{}
 
 	// render the manifests on disk
@@ -62,6 +63,7 @@ func renderMultusConfig(manifestDir, defaultNetworkType string, useDHCP bool) ([
 	data.Data["KUBERNETES_SERVICE_HOST"] = os.Getenv("KUBERNETES_SERVICE_HOST")
 	data.Data["KUBERNETES_SERVICE_PORT"] = os.Getenv("KUBERNETES_SERVICE_PORT")
 	data.Data["RenderDHCP"] = useDHCP
+	data.Data["RenderIpReconciler"] = useWhereabouts
 	data.Data["MultusCNIConfDir"] = MultusCNIConfDir
 	data.Data["SystemCNIConfDir"] = SystemCNIConfDir
 	data.Data["DefaultNetworkType"] = defaultNetworkType

--- a/pkg/network/multus_ipam_test.go
+++ b/pkg/network/multus_ipam_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-var NoDHCPConfig = operv1.Network{
+var NoIPAMConfig = operv1.Network{
 	Spec: operv1.NetworkSpec{
 		AdditionalNetworks: []operv1.AdditionalNetworkDefinition{
 			{Type: operv1.NetworkTypeRaw, Name: "net-attach-1", RawCNIConfig: "{}"},
@@ -53,7 +53,32 @@ var DHCPConfig = operv1.Network{
 	},
 }
 
-var InvalidDHCPConfig = operv1.Network{
+var WhereaboutsConfig = operv1.Network{
+	Spec: operv1.NetworkSpec{
+		AdditionalNetworks: []operv1.AdditionalNetworkDefinition{
+			{
+				Type:         operv1.NetworkTypeRaw,
+				Name:         "net-attach-whereabouts",
+				RawCNIConfig: "{\"cniVersion\":\"0.3.0\",\"type\":\"macvlan\",\"master\":\"eth0\",\"mode\":\"bridge\",\"ipam\":{\"type\":\"whereabouts\",\"range\": \"192.168.2.225/28\"}}",
+			},
+		},
+		ServiceNetwork: []string{"172.30.0.0/16"},
+		ClusterNetwork: []operv1.ClusterNetworkEntry{
+			{
+				CIDR:       "10.128.0.0/15",
+				HostPrefix: 23,
+			},
+		},
+		DefaultNetwork: operv1.DefaultNetworkDefinition{
+			Type: operv1.NetworkTypeOpenShiftSDN,
+			OpenShiftSDNConfig: &operv1.OpenShiftSDNConfig{
+				Mode: operv1.SDNModeNetworkPolicy,
+			},
+		},
+	},
+}
+
+var InvalidIPAMConfig = operv1.Network{
 	Spec: operv1.NetworkSpec{
 		AdditionalNetworks: []operv1.AdditionalNetworkDefinition{
 			{
@@ -175,30 +200,45 @@ func TestRenderWithDHCP(t *testing.T) {
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "dhcp-daemon")))
 }
 
-// TestRenderNoDHCP tests a rendering WITHOUT the DHCP daemonset.
-func TestRenderNoDHCP(t *testing.T) {
+// TestRenderWithWhereabouts tests a rendering with the ip reconciler
+func TestRenderWithWhereabouts(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	crd := NoDHCPConfig.DeepCopy()
+	crd := WhereaboutsConfig.DeepCopy()
 	config := &crd.Spec
 	FillDefaults(config, nil)
 
 	objs, err := renderMultus(config, manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "dhcp-daemon")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("CronJob", "openshift-multus", "ip-reconciler")))
 }
 
-// TestRenderInvalidDHCP tests a rendering with the DHCP daemonset.
-func TestRenderInvalidDHCP(t *testing.T) {
+// TestRenderNoIPAM tests a rendering WITHOUT an IPAM configured.
+func TestRenderNoIPAM(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	crd := InvalidDHCPConfig.DeepCopy()
+	crd := NoIPAMConfig.DeepCopy()
 	config := &crd.Spec
 	FillDefaults(config, nil)
 
 	objs, err := renderMultus(config, manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "dhcp-daemon")))
+	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("CronJob", "openshift-multus", "ip-reconciler")))
+}
+
+// TestRenderInvalidIPAMConfig tests a rendering without auxiliary IPAM, due to an invalid IPAM configuration.
+func TestRenderInvalidIPAMConfig(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	crd := InvalidIPAMConfig.DeepCopy()
+	config := &crd.Spec
+	FillDefaults(config, nil)
+
+	objs, err := renderMultus(config, manifestDir)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "dhcp-daemon")))
+	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("CronJob", "openshift-multus", "ip-reconciler")))
 }
 
 // TestRenderWithDHCPSimpleMacvlan tests a rendering with the DHCP daemonset SimpleMacvlan.

--- a/pkg/network/multus_test.go
+++ b/pkg/network/multus_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	operv1 "github.com/openshift/api/operator/v1"
-	"github.com/openshift/cluster-network-operator/pkg/apply"
 
 	. "github.com/onsi/gomega"
 )
@@ -50,27 +49,11 @@ func TestRenderMultus(t *testing.T) {
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "multus")))
 
 	// It's important that the namespace is first
-	g.Expect(len(objs)).To(Equal(23), "Expected 23 multus related objects")
+	g.Expect(len(objs)).To(Equal(22), "Expected 22 multus related objects")
 	g.Expect(objs[0]).To(HaveKubernetesID("CustomResourceDefinition", "", "network-attachment-definitions.k8s.cni.cncf.io"))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("Namespace", "", "openshift-multus")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "multus")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ServiceAccount", "openshift-multus", "multus")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRoleBinding", "", "multus")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "multus")))
-	g.Expect(objs).To(ContainElement(HaveKubernetesID("CronJob", "openshift-multus", "ip-reconciler")))
-
-	// Make sure every obj is reasonable:
-	// - it is supported
-	// - it reconciles to itself (steady state)
-	for _, obj := range objs {
-		g.Expect(apply.IsObjectSupported(obj)).NotTo(HaveOccurred())
-		cur := obj.DeepCopy()
-		upd := obj.DeepCopy()
-
-		err = apply.MergeObjectForUpdate(cur, upd)
-		g.Expect(err).NotTo(HaveOccurred())
-
-		tweakMetaForCompare(cur)
-		g.Expect(cur).To(Equal(upd))
-	}
 }

--- a/pkg/network/network_metrics_test.go
+++ b/pkg/network/network_metrics_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/gomega"
 	operv1 "github.com/openshift/api/operator/v1"
-	"github.com/openshift/cluster-network-operator/pkg/apply"
 )
 
 var NetworkMetricsDaemonConfig = operv1.Network{
@@ -50,7 +49,7 @@ func TestRenderNetworkMetricsDaemon(t *testing.T) {
 
 	// Check rendered object
 
-	g.Expect(len(objs)).To(Equal(23), "Expected 23 multus related objects")
+	g.Expect(len(objs)).To(Equal(22), "Expected 22 multus related objects")
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "network-metrics-daemon")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("Service", "openshift-multus", "network-metrics-service")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "metrics-daemon-role")))
@@ -58,20 +57,4 @@ func TestRenderNetworkMetricsDaemon(t *testing.T) {
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ServiceMonitor", "openshift-multus", "monitor-network")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("Role", "openshift-multus", "prometheus-k8s")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("RoleBinding", "openshift-multus", "prometheus-k8s")))
-	g.Expect(objs).To(ContainElement(HaveKubernetesID("CronJob", "openshift-multus", "ip-reconciler")))
-
-	// Make sure every obj is reasonable:
-	// - it is supported
-	// - it reconciles to itself (steady state)
-	for _, obj := range objs {
-		g.Expect(apply.IsObjectSupported(obj)).NotTo(HaveOccurred())
-		cur := obj.DeepCopy()
-		upd := obj.DeepCopy()
-
-		err = apply.MergeObjectForUpdate(cur, upd)
-		g.Expect(err).NotTo(HaveOccurred())
-
-		tweakMetaForCompare(cur)
-		g.Expect(cur).To(Equal(upd))
-	}
 }


### PR DESCRIPTION
…by detecting IPAM type usage.

This refactors the dhcp_daemon.go to make the methods generic for use for other IPAM types.

It extends the same concept for DHCP daemon for use with Whereabouts in order to conditionally template the ip-reconciler cronjob.