### PR TITLE
Multus admission controller changes for hypershift

### DIFF
--- a/bindata/network/multus-admission-controller/001-service.yaml
+++ b/bindata/network/multus-admission-controller/001-service.yaml
@@ -3,10 +3,13 @@ apiVersion: v1
 kind: Service
 metadata:
   name: multus-admission-controller
-  namespace: openshift-multus
+  namespace: {{.AdmissionControllerNamespace}}
   labels:
     app: multus-admission-controller
   annotations:
+{{- if .HyperShiftEnabled}}
+    network.operator.openshift.io/cluster-name: {{.ManagementClusterName}}
+{{- end }}
     service.alpha.openshift.io/serving-cert-secret-name: multus-admission-controller-secret
 spec:
   ports:

--- a/bindata/network/multus-admission-controller/002-rbac.yaml
+++ b/bindata/network/multus-admission-controller/002-rbac.yaml
@@ -1,4 +1,10 @@
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: multus-ac
+  namespace: openshift-multus
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -27,5 +33,5 @@ roleRef:
   name: multus-admission-controller-webhook
 subjects:
 - kind: ServiceAccount
-  name: multus
+  name: multus-ac
   namespace: openshift-multus

--- a/bindata/network/multus-admission-controller/003-webhook.yaml
+++ b/bindata/network/multus-admission-controller/003-webhook.yaml
@@ -5,15 +5,23 @@ metadata:
   name: {{.MultusValidatingWebhookName}}
   labels:
     app: multus-admission-controller
+{{- if not .HyperShiftEnabled}}
+# Webhook cannot use the injected CA bundle in hypershift since the endpoint runs in the management cluster
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"
+{{- end }}
 webhooks:
   - name: multus-validating-config.k8s.io
     clientConfig:
+{{- if .HyperShiftEnabled}}
+      url: "https://multus-admission-controller.{{.AdmissionControllerNamespace}}.svc/validate"
+      caBundle: {{.ManagementServiceCABundle}}
+{{ else }}
       service:
         name: multus-admission-controller
-        namespace: openshift-multus
+        namespace: {{.AdmissionControllerNamespace}}
         path: "/validate"
+{{- end }}
     rules:
       - operations: [ "CREATE", "UPDATE" ]
         apiGroups: ["k8s.cni.cncf.io"]

--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: multus-admission-controller
-  namespace: openshift-multus
+  namespace: {{.AdmissionControllerNamespace}}
   labels:
     app: multus-admission-controller
   annotations:
@@ -11,24 +11,74 @@ metadata:
       This deployment launches the Multus admisson controller component.
     release.openshift.io/version: "{{.ReleaseVersion}}"
     networkoperator.openshift.io/non-critical: ""
+{{- if .HyperShiftEnabled}}
+    network.operator.openshift.io/cluster-name:  {{.ManagementClusterName}}
+{{- end }}
 spec:
   replicas: {{.Replicas}}
   selector:
     matchLabels:
       app: multus-admission-controller
-      namespace: openshift-multus
+      namespace: {{.AdmissionControllerNamespace}}
   template:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: multus-admission-controller
-        namespace: openshift-multus
+        namespace: {{.AdmissionControllerNamespace}}
         component: network
         type: infra
         openshift.io/component: network
     spec:
+{{- if .HyperShiftEnabled}}
+      initContainers:
+        - name: hosted-cluster-kubecfg-setup
+          image: "{{.CLIImage}}"
+          command:
+            - /bin/bash
+            - -c
+            - |
+              kc=/var/run/secrets/hosted_cluster/kubeconfig
+              kubectl --kubeconfig $kc config set clusters.default.server "https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}"
+              kubectl --kubeconfig $kc config set clusters.default.certificate-authority /hosted-ca/ca.crt
+              kubectl --kubeconfig $kc config set users.admin.tokenFile /var/run/secrets/hosted_cluster/token
+              kubectl --kubeconfig $kc config set contexts.default.cluster default
+              kubectl --kubeconfig $kc config set contexts.default.user admin
+              kubectl --kubeconfig $kc config set contexts.default.namespace openshift-multus
+              kubectl --kubeconfig $kc config use-context default
+          volumeMounts:
+            - mountPath: /var/run/secrets/hosted_cluster
+              name: hosted-cluster-api-access
+          env:
+            - name: KUBERNETES_SERVICE_PORT
+              value: "{{.KubernetesServicePort}}"
+            - name: KUBERNETES_SERVICE_HOST
+              value: "{{.KubernetesServiceHost}}"
+{{- end }}
       containers:
