### PR TITLE
Add controller to synchronize the API and Ingress VIP fields

### DIFF
--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -34,7 +34,7 @@ func GetClusterName(obj Object) string {
 // This causes fields we own to be updated, and fields we don't own to be preserved.
 // For more information, see https://kubernetes.io/docs/reference/using-api/server-side-apply/
 // The subcontroller, if set, is used to assign field ownership.
-func ApplyObject(ctx context.Context, client cnoclient.Client, obj Object, subcontroller string) error {
+func ApplyObject(ctx context.Context, client cnoclient.Client, obj Object, subcontroller string, subresources ...string) error {
 	name := obj.GetName()
 	namespace := obj.GetNamespace()
 	clusterClient := client.ClientFor(GetClusterName(obj))
@@ -122,7 +122,7 @@ func ApplyObject(ctx context.Context, client cnoclient.Client, obj Object, subco
 		log.Printf("could not encode %s for apply", objDesc)
 		return fmt.Errorf("could not encode for patching: %w", err)
 	}
-	if _, err := clusterClient.Dynamic().Resource(rm.Resource).Namespace(namespace).Patch(ctx, name, types.ApplyPatchType, data, patchOptions); err != nil {
+	if _, err := clusterClient.Dynamic().Resource(rm.Resource).Namespace(namespace).Patch(ctx, name, types.ApplyPatchType, data, patchOptions, subresources...); err != nil {
 		return fmt.Errorf("failed to apply / update %s: %w", objDesc, err)
 	}
 	log.Printf("Apply / Create of %s was successful", objDesc)

--- a/pkg/controller/add_networkconfig.go
+++ b/pkg/controller/add_networkconfig.go
@@ -4,6 +4,7 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/controller/clusterconfig"
 	configmapcainjector "github.com/openshift/cluster-network-operator/pkg/controller/configmap_ca_injector"
 	"github.com/openshift/cluster-network-operator/pkg/controller/egress_router"
+	"github.com/openshift/cluster-network-operator/pkg/controller/infrastructureconfig"
 	"github.com/openshift/cluster-network-operator/pkg/controller/ingressconfig"
 	"github.com/openshift/cluster-network-operator/pkg/controller/operconfig"
 	"github.com/openshift/cluster-network-operator/pkg/controller/pki"
@@ -22,5 +23,6 @@ func init() {
 		configmapcainjector.Add,
 		signer.Add,
 		ingressconfig.Add,
+		infrastructureconfig.Add,
 	)
 }

--- a/pkg/controller/infrastructureconfig/OWNERS
+++ b/pkg/controller/infrastructureconfig/OWNERS
@@ -1,0 +1,5 @@
+reviewers:
+- cybertron
+- creydr
+- dougsland
+approvers:

--- a/pkg/controller/infrastructureconfig/infrastructureconfig_controller.go
+++ b/pkg/controller/infrastructureconfig/infrastructureconfig_controller.go
@@ -1,0 +1,108 @@
+package infrastructureconfig
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"reflect"
+
+	configv1 "github.com/openshift/api/config/v1"
+	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
+	"github.com/openshift/cluster-network-operator/pkg/controller/statusmanager"
+	"github.com/openshift/cluster-network-operator/pkg/names"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const ControllerName = "infrastructureconfig"
+
+// Add attaches our control loop to the manager and watches for infrastructure objects
+func Add(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client) error {
+	return add(mgr, newReconciler(mgr, status, c))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client) reconcile.Reconciler {
+	return &ReconcileInfrastructureConfig{client: c, scheme: mgr.GetScheme(), status: status, apiAndIngressVIPsSyncer: &apiAndIngressVipsSynchronizer{}}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("infrastructureconfig-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to primary resource config.openshift.io/v1/Infrastructure
+	err = c.Watch(&source.Kind{Type: &configv1.Infrastructure{}}, &handler.EnqueueRequestForObject{}, onPremPlatformPredicate())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &ReconcileInfrastructureConfig{}
+
+// ReconcileInfrastructureConfig reconciles a cluster Infrastructure object
+type ReconcileInfrastructureConfig struct {
+	client                  cnoclient.Client
+	scheme                  *runtime.Scheme
+	status                  *statusmanager.StatusManager
+	apiAndIngressVIPsSyncer vipsSynchronizer
+}
+
+// Reconcile watches Infrastructure.config.openshift.io/cluster and syncs the
+// new and deprecated API & Ingress VIP fields to have consistent APIs between
+// versions.
+func (r *ReconcileInfrastructureConfig) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log.Printf("Reconciling Infrastructure.config.openshift.io %s\n", request.Name)
+
+	// Only check on the default infrastructure config
+	if request.Name != names.INFRASTRUCTURE_CONFIG {
+		log.Printf("Ignoring Infrastructure config %s. Only handling Infrastructure config with default name %s", request.Name, names.INFRASTRUCTURE_CONFIG)
+		return reconcile.Result{}, nil
+	}
+
+	// Fetch the infrastructure config
+	infraConfig := &configv1.Infrastructure{}
+	err := r.client.Default().CRClient().Get(ctx, request.NamespacedName, infraConfig)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Return and don't requeue
+			log.Println("Object seems to have been deleted")
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		err = fmt.Errorf("Error while reading infrastructures.%s/cluster: %w", configv1.GroupName, err)
+		log.Println(err)
+		return reconcile.Result{}, err
+	}
+
+	// Sync API & Ingress VIPs
+	updatedInfraConfig := r.apiAndIngressVIPsSyncer.VipsSynchronize(infraConfig)
+
+	if !reflect.DeepEqual(updatedInfraConfig.Status, infraConfig.Status) {
+		if err = r.client.Default().CRClient().Status().Update(ctx, updatedInfraConfig, &client.UpdateOptions{}); err != nil {
+			err = fmt.Errorf("Error while updating infrastructures.%s/cluster status: %w", configv1.GroupName, err)
+			log.Println(err)
+
+			r.status.SetDegraded(statusmanager.InfrastructureConfig, "UpdateInfrastructureStatus", err.Error())
+			return reconcile.Result{}, err
+		}
+
+		log.Printf("Successfully synchronized API & Ingress VIPs in infrastructure config")
+	}
+
+	r.status.SetNotDegraded(statusmanager.InfrastructureConfig)
+	return reconcile.Result{}, nil
+}

--- a/pkg/controller/infrastructureconfig/predicates.go
+++ b/pkg/controller/infrastructureconfig/predicates.go
@@ -1,0 +1,38 @@
+package infrastructureconfig
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// onPremPlatformPredicate implements a create and update predicate function on on-prem platform changes
+func onPremPlatformPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			infra := e.Object.(*configv1.Infrastructure)
+			return isOnPremPlatform(infra)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			infra := e.ObjectNew.(*configv1.Infrastructure)
+			return isOnPremPlatform(infra)
+		},
+	}
+}
+
+func isOnPremPlatform(infra *configv1.Infrastructure) bool {
+	switch infra.Spec.PlatformSpec.Type {
+	case configv1.BareMetalPlatformType:
+		fallthrough
+	case configv1.VSpherePlatformType:
+		fallthrough
+	case configv1.OpenStackPlatformType:
+		fallthrough
+	case configv1.OvirtPlatformType:
+		fallthrough
+	case configv1.NutanixPlatformType:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/controller/infrastructureconfig/sync_vips.go
+++ b/pkg/controller/infrastructureconfig/sync_vips.go
@@ -1,0 +1,107 @@
+package infrastructureconfig
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+	utilslice "k8s.io/utils/strings/slices"
+)
+
+type vipsSynchronizer interface {
+	VipsSynchronize(*configv1.Infrastructure) *configv1.Infrastructure
+}
+
+type apiAndIngressVipsSynchronizer struct{}
+
+// VipsSynchronize synchronizes new API & Ingress VIPs with old fields.
+// It returns if the status was updated and the updated infrastructure object.
+//nolint:staticcheck
+func (*apiAndIngressVipsSynchronizer) VipsSynchronize(infraConfig *configv1.Infrastructure) *configv1.Infrastructure {
+	var apiVIPs, ingressVIPs *[]string // new fields
+	var apiVIP, ingressVIP *string     // old/deprecated fields
+
+	updatedInfraConfig := infraConfig.DeepCopy()
+	switch updatedInfraConfig.Status.Platform {
+	case configv1.BareMetalPlatformType:
+		apiVIPs = &updatedInfraConfig.Status.PlatformStatus.BareMetal.APIServerInternalIPs
+		apiVIP = &updatedInfraConfig.Status.PlatformStatus.BareMetal.APIServerInternalIP
+		ingressVIPs = &updatedInfraConfig.Status.PlatformStatus.BareMetal.IngressIPs
+		ingressVIP = &updatedInfraConfig.Status.PlatformStatus.BareMetal.IngressIP
+
+	case configv1.VSpherePlatformType:
+		apiVIPs = &updatedInfraConfig.Status.PlatformStatus.VSphere.APIServerInternalIPs
+		apiVIP = &updatedInfraConfig.Status.PlatformStatus.VSphere.APIServerInternalIP
+		ingressVIPs = &updatedInfraConfig.Status.PlatformStatus.VSphere.IngressIPs
+		ingressVIP = &updatedInfraConfig.Status.PlatformStatus.VSphere.IngressIP
+
+	case configv1.OpenStackPlatformType:
+		apiVIPs = &updatedInfraConfig.Status.PlatformStatus.OpenStack.APIServerInternalIPs
+		apiVIP = &updatedInfraConfig.Status.PlatformStatus.OpenStack.APIServerInternalIP
+		ingressVIPs = &updatedInfraConfig.Status.PlatformStatus.OpenStack.IngressIPs
+		ingressVIP = &updatedInfraConfig.Status.PlatformStatus.OpenStack.IngressIP
+
+	case configv1.OvirtPlatformType:
+		apiVIPs = &updatedInfraConfig.Status.PlatformStatus.Ovirt.APIServerInternalIPs
+		apiVIP = &updatedInfraConfig.Status.PlatformStatus.Ovirt.APIServerInternalIP
+		ingressVIPs = &updatedInfraConfig.Status.PlatformStatus.Ovirt.IngressIPs
+		ingressVIP = &updatedInfraConfig.Status.PlatformStatus.Ovirt.IngressIP
+
+	case configv1.NutanixPlatformType:
+		apiVIPs = &updatedInfraConfig.Status.PlatformStatus.Nutanix.APIServerInternalIPs
+		apiVIP = &updatedInfraConfig.Status.PlatformStatus.Nutanix.APIServerInternalIP
+		ingressVIPs = &updatedInfraConfig.Status.PlatformStatus.Nutanix.IngressIPs
+		ingressVIP = &updatedInfraConfig.Status.PlatformStatus.Nutanix.IngressIP
+
+	default:
+		// nothing to do for this platform type
+		return updatedInfraConfig
+	}
+
+	if err := syncVIPs(apiVIPs, apiVIP); err != nil {
+		log.Printf("Warning on syncing api VIP fields: %v", err) // this is only a warning -> continue
+	}
+
+	if err := syncVIPs(ingressVIPs, ingressVIP); err != nil {
+		log.Printf("Warning on syncing ingress VIP fields: %v", err) // this is only a warning -> continue
+	}
+
+	return updatedInfraConfig
+}
+
+// syncVIPs syncs the VIPs according to the following rules:
+// | # | Initial value of new field | Initial value of old field | Resulting value of new field | Resulting value of old field | Description |
+// | - | -------------------------- | -------------------------- | ---------------------------- | ---------------------------- | ----------- |
+// | 1 | empty                      | foo                        | [0]: foo                     | foo                          | `new` is empty, `old` with value: set `new[0]` to value from `old` |
+// | 2 | [0]: foo, [1]: bar         | empty                      | [0]: foo, [1]: bar           | foo                          | `new` contains values, `old` is empty: set `old` to value from `new[0]` |
+// | 3 | [0]: foo, [1]: bar         | foo                        | [0]: foo, [1]: bar           | foo                          | `new` contains values, `old` contains `new[0]`: we are fine, as `old` is part of `new` |
+// | 4 | [0]: foo, [1]: bar         | bar                        | [0]: foo, [1]: bar           | foo                          | `new` contains values, `old` contains `new[1]`: as `new[0]` contains the clusters primary IP family, new values take precedence over old values, so set `old` to value from `new[0]` |
+// | 5 | [0]: foo, [1]: bar         | baz                        | [0]: foo, [1]: bar           | foo                          | `new` contains values, `old` contains a value which is not included in `new`: new values take precedence over old values, so set `old` to value from `new[0]` (and return a warning) |
+//
+// it returns in case 5 the error.
+func syncVIPs(newVIPs *[]string, oldVIP *string) error {
+	if len(*newVIPs) == 0 {
+		if *oldVIP != "" {
+			// case 1
+			// -> `new` is empty, `old` with value: set `new[0]` to value from `old`
+			*newVIPs = []string{*oldVIP}
+		}
+	} else {
+		// case 2-5, we have old = new[0]
+		if !utilslice.Contains(*newVIPs, *oldVIP) {
+			// case 5
+			// -> `new` contains values, `old` contains a value which is not
+			// included in `new`: new values take precedence over old
+			// values, so set `old` to value from `new[0]` (and return a
+			// warning)
+			err := fmt.Errorf("old (%s) and new VIPs (%s) were both set and differed. New VIPs field will take precedence.", *oldVIP, strings.Join(*newVIPs, ", "))
+			*oldVIP = (*newVIPs)[0]
+			return err
+		}
+
+		*oldVIP = (*newVIPs)[0]
+	}
+
+	return nil
+}

--- a/pkg/controller/infrastructureconfig/sync_vips_test.go
+++ b/pkg/controller/infrastructureconfig/sync_vips_test.go
@@ -1,0 +1,285 @@
+package infrastructureconfig
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_apiAndIngressVipsSynchronizer_VipsSynchronize(t *testing.T) {
+	tests := []struct {
+		name        string
+		givenStatus configv1.InfrastructureStatus
+		wantStatus  configv1.InfrastructureStatus
+	}{
+		{
+			name: "`new` field is empty, `old` with value: should set `new[0]` to value from `old`",
+			givenStatus: configv1.InfrastructureStatus{
+				Platform: configv1.BareMetalPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					BareMetal: &configv1.BareMetalPlatformStatus{
+						APIServerInternalIP: "fooA",
+						IngressIP:           "fooI",
+					},
+				},
+			},
+			wantStatus: configv1.InfrastructureStatus{
+				Platform: configv1.BareMetalPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					BareMetal: &configv1.BareMetalPlatformStatus{
+						APIServerInternalIP:  "fooA",
+						APIServerInternalIPs: []string{"fooA"},
+						IngressIP:            "fooI",
+						IngressIPs:           []string{"fooI"},
+					},
+				},
+			},
+		},
+		{
+			name: "`new` contains values, `old` is empty: should set `old` to value from `new[0]`",
+			givenStatus: configv1.InfrastructureStatus{
+				Platform: configv1.BareMetalPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					BareMetal: &configv1.BareMetalPlatformStatus{
+						APIServerInternalIPs: []string{"fooA", "barA"},
+						IngressIPs:           []string{"fooI", "barI"},
+					},
+				},
+			},
+			wantStatus: configv1.InfrastructureStatus{
+				Platform: configv1.BareMetalPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					BareMetal: &configv1.BareMetalPlatformStatus{
+						APIServerInternalIP:  "fooA",
+						APIServerInternalIPs: []string{"fooA", "barA"},
+						IngressIP:            "fooI",
+						IngressIPs:           []string{"fooI", "barI"},
+					},
+				},
+			},
+		},
+		{
+			name: "`new` contains values, `old` contains `new[0]`: should not update anything",
+			givenStatus: configv1.InfrastructureStatus{
+				Platform: configv1.BareMetalPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					BareMetal: &configv1.BareMetalPlatformStatus{
+						APIServerInternalIP:  "fooA",
+						APIServerInternalIPs: []string{"fooA", "barA"},
+						IngressIP:            "fooI",
+						IngressIPs:           []string{"fooI", "barI"},
+					},
+				},
+			},
+			wantStatus: configv1.InfrastructureStatus{
+				Platform: configv1.BareMetalPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					BareMetal: &configv1.BareMetalPlatformStatus{
+						APIServerInternalIP:  "fooA",
+						APIServerInternalIPs: []string{"fooA", "barA"},
+						IngressIP:            "fooI",
+						IngressIPs:           []string{"fooI", "barI"},
+					},
+				},
+			},
+		},
+		{
+			name: "`new` contains values, `old` contains `new[1]`: as `new[0]` contains the clusters primary IP family, new values take precedence over old values, so set `old` to value from `new[0]` |",
+			givenStatus: configv1.InfrastructureStatus{
+				Platform: configv1.BareMetalPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					BareMetal: &configv1.BareMetalPlatformStatus{
+						APIServerInternalIP:  "barA",
+						APIServerInternalIPs: []string{"fooA", "barA"},
+						IngressIP:            "barI",
+						IngressIPs:           []string{"fooI", "barI"},
+					},
+				},
+			},
+			wantStatus: configv1.InfrastructureStatus{
+				Platform: configv1.BareMetalPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					BareMetal: &configv1.BareMetalPlatformStatus{
+						APIServerInternalIP:  "fooA",
+						APIServerInternalIPs: []string{"fooA", "barA"},
+						IngressIP:            "fooI",
+						IngressIPs:           []string{"fooI", "barI"},
+					},
+				},
+			},
+		},
+		{
+			name: "`new` contains values, `old` contains a value which is not included in `new`: should set `old` to value from `new[0]` (new values take precedence over old values)",
+			givenStatus: configv1.InfrastructureStatus{
+				Platform: configv1.BareMetalPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					BareMetal: &configv1.BareMetalPlatformStatus{
+						APIServerInternalIP:  "bazA",
+						APIServerInternalIPs: []string{"fooA", "barA"},
+						IngressIP:            "bazI",
+						IngressIPs:           []string{"fooI", "barI"},
+					},
+				},
+			},
+			wantStatus: configv1.InfrastructureStatus{
+				Platform: configv1.BareMetalPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					BareMetal: &configv1.BareMetalPlatformStatus{
+						APIServerInternalIP:  "fooA",
+						APIServerInternalIPs: []string{"fooA", "barA"},
+						IngressIP:            "fooI",
+						IngressIPs:           []string{"fooI", "barI"},
+					},
+				},
+			},
+		},
+		{
+			name: "should work with only one VIP",
+			givenStatus: configv1.InfrastructureStatus{
+				Platform: configv1.BareMetalPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					BareMetal: &configv1.BareMetalPlatformStatus{
+						APIServerInternalIP:  "",
+						APIServerInternalIPs: []string{"fooA"},
+						IngressIP:            "bazI",
+						IngressIPs:           []string{"fooI"},
+					},
+				},
+			},
+			wantStatus: configv1.InfrastructureStatus{
+				Platform: configv1.BareMetalPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					BareMetal: &configv1.BareMetalPlatformStatus{
+						APIServerInternalIP:  "fooA",
+						APIServerInternalIPs: []string{"fooA"},
+						IngressIP:            "fooI",
+						IngressIPs:           []string{"fooI"},
+					},
+				},
+			},
+		},
+		{
+			name: "should handle OpenStack platform",
+			givenStatus: configv1.InfrastructureStatus{
+				Platform: configv1.OpenStackPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					OpenStack: &configv1.OpenStackPlatformStatus{
+						APIServerInternalIP: "fooA",
+						IngressIP:           "fooI",
+					},
+				},
+			},
+			wantStatus: configv1.InfrastructureStatus{
+				Platform: configv1.OpenStackPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					OpenStack: &configv1.OpenStackPlatformStatus{
+						APIServerInternalIP:  "fooA",
+						APIServerInternalIPs: []string{"fooA"},
+						IngressIP:            "fooI",
+						IngressIPs:           []string{"fooI"},
+					},
+				},
+			},
+		},
+		{
+			name: "should handle vSphere platform",
+			givenStatus: configv1.InfrastructureStatus{
+				Platform: configv1.VSpherePlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					VSphere: &configv1.VSpherePlatformStatus{
+						APIServerInternalIP: "fooA",
+						IngressIP:           "fooI",
+					},
+				},
+			},
+			wantStatus: configv1.InfrastructureStatus{
+				Platform: configv1.VSpherePlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					VSphere: &configv1.VSpherePlatformStatus{
+						APIServerInternalIP:  "fooA",
+						APIServerInternalIPs: []string{"fooA"},
+						IngressIP:            "fooI",
+						IngressIPs:           []string{"fooI"},
+					},
+				},
+			},
+		},
+		{
+			name: "should handle oVirt platform",
+			givenStatus: configv1.InfrastructureStatus{
+				Platform: configv1.OvirtPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					Ovirt: &configv1.OvirtPlatformStatus{
+						APIServerInternalIP: "fooA",
+						IngressIP:           "fooI",
+					},
+				},
+			},
+			wantStatus: configv1.InfrastructureStatus{
+				Platform: configv1.OvirtPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					Ovirt: &configv1.OvirtPlatformStatus{
+						APIServerInternalIP:  "fooA",
+						APIServerInternalIPs: []string{"fooA"},
+						IngressIP:            "fooI",
+						IngressIPs:           []string{"fooI"},
+					},
+				},
+			},
+		},
+		{
+			name: "should handle Nutanix platform",
+			givenStatus: configv1.InfrastructureStatus{
+				Platform: configv1.NutanixPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					Nutanix: &configv1.NutanixPlatformStatus{
+						APIServerInternalIP: "fooA",
+						IngressIP:           "fooI",
+					},
+				},
+			},
+			wantStatus: configv1.InfrastructureStatus{
+				Platform: configv1.NutanixPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					Nutanix: &configv1.NutanixPlatformStatus{
+						APIServerInternalIP:  "fooA",
+						APIServerInternalIPs: []string{"fooA"},
+						IngressIP:            "fooI",
+						IngressIPs:           []string{"fooI"},
+					},
+				},
+			},
+		},
+		{
+			name: "should do nothing on non onprem platform",
+			givenStatus: configv1.InfrastructureStatus{
+				Platform: configv1.AWSPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					AWS: &configv1.AWSPlatformStatus{},
+				},
+			},
+			wantStatus: configv1.InfrastructureStatus{
+				Platform: configv1.AWSPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					AWS: &configv1.AWSPlatformStatus{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			givenInfra := &configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status:     tt.givenStatus,
+			}
+
+			a := &apiAndIngressVipsSynchronizer{}
+			gotInfra := a.VipsSynchronize(givenInfra)
+
+			assert.EqualValues(t, tt.wantStatus, gotInfra.Status, "should update status correctly")
+		})
+	}
+}

