### PR TITLE
Add ovn-kubernetes-microshift to image-stream

### DIFF
--- a/manifests/image-references
+++ b/manifests/image-references
@@ -46,6 +46,10 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-ovn-kubernetes:latest
+  - name: ovn-kubernetes-microshift
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-ovn-kubernetes-microshift:latest
   - name: egress-router-cni
     from:
       kind: DockerImage


### PR DESCRIPTION
Reference the ovn-kubernetes-microshift imagestream from an operator for it to be a part of the payload.

Signed-off-by: Zenghui Shi <zshi@redhat.com>