### PR TITLE
SDN-3444: Add runbook url for SBDB connectivity alert

### DIFF
--- a/bindata/network/ovn-kubernetes/common/alert-rules.yaml
+++ b/bindata/network/ovn-kubernetes/common/alert-rules.yaml
@@ -29,7 +29,7 @@ spec:
     - alert: OVNKubernetesControllerDisconnectedSouthboundDatabase
       annotations:
         summary: Networking control plane is degraded on node {{"{{"}} $labels.node {{"}}"}} because OVN controller is not connected to OVN southbound database.
-        # runbook_url: TODO by https://issues.redhat.com/browse/SDN-3444
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-network-operator/OVNKubernetesControllerDisconnectedSouthboundDatabase.md
         description: |
           Networking is degraded on nodes when OVN controller is not connected to OVN southbound database connection. No networking control plane updates will be applied to the node.
       expr: |


### PR DESCRIPTION
Add the runbook url for OVNKubernetesControllerDisconnectedSouthboundDatabase alert

/hold
depends on: https://github.com/openshift/runbooks/pull/68 
Signed-off-by: Patryk Diak <pdiak@redhat.com>