### PR TITLE
ovnkube: limit to expected number of masters and prefer oldest masters

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/alert-rules-control-plane.yaml
@@ -190,8 +190,7 @@ spec:
       expr: |
         # Without max_over_time, failed scrapes could create false negatives, see
         # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
-        count(max_over_time(ovn_db_cluster_server_status{db_name="OVN_Northbound", server_status="cluster member"}[5m])) 
-        != sum(max_over_time(kube_node_role{role="master"}[5m]))
+        count(max_over_time(ovn_db_cluster_server_status{db_name="OVN_Northbound", server_status="cluster member"}[5m])) != {{.OvnkubeMasterReplicas}}
       for: 5m
       labels:
         namespace: {{.HostedClusterNamespace}}
@@ -204,8 +203,7 @@ spec:
       expr: |
         # Without max_over_time, failed scrapes could create false negatives, see
         # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
-        count(max_over_time(ovn_db_cluster_server_status{db_name="OVN_Southbound", server_status="cluster member"}[5m])) 
-        != sum(max_over_time(kube_node_role{role="master"}[5m]))
+        count(max_over_time(ovn_db_cluster_server_status{db_name="OVN_Southbound", server_status="cluster member"}[5m])) != {{.OvnkubeMasterReplicas}}
       for: 5m
       labels:
         namespace: {{.HostedClusterNamespace}}
@@ -272,7 +270,7 @@ spec:
         # Without max_over_time, failed scrapes could create false negatives, see
         # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
         sum(max_over_time(ovn_db_cluster_inbound_connections_total{db_name="OVN_Northbound"}[5m]))
-        != count(max_over_time(kube_node_role{role="master"}[5m])) * (count(max_over_time(kube_node_role{role="master"}[5m]))-1)
+        != {{.OvnkubeMasterReplicas}} * ({{.OvnkubeMasterReplicas}}-1)
       for: 5m
       labels:
         namespace: {{.HostedClusterNamespace}}
@@ -287,7 +285,7 @@ spec:
         # Without max_over_time, failed scrapes could create false negatives, see
         # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
         sum(max_over_time(ovn_db_cluster_inbound_connections_total{db_name="OVN_Southbound"}[5m]))
-        != count(max_over_time(kube_node_role{role="master"}[5m])) * (count(max_over_time(kube_node_role{role="master"}[5m]))-1)
+        != {{.OvnkubeMasterReplicas}} * ({{.OvnkubeMasterReplicas}}-1)
       for: 5m
       labels:
         namespace: {{.HostedClusterNamespace}}
@@ -302,7 +300,7 @@ spec:
         # Without max_over_time, failed scrapes could create false negatives, see
         # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
         sum(max_over_time(ovn_db_cluster_outbound_connections_total{db_name="OVN_Northbound"}[5m]))
-        != count(max_over_time(kube_node_role{role="master"}[5m])) * (count(max_over_time(kube_node_role{role="master"}[5m]))-1)
+        != {{.OvnkubeMasterReplicas}} * ({{.OvnkubeMasterReplicas}}-1)
       for: 5m
       labels:
         namespace: {{.HostedClusterNamespace}}
@@ -317,7 +315,7 @@ spec:
         # Without max_over_time, failed scrapes could create false negatives, see
         # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
         sum(max_over_time(ovn_db_cluster_outbound_connections_total{db_name="OVN_Southbound"}[5m]))
-        != count(max_over_time(kube_node_role{role="master"}[5m])) * (count(max_over_time(kube_node_role{role="master"}[5m]))-1)
+        != {{.OvnkubeMasterReplicas}} * ({{.OvnkubeMasterReplicas}}-1)
       for: 5m
       labels:
         namespace: {{.HostedClusterNamespace}}

--- a/bindata/network/ovn-kubernetes/managed/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/alert-rules-control-plane.yaml
@@ -16,7 +16,7 @@ spec:
     - record: cluster:ovnkube_master_egress_routing_via_host:max
       expr: max(ovnkube_master_egress_routing_via_host)
 
-     # OVN kubernetes master functional alerts
+    # OVN kubernetes master functional alerts
     - alert: NoRunningOvnMaster
       annotations:
         summary: There is no running ovn-kubernetes master.

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -200,7 +200,7 @@ spec:
           bracketify() { case "$1" in *:*) echo "[$1]" ;; *) echo "$1" ;; esac }
 
           # initialize variables
-          ovn_kubernetes_namespace={{.HostedClusterNamespace}}
+          pod_dns_name="${K8S_POD_NAME}.ovnkube-master-internal.{{.HostedClusterNamespace}}.svc.cluster.local"
           ovndb_ctl_ssl_opts="-p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt"
           transport="ssl"
           ovn_raft_conn_ip_url_suffix=""
@@ -252,8 +252,18 @@ spec:
           }
           # end of cluster_exists()
 
+          # RAFT clusters need an odd number of members to achieve consensus.
+          # The CNO determines which members make up the cluster, so if this container
+          # is not supposed to be part of the cluster, wait forever doing nothing
+          # (instad of exiting and causing CrashLoopBackoffs for no reason).
+          if [[ ! "{{.OVN_NB_DB_LIST}}" =~ .*":${pod_dns_name}:".* ]] && [[ ! "{{.OVN_NB_DB_LIST}}" =~ .*":[${pod_dns_name}]:".* ]]; then
+            echo "$(date -Iseconds) - not selected as RAFT member; sleeping..."
+            sleep 1500d
+            exit 0
+          fi
+
           OVN_ARGS="--db-nb-cluster-local-port={{.OVN_NB_RAFT_PORT}} \
-            --db-nb-cluster-local-addr=$(bracketify ${K8S_POD_NAME}.ovnkube-master-internal.{{.HostedClusterNamespace}}.svc.cluster.local) \
+            --db-nb-cluster-local-addr=${pod_dns_name} \
             --no-monitor \
             --db-nb-cluster-local-proto=ssl \
             --ovn-nb-db-ssl-key=/ovn-cert/tls.key \
@@ -296,7 +306,7 @@ spec:
               wait $!
             else
               # either we need to initialize a new cluster or wait for master to create it
