### PR TITLE
Migrate Multicast configuration during SDN migration and rollback

### DIFF
--- a/pkg/client/list_pager.go
+++ b/pkg/client/list_pager.go
@@ -16,20 +16,9 @@ import (
 func ListAllOfSpecifiedType(resourceType schema.GroupVersionResource, ctx context.Context, client Client) ([]*uns.Unstructured, error) {
 	list := []*uns.Unstructured{}
 	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
-		return client.Default().Dynamic().Resource(resourceType).List(ctx, metav1.ListOptions{})
+		return client.Default().Dynamic().Resource(resourceType).List(ctx, opts)
 	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
 		list = append(list, obj.(*uns.Unstructured))
-		return nil
-	})
-	return list, err
-}
-
-func ListAllNodes(ctx context.Context, client Client) ([]*v1.Node, error) {
-	list := []*v1.Node{}
-	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
-		return client.Default().Kubernetes().CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
-		list = append(list, obj.(*v1.Node))
 		return nil
 	})
 	return list, err
@@ -38,7 +27,7 @@ func ListAllNodes(ctx context.Context, client Client) ([]*v1.Node, error) {
 func ListAllNamespaces(ctx context.Context, client Client) ([]*v1.Namespace, error) {
 	list := []*v1.Namespace{}
 	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
-		return client.Default().Kubernetes().CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+		return client.Default().Kubernetes().CoreV1().Namespaces().List(ctx, opts)
 	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
 		list = append(list, obj.(*v1.Namespace))
 		return nil

--- a/pkg/client/list_pager.go
+++ b/pkg/client/list_pager.go
@@ -1,0 +1,47 @@
+package client
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/pager"
+	// cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
+)
+
+// for use with dynamic client
+func ListAllOfSpecifiedType(resourceType schema.GroupVersionResource, ctx context.Context, client Client) ([]*uns.Unstructured, error) {
+	list := []*uns.Unstructured{}
+	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return client.Default().Dynamic().Resource(resourceType).List(ctx, metav1.ListOptions{})
+	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+		list = append(list, obj.(*uns.Unstructured))
+		return nil
+	})
+	return list, err
+}
+
+func ListAllNodes(ctx context.Context, client Client) ([]*v1.Node, error) {
+	list := []*v1.Node{}
+	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return client.Default().Kubernetes().CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+		list = append(list, obj.(*v1.Node))
+		return nil
+	})
+	return list, err
+}
+
+func ListAllNamespaces(ctx context.Context, client Client) ([]*v1.Namespace, error) {
+	list := []*v1.Namespace{}
+	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return client.Default().Kubernetes().CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+		list = append(list, obj.(*v1.Namespace))
+		return nil
+	})
+	return list, err
+}

--- a/pkg/controller/operconfig/migration.go
+++ b/pkg/controller/operconfig/migration.go
@@ -20,6 +20,7 @@ const defaultEgressFirewallName = "default"
 
 var gvrEgressFirewall = schema.GroupVersionResource{Group: "k8s.ovn.org", Version: "v1", Resource: "egressfirewalls"}
 var gvrEgressNetworkPolicy = schema.GroupVersionResource{Group: "network.openshift.io", Version: "v1", Resource: "egressnetworkpolicies"}
