### PR TITLE
hypershift: set multus controller priority appropriate for hosted clusters

### DIFF
--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -139,8 +139,10 @@ spec:
         runAsNonRoot: true
         runAsUser: 65534
       serviceAccountName: multus-ac
-{{- end }}
       priorityClassName: "system-cluster-critical"
+{{- else}}
+      priorityClassName: "hypershift-control-plane"
+{{- end }}
       restartPolicy: Always
 {{- if not .ExternalControlPlane }}
       nodeSelector:


### PR DESCRIPTION
cc @alvaroaleman @csrwng 

Changed in https://github.com/openshift/cluster-network-operator/pull/1516

Fix failure in hypershift CI e.g.
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_hypershift/1702/pull-ci-openshift-hypershift-main-e2e-aws-nested/1563067003344785408