### PR TITLE
OCPBUGS-1515: Use custom uint128 type when validating v6InternalSubnet

### DIFF
--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"math/big"
 	"net"
 	"net/url"
 	"os"
@@ -688,7 +689,7 @@ func validateOVNKubernetes(conf *operv1.NetworkSpec) []error {
 			if err != nil {
 				out = append(out, errors.Errorf("v4InternalSubnet is invalid: %s", err))
 			}
-			if !isInternalSubnetLargeEnough(conf, true) {
+			if !isV4InternalSubnetLargeEnough(conf) {
 				out = append(out, errors.Errorf("v4InternalSubnet is no large enough for the maximum number of nodes which can be supported by ClusterNetwork"))
 			}
 		}
@@ -700,7 +701,7 @@ func validateOVNKubernetes(conf *operv1.NetworkSpec) []error {
 			if err != nil {
 				out = append(out, errors.Errorf("v6InternalSubnet is invalid: %s", err))
 			}
-			if !isInternalSubnetLargeEnough(conf, false) {
+			if !isV6InternalSubnetLargeEnough(conf) {
 				out = append(out, errors.Errorf("v6InternalSubnet is no large enough for the maximum number of nodes which can be supported by ClusterNetwork"))
 			}
 		}
@@ -1508,16 +1509,12 @@ func setOVNObjectAnnotation(objs []*uns.Unstructured, key, value string) error {
 	return nil
 }
 
-func isInternalSubnetLargeEnough(conf *operv1.NetworkSpec, v4 bool) bool {
+func isV4InternalSubnetLargeEnough(conf *operv1.NetworkSpec) bool {
 	var maxNodesNum int
 	subnet := conf.DefaultNetwork.OVNKubernetesConfig.V4InternalSubnet
 	addrLen := 32
-	if !v4 {
-		subnet = conf.DefaultNetwork.OVNKubernetesConfig.V6InternalSubnet
-		addrLen = 128
-	}
 	for _, n := range conf.ClusterNetwork {
-		if (utilnet.IsIPv6CIDRString(n.CIDR) && v4) || (!utilnet.IsIPv6CIDRString(n.CIDR) && !v4) {
+		if utilnet.IsIPv6CIDRString(n.CIDR) {
 			continue
 		}
 		mask, _ := strconv.Atoi(strings.Split(n.CIDR, "/")[1])
@@ -1526,5 +1523,26 @@ func isInternalSubnetLargeEnough(conf *operv1.NetworkSpec, v4 bool) bool {
 	}
 	// We need to ensure each node can be assigned an IP address from the internal subnet
 	intSubnetMask, _ := strconv.Atoi(strings.Split(subnet, "/")[1])
-	return maxNodesNum < (1<<(addrLen-intSubnetMask) - 2)
+	// reserve one IP for the gw, one IP for network and one for broadcasting
+	return maxNodesNum < (1<<(addrLen-intSubnetMask) - 3)
+}
+
+func isV6InternalSubnetLargeEnough(conf *operv1.NetworkSpec) bool {
+	var addrLen uint32
+	maxNodesNum, nodesNum, capacity := new(big.Int), new(big.Int), new(big.Int)
+	subnet := conf.DefaultNetwork.OVNKubernetesConfig.V6InternalSubnet
+	addrLen = 128
+	for _, n := range conf.ClusterNetwork {
+		if !utilnet.IsIPv6CIDRString(n.CIDR) {
+			continue
+		}
+		mask, _ := strconv.Atoi(strings.Split(n.CIDR, "/")[1])
+		nodesNum.Lsh(big.NewInt(1), uint(n.HostPrefix)-uint(mask))
+		maxNodesNum.Add(maxNodesNum, nodesNum)
+	}
+	// We need to ensure each node can be assigned an IP address from the internal subnet
+	intSubnetMask, _ := strconv.Atoi(strings.Split(subnet, "/")[1])
+	capacity.Lsh(big.NewInt(1), uint(addrLen)-uint(intSubnetMask))
+	// reserve one IP for the gw, one IP for network and one for broadcasting
+	return capacity.Cmp(maxNodesNum.Add(maxNodesNum, big.NewInt(3))) != -1
 }

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -650,8 +650,18 @@ func TestValidateOVNKubernetes(t *testing.T) {
 				ContainSubstring(substr))))
 	}
 
+	errNotExpect := func(substr string) {
+		t.Helper()
+		g.Expect(validateOVNKubernetes(config)).To(
+			Not(
+				ContainElement(MatchError(
+					ContainSubstring(substr)))))
+	}
+
 	ovnConfig.V4InternalSubnet = "100.64.0.0/22"
 	errExpect("v4InternalSubnet is no large enough for the maximum number of nodes which can be supported by ClusterNetwork")
+	ovnConfig.V4InternalSubnet = "100.64.0.0/21"
+	errNotExpect("v4InternalSubnet is no large enough for the maximum number of nodes which can be supported by ClusterNetwork")
 	ovnConfig.V6InternalSubnet = "fd01::/48"
 	errExpect("v6InternalSubnet and ClusterNetwork must have matching IP families")
 	ovnConfig.V4InternalSubnet = "10.128.0.0/16"
@@ -667,7 +677,6 @@ func TestValidateOVNKubernetes(t *testing.T) {
 	ovnConfig.GenevePort = ptrToUint32(70001)
 	errExpect("invalid GenevePort 70001")
 
-	// invalid ipv6 mtu
 	config.ServiceNetwork = []string{"fd02::/112"}
 	config.ClusterNetwork = []operv1.ClusterNetworkEntry{{
 		CIDR: "fd01::/48", HostPrefix: 64,
@@ -677,8 +686,12 @@ func TestValidateOVNKubernetes(t *testing.T) {
 	errExpect("v6InternalSubnet overlaps with ClusterNetwork fd01::/48")
 	ovnConfig.V6InternalSubnet = "fd03::/112"
 	errExpect("v6InternalSubnet is no large enough for the maximum number of nodes which can be supported by ClusterNetwork")
+	ovnConfig.V6InternalSubnet = "fd03::/111"
+	errNotExpect("v6InternalSubnet is no large enough for the maximum number of nodes which can be supported by ClusterNetwork")
 	ovnConfig.V6InternalSubnet = "fd02::/64"
 	errExpect("v6InternalSubnet overlaps with ServiceNetwork fd02::/112")
+
+	// invalid ipv6 mtu
 	ovnConfig.MTU = ptrToUint32(576)
 	errExpect("invalid MTU 576")
 


### PR DESCRIPTION
For IPv6, default int value is not large enough to store the number of IPs. In some case, it causes int overflow.

In golang, there is no built-in type for uint128. So create a custom uint128 type for calculating v6 IP number.

Signed-off-by: Peng Liu <pliu@redhat.com>