-              if [[ "${K8S_POD_NAME}.ovnkube-master-internal.{{.HostedClusterNamespace}}.svc.cluster.local" == "${CLUSTER_INITIATOR_IP}" ]]; then
+              if [[ "${pod_dns_name}" == "${CLUSTER_INITIATOR_IP}" ]]; then
                 # set DB election timer at DB creation time if OVN supports it
                 election_timer=
                 if test -n "$(/usr/share/ovn/scripts/ovn-ctl --help 2>&1 | grep "\--db-nb-election-timer")"; then
@@ -338,9 +348,16 @@ spec:
               - |
                 set -x
                 CLUSTER_INITIATOR_IP="{{.OVN_DB_CLUSTER_INITIATOR}}"
-
                 rm -f /var/run/ovn/ovnnb_db.pid
-                if [[ "${K8S_POD_NAME}.ovnkube-master-internal.{{.HostedClusterNamespace}}.svc.cluster.local" == "${CLUSTER_INITIATOR_IP}" ]]; then
+
+                pod_dns_name="${K8S_POD_NAME}.ovnkube-master-internal.{{.HostedClusterNamespace}}.svc.cluster.local"
+
+                # exit early if this DB is not supposed to be part of the cluster
+                if [[ ! "{{.OVN_NB_DB_LIST}}" =~ .*":${pod_dns_name}:".* ]] && [[ ! "{{.OVN_NB_DB_LIST}}" =~ .*":[${pod_dns_name}]:".* ]]; then
+                  exit 0
+                fi
+
+                if [[ "${pod_dns_name}" == "${CLUSTER_INITIATOR_IP}" ]]; then
                   echo "$(date -Iseconds) - nbdb - postStart - waiting for master to be selected"
 
                   # set the connection and inactivity probe
@@ -428,7 +445,11 @@ spec:
                 echo "NB DB Raft leader is unknown to the cluster node."
                 exit 1
               fi
-
+              # set trim-on-compaction if this DB is supposed to be part of the cluster
+              pod_dns_name="${K8S_POD_NAME}.ovnkube-master-internal.{{.HostedClusterNamespace}}.svc.cluster.local"
+              if [[ "{{.OVN_NB_DB_LIST}}" =~ .*":${pod_dns_name}:".* ]] || [[ "{{.OVN_NB_DB_LIST}}" =~ .*":[${pod_dns_name}]:".* ]]; then
+                /usr/bin/ovn-appctl -t /var/run/ovn/ovnnb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on 2>/dev/null
+              fi
         env:
         - name: OVN_LOG_LEVEL
           value: info
@@ -495,7 +516,7 @@ spec:
           trap quit TERM INT
 
           # initialize variables
-          ovn_kubernetes_namespace={{.HostedClusterNamespace}}
+          pod_dns_name="${K8S_POD_NAME}.ovnkube-master-internal.{{.HostedClusterNamespace}}.svc.cluster.local"
           ovndb_ctl_ssl_opts="-p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt"
           transport="ssl"
           ovn_raft_conn_ip_url_suffix=""
@@ -541,8 +562,18 @@ spec:
           }
           # end of cluster_exists()
 
+          # RAFT clusters need an odd number of members to achieve consensus.
+          # The CNO determines which members make up the cluster, so if this container
+          # is not supposed to be part of the cluster, wait forever doing nothing
+          # (instad of exiting and causing CrashLoopBackoffs for no reason).
+          if [[ ! "{{.OVN_SB_DB_LIST}}" =~ .*":${pod_dns_name}:".* ]] && [[ ! "{{.OVN_SB_DB_LIST}}" =~ .*":[${pod_dns_name}]:".* ]]; then
+            echo "$(date -Iseconds) - not selected as RAFT member; sleeping..."
+            sleep 1500d
+            exit 0
+          fi
+
           OVN_ARGS="--db-sb-cluster-local-port={{.OVN_SB_RAFT_PORT}} \
-            --db-sb-cluster-local-addr="${K8S_POD_NAME}.ovnkube-master-internal.{{.HostedClusterNamespace}}.svc.cluster.local" \
+            --db-sb-cluster-local-addr="${pod_dns_name}" \
             --no-monitor \
             --db-sb-cluster-local-proto=ssl \
             --ovn-sb-db-ssl-key=/ovn-cert/tls.key \
@@ -585,7 +616,7 @@ spec:
               wait $!
             else
               # either we need to initialize a new cluster or wait for master to create it
-              if [[ "${K8S_POD_NAME}.ovnkube-master-internal.{{.HostedClusterNamespace}}.svc.cluster.local" == "${CLUSTER_INITIATOR_IP}" ]]; then
+              if [[ "${pod_dns_name}" == "${CLUSTER_INITIATOR_IP}" ]]; then
                 # set DB election timer at DB creation time if OVN supports it
                 election_timer=
                 if test -n "$(/usr/share/ovn/scripts/ovn-ctl --help 2>&1 | grep "\--db-sb-election-timer")"; then
@@ -626,7 +657,15 @@ spec:
                 set -x
                 CLUSTER_INITIATOR_IP="{{.OVN_DB_CLUSTER_INITIATOR}}"
                 rm -f /var/run/ovn/ovnsb_db.pid
-                if [[ "${K8S_POD_NAME}.ovnkube-master-internal.{{.HostedClusterNamespace}}.svc.cluster.local" == "${CLUSTER_INITIATOR_IP}" ]]; then
+
+                pod_dns_name="${K8S_POD_NAME}.ovnkube-master-internal.{{.HostedClusterNamespace}}.svc.cluster.local"
+
+                # exit early if this DB is not supposed to be part of the cluster
+                if [[ ! "{{.OVN_SB_DB_LIST}}" =~ .*":${pod_dns_name}:".* ]] && [[ ! "{{.OVN_SB_DB_LIST}}" =~ .*":[${pod_dns_name}]:".* ]]; then
+                  exit 0
+                fi
+
+                if [[ "${pod_dns_name}" == "${CLUSTER_INITIATOR_IP}" ]]; then
                   echo "$(date -Iseconds) - sdb - postStart - waiting for master to be selected"
 
                   # set the connection and inactivity probe
@@ -679,6 +718,11 @@ spec:
               if [[ ! -z "${leader_status}" ]]; then
                 echo "SB DB Raft leader is unknown to the cluster node."
                 exit 1
