### PR TITLE
Hypershift: Allow configuring hostname and labels on the route

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/008-route.yaml
+++ b/bindata/network/ovn-kubernetes/managed/008-route.yaml
@@ -8,6 +8,11 @@ metadata:
   namespace: {{.HostedClusterNamespace}}
   annotations:
     network.operator.openshift.io/cluster-name:  {{.ManagementClusterName}}
+  {{ if .OVNSbDbRouteLabels }}
+  labels:
+  {{ range $key, $value := .OVNSbDbRouteLabels }}
+    "{{$key}}": "{{$value}}"
+  {{ end }}{{ end  }}
 spec:
   port:
     targetPort: {{.OVN_SB_PORT}}

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -31,6 +31,7 @@ type OVNHyperShiftBootstrapResult struct {
 	ServicePublishingStrategy *hyperv1.ServicePublishingStrategy
 	OVNSbDbRouteHost          string
 	OVNSbDbRouteNodePort      int32
+	OVNSbDbRouteLabels        map[string]string
 	ControlPlaneReplicas      int
 }
 

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -156,15 +156,14 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["ClusterID"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.ClusterID
 	data.Data["ClusterIDLabel"] = ClusterIDLabel
 	data.Data["OVNDbServiceType"] = corev1.ServiceTypeClusterIP
-	data.Data["OVNSbDbRouteHost"] = nil
+	data.Data["OVNSbDbRouteHost"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.OVNSbDbRouteHost
+	data.Data["OVNSbDbRouteLabels"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.OVNSbDbRouteLabels
 	data.Data["OVN_SB_NODE_PORT"] = nil
 	data.Data["OVN_NB_DB_ENDPOINT"] = fmt.Sprintf("ssl:%s:%s", bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.OVNSbDbRouteHost, OVN_SB_DB_ROUTE_PORT)
 	data.Data["OVN_SB_DB_ENDPOINT"] = fmt.Sprintf("ssl:%s:%s", bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.OVNSbDbRouteHost, OVN_SB_DB_ROUTE_PORT)
 	pubStrategy := bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.ServicePublishingStrategy
-	if pubStrategy != nil && pubStrategy.Type == hyperv1.Route {
-		if pubStrategy.Route != nil && pubStrategy.Route.Hostname != "" {
-			data.Data["OVNSbDbRouteHost"] = pubStrategy.Route.Hostname
-		}
+	if bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.OVNSbDbRouteHost == "" && pubStrategy != nil && pubStrategy.Type == hyperv1.Route && pubStrategy.Route != nil && pubStrategy.Route.Hostname != "" {
+		data.Data["OVNSbDbRouteHost"] = pubStrategy.Route.Hostname
 	} else if pubStrategy != nil && pubStrategy.Type == hyperv1.NodePort {
 		data.Data["OVNDbServiceType"] = corev1.ServiceTypeNodePort
 		data.Data["OVN_SB_NODE_PORT"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.OVNSbDbRouteNodePort
@@ -480,8 +479,10 @@ func renderOVNFlowsConfig(bootstrapResult *bootstrap.BootstrapResult, data *rend
 
 func bootstrapOVNHyperShiftConfig(hc *HyperShiftConfig, kubeClient cnoclient.Client) (*bootstrap.OVNHyperShiftBootstrapResult, error) {
 	ovnHypershiftResult := &bootstrap.OVNHyperShiftBootstrapResult{
-		Enabled:   hc.Enabled,
-		Namespace: hc.Namespace,
+		Enabled:            hc.Enabled,
+		Namespace:          hc.Namespace,
+		OVNSbDbRouteHost:   hc.OVNSbDbRouteHost,
+		OVNSbDbRouteLabels: hc.OVNSbDbRouteLabels,
 	}
 
 	if !hc.Enabled {
@@ -518,6 +519,11 @@ func bootstrapOVNHyperShiftConfig(hc *HyperShiftConfig, kubeClient cnoclient.Cli
 			Type: hyperv1.Route,
 		}
 	}
+
+	if ovnHypershiftResult.OVNSbDbRouteHost != "" {
+		return ovnHypershiftResult, nil
+	}
+
 	switch ovnHypershiftResult.ServicePublishingStrategy.Type {
 	case hyperv1.Route:
 		{


### PR DESCRIPTION
This change makes it possible to configure the hostname and labels on
the Hypershift SBDB route through environment variables.

Configuring these is needed when the cluster is private, as in that case
a custom router is used to avoid sending the traffic over the internet.

In order to avoid duplicating the logic to determine if a cluster is
private and then needing to keep it in sync with the Hypershift
Controlplane operator, the simple environment variable approach was
chosen.

Ref https://issues.redhat.com/browse/HOSTEDCP-517

/assign @kyrtapz 