### PR TITLE
Use fixed name for creating EgressFirewall CRs

### DIFF
--- a/pkg/controller/operconfig/migration.go
+++ b/pkg/controller/operconfig/migration.go
@@ -16,6 +16,8 @@ import (
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 )
 
+const defaultEgressFirewallName = "default"
+
 var gvrEgressFirewall = schema.GroupVersionResource{Group: "k8s.ovn.org", Version: "v1", Resource: "egressfirewalls"}
 var gvrEgressNetworkPolicy = schema.GroupVersionResource{Group: "network.openshift.io", Version: "v1", Resource: "egressnetworkpolicies"}
 
@@ -47,7 +49,8 @@ func convertEgressNetworkPolicyToEgressFirewall(ctx context.Context, client cnoc
 				"apiVersion": "k8s.ovn.org/v1",
 				"kind":       "EgressFirewall",
 				"metadata": map[string]interface{}{
-					"name":      enp.GetName(),
+					// The name for the EgressFirewall CR must be 'default', other values are not allowed.
+					"name":      defaultEgressFirewallName,
 					"namespace": enp.GetNamespace(),
 				},
 				"spec": spec,


### PR DESCRIPTION
When migrating the configuration of Egress Firewall from SDN to
OVN, use a fixed name 'default' as the name of EgressFirewall CRs.

It also means when rolling back to SDN, all EgressNetworkPolicy CRs
created by CNO will use 'default' as name.

This is a hard requirement defined in EgressFirewall CRD.

Signed-off-by: Peng Liu <pliu@redhat.com>