### PR TITLE
The Multus admission controller should run as a deployment

### DIFF
--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -1,5 +1,5 @@
 ---
-kind: DaemonSet
+kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: multus-admission-controller
@@ -8,16 +8,15 @@ metadata:
     app: multus-admission-controller
   annotations:
     kubernetes.io/description: |
-      This daemon set launches the Multus admisson controller component on each node.
+      This deployment launches the Multus admisson controller component.
     release.openshift.io/version: "{{.ReleaseVersion}}"
     networkoperator.openshift.io/non-critical: ""
 spec:
+  replicas: 2
   selector:
     matchLabels:
       app: multus-admission-controller
       namespace: openshift-multus
-  updateStrategy:
-    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/pkg/network/multus_admission_controller_test.go
+++ b/pkg/network/multus_admission_controller_test.go
@@ -39,14 +39,14 @@ func TestRenderMultusAdmissionController(t *testing.T) {
 	// disable MultusAdmissionController
 	objs, err := renderMultusAdmissionController(config, manifestDir, false)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "multus-admission-controller")))
+	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("Deployment", "openshift-multus", "multus-admission-controller")))
 
 	// enable MultusAdmissionController
 	enabled := false
 	config.DisableMultiNetwork = &enabled
 	objs, err = renderMultusAdmissionController(config, manifestDir, false)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "multus-admission-controller")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("Deployment", "openshift-multus", "multus-admission-controller")))
 
 	// Check rendered object
 	g.Expect(len(objs)).To(Equal(9))
@@ -54,5 +54,5 @@ func TestRenderMultusAdmissionController(t *testing.T) {
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "multus-admission-controller-webhook")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRoleBinding", "", "multus-admission-controller-webhook")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ValidatingWebhookConfiguration", "", names.MULTUS_VALIDATING_WEBHOOK)))
-	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "multus-admission-controller")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("Deployment", "openshift-multus", "multus-admission-controller")))
 }


### PR DESCRIPTION
It's been running as a daemonset that will run on all masters, however, this isn't necessary, especially in large clusters. This causes some additional apiserver traffic when nodes are rebooted as well.

The intent here is to run two instances for redundancy.