### PR TITLE
Add configmap list/watch rights to cloud-network-config-controller

### DIFF
--- a/bindata/cloud-network-config-controller/002-rbac.yaml
+++ b/bindata/cloud-network-config-controller/002-rbac.yaml
@@ -45,6 +45,8 @@ rules:
   - configmaps
   verbs:
   - get
+  - list
+  - watch
   - create
   - update
   - patch


### PR DESCRIPTION
    The OpenStack CNCC provider plugin requires a ConfigMap that provides
    an additional CA certificate. The CNCC must monitor ConfigMaps in its
    namespace for changes. Add list/watch rights to the CNCC ServiceAccount
    for the CNCC namespace.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>