### PR TITLE
egress_ip: remove redundant config

### DIFF
--- a/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
@@ -102,8 +102,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: OVN_EGRESSIP_HEALTHCHECK_PORT
-          value: "9107"
         image: quay.io/openshift/origin-cluster-network-operator:latest
         name: network-operator
         ports:

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -113,8 +113,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: OVN_EGRESSIP_HEALTHCHECK_PORT
-          value: "9107"
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes


### PR DESCRIPTION
manifests/0000_70_cluster-network-operator_03_deployment.yaml does not need to explicitly specify OVN_EGRESSIP_HEALTHCHECK_PORT

This was a missing change in PR https://github.com/openshift/cluster-network-operator/pull/1539 that
happened afterwards in https://github.com/openshift/cluster-network-operator/pull/1520 and I forgot
to update. Mea culpa.