+              fi
+              # set trim-on-compaction if this DB is supposed to be part of the cluster
+              pod_dns_name="${K8S_POD_NAME}.ovnkube-master-internal.{{.HostedClusterNamespace}}.svc.cluster.local"
+              if [[ "{{.OVN_SB_DB_LIST}}" =~ .*":${pod_dns_name}:".* ]] || [[ "{{.OVN_SB_DB_LIST}}" =~ .*":[${pod_dns_name}]:".* ]]; then
+                /usr/bin/ovn-appctl -t /var/run/ovn/ovnsb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on 2>/dev/null
               fi
         env:
         - name: OVN_LOG_LEVEL

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -272,7 +272,6 @@ spec:
 
           CLUSTER_INITIATOR_IP="{{.OVN_DB_CLUSTER_INITIATOR}}"
           echo "$(date -Iseconds) - starting nbdb  CLUSTER_INITIATOR_IP=${CLUSTER_INITIATOR_IP}, K8S_NODE_IP=${K8S_NODE_IP}"
-          initial_raft_create=true
           initialize="false"
 
           if [[ ! -e ${ovn_db_file} ]]; then
@@ -294,7 +293,6 @@ spec:
 
             if ${cluster_found}; then
               echo "Cluster already exists for DB: ${db}"
-              initial_raft_create=false
               # join existing cluster
               exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
               --db-nb-cluster-remote-port={{.OVN_NB_RAFT_PORT}} \
@@ -582,7 +580,6 @@ spec:
 
           CLUSTER_INITIATOR_IP="{{.OVN_DB_CLUSTER_INITIATOR}}"
           echo "$(date -Iseconds) - starting sbdb  CLUSTER_INITIATOR_IP=${CLUSTER_INITIATOR_IP}"
-          initial_raft_create=true
           initialize="false"
 
           if [[ ! -e ${ovn_db_file} ]]; then
@@ -604,7 +601,6 @@ spec:
 
             if ${cluster_found}; then
               echo "Cluster already exists for DB: ${db}"
-              initial_raft_create=false
               # join existing cluster
               exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
               --db-sb-cluster-remote-port={{.OVN_SB_RAFT_PORT}} \

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -355,19 +355,33 @@ spec:
                   exit 0
                 fi
 
+                # retry an operation a number of times, sleeping 2 seconds between each try
+                retry() {
+                  local tries=${1}
+                  local desc=${2}
+                  local cmd=${3}
+
+                  local retries=0
+                  while ! ${cmd}; do
+                    (( retries += 1 ))
+                    if [[ "${retries}" -gt ${tries} ]]; then
+                      echo "$(date -Iseconds) - ERROR - nbdb ${desc} - too many failed attempts, giving up"
+                      return 1
+                    fi
+                    echo "$(date -Iseconds) - WARN - nbdb ${desc} - failed try ${retries}, retrying..."
+                    sleep 2
+                  done
+                  echo "$(date -Iseconds) - INFO - nbdb ${desc} - success"
+                  return 0
+                }
+
                 if [[ "${pod_dns_name}" == "${CLUSTER_INITIATOR_IP}" ]]; then
                   echo "$(date -Iseconds) - nbdb - postStart - waiting for master to be selected"
 
                   # set the connection and inactivity probe
-                  retries=0
-                  while ! ovn-nbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_NB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_NB_INACTIVITY_PROBE}}; do
-                    (( retries += 1 ))
-                  if [[ "${retries}" -gt 40 ]]; then
-                    echo "$(date -Iseconds) - ERROR RESTARTING - nbdb - too many failed ovn-nbctl attempts, giving up"
-                      exit 1
+                  if ! retry 60 "inactivity-probe" "ovn-nbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_NB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_NB_INACTIVITY_PROBE}}"; then
+                    exit 1
                   fi
-                  sleep 2
-                  done
 
                   # Upgrade the db if required.
                   DB_SCHEMA="/usr/share/ovn/ovn-nb.ovsschema"
@@ -385,15 +399,14 @@ spec:
                       ovsdb-client -t 30 convert "$DB_SERVER" "$DB_SCHEMA"
                   fi
                 fi
-                #configure northd_probe_interval
-                OVN_NB_CTL="ovn-nbctl -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt \
-                --db {{.OVN_NB_DB_LIST}}"
 
+                # read the current northd_probe_interval from the DB
+                OVN_NB_CTL="ovn-nbctl -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt --db "{{.OVN_NB_DB_LIST}}""
                 northd_probe_interval=${OVN_NORTHD_PROBE_INTERVAL:-10000}
                 echo "Setting northd probe interval to ${northd_probe_interval} ms"
                 retries=0
                 current_probe_interval=0
-                while [[ "${retries}" -lt 10 ]]; do
+                while [[ "${retries}" -lt 20 ]]; do
                   current_probe_interval=$(${OVN_NB_CTL} --if-exists get NB_GLOBAL . options:northd_probe_interval)
                   if [[ $? == 0 ]]; then
                     current_probe_interval=$(echo ${current_probe_interval} | tr -d '\"')
@@ -404,21 +417,22 @@ spec:
                   fi
                 done
 
+                # ensure the northd_probe_interval is set to the configured value
                 if [[ "${current_probe_interval}" != "${northd_probe_interval}" ]]; then
-                  retries=0
-                  while [[ "${retries}" -lt 10 ]]; do
-                    ${OVN_NB_CTL} set NB_GLOBAL . options:northd_probe_interval=${northd_probe_interval}
-                    if [[ $? != 0 ]]; then
-                      echo "Failed to set northd probe interval to ${northd_probe_interval}. retrying....."
-                      sleep 2
-                      (( retries += 1 ))
-                    else
-                      echo "Successfully set northd probe interval to ${northd_probe_interval} ms"
-                      break
-                    fi
-                  done
+                  if ! retry 20 "northd-probe" "${OVN_NB_CTL} set NB_GLOBAL . options:northd_probe_interval=${northd_probe_interval}"; then
+                    exit 1
+                  fi
                 fi
 