+{{- if .HyperShiftEnabled}}
+      # hosted-cluster-token creates a token with a custom path(/var/run/secrets/hosted_cluster/token)
+      # The token path is included in the kubeconfig used by webhook container to talk to the hosted clusters API server
+      - name: hosted-cluster-token
+        image: "{{.TokenMinterImage}}"
+        command: [ "/usr/bin/control-plane-operator", "token-minter" ]
+        args:
+          - --service-account-namespace=openshift-multus
+          - --service-account-name=multus-ac
+          - --token-audience={{.TokenAudience}}
+          - --token-file=/var/run/secrets/hosted_cluster/token
+          - --kubeconfig=/etc/kubernetes/kubeconfig
+        resources:
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        volumeMounts:
+          - mountPath: /etc/kubernetes
+            name: admin-kubeconfig
+          - mountPath: /var/run/secrets/hosted_cluster
+            name: hosted-cluster-api-access
+{{- end }}
       - name: multus-admission-controller
         image: {{.MultusAdmissionControllerImage}}
         command:
@@ -45,6 +95,16 @@ spec:
         - name: webhook-certs
           mountPath: /etc/webhook
           readOnly: True
+{{- if .HyperShiftEnabled}}
+        - mountPath: /var/run/secrets/hosted_cluster
+          name: hosted-cluster-api-access
+        - mountPath: /hosted-ca
+          name: hosted-ca-cert
+          readOnly: True
+        env:
+          - name: KUBECONFIG
+            value: "/var/run/secrets/hosted_cluster/kubeconfig"
+{{- end }}
         imagePullPolicy: IfNotPresent
         resources:
           requests:
@@ -74,10 +134,12 @@ spec:
         - name: webhook-certs
           mountPath: /etc/webhook
           readOnly: True
+{{- if not .HyperShiftEnabled}}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
-      serviceAccountName: multus
+      serviceAccountName: multus-ac
+{{- end }}
       priorityClassName: "system-cluster-critical"
       restartPolicy: Always
 {{- if not .ExternalControlPlane }}
@@ -88,6 +150,19 @@ spec:
       - name: webhook-certs
         secret:
           secretName: multus-admission-controller-secret
+{{- if .HyperShiftEnabled}}
+      - name: hosted-cluster-api-access
+        emptyDir: {}
+      - name: hosted-ca-cert
+        secret:
+          secretName: root-ca
+          items:
+            - key: ca.crt
+              path: ca.crt
+      - name: admin-kubeconfig
+        secret:
+          secretName: service-network-admin-kubeconfig
+{{- end }}
       tolerations:
       - key: "node-role.kubernetes.io/master"
         operator: Exists

--- a/bindata/network/multus-admission-controller/monitor.yaml
+++ b/bindata/network/multus-admission-controller/monitor.yaml
@@ -6,30 +6,53 @@ metadata:
     name: monitor-multus-admission-controller
   annotations:
     networkoperator.openshift.io/ignore-errors: ""
+{{- if .HyperShiftEnabled}}
+    network.operator.openshift.io/cluster-name:  {{.ManagementClusterName}}
+{{- end }}
   name: monitor-multus-admission-controller
-  namespace: openshift-multus
+  namespace: {{.AdmissionControllerNamespace}}
 spec:
   endpoints:
   - interval: 30s
     port: metrics
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     scheme: 'https'
+{{- if .HyperShiftEnabled}}
+    bearerTokenSecret:
+      key: ""
+    tlsConfig:
+      ca:
+        configMap:
+          key: service-ca.crt
+          name: openshift-service-ca.crt
+      cert:
+        secret:
+          key: tls.crt
+          name: multus-admission-controller-secret
+      keySecret:
+        key: tls.key
+        name: multus-admission-controller-secret
+      serverName: multus-admission-controller.{{.AdmissionControllerNamespace}}.svc
+{{ else }}
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: multus-admission-controller.openshift-multus.svc
+      serverName: multus-admission-controller.{{.AdmissionControllerNamespace}}.svc
+{{- end }}
+
   jobLabel: app
   namespaceSelector:
     matchNames:
