### PR TITLE
Bug SDN-3458: HyperShift: Differentiate resources deployed by different CNO instances in status manager

### DIFF
--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -79,6 +79,7 @@ type InfraStatus struct {
 	PlatformStatus         *configv1.PlatformStatus
 	ControlPlaneTopology   configv1.TopologyMode
 	InfrastructureTopology configv1.TopologyMode
+	InfraName              string
 
 	// KubeCloudConfig is the contents of the openshift-config-managed/kube-cloud-config ConfigMap
 	KubeCloudConfig map[string]string

--- a/pkg/controller/statusmanager/pod_status.go
+++ b/pkg/controller/statusmanager/pod_status.go
@@ -17,7 +17,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -385,21 +384,17 @@ func isNonCritical(obj metav1.Object) bool {
 }
 
 func (status *StatusManager) listAllStatusObjects() (dss []*appsv1.DaemonSet, deps []*appsv1.Deployment, sss []*appsv1.StatefulSet) {
-	selector, err := labels.Parse(generateStatusSelector)
-	if err != nil {
-		panic(err) // selector is guaranteed valid, unreachable
-	}
 	// these lists can't fail, they're backed by informers
 	for _, lister := range status.dsListers {
-		l, _ := lister.List(selector)
+		l, _ := lister.List(status.labelSelector)
 		dss = append(dss, l...)
 	}
 	for _, lister := range status.depListers {
-		l, _ := lister.List(selector)
+		l, _ := lister.List(status.labelSelector)
 		deps = append(deps, l...)
 	}
 	for _, lister := range status.ssListers {
-		l, _ := lister.List(selector)
+		l, _ := lister.List(status.labelSelector)
 		sss = append(sss, l...)
 	}
 	return

--- a/pkg/controller/statusmanager/pod_watcher.go
+++ b/pkg/controller/statusmanager/pod_watcher.go
@@ -2,7 +2,6 @@ package statusmanager
 
 import (
 	"context"
-
 	"github.com/openshift/cluster-network-operator/pkg/names"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,7 +41,7 @@ func (s *StatusManager) initInformersFor(clusterName, namespace string, includeD
 			0, // resync Period
 			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 			func(options *metav1.ListOptions) {
-				options.LabelSelector = generateStatusSelector
+				options.LabelSelector = s.labelSelector.String()
 			})
 		s.client.ClientFor(clusterName).AddCustomInformer(inf)
 		s.dsInformers[clusterName] = inf
@@ -56,7 +55,7 @@ func (s *StatusManager) initInformersFor(clusterName, namespace string, includeD
 		0, // resync Period
 		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 		func(options *metav1.ListOptions) {
-			options.LabelSelector = generateStatusSelector
+			options.LabelSelector = s.labelSelector.String()
 		})
 	s.client.ClientFor(clusterName).AddCustomInformer(inf)
 	s.depInformers[clusterName] = inf
@@ -68,7 +67,7 @@ func (s *StatusManager) initInformersFor(clusterName, namespace string, includeD
 		0, // resync Period
 		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 		func(options *metav1.ListOptions) {
-			options.LabelSelector = generateStatusSelector
+			options.LabelSelector = s.labelSelector.String()
 		})
 	s.client.ClientFor(clusterName).AddCustomInformer(inf)
 	s.ssInformers[clusterName] = inf

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -44,8 +44,13 @@ const NonCriticalAnnotation = "networkoperator.openshift.io/non-critical"
 // GenerateStatusLabel can be set by the various Controllers to tell the
 // StatusController that this object is relevant, and should be included
 // when generating status from deployed pods.
-// Currently, this is looked for on Deployments, DaemonSets, and StatefulSets
+// Currently, this is looked for on Deployments, DaemonSets, and StatefulSets.
+// Its value reflects which cluster the resource belongs to. This helps avoid an overlap
+// in Hypershift where there can be multiple CNO instances running in the management cluster.
 const GenerateStatusLabel = "networkoperator.openshift.io/generates-operator-status"
+
+// StandAloneClusterName is a value used for GenerateStatusLabel label when running in non-Hypershift environments
+const StandAloneClusterName = "stand-alone"
 
 // NetworkMigrationAnnotation is an annotation on the networks.operator.openshift.io CR to indicate
 // that executing network migration (switching the default network type of the cluster) is allowed.

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -30,6 +30,7 @@ func InfraStatus(client cnoclient.Client) (*bootstrap.InfraStatus, error) {
 		PlatformType:           infraConfig.Status.PlatformStatus.Type,
 		PlatformStatus:         infraConfig.Status.PlatformStatus,
 		ControlPlaneTopology:   infraConfig.Status.ControlPlaneTopology,
+		InfraName:              infraConfig.Status.InfrastructureName,
 		InfrastructureTopology: infraConfig.Status.InfrastructureTopology,
 		APIServers:             map[string]bootstrap.APIServer{},
 	}


### PR DESCRIPTION
CNO should only reconcile its status based on the resources it rendered.
In the management cluster there is the default CNO and one CNO per hosted clusters control namespace.
By using a label value set to the infrastructure name we can differentiate the resources rendered by different CNO instances.

In stand-alone environments the value is a non-empty constant so it doesn't overlap with older CNO versions.

Additionally start watching deployments in the hosted cluster control plane namespace sine we added CNCC and multus admission controller to it.