+                # Enable/disable IPsec
+                {{ if .OVNIPsecEnable }}
+                ipsec=true
+                {{ else }}
+                ipsec=false
+                {{ end }}
+                if ! retry 20 "ipsec" "${OVN_NB_CTL} set nb_global . ipsec=${ipsec}"; then
+                  exit 1
+                fi
           preStop:
             exec:
               command:
@@ -661,19 +675,33 @@ spec:
                   exit 0
                 fi
 
+                # retry an operation a number of times, sleeping 2 seconds between each try
+                retry() {
+                  local tries=${1}
+                  local desc=${2}
+                  local cmd=${3}
+
+                  local retries=0
+                  while ! ${cmd}; do
+                    (( retries += 1 ))
+                    if [[ "${retries}" -gt ${tries} ]]; then
+                      echo "$(date -Iseconds) - ERROR - nbdb ${desc} - too many failed attempts, giving up"
+                      return 1
+                    fi
+                    echo "$(date -Iseconds) - WARN - nbdb ${desc} - failed try ${retries}, retrying..."
+                    sleep 2
+                  done
+                  echo "$(date -Iseconds) - INFO - nbdb ${desc} - success"
+                  return 0
+                }
+
                 if [[ "${pod_dns_name}" == "${CLUSTER_INITIATOR_IP}" ]]; then
                   echo "$(date -Iseconds) - sdb - postStart - waiting for master to be selected"
 
                   # set the connection and inactivity probe
-                  retries=0
-                  while ! ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_CONTROLLER_INACTIVITY_PROBE}}; do
-                    (( retries += 1 ))
-                  if [[ "${retries}" -gt 40 ]]; then
-                    echo "$(date -Iseconds) - ERROR RESTARTING - sbdb - too many failed ovn-sbctl attempts, giving up"
-                      exit 1
+                  if ! retry 60 "inactivity-probe" "ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_CONTROLLER_INACTIVITY_PROBE}}"; then
+                    exit 1
                   fi
-                  sleep 2
-                  done
 
                   # Upgrade the db if required.
                   DB_SCHEMA="/usr/share/ovn/ovn-sb.ovsschema"
@@ -690,6 +718,12 @@ spec:
                       echo "Upgrading database $schema_name from schema version $db_version to $target_version"
                       ovsdb-client -t 30 convert "$DB_SERVER" "$DB_SCHEMA"
                   fi
+                fi
+
+                # Kill some time while the cluster converges by checking IPsec status
+                OVN_SB_CTL="ovn-sbctl -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt --db "{{.OVN_SB_DB_LIST}}""
+                if ! retry 20 "ipsec" "${OVN_SB_CTL} get sb_global . ipsec"; then
+                  exit 1
                 fi
           preStop:
             exec:

--- a/bindata/network/ovn-kubernetes/self-hosted/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/alert-rules-control-plane.yaml
@@ -189,8 +189,7 @@ spec:
       expr: |
         # Without max_over_time, failed scrapes could create false negatives, see
         # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
-        count(max_over_time(ovn_db_cluster_server_status{db_name="OVN_Northbound", server_status="cluster member"}[5m])) 
-        != sum(max_over_time(kube_node_role{role="master"}[5m]))
+        count(max_over_time(ovn_db_cluster_server_status{db_name="OVN_Northbound", server_status="cluster member"}[5m])) != {{.OvnkubeMasterReplicas}}
       for: 5m
       labels:
         namespace: openshift-ovn-kubernetes
@@ -203,8 +202,7 @@ spec:
       expr: |
         # Without max_over_time, failed scrapes could create false negatives, see
         # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
-        count(max_over_time(ovn_db_cluster_server_status{db_name="OVN_Southbound", server_status="cluster member"}[5m])) 
-        != sum(max_over_time(kube_node_role{role="master"}[5m]))
+        count(max_over_time(ovn_db_cluster_server_status{db_name="OVN_Southbound", server_status="cluster member"}[5m])) != {{.OvnkubeMasterReplicas}}
       for: 5m
       labels:
         namespace: openshift-ovn-kubernetes
@@ -271,7 +269,7 @@ spec:
         # Without max_over_time, failed scrapes could create false negatives, see
         # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
         sum(max_over_time(ovn_db_cluster_inbound_connections_total{db_name="OVN_Northbound"}[5m]))
-        != count(max_over_time(kube_node_role{role="master"}[5m])) * (count(max_over_time(kube_node_role{role="master"}[5m]))-1)
+        != {{.OvnkubeMasterReplicas}} * ({{.OvnkubeMasterReplicas}}-1)
       for: 5m
       labels:
         namespace: openshift-ovn-kubernetes
@@ -286,7 +284,7 @@ spec:
         # Without max_over_time, failed scrapes could create false negatives, see
         # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
         sum(max_over_time(ovn_db_cluster_inbound_connections_total{db_name="OVN_Southbound"}[5m]))
-        != count(max_over_time(kube_node_role{role="master"}[5m])) * (count(max_over_time(kube_node_role{role="master"}[5m]))-1)
+        != {{.OvnkubeMasterReplicas}} * ({{.OvnkubeMasterReplicas}}-1)
       for: 5m
       labels:
         namespace: openshift-ovn-kubernetes
@@ -301,7 +299,7 @@ spec:
         # Without max_over_time, failed scrapes could create false negatives, see
         # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
         sum(max_over_time(ovn_db_cluster_outbound_connections_total{db_name="OVN_Northbound"}[5m]))
-        != count(max_over_time(kube_node_role{role="master"}[5m])) * (count(max_over_time(kube_node_role{role="master"}[5m]))-1)
+        != {{.OvnkubeMasterReplicas}} * ({{.OvnkubeMasterReplicas}}-1)
       for: 5m
       labels:
         namespace: openshift-ovn-kubernetes
@@ -316,7 +314,7 @@ spec:
         # Without max_over_time, failed scrapes could create false negatives, see
         # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
         sum(max_over_time(ovn_db_cluster_outbound_connections_total{db_name="OVN_Southbound"}[5m]))