-    - openshift-multus
+    - {{.AdmissionControllerNamespace}}
   selector:
     matchLabels:
-       app: multus-admission-controller
+      app: multus-admission-controller
+{{- if not .HyperShiftEnabled}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: prometheus-k8s
-  namespace: openshift-multus
+  namespace: {{.AdmissionControllerNamespace}}
 rules:
 - apiGroups:
   - ""
@@ -46,7 +69,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: prometheus-k8s
-  namespace: openshift-multus
+  namespace: {{.AdmissionControllerNamespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -55,3 +78,4 @@ subjects:
 - kind: ServiceAccount
   name: prometheus-k8s
   namespace: openshift-monitoring
+{{- end }}

--- a/bindata/network/multus-admission-controller/rules.yaml
+++ b/bindata/network/multus-admission-controller/rules.yaml
@@ -6,8 +6,11 @@ metadata:
     role: alert-rules
   annotations:
     networkoperator.openshift.io/ignore-errors: ""
+{{- if .HyperShiftEnabled}}
+    network.operator.openshift.io/cluster-name:  {{.ManagementClusterName}}
+{{- end }}
   name: prometheus-k8s-rules
-  namespace: openshift-multus
+  namespace: {{.AdmissionControllerNamespace}}
 spec:
   groups:
   - name: multus-admission-controller-monitor-service.rules
@@ -16,6 +19,5 @@ spec:
         max  (network_attachment_definition_enabled_instance_up) by (networks)
       record: cluster:network_attachment_definition_enabled_instance_up:max
     - expr: |
-       max  (network_attachment_definition_instances) by (networks)
+        max  (network_attachment_definition_instances) by (networks)
       record: cluster:network_attachment_definition_instances:max
-  

--- a/cmd/cluster-network-operator/main.go
+++ b/cmd/cluster-network-operator/main.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 	"log"
 	"math/rand"
 	"net/url"
 	"os"
 	"time"
 
+	"github.com/openshift/cluster-network-operator/pkg/names"
 	"github.com/openshift/cluster-network-operator/pkg/operator"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/spf13/cobra"
@@ -90,7 +90,7 @@ which is a kubeconfig from which to take just the URL to the apiserver`,
 	cmd2.Use = "start"
 	cmd2.Short = "Start the cluster network operator"
 	extraClusters = cmd2.Flags().StringToString("extra-clusters", nil, "extra clusters, pairs of cluster name and kubeconfig path")
-	inClusterClientName = cmd2.Flags().String("in-cluster-client-name", cnoclient.DefaultClusterName, "client name for in-cluster config(service account or kubeconfig)")
+	inClusterClientName = cmd2.Flags().String("in-cluster-client-name", names.DefaultClusterName, "client name for in-cluster config(service account or kubeconfig)")
 	cmd.AddCommand(cmd2)
 
 	cmd.AddCommand(newMTUProberCommand())

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/openshift/cluster-network-operator/pkg/names"
 	"github.com/openshift/cluster-network-operator/pkg/util/k8s"
 	clientConfig "github.com/openshift/library-go/pkg/config/client"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -34,9 +35,7 @@ import (
 )
 
 const (
-	defaultResyncPeriod   = 5 * time.Minute
-	DefaultClusterName    = "default"
-	ManagementClusterName = "management"
+	defaultResyncPeriod = 5 * time.Minute
 )
 
 func init() {
@@ -138,7 +137,7 @@ func (c *OperatorClient) ClientFor(name string) ClusterClient {
 }
 
 func (c *OperatorClient) Default() ClusterClient {
-	return c.clusterClients[DefaultClusterName]
+	return c.clusterClients[names.DefaultClusterName]
 }
 
 func (c *OperatorClient) Start(ctx context.Context) error {

--- a/pkg/client/fake/fake_client.go
+++ b/pkg/client/fake/fake_client.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/klog/v2"
 
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
+	"github.com/openshift/cluster-network-operator/pkg/names"
 
 	osoperclient "github.com/openshift/client-go/operator/clientset/versioned"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
@@ -49,7 +50,7 @@ func (fc *FakeClient) ClientFor(name string) cnoclient.ClusterClient {
 }
 
 func (fc *FakeClient) Default() cnoclient.ClusterClient {
-	return fc.ClientFor(cnoclient.DefaultClusterName)
+	return fc.ClientFor(names.DefaultClusterName)
 }
 
 func (fc *FakeClient) Start(context.Context) error {
@@ -100,7 +101,7 @@ func NewFakeClient(objs ...crclient.Object) cnoclient.Client {
 
 	return &FakeClient{
 		clusterClients: map[string]*FakeClusterClient{
-			cnoclient.DefaultClusterName: &fc,
+			names.DefaultClusterName: &fc,
 		},
 	}
 }

--- a/pkg/controller/statusmanager/pod_watcher.go
+++ b/pkg/controller/statusmanager/pod_watcher.go
@@ -3,7 +3,7 @@ package statusmanager
 import (
 	"context"
 
-	"github.com/openshift/cluster-network-operator/pkg/client"
+	"github.com/openshift/cluster-network-operator/pkg/names"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -79,7 +79,7 @@ func (s *StatusManager) AddPodWatcher(mgr manager.Manager) error {
 
 	// If Hypershift is enable, also watch that single namespace
 	if s.hyperShiftConfig.Enabled {
-		s.initInformersFor(client.ManagementClusterName, s.hyperShiftConfig.Namespace, true)
+		s.initInformersFor(names.ManagementClusterName, s.hyperShiftConfig.Namespace, true)
 	}
 
 	pw := &PodWatcher{

--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -266,7 +266,7 @@ func (status *StatusManager) writeHypershiftStatus(operStatus *operv1.NetworkSta
 	}
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		hcp := &hyperv1.HostedControlPlane{ObjectMeta: metav1.ObjectMeta{Name: status.hyperShiftConfig.Name}}
-		err := status.client.ClientFor(cnoclient.ManagementClusterName).CRClient().Get(
+		err := status.client.ClientFor(names.ManagementClusterName).CRClient().Get(
 			context.TODO(), types.NamespacedName{Namespace: status.hyperShiftConfig.Namespace, Name: status.hyperShiftConfig.Name}, hcp)
 		if err != nil {
 			if errors.IsNotFound(err) {
@@ -310,7 +310,7 @@ func (status *StatusManager) writeHypershiftStatus(operStatus *operv1.NetworkSta
 			buf = []byte(fmt.Sprintf("(failed to convert to YAML: %s)", err))
 		}
 
-		if err := status.client.ClientFor(cnoclient.ManagementClusterName).CRClient().Status().Update(context.TODO(), hcp); err != nil {
+		if err := status.client.ClientFor(names.ManagementClusterName).CRClient().Status().Update(context.TODO(), hcp); err != nil {
 			return err
 		}
 		log.Printf("Set HostedControlPlane conditions:\n%s", buf)

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -160,3 +160,9 @@ const IPFamilyDualStack = "dual-stack"
 // of the apiserver, but only for rendered manifests. CNO itself will not use it
 const EnvApiOverrideHost = "APISERVER_OVERRIDE_HOST"
 const EnvApiOverridePort = "APISERVER_OVERRIDE_PORT"
+
+// ManagementClusterName provides the name of the management cluster, for use with Hypershift.
+const ManagementClusterName = "management"
+
+// DefaultClusterName provides the name of the default cluster, for use with Hypershift (or non-Hypershift)
+const DefaultClusterName = "default"

--- a/pkg/network/cloud_network.go
+++ b/pkg/network/cloud_network.go
@@ -1,10 +1,10 @@
 package network
 
 import (
-	"github.com/openshift/cluster-network-operator/pkg/client"
-	"github.com/openshift/cluster-network-operator/pkg/names"
 	"os"
 	"path/filepath"
+
+	"github.com/openshift/cluster-network-operator/pkg/names"
 
 	"github.com/pkg/errors"
 
@@ -86,12 +86,12 @@ func renderCloudNetworkConfigController(conf *operv1.NetworkSpec, bootstrapResul
 		data.Data["CLIImage"] = os.Getenv("CLI_IMAGE")
 		data.Data["TokenMinterImage"] = os.Getenv("TOKEN_MINTER_IMAGE")
 		data.Data["TokenAudience"] = os.Getenv("TOKEN_AUDIENCE")
-		data.Data["ManagementClusterName"] = client.ManagementClusterName
+		data.Data["ManagementClusterName"] = names.ManagementClusterName
 		data.Data["HostedClusterNamespace"] = hcpCfg.Namespace
 		caOverride.ObjectMeta = metav1.ObjectMeta{
 			Namespace:   hcpCfg.Namespace,
 			Name:        "cloud-network-config-controller-kube-cloud-config",
-			Annotations: map[string]string{names.ClusterNameAnnotation: client.ManagementClusterName},
+			Annotations: map[string]string{names.ClusterNameAnnotation: names.ManagementClusterName},
 		}
 		manifestDirs = append(manifestDirs, filepath.Join(manifestDir, "cloud-network-config-controller/managed"))
 	} else {

--- a/pkg/network/multus_admission_controller_test.go
+++ b/pkg/network/multus_admission_controller_test.go
@@ -7,9 +7,9 @@ import (
 	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/names"
 
+	cnofake "github.com/openshift/cluster-network-operator/pkg/client/fake"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
 )
 
 var MultusAdmissionControllerConfig = operv1.Network{
@@ -40,7 +40,7 @@ func TestRenderMultusAdmissionController(t *testing.T) {
 	config.DisableMultiNetwork = &disabled
 	fillDefaults(config, nil)
 
-	fakeClient := fake.NewSimpleClientset(
+	fakeClient := cnofake.NewFakeClient(
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test1-ignored",
@@ -76,7 +76,7 @@ func TestRenderMultusAdmissionController(t *testing.T) {
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("Deployment", "openshift-multus", "multus-admission-controller")))
 
 	// Check rendered object
-	g.Expect(len(objs)).To(Equal(9))
+	g.Expect(len(objs)).To(Equal(10))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("Service", "openshift-multus", "multus-admission-controller")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "multus-admission-controller-webhook")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRoleBinding", "", "multus-admission-controller-webhook")))
@@ -88,7 +88,7 @@ func TestRenderMultusAdmissionController(t *testing.T) {
 func TestRenderMultusAdmissionControllerGetNamespace(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	fakeClient := fake.NewSimpleClientset(
+	fakeClient := cnofake.NewFakeClient(
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test1-ignored",

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -18,7 +18,6 @@ import (
 	iputil "github.com/openshift/cluster-network-operator/pkg/util/ip"
 
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/client-go/kubernetes"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -45,7 +44,7 @@ func Render(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapResult
 
 	// render MultusAdmissionController
 	o, err = renderMultusAdmissionController(conf, manifestDir,
-		bootstrapResult.Infra.ControlPlaneTopology == configv1.ExternalTopologyMode, bootstrapResult, client.Default().Kubernetes())
+		bootstrapResult.Infra.ControlPlaneTopology == configv1.ExternalTopologyMode, bootstrapResult, client)
 	if err != nil {
 		return nil, progressing, err
 	}
@@ -649,7 +648,7 @@ func getMultusAdmissionControllerReplicas(bootstrapResult *bootstrap.BootstrapRe
 }
 
 // renderMultusAdmissionController generates the manifests of Multus Admission Controller
-func renderMultusAdmissionController(conf *operv1.NetworkSpec, manifestDir string, externalControlPlane bool, bootstrapResult *bootstrap.BootstrapResult, client kubernetes.Interface) ([]*uns.Unstructured, error) {
+func renderMultusAdmissionController(conf *operv1.NetworkSpec, manifestDir string, externalControlPlane bool, bootstrapResult *bootstrap.BootstrapResult, client cnoclient.Client) ([]*uns.Unstructured, error) {
 	if *conf.DisableMultiNetwork {
 		return nil, nil
 	}
@@ -658,7 +657,7 @@ func renderMultusAdmissionController(conf *operv1.NetworkSpec, manifestDir strin
 	out := []*uns.Unstructured{}
 
 	objs, err := renderMultusAdmissonControllerConfig(manifestDir, externalControlPlane,
-		getMultusAdmissionControllerReplicas(bootstrapResult), client)
+		bootstrapResult, client)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The multus admission controller should run on the management cluster for hypershift

This applies the appropriate label for network.operator.openshift.io/cluster-name

Additionally, it also moves the default and hypershift cluster names to the names package, instead of as constants in the client package.