### PR TITLE
Pass enable-udp-aggregation=true to ovn-kubernetes

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/004-config.yaml
@@ -16,6 +16,7 @@ data:
     encap-port="{{.GenevePort}}"
     enable-lflow-cache=true
     lflow-cache-limit-kb=1048576
+    enable-udp-aggregation={{.EnableUDPAggregation}}
 
     [kubernetes]
     service-cidrs="{{.OVN_service_cidr}}"

--- a/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
@@ -16,6 +16,7 @@ data:
     encap-port="{{.GenevePort}}"
     enable-lflow-cache=true
     lflow-cache-limit-kb=1048576
+    enable-udp-aggregation={{.EnableUDPAggregation}}
 
     [kubernetes]
     service-cidrs="{{.OVN_service_cidr}}"

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -36,9 +36,10 @@ type OVNHyperShiftBootstrapResult struct {
 }
 
 type OVNConfigBoostrapResult struct {
-	GatewayMode      string
-	NodeMode         string
-	HyperShiftConfig *OVNHyperShiftBootstrapResult
+	GatewayMode           string
+	NodeMode              string
+	HyperShiftConfig      *OVNHyperShiftBootstrapResult
+	DisableUDPAggregation bool
 }
 
 // OVNUpdateStatus contains the status of existing daemonset


### PR DESCRIPTION
Re-push of #1489; that got reverted (#1510) because [QE had reported that it caused performance regressions](https://bugzilla.redhat.com/show_bug.cgi?id=2085089#c37). However

1. Most of the problem turned out to be because [un-labeled numbers in the perf results had been interpreted as being in milliseconds when they were actually microseconds](https://bugzilla.redhat.com/show_bug.cgi?id=2085089#c43); there _was_ an increase in latency, but it was tiny and expected, not large and problematic.
2. The rest of the problem is with a dubious test scenario which tests how fast the network is when using [a network protocol that is, essentially, maximally "optimized" for slowness](https://bugzilla.redhat.com/show_bug.cgi?id=2085089#c46) by doing fully-serialized request / response / request / response / request / response... with tiny packets.

No one has been able to suggest a real-world use case that would see the sort of drastic slowdowns seen in the "Request/Response operations" test:
1. RTP/RTSP/WebRTC and other streaming protocols don't look like that, because they just keep sending packets, rather than sending 1 response packet for each request packet. (And of course, streaming protocols are what the UDP aggregation feature was intended to speed up, and [it _did_ speed them up](https://bugzilla.redhat.com/show_bug.cgi?id=2085089#c37); the 64-byte packet size streaming throughput nearly doubled.)
2. DNS doesn't look like that, because (a) no one ever does 10,000 DNS requests all at once, (b) if they did, they'd parallelize them rather than doing them 1-by-1, (c) the DNS protocol has specific design features to minimize the need for serialized lookups (eg, when you get a CNAME record, it automatically includes the corresonding A record as well so you don't have to make a second request) because people figured out in the 1980s that you shouldn't design protocols that require lots of small serialized requests and responses.
3. HTTP/3 doesn't look like that because (a) it uses large packets when sending large data, (b) as in the streaming case, a single request can result in many response packets, rather than being 1-to-1, (c) a single HTTP/3 connection can have multiple concurrent request/response streams.

etc

Additionally, testing a protocol like this inside a kubernetes clusters is an implausibly-"best" best case scenario; in most normal environments, the client and server would be farther apart from each other (in terms of network topology), and thus a protocol like the "Request/Response operations" test that was extremely latency-sensitive would have much worse behavior, making it even more likely that the developers would change the way it worked.

So, this PR re-enables the feature.