### PR TITLE
Migrate Egress IP configuration during SDN migration and rollback

### DIFF
--- a/pkg/client/list_pager.go
+++ b/pkg/client/list_pager.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/pager"
-	// cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 )
 
 // for use with dynamic client

--- a/pkg/controller/operconfig/migration.go
+++ b/pkg/controller/operconfig/migration.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -18,12 +19,28 @@ import (
 )
 
 const defaultEgressFirewallName = "default"
+const egressCIDRAnnotationName = "networkoperator.openshift.io/sdn-to-ovn-migration"
+const egressIPNodeConfig = "cloud.network.openshift.io/egress-ipconfig"
+const egressAssignable = "k8s.ovn.org/egress-assignable"
 const multicastEnabledSDN = "netnamespace.network.openshift.io/multicast-enabled"
 const multicastEnabledOVN = "k8s.ovn.org/multicast-enabled"
 
 var gvrEgressFirewall = schema.GroupVersionResource{Group: "k8s.ovn.org", Version: "v1", Resource: "egressfirewalls"}
 var gvrEgressNetworkPolicy = schema.GroupVersionResource{Group: "network.openshift.io", Version: "v1", Resource: "egressnetworkpolicies"}
+var gvrEgressIp = schema.GroupVersionResource{Group: "k8s.ovn.org", Version: "v1", Resource: "egressips"}
+var gvrHostSubnet = schema.GroupVersionResource{Group: "network.openshift.io", Version: "v1", Resource: "hostsubnets"}
 var gvrNetnamespace = schema.GroupVersionResource{Group: "network.openshift.io", Version: "v1", Resource: "netnamespaces"}
