### PR TITLE
OVN-K: add patch/update service permissions to controller

### DIFF
--- a/bindata/network/ovn-kubernetes/common/003-rbac-controller.yaml
+++ b/bindata/network/ovn-kubernetes/common/003-rbac-controller.yaml
@@ -78,6 +78,7 @@ rules:
 - apiGroups: [""]
   resources:
   - "nodes/status"
+  - services
   verbs:
   - patch
   - update


### PR DESCRIPTION
The Egress Service controller requires these permissions as it updates annotations on services

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>