### PR TITLE
[release-11] Bug OCPBUGS-1075: HyperShift: Differentiate resources deployed by different CNO instances

### DIFF
--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -77,6 +77,7 @@ type InfraStatus struct {
 	PlatformRegion       string
 	PlatformStatus       *configv1.PlatformStatus
 	ExternalControlPlane bool
+	InfraName            string
 
 	// KubeCloudConfig is the contents of the openshift-config-managed/kube-cloud-config ConfigMap
 	KubeCloudConfig map[string]string

--- a/pkg/controller/statusmanager/pod_status.go
+++ b/pkg/controller/statusmanager/pod_status.go
@@ -17,7 +17,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -385,21 +384,17 @@ func isNonCritical(obj metav1.Object) bool {
 }
 
 func (status *StatusManager) listAllStatusObjects() (dss []*appsv1.DaemonSet, deps []*appsv1.Deployment, sss []*appsv1.StatefulSet) {
-	selector, err := labels.Parse(generateStatusSelector)
-	if err != nil {
-		panic(err) // selector is guaranteed valid, unreachable
-	}
 	// these lists can't fail, they're backed by informers
 	for _, lister := range status.dsListers {
-		l, _ := lister.List(selector)
+		l, _ := lister.List(status.labelSelector)
 		dss = append(dss, l...)
 	}
 	for _, lister := range status.depListers {
-		l, _ := lister.List(selector)
+		l, _ := lister.List(status.labelSelector)
 		deps = append(deps, l...)
 	}
 	for _, lister := range status.ssListers {
-		l, _ := lister.List(selector)
+		l, _ := lister.List(status.labelSelector)
 		sss = append(sss, l...)
 	}
 	return

--- a/pkg/controller/statusmanager/pod_watcher.go
+++ b/pkg/controller/statusmanager/pod_watcher.go
@@ -42,7 +42,7 @@ func (s *StatusManager) initInformersFor(clusterName, namespace string, stateful
 			0, // resync Period
 			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 			func(options *metav1.ListOptions) {
-				options.LabelSelector = generateStatusSelector
+				options.LabelSelector = s.labelSelector.String()
 			})
 		s.client.ClientFor(clusterName).AddCustomInformer(inf)
 		s.dsInformers[clusterName] = inf
@@ -54,7 +54,7 @@ func (s *StatusManager) initInformersFor(clusterName, namespace string, stateful
 			0, // resync Period
 			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 			func(options *metav1.ListOptions) {
-				options.LabelSelector = generateStatusSelector
+				options.LabelSelector = s.labelSelector.String()
 			})
 		s.client.ClientFor(clusterName).AddCustomInformer(inf)
 		s.depInformers[clusterName] = inf
@@ -66,7 +66,7 @@ func (s *StatusManager) initInformersFor(clusterName, namespace string, stateful
 		0, // resync Period
 		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 		func(options *metav1.ListOptions) {
-			options.LabelSelector = generateStatusSelector
+			options.LabelSelector = s.labelSelector.String()
 		})
 	s.client.ClientFor(clusterName).AddCustomInformer(inf)
 	s.ssInformers[clusterName] = inf

--- a/pkg/controller/statusmanager/status_manager_test.go
+++ b/pkg/controller/statusmanager/status_manager_test.go
@@ -106,7 +106,7 @@ func conditionsEqual(oldConditions, newConditions []operv1.OperatorCondition) bo
 
 func TestStatusManager_set(t *testing.T) {
 	client := fake.NewFakeClient()
-	status := New(client, "testing")
+	status := New(client, "testing", "")
 
 	// No operator config yet; should reflect this in the cluster operator
 	status.set(false)
@@ -242,7 +242,7 @@ func TestStatusManager_set(t *testing.T) {
 
 func TestStatusManagerSetDegraded(t *testing.T) {
 	client := fake.NewFakeClient()
-	status := New(client, "testing")
+	status := New(client, "testing", "")
 
 	_, err := getOC(client)
 	if !errors.IsNotFound(err) {
@@ -334,7 +334,7 @@ func TestStatusManagerSetDegraded(t *testing.T) {
 
 func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 	client := fake.NewFakeClient()
-	status := New(client, "testing")
+	status := New(client, "testing", "")
 	setFakeListers(status)
 	no := &operv1.Network{ObjectMeta: metav1.ObjectMeta{Name: names.OPERATOR_CONFIG}}
 	set(t, client, no)
@@ -934,7 +934,7 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 
 func TestStatusManagerSetFromDeployments(t *testing.T) {
 	client := fake.NewFakeClient()
-	status := New(client, "testing")
+	status := New(client, "testing", "")
 	setFakeListers(status)
 	no := &operv1.Network{ObjectMeta: metav1.ObjectMeta{Name: names.OPERATOR_CONFIG}}
 	set(t, client, no)
@@ -1226,7 +1226,7 @@ func setLastPodState(t *testing.T, client cnoclient.Client, name string, ps podS
 
 func TestStatusManagerCheckCrashLoopBackOffPods(t *testing.T) {
 	client := fake.NewFakeClient()
-	status := New(client, "testing")
+	status := New(client, "testing", "")
 	setFakeListers(status)
 	no := &operv1.Network{ObjectMeta: metav1.ObjectMeta{Name: names.OPERATOR_CONFIG}}
 	set(t, client, no)
@@ -1437,6 +1437,85 @@ func TestStatusManagerCheckCrashLoopBackOffPods(t *testing.T) {
 			Type:   operv1.OperatorStatusTypeProgressing,
 			Status: operv1.ConditionTrue,
 			Reason: "Deploying",
+		},
+		{
+			Type:   operv1.OperatorStatusTypeAvailable,
+			Status: operv1.ConditionTrue,
+		},
+	}) {
+		t.Fatalf("unexpected Status.Conditions: %#v", oc.Status.Conditions)
+	}
+}
+
+// In HyperShift environment there is more than one CNO running in the management cluster.
+// The default CNO runs against the management cluster but there is also one CNO per hosted cluster.
+// Make sure that the default CNO does not reconcile its status based on resources created by the hosted clusters CNO.
+func TestStatusManagerHyperShift(t *testing.T) {
+	validConditions := []operv1.OperatorCondition{
+		{
+			Type:   operv1.OperatorStatusTypeDegraded,
+			Status: operv1.ConditionFalse,
+		},
+		{
+			Type:   operv1.OperatorStatusTypeProgressing,
+			Status: operv1.ConditionFalse,
+		},
+		{
+			Type:   operv1.OperatorStatusTypeUpgradeable,
+			Status: operv1.ConditionTrue,
+		},
+	}
+
+	// mgmt status
+	mgmtClient := fake.NewFakeClient()
+	mgmtStatus := New(mgmtClient, "testing", "")
+	setFakeListers(mgmtStatus)
+	no := &operv1.Network{ObjectMeta: metav1.ObjectMeta{Name: names.OPERATOR_CONFIG}}
+	set(t, mgmtClient, no)
+	mgmtStatus.set(true, validConditions...)
+
+	// Create valid minimal Deployment in the management cluster
+	depMgmt := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "one", Name: "alpha", Labels: sl}, Status: appsv1.DeploymentStatus{
+		AvailableReplicas: 1,
+	}}
+	set(t, mgmtClient, depMgmt)
+
+	// Create minimal failing Deployment in the hosted clusters control namespace(mgmt cluster) that should not be managed by mgmtStatus
+	depHCP := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "hcp-cluster-ns",
+			Name:        "beta",
+			Labels:      map[string]string{names.GenerateStatusLabel: "hosted-cluster-id"},
+			Annotations: map[string]string{names.ClusterNameAnnotation: cnoclient.ManagementClusterName},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "beta"},
+			},
+		}, Status: appsv1.DeploymentStatus{
+			UnavailableReplicas: 1,
+		}}
+	set(t, mgmtClient, depHCP)
+
+	mgmtStatus.SetFromPods()
+
+	// mgmt conditions should not reflect the failures in hosted clusters namespace
+	oc, err := getOC(mgmtClient)
+	if err != nil {
+		t.Fatalf("error getting ClusterOperator: %v", err)
+	}
+	if !conditionsInclude(oc.Status.Conditions, []operv1.OperatorCondition{
+		{
+			Type:   operv1.OperatorStatusTypeDegraded,
+			Status: operv1.ConditionFalse,
+		},
+		{
+			Type:   operv1.OperatorStatusTypeProgressing,
+			Status: operv1.ConditionFalse,
+		},
+		{
+			Type:   operv1.OperatorStatusTypeUpgradeable,
+			Status: operv1.ConditionTrue,
 		},
 		{
 			Type:   operv1.OperatorStatusTypeAvailable,

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -44,8 +44,13 @@ const NonCriticalAnnotation = "networkoperator.openshift.io/non-critical"
 // GenerateStatusLabel can be set by the various Controllers to tell the
 // StatusController that this object is relevant, and should be included
 // when generating status from deployed pods.
-// Currently, this is looked for on Deployments, DaemonSets, and StatefulSets
+// Currently, this is looked for on Deployments, DaemonSets, and StatefulSets.
+// Its value reflects which cluster the resource belongs to. This helps avoid an overlap
+// in Hypershift where there can be multiple CNO instances running in the management cluster.
 const GenerateStatusLabel = "networkoperator.openshift.io/generates-operator-status"
+
+// StandAloneClusterName is a value used for GenerateStatusLabel label when running in non-Hypershift environments
+const StandAloneClusterName = "stand-alone"
 
 // NetworkMigrationAnnotation is an annotation on the networks.operator.openshift.io CR to indicate
 // that executing network migration (switching the default network type of the cluster) is allowed.

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -30,6 +30,7 @@ func InfraStatus(client cnoclient.Client) (*bootstrap.InfraStatus, error) {
 		PlatformType:         infraConfig.Status.PlatformStatus.Type,
 		PlatformStatus:       infraConfig.Status.PlatformStatus,
 		ExternalControlPlane: infraConfig.Status.ControlPlaneTopology == configv1.ExternalTopologyMode,
+		InfraName:            infraConfig.Status.InfrastructureName,
 		APIServers:           map[string]bootstrap.APIServer{},
 	}
 


### PR DESCRIPTION
Cherry pick of [d548cc66d883059cd22ab7fc176ebdef0d7c266bc](https://github.com/openshift/cluster-network-operator/pull/1541/commits/d548cc66d883059cd22ab7fc176ebdef0d7c266b)

/cc @jcaamano @zshi-redhat 

Signed-off-by: Patryk Diak <pdiak@redhat.com>
(cherry picked from commit d548cc66d883059cd22ab7fc176ebdef0d7c266b)
Signed-off-by: Patryk Diak <pdiak@redhat.com>