### PR TITLE
Multus admission controller: Wait for token in Hypershift

### DIFF
--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -82,15 +82,29 @@ spec:
       - name: multus-admission-controller
         image: {{.MultusAdmissionControllerImage}}
         command:
-        - /usr/bin/webhook
-        args:
-        - -bind-address=0.0.0.0
-        - -port=6443
-        - -tls-private-key-file=/etc/webhook/tls.key
-        - -tls-cert-file=/etc/webhook/tls.crt
-        - -alsologtostderr=true
-        - -metrics-listen-address=127.0.0.1:9091
-        - -ignore-namespaces=openshift-etcd,openshift-console,openshift-ingress-canary,{{.IgnoredNamespace}}
+        - /bin/bash
+        - -c
+        - |-
+          set -euo pipefail
+{{- if .HyperShiftEnabled}}
+          retries=0
+          while [ ! -f /var/run/secrets/hosted_cluster/token ]; do
+            (( retries += 1 ))
+            sleep 1
+            if [[ "${retries}" -gt 30 ]]; then
+              echo "$(date -Iseconds) - Hosted cluster token not found"
+                exit 1
+            fi
+          done
+{{- end }}
+          exec /usr/bin/webhook \
+            -bind-address=0.0.0.0 \
+            -port=6443 \
+            -tls-private-key-file=/etc/webhook/tls.key \
+            -tls-cert-file=/etc/webhook/tls.crt \
+            -alsologtostderr=true \
+            -metrics-listen-address=127.0.0.1:9091 \
+            -ignore-namespaces=openshift-etcd,openshift-console,openshift-ingress-canary,{{.IgnoredNamespace}}
         volumeMounts:
         - name: webhook-certs
           mountPath: /etc/webhook


### PR DESCRIPTION
The token is created and rotated by a sidecar to the admission
controller, which means most of the time it won't be there yet when the
process tries to read it during startup. Wait until it is there before
starting.

/assign @dougbtv @kyrtapz 

We have a check in our CI that pods don't restart and this makes it fail regularly, e.G. here: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_hypershift/1689/pull-ci-openshift-hypershift-main-e2e-aws/1565002270200827904#1:build-log.txt%3A1927