### PR TITLE
Enable egress_ip health check port

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/004-config.yaml
@@ -31,6 +31,9 @@ data:
     enable-egress-ip=true
     enable-egress-firewall=true
     enable-egress-qos=true
+{{- if .ReachabilityNodePort }}
+    egressip-node-healthcheck-port={{.ReachabilityNodePort}}
+{{- end }}
 
     [gateway]
     mode={{.OVN_GATEWAY_MODE}}
@@ -107,8 +110,12 @@ data:
     In hypershift ovnkube-master pods run in the management cluster and they don't have direct connectivity to ovnkube-node pods(hosted cluster).
     EgressIP reachability check tries to open a connection to egress nodes management IP which doesn't currently work in a hypershift deployment.
     As a workaround disable EgressIP reachability check, this means EgressIP will take longer to reassign if there is a node that becomes unreachable.
+    TODO(FF): remove this soon
     */}}
     egressip-reachability-total-timeout=0
+{{- if .ReachabilityNodePort }}
+    egressip-node-healthcheck-port={{.ReachabilityNodePort}}
+{{- end }}
 
     [gateway]
     mode={{.OVN_GATEWAY_MODE}}

--- a/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
@@ -34,6 +34,9 @@ data:
     {{- if .ReachabilityTotalTimeoutSeconds }}
     egressip-reachability-total-timeout={{.ReachabilityTotalTimeoutSeconds}}
     {{- end }}
+{{- if .ReachabilityNodePort }}
+    egressip-node-healthcheck-port={{.ReachabilityNodePort}}
+{{- end }}
 
     [gateway]
     mode={{.OVN_GATEWAY_MODE}}

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -58,6 +58,9 @@ const OVN_NODE_MODE_DPU_HOST = "dpu-host"
 const OVN_NODE_MODE_DPU = "dpu"
 const OVN_NODE_SELECTOR_DPU = "network.operator.openshift.io/dpu: ''"
 
+// gRPC healthcheck port. See: https://github.com/openshift/enhancements/pull/1209
+const OVN_EGRESSIP_HEALTHCHECK_PORT = "9107"
+
 var OVN_MASTER_DISCOVERY_TIMEOUT = 250
 
 const (
@@ -291,6 +294,13 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	}
 
 	data.Data["ReachabilityTotalTimeoutSeconds"] = c.EgressIPConfig.ReachabilityTotalTimeoutSeconds
+
+	reachability_node_port := os.Getenv("OVN_EGRESSIP_HEALTHCHECK_PORT")
+	if len(reachability_node_port) == 0 {
+		reachability_node_port = OVN_EGRESSIP_HEALTHCHECK_PORT
+		klog.Infof("OVN_EGRESSIP_HEALTHCHECK_PORT env var is not defined. Using: %s", reachability_node_port)
+	}
+	data.Data["ReachabilityNodePort"] = reachability_node_port
 
 	exportNetworkFlows := conf.ExportNetworkFlows
 	if exportNetworkFlows != nil {

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -184,6 +184,7 @@ platform-type="GCP"
 enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
+egressip-node-healthcheck-port=9107
 
 [gateway]
 mode=shared
@@ -211,6 +212,7 @@ platform-type="GCP"
 enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
+egressip-node-healthcheck-port=9107
 
 [gateway]
 mode=shared
@@ -241,6 +243,7 @@ platform-type="GCP"
 enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
+egressip-node-healthcheck-port=9107
 
 [gateway]
 mode=local
@@ -283,6 +286,7 @@ enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
 egressip-reachability-total-timeout=3
+egressip-node-healthcheck-port=9107
 
 [gateway]
 mode=local
@@ -327,6 +331,7 @@ enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
 egressip-reachability-total-timeout=0
+egressip-node-healthcheck-port=9107
 
 [gateway]
 mode=local
@@ -370,6 +375,7 @@ platform-type="GCP"
 enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
+egressip-node-healthcheck-port=9107
 
 [gateway]
 mode=local
@@ -413,6 +419,7 @@ platform-type="GCP"
 enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
+egressip-node-healthcheck-port=9107
 
 [gateway]
 mode=shared
@@ -445,6 +452,7 @@ platform-type="GCP"
 enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
+egressip-node-healthcheck-port=9107
 
 [gateway]
 mode=shared


### PR DESCRIPTION
Use --egressip-node-healthcheck-port flag to enable healthcheck
session between ovn-master and egress nodes.

Using port 9107 and having it listed under `dev-guide/host-port-registry.md`:
https://github.com/openshift/enhancements/pull/1209

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>
Reported-at: https://issues.redhat.com/browse/SDN-3156
