### PR TITLE
Bug 2108232: Revert "Bug 2085089: Pass enable-udp-aggregation=true to ovn-kubernetes"

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/004-config.yaml
@@ -16,7 +16,6 @@ data:
     encap-port="{{.GenevePort}}"
     enable-lflow-cache=true
     lflow-cache-limit-kb=1048576
-    enable-udp-aggregation=true
 
     [kubernetes]
     service-cidrs="{{.OVN_service_cidr}}"

--- a/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
@@ -16,7 +16,6 @@ data:
     encap-port="{{.GenevePort}}"
     enable-lflow-cache=true
     lflow-cache-limit-kb=1048576
-    enable-udp-aggregation=true
 
     [kubernetes]
     service-cidrs="{{.OVN_service_cidr}}"

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -239,7 +239,6 @@ cluster-subnets="10.128.0.0/15/23,10.0.0.0/14/24"
 encap-port="8061"
 enable-lflow-cache=true
 lflow-cache-limit-kb=1048576
-enable-udp-aggregation=true
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -284,7 +283,6 @@ cluster-subnets="10.128.0.0/15/23,10.0.0.0/14/24"
 encap-port="8061"
 enable-lflow-cache=true
 lflow-cache-limit-kb=1048576
-enable-udp-aggregation=true
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -171,7 +171,6 @@ cluster-subnets="10.128.0.0/15/23,10.0.0.0/14/24"
 encap-port="8061"
 enable-lflow-cache=true
 lflow-cache-limit-kb=1048576
-enable-udp-aggregation=true
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -199,7 +198,6 @@ cluster-subnets="10.128.0.0/15/23,10.0.0.0/14/24"
 encap-port="8061"
 enable-lflow-cache=true
 lflow-cache-limit-kb=1048576
-enable-udp-aggregation=true
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -331,7 +329,6 @@ cluster-subnets="10.128.0.0/15/23,10.0.0.0/14/24"
 encap-port="8061"
 enable-lflow-cache=true
 lflow-cache-limit-kb=1048576
-enable-udp-aggregation=true
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -375,7 +372,6 @@ cluster-subnets="10.128.0.0/15/23,10.0.0.0/14/24"
 encap-port="8061"
 enable-lflow-cache=true
 lflow-cache-limit-kb=1048576
-enable-udp-aggregation=true
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -409,7 +405,6 @@ cluster-subnets="10.128.0.0/15/23,10.0.0.0/14/24"
 encap-port="8061"
 enable-lflow-cache=true
 lflow-cache-limit-kb=1048576
-enable-udp-aggregation=true
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"


### PR DESCRIPTION
Reverts openshift/cluster-network-operator#1489 since this causes a performance regression.