+var gvrNetnamespace = schema.GroupVersionResource{Group: "network.openshift.io", Version: "v1", Resource: "netnamespaces"}
 
 func migrateMulticastEnablement(ctx context.Context, operConfig *operv1.Network, client cnoclient.Client) error {
 	switch operConfig.Spec.Migration.NetworkType {

--- a/pkg/controller/operconfig/migration.go
+++ b/pkg/controller/operconfig/migration.go
@@ -113,7 +113,10 @@ func enableMulticastSDN(ctx context.Context, client cnoclient.Client) error {
 				multicastEnabledMap := map[string]string{
 					multicastEnabledSDN: "true",
 				}
-				uns.SetNestedStringMap(nns.Object, multicastEnabledMap, "metadata", "annotations")
+				err = uns.SetNestedStringMap(nns.Object, multicastEnabledMap, "metadata", "annotations")
+				if err != nil {
+					return err
+				}
 				_, err = client.Default().Dynamic().Resource(gvrNetnamespace).Update(ctx, nns, metav1.UpdateOptions{})
 				return err
 			}); err != nil {

--- a/pkg/controller/operconfig/migration_test.go
+++ b/pkg/controller/operconfig/migration_test.go
@@ -1,0 +1,136 @@
+package operconfig
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	// . "github.com/onsi/gomega"
+	v1 "github.com/openshift/api/network/v1"
+	"github.com/openshift/cluster-network-operator/pkg/client/fake"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const testMigrationNamespace = "openshift-multus"
+
+func init() {
+	utilruntime.Must(v1.AddToScheme(scheme.Scheme))
+}
+
+func TestMulticastMigration(t *testing.T) {
+
+	testCases := []struct {
+		name    string
+		objects []crclient.Object
+	}{
+		{
+			name: "Multicast annotation present on netnamespace object",
+			objects: []crclient.Object{
+				&uns.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "network.openshift.io/v1",
+						"kind":       "NetNamespace",
+						"netname":    testMigrationNamespace,
+						"metadata": map[string]interface{}{
+							"name": testMigrationNamespace,
+							"annotations": map[string]interface{}{
+								multicastEnabledSDN: "true",
+							},
+						},
+					},
+				},
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testMigrationNamespace,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// g := gomega.NewWithT(t)
+			client := fake.NewFakeClient(tc.objects...)
+
+			err := enableMulticastOVN(context.Background(), client)
+			if err != nil {
+				t.Fatalf("enableMulticastOVN: %v", err)
+			}
+
+			ns, err := client.Default().Kubernetes().CoreV1().Namespaces().Get(context.Background(), testMigrationNamespace, metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if _, ok := ns.Annotations[multicastEnabledOVN]; !ok {
+				t.Errorf("expect namespace to be marked with multicast-enabled annotation")
+			}
+			if ns.Annotations[multicastEnabledOVN] != "true" {
+				t.Errorf("expected multicast-enabled annotation to be set to \"true\"")
+			}
+		})
+	}
+}
+
+func TestMulticastMigrationRollback(t *testing.T) {
+	namespaceAnnotation := map[string]string{
+		multicastEnabledOVN: "true",
+	}
+
+	testCases := []struct {
+		name    string
+		objects []crclient.Object
+	}{
+		{
+			name: "Multicast annotation present on netnamespace object",
+			objects: []crclient.Object{
+				&uns.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "network.openshift.io/v1",
+						"kind":       "NetNamespace",
+						"netname":    testMigrationNamespace,
+						"metadata": map[string]interface{}{
+							"name": testMigrationNamespace,
+						},
+					},
+				},
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        testMigrationNamespace,
+						Annotations: namespaceAnnotation,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// g := gomega.NewWithT(t)
+			client := fake.NewFakeClient(tc.objects...)
+
+			err := enableMulticastSDN(context.Background(), client)
+			if err != nil {
+				t.Fatalf("enableMulticastOVN: %v", err)
+			}
+
+			nns, err := client.Default().Dynamic().Resource(gvrNetnamespace).Get(context.Background(), testMigrationNamespace, metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			meme := nns.GetAnnotations()
+			fmt.Println(meme)
+			if _, ok := nns.GetAnnotations()[multicastEnabledSDN]; !ok {
+				t.Errorf("expect netnamespace to be marked with multicast-enabled annotation")
+			}
+			if nns.GetAnnotations()[multicastEnabledSDN] != "true" {
+				t.Errorf("expected multicast-enabled annotation to be set to \"true\"")
+			}
+		})
+	}
+}

--- a/pkg/controller/operconfig/mtu_probe_test.go
+++ b/pkg/controller/operconfig/mtu_probe_test.go
@@ -7,7 +7,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
-	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -88,22 +88,4 @@ func TestProbeMTU(t *testing.T) {
 			}
 		})
 	}
-}
-
-type fakeCNOClient struct {
-	cnoclient.Client
-	clusterClient cnoclient.ClusterClient
-}
-
-func (f *fakeCNOClient) Default() cnoclient.ClusterClient {
-	return f.clusterClient
-}
-
-type fakeClusterClient struct {
-	cnoclient.ClusterClient
-	crclient crclient.Client
-}
-
-func (f *fakeClusterClient) CRClient() crclient.Client {
-	return f.crclient
 }

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -408,6 +408,12 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 				return reconcile.Result{}, err
 			}
 		}
+		if migration.Features == nil || migration.Features.Multicast {
+			err = migrateMulticastEnablement(ctx, operConfig, r.client)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+		}
 	}
 
 	// Update Network.config.openshift.io.Status

--- a/pkg/controller/operconfig/test_helpers.go
+++ b/pkg/controller/operconfig/test_helpers.go
@@ -1,0 +1,24 @@
+package operconfig
+
+import (
+	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type fakeCNOClient struct {
+	cnoclient.Client
+	clusterClient cnoclient.ClusterClient
+}
+
+func (f *fakeCNOClient) Default() cnoclient.ClusterClient {
+	return f.clusterClient
+}
+
+type fakeClusterClient struct {
+	cnoclient.ClusterClient
+	crclient crclient.Client
+}
+
+func (f *fakeClusterClient) CRClient() crclient.Client {
+	return f.crclient
+}


### PR DESCRIPTION
Patch that addresses blocker epic [OVN Migration Further Solution Enhancement](https://issues.redhat.com/browse/NP-20).

Multicast migration is simple, only annotations need to be updated.