### PR TITLE
Bug 2103680: Revert "controller/clusterconfig: Take advantage of patch."

### DIFF
--- a/pkg/controller/clusterconfig/clusterconfig_controller.go
+++ b/pkg/controller/clusterconfig/clusterconfig_controller.go
@@ -6,7 +6,6 @@ import (
 	"log"
 
 	configv1 "github.com/openshift/api/config/v1"
-	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/apply"
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 	"github.com/openshift/cluster-network-operator/pkg/controller/statusmanager"
@@ -14,7 +13,6 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/network"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -96,21 +94,22 @@ func (r *ReconcileClusterConfig) Reconcile(ctx context.Context, request reconcil
 		return reconcile.Result{}, err
 	}
 
-	// Generate a stub operator config and patch it in
-	// This will cause only the fields we change to be set.
-	operConfig := &operv1.Network{
-		TypeMeta:   metav1.TypeMeta{APIVersion: operv1.GroupVersion.String(), Kind: "Network"},
-		ObjectMeta: metav1.ObjectMeta{Name: names.OPERATOR_CONFIG},
+	operatorConfig, err := r.UpdateOperatorConfig(ctx, *clusterConfig)
+	if err != nil {
+		log.Printf("Failed to generate NetworkConfig CRD: %v", err)
+		r.status.SetDegraded(statusmanager.ClusterConfig, "UpdateOperatorConfig",
+			fmt.Sprintf("Internal error while converting cluster configuration: %v", err))
+		return reconcile.Result{}, err
 	}
-	network.MergeClusterConfig(&operConfig.Spec, clusterConfig.Spec)
 
-	if err := apply.ApplyObject(ctx, r.client, operConfig, "clusterconfig"); err != nil {
-		r.status.SetDegraded(statusmanager.ClusterConfig, "ApplyOperatorConfig",
-			fmt.Sprintf("Error while trying to update operator configuration: %v", err))
-		log.Printf("Could not propagate configuration from network.config.openshift.io to network.operator.openshift.io: %v", err)
-		return reconcile.Result{}, fmt.Errorf("could not apply updated operator configuration: %w", err)
+	if operatorConfig != nil {
+		if err := apply.ApplyObject(ctx, r.client, operatorConfig, "clusterconfig"); err != nil {
+			log.Printf("Could not apply operator config: %v", err)
+			r.status.SetDegraded(statusmanager.ClusterConfig, "ApplyOperatorConfig",
+				fmt.Sprintf("Error while trying to update operator configuration: %v", err))
+			return reconcile.Result{}, err
+		}
 	}
-	log.Println("Successfully updated Operator config from Cluster config")
 
 	r.status.SetNotDegraded(statusmanager.ClusterConfig)
 	return reconcile.Result{}, nil

--- a/pkg/controller/clusterconfig/config.go
+++ b/pkg/controller/clusterconfig/config.go
@@ -1,0 +1,46 @@
+package clusterconfig
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/pkg/errors"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/cluster-network-operator/pkg/names"
+	"github.com/openshift/cluster-network-operator/pkg/network"
+	k8sutil "github.com/openshift/cluster-network-operator/pkg/util/k8s"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// UpdateOperatorConfig merges the cluster network configuration in to the
+// operator configuration.
+// The operator's CRD is necessarily much more complicated, and 99% of users
+// will not need to create or touch it. So, they can touch the Network config.
+// Any changes in the cluster config will be noticed by the operator and merged
+// in to the operator CRD.
+// This returns nil if no changes have been detected.
+func (r *ReconcileClusterConfig) UpdateOperatorConfig(ctx context.Context, clusterConfig configv1.Network) (*uns.Unstructured, error) {
+	operConfig := &operv1.Network{
+		TypeMeta:   metav1.TypeMeta{APIVersion: operv1.GroupVersion.String(), Kind: "Network"},
+		ObjectMeta: metav1.ObjectMeta{Name: names.OPERATOR_CONFIG},
+	}
+
+	err := r.client.Default().CRClient().Get(ctx, types.NamespacedName{Name: names.OPERATOR_CONFIG}, operConfig)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, errors.Wrapf(err, "could not retrieve Network.operator.openshift.io/v1 %s", names.OPERATOR_CONFIG)
+	}
+
+	newOperConfig := operConfig.DeepCopy()
+	network.MergeClusterConfig(&newOperConfig.Spec, clusterConfig.Spec)
+	if reflect.DeepEqual(newOperConfig.Spec, operConfig.Spec) {
+		return nil, nil
+	}
+
+	return k8sutil.ToUnstructured(newOperConfig)
+}


### PR DESCRIPTION
`DisableNetworkDiagnostics` is a bool variable(not a pointer) which means we were always setting it to false.

Revert `b2cf367fd3c8c3e676808e386c826f0abae1dbf6` for now, I think we might need to update the API and deprecate `DisableNetworkDiagnostics` field for something new that can be unset.
 
This reverts commit b2cf367fd3c8c3e676808e386c826f0abae1dbf6.