-        != count(max_over_time(kube_node_role{role="master"}[5m])) * (count(max_over_time(kube_node_role{role="master"}[5m]))-1)
+        != {{.OvnkubeMasterReplicas}} * ({{.OvnkubeMasterReplicas}}-1)
       for: 5m
       labels:
         namespace: openshift-ovn-kubernetes

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
@@ -225,7 +225,6 @@ spec:
 
           CLUSTER_INITIATOR_IP="{{.OVN_DB_CLUSTER_INITIATOR}}"
           echo "$(date -Iseconds) - starting nbdb  CLUSTER_INITIATOR_IP=${CLUSTER_INITIATOR_IP}, K8S_NODE_IP=${K8S_NODE_IP}"
-          initial_raft_create=true
           initialize="false"
           
           if [[ ! -e ${ovn_db_file} ]]; then
@@ -247,7 +246,6 @@ spec:
 
             if ${cluster_found}; then
               echo "Cluster already exists for DB: ${db}"
-              initial_raft_create=false
               # join existing cluster
               exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
               --db-nb-cluster-remote-port={{.OVN_NB_RAFT_PORT}} \
@@ -595,7 +593,6 @@ spec:
 
           CLUSTER_INITIATOR_IP="{{.OVN_DB_CLUSTER_INITIATOR}}"
           echo "$(date -Iseconds) - starting sbdb  CLUSTER_INITIATOR_IP=${CLUSTER_INITIATOR_IP}"
-          initial_raft_create=true
           initialize="false"
           
           if [[ ! -e ${ovn_db_file} ]]; then
@@ -617,7 +614,6 @@ spec:
 
             if ${cluster_found}; then
               echo "Cluster already exists for DB: ${db}"
-              initial_raft_create=false
               # join existing cluster
               exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
               --db-sb-cluster-remote-port={{.OVN_SB_RAFT_PORT}} \

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
@@ -205,6 +205,16 @@ spec:
           }
           # end of cluster_exists()
 
+          # RAFT clusters need an odd number of members to achieve consensus.
+          # The CNO determines which members make up the cluster, so if this container
+          # is not supposed to be part of the cluster, wait forever doing nothing
+          # (instad of exiting and causing CrashLoopBackoffs for no reason).
+          if [[ ! "{{.OVN_NB_DB_LIST}}" =~ .*":${K8S_NODE_IP}:".* ]] && [[ ! "{{.OVN_NB_DB_LIST}}" =~ .*":[${K8S_NODE_IP}]:".* ]]; then
+            echo "$(date -Iseconds) - not selected as RAFT member; sleeping..."
+            sleep 1500d
+            exit 0
+          fi
+
           OVN_ARGS="--db-nb-cluster-local-port={{.OVN_NB_RAFT_PORT}} \
             --db-nb-cluster-local-addr=$(bracketify ${K8S_NODE_IP}) \
             --no-monitor \
@@ -292,6 +302,12 @@ spec:
                 set -x
                 CLUSTER_INITIATOR_IP="{{.OVN_DB_CLUSTER_INITIATOR}}"
                 rm -f /var/run/ovn/ovnnb_db.pid
+
+                # exit early if this DB is not supposed to be part of the cluster
+                if [[ ! "{{.OVN_NB_DB_LIST}}" =~ .*":${K8S_NODE_IP}:".* ]] && [[ ! "{{.OVN_NB_DB_LIST}}" =~ .*":[${K8S_NODE_IP}]:".* ]]; then
+                  exit 0
+                fi
+
                 if [[ "${K8S_NODE_IP}" == "${CLUSTER_INITIATOR_IP}" ]]; then
                   echo "$(date -Iseconds) - nbdb - postStart - waiting for master to be selected"
 
@@ -385,10 +401,11 @@ spec:
               if [[ ! -z "${leader_status}" ]]; then
                 echo "NB DB Raft leader is unknown to the cluster node."
                 exit 1
-              else
+              fi
+              # set trim-on-compaction if this DB is supposed to be part of the cluster
+              if [[ "{{.OVN_NB_DB_LIST}}" =~ .*":${K8S_NODE_IP}:".* ]] || [[ "{{.OVN_NB_DB_LIST}}" =~ .*":[${K8S_NODE_IP}]:".* ]]; then
                 /usr/bin/ovn-appctl -t /var/run/ovn/ovnnb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on 2>/dev/null
               fi
-
         env:
         - name: OVN_LOG_LEVEL
           value: info 
@@ -558,6 +575,16 @@ spec:
           }
           # end of cluster_exists()
 
+          # RAFT clusters need an odd number of members to achieve consensus.
+          # The CNO determines which members make up the cluster, so if this container
+          # is not supposed to be part of the cluster, wait forever doing nothing
+          # (instad of exiting and causing CrashLoopBackoffs for no reason).
+          if [[ ! "{{.OVN_SB_DB_LIST}}" =~ .*":${K8S_NODE_IP}:".* ]] && [[ ! "{{.OVN_SB_DB_LIST}}" =~ .*":[${K8S_NODE_IP}]:".* ]]; then
+            echo "$(date -Iseconds) - not selected as RAFT member; sleeping..."
+            sleep 1500d
+            exit 0
+          fi
+
           OVN_ARGS="--db-sb-cluster-local-port={{.OVN_SB_RAFT_PORT}} \
             --db-sb-cluster-local-addr=$(bracketify ${K8S_NODE_IP}) \
             --no-monitor \
@@ -643,6 +670,12 @@ spec:
                 set -x
                 CLUSTER_INITIATOR_IP="{{.OVN_DB_CLUSTER_INITIATOR}}"
                 rm -f /var/run/ovn/ovnsb_db.pid
+
+                # exit early if this DB is not supposed to be part of the cluster
+                if [[ ! "{{.OVN_SB_DB_LIST}}" =~ .*":${K8S_NODE_IP}:".* ]] && [[ ! "{{.OVN_SB_DB_LIST}}" =~ .*":[${K8S_NODE_IP}]:".* ]]; then
+                  exit 0
+                fi
+
                 if [[ "${K8S_NODE_IP}" == "${CLUSTER_INITIATOR_IP}" ]]; then
                   echo "$(date -Iseconds) - sdb - postStart - waiting for master to be selected"
 
@@ -698,7 +731,9 @@ spec:
               if [[ ! -z "${leader_status}" ]]; then
                 echo "SB DB Raft leader is unknown to the cluster node."
                 exit 1