--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -48,6 +48,7 @@ const (
 	EgressRouterConfig
 	RolloutHung
 	CertificateSigner
+	InfrastructureConfig
 	maxStatusLevel
 )
 

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -15,6 +15,9 @@ const CLUSTER_CONFIG = "cluster"
 // PROXY_CONFIG is the name of the default proxy object.
 const PROXY_CONFIG = "cluster"
 
+// INFRASTRUCTURE_CONFIG is the name of the default infrastructure object.
+const INFRASTRUCTURE_CONFIG = "cluster"
+
 // APPLIED_PREFIX is the prefix applied to the config maps
 // where we store previously applied configuration
 const APPLIED_PREFIX = "applied-"


### PR DESCRIPTION
For the dual stack API & Ingress VIP support, we have to add additional fields to onprem platform statuses (https://github.com/openshift/api/pull/1152). 
To have consistent APIs between versions and keep backwards compatible for components consuming the old VIP fields, we need to keep the new and old VIP fields in sync. This is addressed by this PR by adding a new controller to the CNO which keeps the old and new VIP fields in `Infrastructure.config.openshift.io/cluster` in sync.

**Special notes for reviewers:**
* we added an `OWNERS` file in the folder with adding the bare metal team as reviewers for this controller, as it could make sense to have one of the team members reviewing changes on this component.