+var gvrCloudPrivateIPConfig = schema.GroupVersionResource{Group: "cloud.network.openshift.io", Version: "v1", Resource: "cloudprivateipconfigs"}
+
+type NodeEgressIpConfig struct {
+	Interface string
+	IfAddr    map[string]string
+	Capacity  map[string]int
+}
+
+type OVNMigrationNodeAnnotation struct {
+	EgressCIDRs []string
+}
 
 func migrateMulticastEnablement(ctx context.Context, operConfig *operv1.Network, client cnoclient.Client) error {
 	switch operConfig.Spec.Migration.NetworkType {
@@ -42,6 +59,21 @@ func migrateEgressFirewallCRs(ctx context.Context, operConfig *operv1.Network, c
 		return convertEgressNetworkPolicyToEgressFirewall(ctx, client)
 	case string(operv1.NetworkTypeOpenShiftSDN):
 		return convertEgressFirewallToEgressNetworkPolicy(ctx, client)
+	}
+
+	return nil
+}
+
+func migrateEgressIpCRs(ctx context.Context, operConfig *operv1.Network, client cnoclient.Client) error {
+	switch operConfig.Spec.Migration.NetworkType {
+	case string(operv1.NetworkTypeOVNKubernetes):
+		egressIpList, netNamespaceList, err := convertSdnEgressIpToOvnEgressIp(ctx, client)
+		if err != nil {
+			return err
+		}
+		return applyEgressIpList(ctx, client, egressIpList, netNamespaceList)
+	case string(operv1.NetworkTypeOpenShiftSDN):
+		return convertOvnEgressIpToSdnEgressIp(ctx, client)
 	}
 
 	return nil
@@ -206,6 +238,209 @@ func convertEgressFirewallToEgressNetworkPolicy(ctx context.Context, client cnoc
 	return nil
 }
 
+func convertSdnEgressIpToOvnEgressIp(ctx context.Context, client cnoclient.Client) ([]*uns.Unstructured, []*uns.Unstructured, error) {
+
+	// 1. query for hostsubnets and netnamespaces
+	hostSubnetList, err := cnoclient.ListAllOfSpecifiedType(gvrHostSubnet, ctx, client)
+	if err != nil {
+		return nil, nil, err
+	}
+	netNamespaceList, err := cnoclient.ListAllOfSpecifiedType(gvrNetnamespace, ctx, client)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// 2. iterate through hostsubnets
+	//    - any with egressIP configured will cause update to node label "egress-assignable"
+	hostSubnetFound := false
+	for _, hsn := range hostSubnetList {
+		hostSubnetHasEgressIpConfigAutomatic := hostSubnetHasEgressIpConfigAutomatic(*hsn)
+		hostSubnetHasEgressIpConfigManual := hostSubnetHasEgressIpConfigManual(*hsn)
+
+		// mark node from hostsubnet with annotation as follows:
+		// - k8s.ovn.org/egress-assignable: ""
+		if hostSubnetHasEgressIpConfigAutomatic || hostSubnetHasEgressIpConfigManual {
+			hostSubnetFound = true
+			if err := labelNodeAndRemoveHostSubnetConfig(ctx, client, hsn); err != nil {
+				return nil, nil, err
+			}
+		}
+
+		if hostSubnetHasEgressIpConfigManual {
+			log.Printf("Manual configuration of SDN egressIP detected and is unsupported for migration; OVN egressIPs will be generated but will not maintain individual node assignments from SDN hostsubnets")
+		}
+	}
+
+	if !hostSubnetFound {
+		log.Printf("did not find a hostsubnet object with egressIP configured, quitting process early")
+		return nil, nil, nil
+	} else {
+		log.Printf("found hostsubnet object with egressIP configured, continuing...")
+	}
+
+	// 3. iterate through netnamespaces
+	//    - any with egressIP configured will cause an egressIP ovn resource to be created via k8s api
+	//    - a corresponding namespace label will be added to match the egressIP resource's namespace selector field
+	egressIpList := []*uns.Unstructured{}
+	for _, nns := range netNamespaceList {
+		if netNamespaceHasEgressIpConfig(*nns) {
+			// config detected, translating to ovn
+			// - delete cloudprivateipconfig if it exists
+			// - create egressip custom resource for ovn
+			if err := deleteCloudPrivateIpConfigs(ctx, client, nns.Object["egressIPs"].([]interface{})); err != nil {
+				return nil, nil, err
+			}
+
+			egressIpName := fmt.Sprint("egressip-", nns.GetName())
+			egressIP := unstructuredEgressIpObject(egressIpName, nns.Object["egressIPs"].([]interface{}), nns.Object["netname"])
+			egressIpList = append(egressIpList, egressIP)
+		}
+	}
+
+	return egressIpList, netNamespaceList, nil // success
+}
+
+func convertOvnEgressIpToSdnEgressIp(ctx context.Context, client cnoclient.Client) error {
+	egressIpRollbackReady, err := sdnEgressIpResourcesReady(ctx, client)
+	if !egressIpRollbackReady {
+		return nil // wait for all SDN egressIP resources to be created before rollback
+	} else if err != nil {
+		return err
+	}
+
+	// 1. query for egressips
+	egressIpList, err := cnoclient.ListAllOfSpecifiedType(gvrEgressIp, ctx, client)
+	if err != nil {
+		return err
+	}
+
+	// 2. query for nodes
+	nodeList, err := client.Default().Kubernetes().CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	// 3. iterate through egressIP objects and generate netnamespaces
+	//    - value of `namespaceSelector` will determine netnamespace's name
+	//    - egressIP list will be copied to egressIPs field for netnamespace
+	for _, eip := range egressIpList {
+		// translate egressIPs to SDN netnamespaces
+		// - delete cloudprivateipconfig if it exists
+		// - create egressip to netnamespace resources for sdn
+
+		egressIps := eip.Object["spec"].(map[string]interface{})["egressIPs"].([]interface{})
+
+		if err := deleteCloudPrivateIpConfigs(ctx, client, egressIps); err != nil {
+			return err
+		}
+
+		eipNamespace, found, err := uns.NestedString(eip.Object, "spec", "namespaceSelector", "matchLabels", "kubernetes.io/metadata.name")
+		if !found || err != nil {
+			return fmt.Errorf("kubernetes.io/metadata.name not found in egressIP object %s, probable underlying error: %v", eip.GetName(), err)
+		}
+
+		if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			nns, err := client.Default().Dynamic().Resource(gvrNetnamespace).Get(ctx, eipNamespace, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+
+			nns.Object["egressIPs"] = egressIps
+			_, err = client.Default().Dynamic().Resource(gvrNetnamespace).Update(ctx, nns, metav1.UpdateOptions{})
+			return err
+		}); err != nil {
+			return err
+		}
+	}
+
+	// 4. iterate through nodes and generate hostsubnets for any that are egress-assignable
+	for _, node := range nodeList.Items {
+		if node.Labels == nil {
+			continue
+		}
+		if _, ok := node.Labels[egressAssignable]; ok {
+			// generate egressCIDRs field
+			// if "egressCIDRAnnotationName" node annotation exists, automatic sdn config was used and we shall reuse old config
+			// else, manual sdn config was used and we shall use node's subnet CIDR (cannot restore egressIPs)
+			var egressCIDRsArr []string
+			if _, ok := node.Annotations[egressCIDRAnnotationName]; ok {
+				ovnMigrationNodeAnnotation := OVNMigrationNodeAnnotation{}
+				if err := json.Unmarshal([]byte(node.Annotations[egressCIDRAnnotationName]), &ovnMigrationNodeAnnotation); err != nil {
+					return err
+				}
+				egressCIDRsArr = ovnMigrationNodeAnnotation.EgressCIDRs
+			} else {
+				egressIpConfig := node.Annotations[egressIPNodeConfig]
+				egressIpConfigArr := make([]NodeEgressIpConfig, 0)
+				if err := json.Unmarshal([]byte(egressIpConfig), &egressIpConfigArr); err != nil {
+					return err
+				}
+				if len(egressIpConfigArr) <= 0 {
+					return fmt.Errorf("unexpected error: egress-ipconfig annotation is empty")
+				}
+				nodeSubnet, ok := egressIpConfigArr[0].IfAddr["ipv4"]
+				if !ok {
+					return fmt.Errorf("unexpected error: egress-ipconfig annotation missing ipv4 entry")
+				}
+				egressCIDRsArr = []string{nodeSubnet}
+			}
+
+			if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				hsn, err := client.Default().Dynamic().Resource(gvrHostSubnet).Get(ctx, node.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				if err := uns.SetNestedStringSlice(hsn.Object, egressCIDRsArr, "egressCIDRs"); err != nil {
+					return err
+				}
+				_, err = client.Default().Dynamic().Resource(gvrHostSubnet).Update(ctx, hsn, metav1.UpdateOptions{})
+				return err
+			}); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil // success
+}
+
+func sdnEgressIpResourcesReady(ctx context.Context, client cnoclient.Client) (bool, error) {
+	// get all nodes
+	// get all hostsubnets
+	// iterate over all node names and return false if any of them don't have an associated hostsubnet
+	nodeList, err := client.Default().Kubernetes().CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+	hostSubnetList, err := cnoclient.ListAllOfSpecifiedType(gvrHostSubnet, ctx, client)
+	if err != nil {
+		return false, err
+	}
+
+	for _, node := range nodeList.Items {
+		found := false
+		for _, hostSubnet := range hostSubnetList {
+			if hostSubnet.Object["host"] == node.Name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false, nil
+		}
+	}
+
+	result, err := netNamespacesExistForAllNamespaces(ctx, client)
+	if !result {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
 func netNamespacesExistForAllNamespaces(ctx context.Context, client cnoclient.Client) (bool, error) {
 	// get all namespaces
 	// get all netnamespaces
@@ -233,4 +468,151 @@ func netNamespacesExistForAllNamespaces(ctx context.Context, client cnoclient.Cl
 	}
 
 	return true, nil
+}
+
+func netNamespaceHasEgressIpConfig(nns uns.Unstructured) bool {
+	if nns.Object["egressIPs"] != nil {
+		return len(nns.Object["egressIPs"].([]interface{})) > 0
+	}
+	return false
+}
+
+func hostSubnetHasEgressIpConfigAutomatic(hsn uns.Unstructured) bool {
+	if hsn.Object["egressIPs"] != nil && hsn.Object["egressCIDRs"] != nil {
+		return len(hsn.Object["egressIPs"].([]interface{})) > 0 && len(hsn.Object["egressCIDRs"].([]interface{})) > 0
+	}
+	return false
+}
+
+func hostSubnetHasEgressIpConfigManual(hsn uns.Unstructured) bool {
+	if hsn.Object["egressIPs"] != nil && hsn.Object["egressCIDRs"] == nil {
+		return len(hsn.Object["egressIPs"].([]interface{})) > 0
+	}
+	return false
+}
+
+func labelNodeAndRemoveHostSubnetConfig(ctx context.Context, client cnoclient.Client, hsn *uns.Unstructured) error {
+	// label node as egressassignable
+	hostStr := fmt.Sprintf("%v", hsn.Object["host"])
+
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		nodeObj, err := client.Default().Kubernetes().CoreV1().Nodes().Get(ctx, hostStr, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		if nodeObj.Labels == nil {
+			nodeObj.Labels = make(map[string]string)
+		}
+		if _, ok := nodeObj.Labels[egressAssignable]; !ok {
+			nodeObj.Labels[egressAssignable] = ""
+		}
+
+		// copy egressCIDRs to node label if possible
+		// - if egressCIDRs contains values (automatic config), on rollback this annotation will provide the respective hostsubnet with its original egressCIDRs values
+		// - if egressCIDRs is empty (manual config), on rollback this label will not exist, and so we default to node's subnet for egressCIDR field.
+		egressCIDRs, found, err := uns.NestedStringSlice(hsn.Object, "egressCIDRs")
+		if err != nil {
+			return fmt.Errorf("egressCIDRs not found in HostSubnet object %s, probable underlying error: %v", hsn.GetName(), err)
+		} else if found {
+			// automatic configuration
+			ovnMigrationAnnotation := OVNMigrationNodeAnnotation{
+				EgressCIDRs: egressCIDRs,
+			}
+
+			if nodeObj.Annotations == nil {
+				nodeObj.Annotations = make(map[string]string)
+			}
+			if _, ok := nodeObj.Annotations[egressCIDRAnnotationName]; !ok {
+				egressCIDRsText, err := json.Marshal(ovnMigrationAnnotation)
+				if err != nil {
+					return err
+				}
+				nodeObj.Annotations[egressCIDRAnnotationName] = string(egressCIDRsText)
+			}
+		}
+		_, err = client.Default().Kubernetes().CoreV1().Nodes().Update(ctx, nodeObj, metav1.UpdateOptions{})
+		return err
+	}); err != nil {
+		return err
+	}
+
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		hsn, err := client.Default().Dynamic().Resource(gvrHostSubnet).Get(ctx, hsn.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		// now remove egressIP config from hostsubnet
+		hsn.Object["egressCIDRs"] = nil
+		hsn.Object["egressIPs"] = nil
+		_, err = client.Default().Dynamic().Resource(gvrHostSubnet).Update(ctx, hsn, metav1.UpdateOptions{})
+		return err
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func deleteCloudPrivateIpConfigs(ctx context.Context, client cnoclient.Client, egressIps []interface{}) error {
+	for _, egressIp := range egressIps {
+		egressIpStr := fmt.Sprintf("%v", egressIp)
+		// delete cloudprivateipconfig
+		err := client.Default().Dynamic().Resource(gvrCloudPrivateIPConfig).Delete(ctx, egressIpStr, metav1.DeleteOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			} else {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func applyEgressIpList(ctx context.Context, client cnoclient.Client, egressIpList []*uns.Unstructured, netNamespaceList []*uns.Unstructured) error {
+	for _, egressIp := range egressIpList {
+		if err := apply.ApplyObject(ctx, client, egressIp, ""); err != nil {
+			return err
+		}
+	}
+
+	for _, nns := range netNamespaceList {
+		if netNamespaceHasEgressIpConfig(*nns) {
+			if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				nns, err := client.Default().Dynamic().Resource(gvrNetnamespace).Get(ctx, nns.GetName(), metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				// now remove egressIP config from netnamespace
+				nns.Object["egressIPs"] = nil
+				_, err = client.Default().Dynamic().Resource(gvrNetnamespace).Update(ctx, nns, metav1.UpdateOptions{})
+				return err
+			}); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func unstructuredEgressIpObject(egressIpName string, egressIps []interface{}, netname interface{}) *uns.Unstructured {
+	return &uns.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "k8s.ovn.org/v1",
+			"kind":       "EgressIP",
+			"metadata": map[string]interface{}{
+				"name": egressIpName,
+			},
+			"spec": map[string]interface{}{
+				"egressIPs": egressIps,
+				"namespaceSelector": map[string]interface{}{
+					"matchLabels": map[string]interface{}{
+						"kubernetes.io/metadata.name": netname,
+					},
+				},
+			},
+		},
+	}
 }

--- a/pkg/controller/operconfig/migration_test.go
+++ b/pkg/controller/operconfig/migration_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	// . "github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	v1 "github.com/openshift/api/network/v1"
 	"github.com/openshift/cluster-network-operator/pkg/client/fake"
 	corev1 "k8s.io/api/core/v1"
@@ -17,9 +17,470 @@ import (
 )
 
 const testMigrationNamespace = "openshift-multus"
+const testMigrationHost = "egressip-test-host"
 
 func init() {
 	utilruntime.Must(v1.AddToScheme(scheme.Scheme))
+}
+
+func TestEgressIpMigration(t *testing.T) {
+	nnsEgressIpsStrArrSingle := []string{"10.0.128.5"}
+	nnsEgressIpsIfcArrSingle := ConvertToUnstructuredInterface(nnsEgressIpsStrArrSingle)
+	nnsEgressIpsStrArrMult := []string{"10.0.128.5", "10.0.128.6", "10.0.128.7"}
+	nnsEgressIpsIfcArrMult := ConvertToUnstructuredInterface(nnsEgressIpsStrArrMult)
+
+	testCases := []struct {
+		name                 string
+		objects              []crclient.Object
+		expectedEgressIpList []string
+	}{
+		{
+			name: "Hostsubnet has automatic config and netnamespace has one egressIP",
+			objects: []crclient.Object{
+				&v1.HostSubnet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testMigrationHost,
+					},
+					EgressCIDRs: []v1.HostSubnetEgressCIDR{"10.0.128.0/17"},
+					EgressIPs:   []v1.HostSubnetEgressIP{"10.0.128.5"},
+					Host:        testMigrationHost,
+				},
+				&uns.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "network.openshift.io/v1",
+						"kind":       "NetNamespace",
+						"egressIPs":  nnsEgressIpsIfcArrSingle,
+						"netname":    testMigrationNamespace,
+						"metadata": map[string]interface{}{
+							"name": testMigrationNamespace,
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testMigrationHost,
+					},
+				},
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testMigrationNamespace,
+					},
+				},
+			},
+			expectedEgressIpList: nnsEgressIpsStrArrSingle,
+		},
+		{
+			name: "Hostsubnet has automatic config and netnamespace has multiple egressIPs",
+			objects: []crclient.Object{
+				&v1.HostSubnet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testMigrationHost,
+					},
+					EgressCIDRs: []v1.HostSubnetEgressCIDR{"10.0.128.0/17"},
+					EgressIPs:   []v1.HostSubnetEgressIP{"10.0.128.5", "10.0.128.6", "10.0.128.7"},
+					Host:        testMigrationHost,
+				},
+				&uns.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "network.openshift.io/v1",
+						"kind":       "NetNamespace",
+						"egressIPs":  nnsEgressIpsIfcArrMult,
+						"netname":    testMigrationNamespace,
+						"metadata": map[string]interface{}{
+							"name": testMigrationNamespace,
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testMigrationHost,
+					},
+				},
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testMigrationNamespace,
+					},
+				},
+			},
+			expectedEgressIpList: nnsEgressIpsStrArrMult,
+		},
+		{
+			name: "Hostsubnet has manual config and netnamespace has one egressIP",
+			objects: []crclient.Object{
+				&v1.HostSubnet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testMigrationHost,
+					},
+					EgressIPs: []v1.HostSubnetEgressIP{"10.0.128.5"},
+					Host:      testMigrationHost,
+				},
+				&uns.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "network.openshift.io/v1",
+						"kind":       "NetNamespace",
+						"egressIPs":  nnsEgressIpsIfcArrSingle,
+						"netname":    testMigrationNamespace,
+						"metadata": map[string]interface{}{
+							"name": testMigrationNamespace,
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testMigrationHost,
+					},
+				},
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testMigrationNamespace,
+					},
+				},
+			},
+			expectedEgressIpList: nnsEgressIpsStrArrSingle,
+		},
+		{
+			name: "Hostsubnet has manual config and netnamespace has multiple egressIPs",
+			objects: []crclient.Object{
+				&v1.HostSubnet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testMigrationHost,
+					},
+					EgressIPs: []v1.HostSubnetEgressIP{"10.0.128.5", "10.0.128.6", "10.0.128.7"},
+					Host:      testMigrationHost,
+				},
+				&uns.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "network.openshift.io/v1",
+						"kind":       "NetNamespace",
+						"egressIPs":  nnsEgressIpsIfcArrMult,
+						"netname":    testMigrationNamespace,
+						"metadata": map[string]interface{}{
+							"name": testMigrationNamespace,
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testMigrationHost,
+					},
+				},
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testMigrationNamespace,
+					},
+				},
+			},
+			expectedEgressIpList: nnsEgressIpsStrArrMult,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			client := fake.NewFakeClient(tc.objects...)
+
+			egressIpList, _, err := convertSdnEgressIpToOvnEgressIp(context.Background(), client)
+			if err != nil {
+				t.Fatalf("convertSdnEgressIpToOvnEgressIp: %v", err)
+			}
+			// Collect all egressIP strings in a single slice
+			var egressIpValueList []string
+			for _, egressIp := range egressIpList {
+				egressIpsSlice := egressIp.Object["spec"].(map[string]interface{})["egressIPs"].([]interface{})
+				egressIpsStringSlice := make([]string, len(egressIpsSlice))
+				for i := range egressIpsSlice {
+					egressIpsStringSlice[i] = egressIpsSlice[i].(string)
+				}
+				egressIpValueList = append(egressIpValueList, egressIpsStringSlice...)
+			}
+
+			// Check if values match exactly
+			expectedEgressIpList := ConvertToUnstructuredInterface(tc.expectedEgressIpList)
+			g.Expect(egressIpValueList).To(ConsistOf(expectedEgressIpList...), "expected applied OVN egressIPs to have egressIP list matching input SDN config")
+
+			// Check that node annotation has been added
+			nodeObj, err := client.Default().Kubernetes().CoreV1().Nodes().Get(context.Background(), testMigrationHost, metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if _, ok := nodeObj.Labels[egressAssignable]; !ok {
+				t.Errorf("expect node to be marked with egress-assignable annotation")
+			}
+		})
+	}
+}
+
+func TestEgressIpRollbackMigration(t *testing.T) {
+	egressIpsStrArrSingle := []string{"10.0.128.5"}
+	egressIpsIfcArrSingle := ConvertToUnstructuredInterface(egressIpsStrArrSingle)
+	egressIpsStrArrMult := []string{"10.0.128.5", "10.0.128.6", "10.0.128.7"}
+	egressIpsIfcArrMult := ConvertToUnstructuredInterface(egressIpsStrArrMult)
+
+	egressCIDRsStrArr := []string{"10.0.128.0/17"}
+	nodeAnnotationMap := make(map[string]string, 0)
+	nodeAnnotationMap[egressIPNodeConfig] = "[{\"interface\":\"nic0\",\"ifaddr\":{\"ipv4\":\"10.0.128.0/17\"},\"capacity\":{\"ip\":10}}]"
+
+	egressCIDRsStrArrWithEgressCidrAnnotation := []string{"10.0.128.0/18"}
+	nodeAnnotationMapWithEgressCidrAnnotation := make(map[string]string, 0)
+	nodeAnnotationMapWithEgressCidrAnnotation[egressIPNodeConfig] = "[{\"interface\":\"nic0\",\"ifaddr\":{\"ipv4\":\"10.0.128.0/17\"},\"capacity\":{\"ip\":10}}]"
+	nodeAnnotationMapWithEgressCidrAnnotation[egressCIDRAnnotationName] = "{\"EgressCIDRs\":[\"10.0.128.0/18\"]}"
+
+	nodeLabelMap := make(map[string]string)
+	nodeLabelMap[egressAssignable] = ""
+
+	testCases := []struct {
+		name                    string
+		objects                 []crclient.Object
+		expectedEgressIpsList   []string
+		expectedEgressCIDRsList []string
+	}{
+		{
+			name: "egressIP has one IP listed",
+			objects: []crclient.Object{
+				&v1.HostSubnet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testMigrationHost,
+					},
+					Host: testMigrationHost,
+				},
+				&uns.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "network.openshift.io/v1",
+						"kind":       "NetNamespace",
+						"netname":    testMigrationNamespace,
+						"metadata": map[string]interface{}{
+							"name": testMigrationNamespace,
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        testMigrationHost,
+						Annotations: nodeAnnotationMap,
+						Labels:      nodeLabelMap,
+					},
+				},
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testMigrationNamespace,
+					},
+				},
+				&uns.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "k8s.ovn.org/v1",
+						"kind":       "EgressIP",
+						"metadata": map[string]interface{}{
+							"name": "egress-group1",
+						},
+						"spec": map[string]interface{}{
+							"egressIPs": egressIpsIfcArrSingle,
+							"namespaceSelector": map[string]interface{}{
+								"matchLabels": map[string]interface{}{
+									"kubernetes.io/metadata.name": testMigrationNamespace,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedEgressIpsList:   egressIpsStrArrSingle,
+			expectedEgressCIDRsList: egressCIDRsStrArr,
+		},
+		{
+			name: "egressIP has multiple IPs listed",
+			objects: []crclient.Object{
+				&v1.HostSubnet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testMigrationHost,
+					},
+					Host: testMigrationHost,
+				},
+				&uns.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "network.openshift.io/v1",
+						"kind":       "NetNamespace",
+						"netname":    testMigrationNamespace,
+						"metadata": map[string]interface{}{
+							"name": testMigrationNamespace,
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        testMigrationHost,
+						Annotations: nodeAnnotationMap,
+						Labels:      nodeLabelMap,
+					},
+				},
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testMigrationNamespace,
+					},
+				},
+				&uns.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "k8s.ovn.org/v1",
+						"kind":       "EgressIP",
+						"metadata": map[string]interface{}{
+							"name": "egress-group1",
+						},
+						"spec": map[string]interface{}{
+							"egressIPs": egressIpsIfcArrMult,
+							"namespaceSelector": map[string]interface{}{
+								"matchLabels": map[string]interface{}{
+									"kubernetes.io/metadata.name": testMigrationNamespace,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedEgressIpsList:   egressIpsStrArrMult,
+			expectedEgressCIDRsList: egressCIDRsStrArr,
+		},
+		{
+			name: "egressIP has one IP listed and node has egressCIDR rollback annotation",
+			objects: []crclient.Object{
+				&v1.HostSubnet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testMigrationHost,
+					},
+					Host: testMigrationHost,
+				},
+				&uns.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "network.openshift.io/v1",
+						"kind":       "NetNamespace",
+						"netname":    testMigrationNamespace,
+						"metadata": map[string]interface{}{
+							"name": testMigrationNamespace,
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        testMigrationHost,
+						Annotations: nodeAnnotationMapWithEgressCidrAnnotation,
+						Labels:      nodeLabelMap,
+					},
+				},
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testMigrationNamespace,
+					},
+				},
+				&uns.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "k8s.ovn.org/v1",
+						"kind":       "EgressIP",
+						"metadata": map[string]interface{}{
+							"name": "egress-group1",
+						},
+						"spec": map[string]interface{}{
+							"egressIPs": egressIpsIfcArrSingle,
+							"namespaceSelector": map[string]interface{}{
+								"matchLabels": map[string]interface{}{
+									"kubernetes.io/metadata.name": testMigrationNamespace,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedEgressIpsList:   egressIpsStrArrSingle,
+			expectedEgressCIDRsList: egressCIDRsStrArrWithEgressCidrAnnotation,
+		},
+		{
+			name: "egressIP has multiple IPs listed and node has egressCIDR rollback annotation",
+			objects: []crclient.Object{
+				&v1.HostSubnet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testMigrationHost,
+					},
+					Host: testMigrationHost,
+				},
+				&uns.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "network.openshift.io/v1",
+						"kind":       "NetNamespace",
+						"netname":    testMigrationNamespace,
+						"metadata": map[string]interface{}{
+							"name": testMigrationNamespace,
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        testMigrationHost,
+						Annotations: nodeAnnotationMapWithEgressCidrAnnotation,
+						Labels:      nodeLabelMap,
+					},
+				},
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testMigrationNamespace,
+					},
+				},
+				&uns.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "k8s.ovn.org/v1",
+						"kind":       "EgressIP",
+						"metadata": map[string]interface{}{
+							"name": "egress-group1",
+						},
+						"spec": map[string]interface{}{
+							"egressIPs": egressIpsIfcArrMult,
+							"namespaceSelector": map[string]interface{}{
+								"matchLabels": map[string]interface{}{
+									"kubernetes.io/metadata.name": testMigrationNamespace,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedEgressIpsList:   egressIpsStrArrMult,
+			expectedEgressCIDRsList: egressCIDRsStrArrWithEgressCidrAnnotation,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			client := fake.NewFakeClient(tc.objects...)
+
+			err := convertOvnEgressIpToSdnEgressIp(context.Background(), client)
+			if err != nil {
+				t.Fatalf("convertOvnEgressIpToSdnEgressIp: %v", err)
+			}
+
+			// Get the Hostsubnet and Netnamespace that should be updated
+			hsn, err := client.Default().Dynamic().Resource(gvrHostSubnet).Get(context.Background(), testMigrationHost, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("failed to get hostsubnet: %v", err)
+			}
+			nns, err := client.Default().Dynamic().Resource(gvrNetnamespace).Get(context.Background(), testMigrationNamespace, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("failed to get netnamespace: %v", err)
+			}
+
+			// Check if Hostsubnets has correct egressCIDRs field
+			hsnEgressCIDRs, found, err := uns.NestedStringSlice(hsn.Object, "egressCIDRs")
+			if !found || err != nil {
+				t.Fatalf("failed to find egressCIDRs for hostsubnet %s, probable cause: %v", hsn.GetName(), err)
+			}
+			expectedEgressCIDRsList := ConvertToUnstructuredInterface(tc.expectedEgressCIDRsList)
+			g.Expect(hsnEgressCIDRs).To(ConsistOf(expectedEgressCIDRsList...), "expected applied SDN hostsubnet to have egressCIDRs matching input OVN config")
+
+			// Check if Netnamespaces has correct egressIPs field
+			nnsEgressIPs, found, err := uns.NestedStringSlice(nns.Object, "egressIPs")
+			if !found || err != nil {
+				t.Fatalf("failed to find egressIPs for netnamespace %s, probable cause: %v", nns.GetName(), err)
+			}
+			expectedEgressIpsList := ConvertToUnstructuredInterface(tc.expectedEgressIpsList)
+			g.Expect(nnsEgressIPs).To(ConsistOf(expectedEgressIpsList...), "expected applied SDN netnamespace to have egressIPs matching input OVN config")
+		})
+	}
 }
 
 func TestMulticastMigration(t *testing.T) {
@@ -55,7 +516,6 @@ func TestMulticastMigration(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// g := gomega.NewWithT(t)
 			client := fake.NewFakeClient(tc.objects...)
 
 			err := enableMulticastOVN(context.Background(), client)
@@ -111,7 +571,6 @@ func TestMulticastMigrationRollback(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// g := gomega.NewWithT(t)
 			client := fake.NewFakeClient(tc.objects...)
 
 			err := enableMulticastSDN(context.Background(), client)
@@ -133,4 +592,12 @@ func TestMulticastMigrationRollback(t *testing.T) {
 			}
 		})
 	}
+}
+
+func ConvertToUnstructuredInterface(input []string) []interface{} {
+	output := make([]interface{}, len(input))
+	for i, v := range input {
+		output[i] = v
+	}
+	return output
 }


### PR DESCRIPTION
Patch that addresses blocker epic [OVN Migration Further Solution Enhancement](https://issues.redhat.com/browse/NP-20). 

With this patch, CNO will convert HostSubnets and Netnamespaces configured with egressIP to egressIP CR when migrating from Openshift SDN to OVN-Kubernetes. When rolling back, CNO will convert egressIP CR into configuration updates for HostSubnets and Netnamespaces. When said resources get recreated during rollback, the configuration updates will be applied, restoring egressIP config.

Of note: this feature only supports automatically configured egressIP migration for SDN to OVN migration. Manually configured SDN egressIPs are NOT supported and **the documentation should explicitly state this**.

Review comments are welcome and encouraged, as this feature is blocking the release of 4.12.