-              else
+              fi
+              # set trim-on-compaction if this DB is supposed to be part of the cluster
+              if [[ "{{.OVN_SB_DB_LIST}}" =~ .*":${K8S_NODE_IP}:".* ]] || [[ "{{.OVN_SB_DB_LIST}}" =~ .*":[${K8S_NODE_IP}]:".* ]]; then
                 /usr/bin/ovn-appctl -t /var/run/ovn/ovnsb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on 2>/dev/null
               fi
         env:

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
@@ -306,19 +306,33 @@ spec:
                   exit 0
                 fi
 
+                # retry an operation a number of times, sleeping 2 seconds between each try
+                retry() {
+                  local tries=${1}
+                  local desc=${2}
+                  local cmd=${3}
+
+                  local retries=0
+                  while ! ${cmd}; do
+                    (( retries += 1 ))
+                    if [[ "${retries}" -gt ${tries} ]]; then
+                      echo "$(date -Iseconds) - ERROR - nbdb ${desc} - too many failed attempts, giving up"
+                      return 1
+                    fi
+                    echo "$(date -Iseconds) - WARN - nbdb ${desc} - failed try ${retries}, retrying..."
+                    sleep 2
+                  done
+                  echo "$(date -Iseconds) - INFO - nbdb ${desc} - success"
+                  return 0
+                }
+
                 if [[ "${K8S_NODE_IP}" == "${CLUSTER_INITIATOR_IP}" ]]; then
                   echo "$(date -Iseconds) - nbdb - postStart - waiting for master to be selected"
 
                   # set the connection and inactivity probe
-                  retries=0
-                  while ! ovn-nbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_NB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_NB_INACTIVITY_PROBE}}; do
-                    (( retries += 1 ))
-                  if [[ "${retries}" -gt 40 ]]; then
-                    echo "$(date -Iseconds) - ERROR RESTARTING - nbdb - too many failed ovn-nbctl attempts, giving up"
-                      exit 1
+                  if ! retry 60 "inactivity-probe" "ovn-nbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_NB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_NB_INACTIVITY_PROBE}}"; then
+                    exit 1
                   fi
-                  sleep 2
-                  done
 
                   # Upgrade the db if required.
                   DB_SCHEMA="/usr/share/ovn/ovn-nb.ovsschema"
@@ -336,14 +350,14 @@ spec:
                       ovsdb-client -t 30 convert "$DB_SERVER" "$DB_SCHEMA"
                   fi
                 fi
-                #configure northd_probe_interval
-                OVN_NB_CTL="ovn-nbctl -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt \
-                --db "{{.OVN_NB_DB_LIST}}""
+
+                # read the current northd_probe_interval from the DB
+                OVN_NB_CTL="ovn-nbctl -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt --db "{{.OVN_NB_DB_LIST}}""
                 northd_probe_interval=${OVN_NORTHD_PROBE_INTERVAL:-10000}
                 echo "Setting northd probe interval to ${northd_probe_interval} ms"
                 retries=0
                 current_probe_interval=0
-                while [[ "${retries}" -lt 10 ]]; do
+                while [[ "${retries}" -lt 20 ]]; do
                   current_probe_interval=$(${OVN_NB_CTL} --if-exists get NB_GLOBAL . options:northd_probe_interval)
                   if [[ $? == 0 ]]; then
                     current_probe_interval=$(echo ${current_probe_interval} | tr -d '\"')
@@ -354,26 +368,22 @@ spec:
                   fi
                 done
 
+                # ensure the northd_probe_interval is set to the configured value
                 if [[ "${current_probe_interval}" != "${northd_probe_interval}" ]]; then
-                  retries=0
-                  while [[ "${retries}" -lt 10 ]]; do
-                    ${OVN_NB_CTL} set NB_GLOBAL . options:northd_probe_interval=${northd_probe_interval}
-                    if [[ $? != 0 ]]; then
-                      echo "Failed to set northd probe interval to ${northd_probe_interval}. retrying....."
-                      sleep 2
-                      (( retries += 1 ))
-                    else
-                      echo "Successfully set northd probe interval to ${northd_probe_interval} ms"
-                      break
-                    fi
-                  done
+                  if ! retry 20 "northd-probe" "${OVN_NB_CTL} set NB_GLOBAL . options:northd_probe_interval=${northd_probe_interval}"; then
+                    exit 1
+                  fi
                 fi
 
+                # Enable/disable IPsec
                 {{ if .OVNIPsecEnable }}
-                ${OVN_NB_CTL} set nb_global . ipsec=true
+                ipsec=true
                 {{ else }}
-                ${OVN_NB_CTL} set nb_global . ipsec=false
+                ipsec=false
                 {{ end }}
+                if ! retry 20 "ipsec" "${OVN_NB_CTL} set nb_global . ipsec=${ipsec}"; then
+                  exit 1
+                fi
           preStop:
             exec:
               command:
@@ -672,19 +682,33 @@ spec:
                   exit 0
                 fi
 
+                # retry an operation a number of times, sleeping 2 seconds between each try
+                retry() {
+                  local tries=${1}
+                  local desc=${2}
+                  local cmd=${3}
+
+                  local retries=0
+                  while ! ${cmd}; do
+                    (( retries += 1 ))
+                    if [[ "${retries}" -gt ${tries} ]]; then
+                      echo "$(date -Iseconds) - ERROR - nbdb ${desc} - too many failed attempts, giving up"
+                      return 1
+                    fi
+                    echo "$(date -Iseconds) - WARN - nbdb ${desc} - failed try ${retries}, retrying..."
+                    sleep 2
+                  done
+                  echo "$(date -Iseconds) - INFO - nbdb ${desc} - success"
+                  return 0
+                }
+
                 if [[ "${K8S_NODE_IP}" == "${CLUSTER_INITIATOR_IP}" ]]; then
                   echo "$(date -Iseconds) - sdb - postStart - waiting for master to be selected"
 
                   # set the connection and inactivity probe
-                  retries=0
-                  while ! ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_CONTROLLER_INACTIVITY_PROBE}}; do
-                    (( retries += 1 ))
-                  if [[ "${retries}" -gt 40 ]]; then
-                    echo "$(date -Iseconds) - ERROR RESTARTING - sbdb - too many failed ovn-sbctl attempts, giving up"
-                      exit 1
+                  if ! retry 60 "inactivity-probe" "ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_CONTROLLER_INACTIVITY_PROBE}}"; then
+                    exit 1
                   fi
