### PR TITLE
OKD-49: Adds support for scos to multus

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -38,7 +38,7 @@ data:
     rhelmajor=
     # detect which version we're using in order to copy the proper binaries
     case "${ID}" in
-      rhcos) rhelmajor=8
+      rhcos|scos) rhelmajor=8
       ;;
       rhel) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)
       ;;


### PR DESCRIPTION
This PR adds support for scos to the cnibincopy.sh script for multus.

Closes [OKD-49](https://issues.redhat.com//browse/OKD-49)

cc @LorbusChris