### PR TITLE
Bug OCPBUGS-216: Kuryr: Bump timeoutSeconds for livenessProbe

### DIFF
--- a/bindata/network/kuryr/006-controller.yaml
+++ b/bindata/network/kuryr/006-controller.yaml
@@ -51,6 +51,7 @@ spec:
             path: /alive
             port: {{ default 8091 .ControllerProbesPort }}
           initialDelaySeconds: 15
+          timeoutSeconds: 10
 {{ end }}
         env:
         # Tell controller to talk to the apiserver directly.


### PR DESCRIPTION
By default livenessProbe times out after 1 second. We just saw that this
is sometimes too little for the Kuryr health server to respond, so this
commit bumps that time to 10s.