-                  sleep 2
-                  done
 
                   # Upgrade the db if required.
                   DB_SCHEMA="/usr/share/ovn/ovn-sb.ovsschema"
@@ -701,6 +725,12 @@ spec:
                       echo "Upgrading database $schema_name from schema version $db_version to $target_version"
                       ovsdb-client -t 30 convert "$DB_SERVER" "$DB_SCHEMA"
                   fi
+                fi
+
+                # Kill some time while the cluster converges by checking IPsec status
+                OVN_SB_CTL="ovn-sbctl -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt --db "{{.OVN_SB_DB_LIST}}""
+                if ! retry 20 "ipsec" "${OVN_SB_CTL} get sb_global . ipsec"; then
+                  exit 1
                 fi
           preStop:
             exec:

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -125,6 +125,9 @@ func add(mgr manager.Manager, r *ReconcileOperConfig) error {
 		UpdateFunc: func(_ event.UpdateEvent) bool {
 			return false
 		},
+		DeleteFunc: func(_ event.DeleteEvent) bool {
+			return true
+		},
 	}
 	if err := c.Watch(
 		&source.Kind{Type: &corev1.Node{}},

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -99,6 +99,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data := render.MakeRenderData()
 	data.Data["ReleaseVersion"] = os.Getenv("RELEASE_VERSION")
 	data.Data["OvnImage"] = os.Getenv("OVN_IMAGE")
+	data.Data["OvnkubeMasterReplicas"] = len(bootstrapResult.OVN.MasterAddresses)
 	data.Data["KubeRBACProxyImage"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
 	data.Data["Socks5ProxyImage"] = os.Getenv("SOCKS5_PROXY_IMAGE")
 	data.Data["KUBERNETES_SERVICE_HOST"] = apiServer.Host
@@ -160,7 +161,6 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	// Hypershift
 	data.Data["ManagementClusterName"] = names.ManagementClusterName
 	data.Data["HostedClusterNamespace"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.Namespace
-	data.Data["OvnkubeMasterReplicas"] = len(bootstrapResult.OVN.MasterAddresses)
 	data.Data["ClusterID"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.ClusterID
 	data.Data["ClusterIDLabel"] = ClusterIDLabel
 	data.Data["OVNDbServiceType"] = corev1.ServiceTypeClusterIP

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -949,7 +949,29 @@ func bootstrapOVNGatewayConfig(conf *operv1.Network, kubeClient crclient.Client)
 	klog.Infof("Gateway mode is %s", modeOverride)
 }
 
-func getMasterAddresses(kubeClient crclient.Client, controlPlaneReplicaCount int, hypershift bool) ([]string, error) {
+type nodeInfo struct {
+	address string
+	created time.Time
+}
+
+type nodeInfoList []nodeInfo
+
+func (l nodeInfoList) Len() int {
+	return len(l)
+}
+
+func (l nodeInfoList) Swap(i, j int) {
+	l[i], l[j] = l[j], l[i]
+}
+
+func (l nodeInfoList) Less(i, j int) bool {
+	return l[i].created.Before(l[j].created)
+}
+
+// getMasterAddresses determines the addresses (IP or DNS names) of the ovn-kubernetes
+// control plane nodes. It returns the list of addresses and an updated timeout,
+// or an error.
+func getMasterAddresses(kubeClient crclient.Client, controlPlaneReplicaCount int, hypershift bool, timeout int) ([]string, int, error) {
 	var heartBeat int
 	masterNodeList := &corev1.NodeList{}
 	ovnMasterAddresses := make([]string, 0, controlPlaneReplicaCount)
@@ -958,54 +980,75 @@ func getMasterAddresses(kubeClient crclient.Client, controlPlaneReplicaCount int
 		for i := 0; i < controlPlaneReplicaCount; i++ {
 			ovnMasterAddresses = append(ovnMasterAddresses, fmt.Sprintf("ovnkube-master-%d.ovnkube-master-internal.%s.svc.cluster.local", i, os.Getenv("HOSTED_CLUSTER_NAMESPACE")))
 		}
-	} else {
-		err := wait.PollImmediate(OVN_MASTER_DISCOVERY_POLL*time.Second, time.Duration(OVN_MASTER_DISCOVERY_TIMEOUT)*time.Second, func() (bool, error) {
-			matchingLabels := &crclient.MatchingLabels{"node-role.kubernetes.io/master": ""}
-			if err := kubeClient.List(context.TODO(), masterNodeList, matchingLabels); err != nil {
-				return false, err
-			}
-			if len(masterNodeList.Items) != 0 && controlPlaneReplicaCount == len(masterNodeList.Items) {
-				return true, nil
-			}
-
-			heartBeat++
-			if heartBeat%3 == 0 {
-				klog.V(2).Infof("Waiting to complete OVN bootstrap: found (%d) master nodes out of (%d) expected: timing out in %d seconds",
-					len(masterNodeList.Items), controlPlaneReplicaCount, OVN_MASTER_DISCOVERY_TIMEOUT-OVN_MASTER_DISCOVERY_POLL*heartBeat)
-			}
-			return false, nil
-		})
-		if wait.ErrWaitTimeout == err {
-			klog.Warningf("Timeout exceeded while bootstraping OVN, expected amount of control plane nodes (%v) do not match found (%v): %s, continuing deployment with found replicas", controlPlaneReplicaCount, len(masterNodeList.Items))
-			// On certain types of cluster this condition will never be met (assisted installer, for example)
-			// As to not hold the reconciliation loop for too long on such clusters: dynamically modify the timeout
-			// to a shorter and shorter value. Never reach 0 however as that will result in a `PollInfinity`.
-			// Right now we'll do:
-			// - First reconciliation 250 second timeout
-			// - Second reconciliation 130 second timeout
-			// - >= Third reconciliation 10 second timeout
-			if OVN_MASTER_DISCOVERY_TIMEOUT-OVN_MASTER_DISCOVERY_BACKOFF > 0 {
-				OVN_MASTER_DISCOVERY_TIMEOUT = OVN_MASTER_DISCOVERY_TIMEOUT - OVN_MASTER_DISCOVERY_BACKOFF
-			}
-		} else if err != nil {
-			return nil, fmt.Errorf("Unable to bootstrap OVN, err: %v", err)
-		}
-
-		for _, masterNode := range masterNodeList.Items {
-			var ip string
-			for _, address := range masterNode.Status.Addresses {
-				if address.Type == corev1.NodeInternalIP {
-					ip = address.Address
-					break
-				}
-			}
-			if ip == "" {
-				return nil, fmt.Errorf("No InternalIP found on master node '%s'", masterNode.Name)
-			}
-			ovnMasterAddresses = append(ovnMasterAddresses, ip)
-		}
+		sort.Strings(ovnMasterAddresses)
+		return ovnMasterAddresses, timeout, nil
 	}
-	return ovnMasterAddresses, nil
+
+	// Not Hypershift... find all master nodes by label
+	err := wait.PollImmediate(OVN_MASTER_DISCOVERY_POLL*time.Second, time.Duration(timeout)*time.Second, func() (bool, error) {
+		ctx, cancel := context.WithTimeout(context.TODO(), time.Duration(timeout)*time.Second)
+		defer cancel()
+
+		matchingLabels := &crclient.MatchingLabels{"node-role.kubernetes.io/master": ""}
+		if err := kubeClient.List(ctx, masterNodeList, matchingLabels); err != nil {
+			return false, err
+		}
+		if len(masterNodeList.Items) != 0 && controlPlaneReplicaCount == len(masterNodeList.Items) {
+			return true, nil
+		}
+
+		heartBeat++
+		if heartBeat%3 == 0 {
+			klog.V(2).Infof("Waiting to complete OVN bootstrap: found (%d) master nodes out of (%d) expected: timing out in %d seconds",
+				len(masterNodeList.Items), controlPlaneReplicaCount, timeout-OVN_MASTER_DISCOVERY_POLL*heartBeat)
+		}
+		return false, nil
+	})
+	if wait.ErrWaitTimeout == err {
+		klog.Warningf("Timeout exceeded while bootstraping OVN, expected amount of control plane nodes (%v) do not match found (%v): continuing deployment with found replicas",
+			controlPlaneReplicaCount, len(masterNodeList.Items))
+		// On certain types of cluster this condition will never be met (assisted installer, for example)
+		// As to not hold the reconciliation loop for too long on such clusters: dynamically modify the timeout
+		// to a shorter and shorter value. Never reach 0 however as that will result in a `PollInfinity`.
+		// Right now we'll do:
+		// - First reconciliation 250 second timeout
+		// - Second reconciliation 130 second timeout
+		// - >= Third reconciliation 10 second timeout
+		if timeout-OVN_MASTER_DISCOVERY_BACKOFF > 0 {
+			timeout = timeout - OVN_MASTER_DISCOVERY_BACKOFF
+		}
+	} else if err != nil {
+		return nil, timeout, fmt.Errorf("unable to bootstrap OVN, err: %v", err)
+	}
+
+	nodeList := make(nodeInfoList, 0, len(masterNodeList.Items))
+	for _, node := range masterNodeList.Items {
+		ni := nodeInfo{created: node.CreationTimestamp.Time}
+		for _, address := range node.Status.Addresses {
+			if address.Type == corev1.NodeInternalIP {
+				ni.address = address.Address
+				break
+			}
+		}
+		if ni.address == "" {
+			return nil, timeout, fmt.Errorf("no InternalIP found on master node '%s'", node.Name)
+		}
+
+		nodeList = append(nodeList, ni)
+	}
+
+	// Take the oldest masters up to the expected number of replicas
+	sort.Stable(nodeList)
+	for i, ni := range nodeList {
+		if i >= controlPlaneReplicaCount {
+			break
+		}
+		ovnMasterAddresses = append(ovnMasterAddresses, ni.address)
+	}
+	sort.Strings(ovnMasterAddresses)
+	klog.V(2).Infof("Preferring %s for database clusters", ovnMasterAddresses)
+
+	return ovnMasterAddresses, timeout, nil
 }
 
 func bootstrapOVN(conf *operv1.Network, kubeClient cnoclient.Client) (*bootstrap.OVNBootstrapResult, error) {
@@ -1034,12 +1077,11 @@ func bootstrapOVN(conf *operv1.Network, kubeClient cnoclient.Client) (*bootstrap
 		controlPlaneReplicaCount, _ = strconv.Atoi(rcD.ControlPlane.Replicas)
 	}
 
-	ovnMasterAddresses, err := getMasterAddresses(kubeClient.ClientFor("").CRClient(), controlPlaneReplicaCount, hc.Enabled)
+	ovnMasterAddresses, newTimeout, err := getMasterAddresses(kubeClient.ClientFor("").CRClient(), controlPlaneReplicaCount, hc.Enabled, OVN_MASTER_DISCOVERY_TIMEOUT)
 	if err != nil {
 		return nil, err
 	}
-
-	sort.Strings(ovnMasterAddresses)
+	OVN_MASTER_DISCOVERY_TIMEOUT = newTimeout
 
 	// clusterInitiator is used to avoid a split-brain scenario for the OVN NB/SB DBs. We want to consistently initialize
 	// any OVN cluster which is bootstrapped here, to the same initiator (should it still exists), hence we annotate the


### PR DESCRIPTION
Sometimes the number of masters changes, like when in the etcd test:

`etcd [apigroup:config.openshift.io] is able to vertically scale up and down with a single node`

This leads to problems like:

`I0909 11:16:02.221234       1 ovn_kubernetes.go:938] Waiting to complete OVN bootstrap: found (4) master nodes out of (3) expected: timing out in 235 seconds`

ovsdb-server only ever wants an odd number of members to ensure consensus in RAFT clusters. If we have 4 members and one of them is dead (like when the 4th one gets deleted) the RAFT cluster gets a bit unhappy.

The CNO currently renders the ovnkube master pods with the IP addresses of all master nodes, regardless of how many control plane nodes were actually requested at install time. That's not cool. Don't do that.

Instead, cap the number of members at the control plane replica count and prefer nodes with existing ovnkube-master pods running on them already. Then tell any NB/SB pods that aren't in the capped list to exit early and not join the cluster.

@jluhrsen @tssurya 