### PR TITLE
[release-4.10] OCPBUGS-1538: Make northd probe interval default to 10 seconds

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -323,7 +323,7 @@ spec:
                 #configure northd_probe_interval
                 OVN_NB_CTL="ovn-nbctl -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt \
                 --db "{{.OVN_NB_DB_LIST}}""
-                northd_probe_interval=${OVN_NORTHD_PROBE_INTERVAL:-5000}
+                northd_probe_interval=${OVN_NORTHD_PROBE_INTERVAL:-10000}
                 echo "Setting northd probe interval to ${northd_probe_interval} ms"
                 retries=0
                 current_probe_interval=0

--- a/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
@@ -62,7 +62,7 @@ spec:
         - name: OVN_SB_RAFT_ELECTION_TIMER
           value: "16"
         - name: OVN_NORTHD_PROBE_INTERVAL
-          value: "5000"
+          value: "10000"
         - name: OVN_CONTROLLER_INACTIVITY_PROBE
           value: "180000"
         - name: OVN_NB_INACTIVITY_PROBE

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -68,7 +68,7 @@ spec:
         - name: OVN_SB_RAFT_ELECTION_TIMER
           value: "16"
         - name: OVN_NORTHD_PROBE_INTERVAL
-          value: "5000"
+          value: "10000"
         - name: OVN_CONTROLLER_INACTIVITY_PROBE
           value: "180000"
         - name: OVN_NB_INACTIVITY_PROBE


### PR DESCRIPTION
/cc @trozet 
brings in https://github.com/openshift/cluster-network-operator/pull/1386/commits/eebce7172b9fc236a454809dc1768fcf7b3703fd and https://github.com/openshift/cluster-network-operator/pull/1494/files (which is the right fix)