### PR TITLE
Allow empty vSphere status field in VIP sync

### DIFF
--- a/pkg/controller/infrastructureconfig/sync_vips.go
+++ b/pkg/controller/infrastructureconfig/sync_vips.go
@@ -17,38 +17,39 @@ type apiAndIngressVipsSynchronizer struct{}
 
 // VipsSynchronize synchronizes new API & Ingress VIPs with old fields.
 // It returns if the status was updated and the updated infrastructure object.
+//
 //nolint:staticcheck
 func (*apiAndIngressVipsSynchronizer) VipsSynchronize(infraConfig *configv1.Infrastructure) *configv1.Infrastructure {
 	var apiVIPs, ingressVIPs *[]string // new fields
 	var apiVIP, ingressVIP *string     // old/deprecated fields
 
 	updatedInfraConfig := infraConfig.DeepCopy()
-	switch updatedInfraConfig.Status.Platform {
-	case configv1.BareMetalPlatformType:
+	switch {
+	case updatedInfraConfig.Status.Platform == configv1.BareMetalPlatformType:
 		apiVIPs = &updatedInfraConfig.Status.PlatformStatus.BareMetal.APIServerInternalIPs
 		apiVIP = &updatedInfraConfig.Status.PlatformStatus.BareMetal.APIServerInternalIP
 		ingressVIPs = &updatedInfraConfig.Status.PlatformStatus.BareMetal.IngressIPs
 		ingressVIP = &updatedInfraConfig.Status.PlatformStatus.BareMetal.IngressIP
 
-	case configv1.VSpherePlatformType:
+	case updatedInfraConfig.Status.Platform == configv1.VSpherePlatformType && updatedInfraConfig.Status.PlatformStatus.VSphere != nil: // VSphere UPI doesn't populate VSphere field
 		apiVIPs = &updatedInfraConfig.Status.PlatformStatus.VSphere.APIServerInternalIPs
 		apiVIP = &updatedInfraConfig.Status.PlatformStatus.VSphere.APIServerInternalIP
 		ingressVIPs = &updatedInfraConfig.Status.PlatformStatus.VSphere.IngressIPs
 		ingressVIP = &updatedInfraConfig.Status.PlatformStatus.VSphere.IngressIP
 
-	case configv1.OpenStackPlatformType:
+	case updatedInfraConfig.Status.Platform == configv1.OpenStackPlatformType:
 		apiVIPs = &updatedInfraConfig.Status.PlatformStatus.OpenStack.APIServerInternalIPs
 		apiVIP = &updatedInfraConfig.Status.PlatformStatus.OpenStack.APIServerInternalIP
 		ingressVIPs = &updatedInfraConfig.Status.PlatformStatus.OpenStack.IngressIPs
 		ingressVIP = &updatedInfraConfig.Status.PlatformStatus.OpenStack.IngressIP
 
-	case configv1.OvirtPlatformType:
+	case updatedInfraConfig.Status.Platform == configv1.OvirtPlatformType:
 		apiVIPs = &updatedInfraConfig.Status.PlatformStatus.Ovirt.APIServerInternalIPs
 		apiVIP = &updatedInfraConfig.Status.PlatformStatus.Ovirt.APIServerInternalIP
 		ingressVIPs = &updatedInfraConfig.Status.PlatformStatus.Ovirt.IngressIPs
 		ingressVIP = &updatedInfraConfig.Status.PlatformStatus.Ovirt.IngressIP
 
-	case configv1.NutanixPlatformType:
+	case updatedInfraConfig.Status.Platform == configv1.NutanixPlatformType:
 		apiVIPs = &updatedInfraConfig.Status.PlatformStatus.Nutanix.APIServerInternalIPs
 		apiVIP = &updatedInfraConfig.Status.PlatformStatus.Nutanix.APIServerInternalIP
 		ingressVIPs = &updatedInfraConfig.Status.PlatformStatus.Nutanix.IngressIPs

--- a/pkg/controller/infrastructureconfig/sync_vips_test.go
+++ b/pkg/controller/infrastructureconfig/sync_vips_test.go
@@ -267,6 +267,19 @@ func Test_apiAndIngressVipsSynchronizer_VipsSynchronize(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "should not panic on empty PlatformStatus.VSphere field (VSphere UPI doesn't populate VSphere field)",
+			givenStatus: configv1.InfrastructureStatus{
+				Platform: configv1.VSpherePlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					VSphere: nil,
+				},
+			},
+			wantStatus: configv1.InfrastructureStatus{
+				Platform:       configv1.VSpherePlatformType,
+				PlatformStatus: &configv1.PlatformStatus{},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
VSphere UPI doesn't populate VSphere field. So with vSphere we should only handle the case, that `Status.Platform == configv1.VSpherePlatformType && Status.PlatformStatus.VSphere != nil` 