### PR TITLE
Use local MTU when node replica is zero in hypershift

### DIFF
--- a/pkg/controller/operconfig/mtu_probe.go
+++ b/pkg/controller/operconfig/mtu_probe.go
@@ -48,6 +48,10 @@ func (r *ReconcileOperConfig) probeMTU(ctx context.Context, oc *operv1.Network, 
 			klog.Infof("AWS cluster, omitting MTU probing and using default of %d", azureMTU)
 			return azureMTU, nil
 		}
+		if infra.PlatformType == configv1.BareMetalPlatformType {
+			klog.Infof("Baremetal cluster, omitting MTU probing and using host local MTU")
+			return 0, nil
+		}
 	}
 	mtu, err := r.readMTUConfigMap(ctx)
 	if err == nil {


### PR DESCRIPTION
Closes #[HOSTEDCP-562](https://issues.redhat.com//browse/HOSTEDCP-562)

Signed-off-by: Zenghui Shi <zshi@redhat.com>