### PR TITLE
Bug 2103680: avoid overrriding disableNetworkDiagnostics on reconciliation

### DIFF
--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -94,6 +94,17 @@ func ApplyObject(ctx context.Context, client cnoclient.Client, obj Object, subco
 		}
 	}
 
+	merge := getMergeForUpdate(obj)
+	if merge != nil {
+		// this object requires some of the existing data merged into the
+		// updated object, this is on exceptional cases where the server-side
+		// apply is not doing what we want
+		obj, err = merge(ctx, clusterClient)
+		if err != nil {
+			return fmt.Errorf("failed to merge object %s: %w", objDesc, err)
+		}
+	}
+
 	fieldManager := "cluster-network-operator"
 	if subcontroller != "" {
 		fieldManager = fmt.Sprintf("%s/%s", fieldManager, subcontroller)

--- a/pkg/apply/merge.go
+++ b/pkg/apply/merge.go
@@ -1,0 +1,103 @@
+package apply
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	operv1 "github.com/openshift/api/operator/v1"
+	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// getCurrentFromUnstructured retrieves the current unstructured object in the
+// database from the provided one
+func getCurrentFromUnstructured(ctx context.Context, client cnoclient.ClusterClient, updated *uns.Unstructured) (*uns.Unstructured, error) {
+	name := updated.GetName()
+	namespace := updated.GetNamespace()
+	gkv := updated.GroupVersionKind()
+	objDesc := fmt.Sprintf("(%s) %s/%s", gkv.String(), namespace, name)
+
+	current := &uns.Unstructured{}
+	current.SetGroupVersionKind(gkv)
+	err := client.CRClient().Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, current)
+	if apierrors.IsNotFound(err) {
+		log.Printf("Object %s does not exist, no merge needed", objDesc)
+		return nil, nil
+	}
+	if err != nil {
+		err = fmt.Errorf("Object %s could not be retrieved, %w", objDesc, err)
+		return nil, err
+	}
+
+	return current, nil
+}
+
+// mergeOperConfigForUpdate handle server-side apply exceptions for the operator
+// config object
+func mergeOperConfigForUpdate(current, updated *uns.Unstructured) error {
+	if current == nil {
+		// if there is no existing object, merge is not needed
+		return nil
+	}
+
+	// unfortunately disableNetworkDiagnostics it's not a pointer so we can't
+	// make it a noop in the server side apply
+	// since it's supposed to be changed by the user and not programmatically
+	// lets make sure it stays at its current value here
+	disableNetworkDiagnostics, found, err := uns.NestedBool(current.Object, "spec", "disableNetworkDiagnostics")
+	if err != nil {
+		return err
+	}
+	if found {
+		if err := uns.SetNestedField(updated.Object, disableNetworkDiagnostics, "spec", "disableNetworkDiagnostics"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// mergerFunction provided by getMergeForUpdate merges the existing object with
+// the updated object. Returns the merged updated object as unstructured. Note
+// that this merger function is not supposed to make any changes in the database.
+type mergerFunction func(ctx context.Context, client cnoclient.ClusterClient) (*uns.Unstructured, error)
+
+// getMergeForUpdate returns a function for the provided object that merges some
+// of the existing data into the object as an exception to situations that are
+// not handled correctly in the server-side apply
+func getMergeForUpdate(obj Object) mergerFunction {
+	var doMerge func(current, updated *uns.Unstructured) error
+
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	if gvk.Group == operv1.GroupName && gvk.Kind == "Network" {
+		doMerge = mergeOperConfigForUpdate
+	}
+
+	if doMerge != nil {
+		return func(ctx context.Context, client cnoclient.ClusterClient) (*uns.Unstructured, error) {
+			updated, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+			if err != nil {
+				return nil, err
+			}
+			updatedUns := &uns.Unstructured{Object: updated}
+
+			currentUns, err := getCurrentFromUnstructured(ctx, client, updatedUns)
+			if err != nil {
+				return nil, err
+			}
+
+			err = doMerge(currentUns, updatedUns)
+			if err != nil {
+				return nil, err
+			}
+			return updatedUns, nil
+		}
+	}
+
+	return nil
+}

--- a/pkg/apply/merge_test.go
+++ b/pkg/apply/merge_test.go
@@ -1,0 +1,84 @@
+package apply
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	operv1 "github.com/openshift/api/operator/v1"
+	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
+	"github.com/openshift/cluster-network-operator/pkg/client/fake"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func init() {
+	utilruntime.Must(operv1.AddToScheme(scheme.Scheme))
+}
+
+func Test_Merge(t *testing.T) {
+	tests := []struct {
+		name     string
+		kind     schema.GroupVersionKind
+		initial  Object
+		input    Object
+		expected Object
+	}{
+		{
+			"no merge if operator config does not exist",
+			schema.GroupVersionKind{
+				Group:   operv1.GroupName,
+				Kind:    "Network",
+				Version: operv1.GroupVersion.Version,
+			},
+			nil,
+			&operv1.Network{},
+			&operv1.Network{},
+		},
+		{
+			"merge operator config DisableNetworkDiagnostics remains at current value",
+			schema.GroupVersionKind{
+				Group:   operv1.GroupName,
+				Kind:    "Network",
+				Version: operv1.GroupVersion.Version,
+			},
+			&operv1.Network{
+				Spec: operv1.NetworkSpec{
+					DisableNetworkDiagnostics: true,
+				},
+			},
+			&operv1.Network{},
+			&operv1.Network{
+				Spec: operv1.NetworkSpec{
+					DisableNetworkDiagnostics: true,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			var client cnoclient.Client
+			if tt.initial != nil {
+				client = fake.NewFakeClient(tt.initial)
+			} else {
+				client = fake.NewFakeClient()
+			}
+			tt.input.GetObjectKind().SetGroupVersionKind(tt.kind)
+			tt.expected.GetObjectKind().SetGroupVersionKind(tt.kind)
+			merge := getMergeForUpdate(tt.input)
+			g.Expect(merge).NotTo(BeNil())
+			uns, err := merge(context.Background(), client.Default())
+			g.Expect(err).NotTo(HaveOccurred())
+			output := reflect.New(reflect.ValueOf(tt.expected).Elem().Type()).Interface()
+			err = runtime.DefaultUnstructuredConverter.FromUnstructured(uns.Object, output)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal(tt.expected))
+		})
+	}
+}

--- a/pkg/client/fake/fake_client.go
+++ b/pkg/client/fake/fake_client.go
@@ -2,6 +2,7 @@ package fake
 
 import (
 	"context"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -66,7 +67,7 @@ func (fc *FakeClient) Clients() map[string]cnoclient.ClusterClient {
 func isOpenShiftObject(obj crclient.Object) bool {
 	kKind, _, _ := scheme.Scheme.ObjectKinds(obj)
 	for _, v := range kKind {
-		if v.Group == "config.openshift.io" {
+		if strings.HasSuffix(v.Group, "openshift.io") {
 			return true
 		}
 	}


### PR DESCRIPTION
Unfortunately disableNetworkDiagnostics is not setup as a pointer and is
overriden to the default value on the server-side apply when the cluster
config is reconciliated.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>