### PR TITLE
Bug 1894268: Allow users to specify ovnkube join subnet

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/004-config.yaml
@@ -35,6 +35,12 @@ data:
     [gateway]
     mode={{.OVN_GATEWAY_MODE}}
     nodeport=true
+{{- if (index . "V4JoinSubnet") }}
+    v4-join-subnet="{{.V4JoinSubnet}}"
+{{- end }}
+{{- if (index . "V6JoinSubnet") }}
+    v6-join-subnet="{{.V6JoinSubnet}}"
+{{- end }}
 {{- if .OVNHybridOverlayEnable }}
 
     [hybridoverlay]

--- a/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
@@ -38,6 +38,12 @@ data:
     [gateway]
     mode={{.OVN_GATEWAY_MODE}}
     nodeport=true
+{{- if (index . "V4JoinSubnet") }}
+    v4-join-subnet="{{.V4JoinSubnet}}"
+{{- end }}
+{{- if (index . "V6JoinSubnet") }}
+    v6-join-subnet="{{.V6JoinSubnet}}"
+{{- end }}
 {{- if .OVNHybridOverlayEnable }}
 
     [hybridoverlay]


### PR DESCRIPTION
Some users need to be able to specify the v4 and v6 join subnets
to use for ovn-k. In particular, they may be already using the
ones that ovn-k uses as default, and they need a way to be able to
specify a different set of subnets as join subnets. This commit
creates the config option for the same. Eventually this will be
consumed by the CNO using rendered bootstrap data and passed to the
ovn-k daemonsets.

Signed-off-by: Peng Liu <pliu@redhat.com>