### PR TITLE
Add sysctl whitelist controller

### DIFF
--- a/bindata/allowlist/config/configmap.yaml
+++ b/bindata/allowlist/config/configmap.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cni-sysctl-allowlist
+  namespace: openshift-multus
+  annotations:
+    kubernetes.io/description: |
+      Sysctl allowlist for nodes
+    release.openshift.io/version: "{{.ReleaseVersion}}"
+data:
+  #
+  # Safe sysctls
+  # -------------
+  # add to this list only sysctls that
+  # * must not have any influence on any other pod on the node
+  # * must not allow to harm the node's health
+  # * must not allow to gain CPU or memory resources outside of the resource limit of the pod
+  #
+  allowlist.conf: |-
+    ^net.ipv4.conf.IFNAME.accept_ra$
+    ^net.ipv4.conf.IFNAME.accept_redirects$
+    ^net.ipv4.conf.IFNAME.accept_source_route$
+    ^net.ipv4.conf.IFNAME.arp_accept$
+    ^net.ipv4.conf.IFNAME.arp_notify$
+    ^net.ipv4.conf.IFNAME.disable_policy$
+    ^net.ipv4.conf.IFNAME.secure_redirects$
+    ^net.ipv4.conf.IFNAME.send_redirects$
+    ^net.ipv6.conf.IFNAME.accept_ra$
+    ^net.ipv6.conf.IFNAME.accept_redirects$
+    ^net.ipv6.conf.IFNAME.accept_source_route$
+    ^net.ipv6.conf.IFNAME.arp_accept$
+    ^net.ipv6.conf.IFNAME.arp_notify$
+    ^net.ipv6.neigh.IFNAME.base_reachable_time_ms$
+    ^net.ipv6.neigh.IFNAME.retrans_time_ms$

--- a/bindata/allowlist/daemonset/daemonset.yaml
+++ b/bindata/allowlist/daemonset/daemonset.yaml
@@ -1,0 +1,46 @@
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: cni-sysctl-allowlist-ds
+  namespace: openshift-multus
+spec:
+  selector:
+    matchLabels:
+      app: cni-sysctl-allowlist-ds
+  template:
+    metadata:
+      labels:
+        app: cni-sysctl-allowlist-ds
+    spec:
+      containers:
+        - name: kube-multus-additional-cni-plugins
+          image:  {{.MultusImage}}
+          command: ["/bin/bash", "-c", "cp /entrypoint/allowlist.conf /host/etc/cni/tuning/ && touch /ready/ready && sleep INF"]
+          securityContext:
+            privileged: true
+          readinessProbe:
+            exec:
+              command: ["/bin/bash", "-c", "test -f /ready/ready"]
+            initialDelaySeconds: 1
+          volumeMounts:
+            - mountPath: /entrypoint
+              name: cni-sysctl-allowlist
+            - mountPath: /host/etc/cni/tuning/
+              name: tuning-conf-dir
+              readOnly: false
+            - mountPath: /ready
+              name: ready
+              readOnly: false
+      volumes:
+        - name: cni-sysctl-allowlist
+          configMap:
+            name: {{.CniSysctlAllowlist}}
+            namespace: openshift-multus
+          defaultMode: 0744
+        - hostPath:
+            path: /etc/cni/tuning/
+            type: DirectoryOrCreate
+          name: tuning-conf-dir
+        - name: ready
+          emptyDir: { }

--- a/bindata/network/multus/004-sysctl-configmap.yaml
+++ b/bindata/network/multus/004-sysctl-configmap.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{.CniSysctlAllowlist}}
+  namespace: openshift-multus
+  annotations:
+    kubernetes.io/description: |
+      Sysctl allowlist for nodes.
+    release.openshift.io/version: "{{.ReleaseVersion}}"
+data:
+  #
+  # Safe sysctls
+  # -------------
+  # add to this list only sysctls that
+  # * must not have any influence on any other pod on the node
+  # * must not allow to harm the node's health
+  # * must not allow to gain CPU or memory resources outside of the resource limit of the pod
+  #
+  allowlist.conf: |-
+    ^net.ipv4.conf.IFNAME.accept_ra$
+    ^net.ipv4.conf.IFNAME.accept_redirects$
+    ^net.ipv4.conf.IFNAME.accept_source_route$
+    ^net.ipv4.conf.IFNAME.arp_accept$
+    ^net.ipv4.conf.IFNAME.arp_notify$
+    ^net.ipv4.conf.IFNAME.disable_policy$
+    ^net.ipv4.conf.IFNAME.secure_redirects$
+    ^net.ipv4.conf.IFNAME.send_redirects$
+    ^net.ipv6.conf.IFNAME.accept_ra$
+    ^net.ipv6.conf.IFNAME.accept_redirects$
+    ^net.ipv6.conf.IFNAME.accept_source_route$
+    ^net.ipv6.conf.IFNAME.arp_accept$
+    ^net.ipv6.conf.IFNAME.arp_notify$
+    ^net.ipv6.neigh.IFNAME.base_reachable_time_ms$
+    ^net.ipv6.neigh.IFNAME.retrans_time_ms$

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -102,31 +102,6 @@ data:
       exit 1
     fi
     rm -Rf $UPGRADE_DIRECTORY
-
-  #
-  # Safe sysctls
-  # -------------
-  # add to this list only sysctls that
-  # * must not have any influence on any other pod on the node
-  # * must not allow to harm the node's health
-  # * must not allow to gain CPU or memory resources outside of the resource limit of the pod
-  #
-  allowlist.conf: |-
-    ^net.ipv4.conf.IFNAME.accept_ra$
-    ^net.ipv4.conf.IFNAME.accept_redirects$
-    ^net.ipv4.conf.IFNAME.accept_source_route$
-    ^net.ipv4.conf.IFNAME.arp_accept$
-    ^net.ipv4.conf.IFNAME.arp_notify$
-    ^net.ipv4.conf.IFNAME.disable_policy$
-    ^net.ipv4.conf.IFNAME.secure_redirects$
-    ^net.ipv4.conf.IFNAME.send_redirects$
-    ^net.ipv6.conf.IFNAME.accept_ra$
-    ^net.ipv6.conf.IFNAME.accept_redirects$
-    ^net.ipv6.conf.IFNAME.accept_source_route$
-    ^net.ipv6.conf.IFNAME.arp_accept$
-    ^net.ipv6.conf.IFNAME.arp_notify$
-    ^net.ipv6.neigh.IFNAME.base_reachable_time_ms$
-    ^net.ipv6.neigh.IFNAME.retrans_time_ms$
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -303,7 +278,7 @@ spec:
           value: "/usr/src/egress-router-cni/bin/"
       - name: cni-plugins
         image: {{.CNIPluginsImage}}
-        command: ["/bin/bash", "-c", "/entrypoint/cnibincopy.sh && cp /entrypoint/allowlist.conf /host/etc/cni/tuning/"]
+        command: ["/bin/bash", "-c", "/entrypoint/cnibincopy.sh && cp -n /sysctls/allowlist.conf /host/etc/cni/tuning/"]
         volumeMounts:
         - mountPath: /entrypoint
           name: cni-binary-copy
@@ -315,6 +290,8 @@ spec:
         - mountPath: /host/etc/cni/tuning/
           name: tuning-conf-dir
           readOnly: false
+        - mountPath: /sysctls
+          name: cni-sysctl-allowlist
         env:
         - name: RHEL7_SOURCE_DIRECTORY
           value: "/usr/src/plugins/rhel7/bin/"
@@ -538,6 +515,10 @@ spec:
             path: /etc/cni/tuning/
             type: DirectoryOrCreate
           name: tuning-conf-dir
+        - name: cni-sysctl-allowlist
+          configMap:
+            name: {{.CniSysctlAllowlist}}
+            defaultMode: 0744
 {{if .RenderIpReconciler}}
 ---
 apiVersion: batch/v1

--- a/pkg/controller/add_networkconfig.go
+++ b/pkg/controller/add_networkconfig.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"github.com/openshift/cluster-network-operator/pkg/controller/allowlist"
 	"github.com/openshift/cluster-network-operator/pkg/controller/clusterconfig"
 	configmapcainjector "github.com/openshift/cluster-network-operator/pkg/controller/configmap_ca_injector"
 	"github.com/openshift/cluster-network-operator/pkg/controller/egress_router"
@@ -24,5 +25,6 @@ func init() {
 		signer.Add,
 		ingressconfig.Add,
 		infrastructureconfig.Add,
+		allowlist.Add,
 	)
 }

--- a/pkg/controller/allowlist/allowlist_controller.go
+++ b/pkg/controller/allowlist/allowlist_controller.go
@@ -1,0 +1,210 @@
+package allowlist
+
+import (
+	"context"
+	"github.com/openshift/cluster-network-operator/pkg/render"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"log"
+	"os"
+	"time"
+
+	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
+	"github.com/openshift/cluster-network-operator/pkg/controller/statusmanager"
+	"github.com/openshift/cluster-network-operator/pkg/names"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	allowlistDsName      = "cni-sysctl-allowlist-ds"
+	allowlistAnnotation  = "app=cni-sysctl-allowlist-ds"
+	manifestDir          = "../../bindata/allowlist/daemonset"
+	allowlistManifestDir = "../../bindata/network/multus/004-sysctl-configmap.yaml"
+)
+
+func Add(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client) error {
+	return add(mgr, newReconciler(mgr, status, c))
+}
+
+func newReconciler(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client) reconcile.Reconciler {
+	return &ReconcileAllowlist{client: c, scheme: mgr.GetScheme(), status: status}
+}
+
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	c, err := controller.New("allowlist-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+	err = c.Watch(&source.Kind{Type: &corev1.ConfigMap{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+var _ reconcile.Reconciler = &ReconcileAllowlist{}
+
+type ReconcileAllowlist struct {
+	client cnoclient.Client
+	scheme *runtime.Scheme
+	status *statusmanager.StatusManager
+}
+
+func (r *ReconcileAllowlist) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	if exists, err := daemonsetConfigExists(ctx, r.client); !exists {
+		err = createObjects(ctx, r.client, allowlistManifestDir)
+		if err != nil {
+			return reconcile.Result{}, errors.Wrapf(err, "error creating allowlist config map")
+		}
+	} else if err != nil {
+		return reconcile.Result{}, errors.Wrapf(err, "error looking up allowlist config map")
+	}
+
+	if request.Namespace != names.MULTUS_NAMESPACE || request.Name != names.ALLOWLIST_CONFIG_NAME {
+		return reconcile.Result{}, nil
+	}
+
+	configMap, err := getConfig(ctx, r.client, request.NamespacedName)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// No action to be taken if user deletes the config map. The sysctl's will stay unmodified until config map is recreated
+	if configMap == nil {
+		return reconcile.Result{}, nil
+	}
+
+	defer cleanup(ctx, r.client)
+
+	// If daemonset still exists, delete it and reconcile again
+	if daemonsetExists, err := daemonsetExists(ctx, r.client); daemonsetExists {
+		return reconcile.Result{}, errors.New("daemonset already exist: deleting and retrying")
+	} else if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	err = createObjects(ctx, r.client, manifestDir)
+	if err != nil {
+		return reconcile.Result{}, errors.Wrapf(err, "error creating allowlist daemonset")
+	}
+
+	err = checkDsPodsReady(ctx, r.client)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	return reconcile.Result{}, nil
+}
+
+func createObjects(ctx context.Context, client cnoclient.Client, manifestDir string) error {
+	data := render.MakeRenderData()
+	data.Data["MultusImage"] = os.Getenv("MULTUS_IMAGE")
+	data.Data["CniSysctlAllowlist"] = names.ALLOWLIST_CONFIG_NAME
+	data.Data["ReleaseVersion"] = os.Getenv("RELEASE_VERSION")
+	manifests, err := render.RenderDir(manifestDir, &data)
+	if err != nil {
+		return err
+	}
+	for _, obj := range manifests {
+
+		err = createObject(ctx, client, obj)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getConfig(ctx context.Context, client cnoclient.Client, namespacedName types.NamespacedName) (*corev1.ConfigMap, error) {
+	configMap := &corev1.ConfigMap{}
+	err := client.Default().CRClient().Get(ctx, namespacedName, configMap)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return configMap, nil
+}
+
+func createObject(ctx context.Context, client cnoclient.Client, obj *unstructured.Unstructured) error {
+	err := client.Default().CRClient().Create(ctx, obj)
+	if err != nil {
+		return errors.Wrapf(err, "error creating %s %s/%s", obj.GroupVersionKind(), obj.GetNamespace(), obj.GetName())
+	}
+	return nil
+}
+
+func checkDsPodsReady(ctx context.Context, client cnoclient.Client) error {
+	err := wait.Poll(time.Second, time.Minute, func() (done bool, err error) {
+		podList, err := client.Default().Kubernetes().CoreV1().Pods(names.MULTUS_NAMESPACE).List(
+			ctx, metav1.ListOptions{LabelSelector: allowlistAnnotation})
+		if err != nil {
+			return false, err
+		}
+		for _, pod := range podList.Items {
+			if !pod.Status.ContainerStatuses[0].Ready {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func cleanup(ctx context.Context, client cnoclient.Client) {
+	if exists, err := daemonsetExists(ctx, client); exists {
+		err = deleteDeamonSet(ctx, client)
+		if err != nil {
+			log.Printf("Error cleaning up allow list daemonset: %+v", err)
+		}
+	} else if err != nil && !apierrors.IsNotFound(err) {
+		log.Printf("Error looking up allowlist daemonset : %+v", err)
+	}
+}
+
+func deleteDeamonSet(ctx context.Context, client cnoclient.Client) error {
+	err := client.Default().Kubernetes().AppsV1().DaemonSets(names.MULTUS_NAMESPACE).Delete(
+		ctx, allowlistDsName, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func daemonsetExists(ctx context.Context, client cnoclient.Client) (bool, error) {
+	ds, err := client.Default().Kubernetes().AppsV1().DaemonSets(names.MULTUS_NAMESPACE).Get(
+		ctx, allowlistDsName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return ds != nil, nil
+}
+
+func daemonsetConfigExists(ctx context.Context, client cnoclient.Client) (bool, error) {
+	cm, err := client.Default().Kubernetes().CoreV1().ConfigMaps(names.MULTUS_NAMESPACE).Get(
+		ctx, names.ALLOWLIST_CONFIG_NAME, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return cm != nil, nil
+}

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -27,6 +27,14 @@ const APPLIED_PREFIX = "applied-"
 // Should match 00_namespace.yaml
 const APPLIED_NAMESPACE = "openshift-network-operator"
 
+// MULTUS_NAMESPACE is the namespace where applied configuration
+// configmaps are stored.
+// Should match 00_namespace.yaml
+const MULTUS_NAMESPACE = "openshift-multus"
+
+// ALLOWLIST_CONFIG_NAME is the name of the allowlist ConfigMap
+const ALLOWLIST_CONFIG_NAME = "cni-sysctl-allowlist"
+
 // IgnoreObjectErrorAnnotation is an annotation we can set on objects
 // to signal to the reconciler that we don't care if they fail to create
 // or update. Useful when we want to make a CR for which the CRD may not exist yet.

--- a/pkg/network/multus.go
+++ b/pkg/network/multus.go
@@ -75,6 +75,7 @@ func renderMultusConfig(manifestDir, defaultNetworkType string, useDHCP bool, us
 	data.Data["HTTP_PROXY"] = proxy.HTTPProxy
 	data.Data["HTTPS_PROXY"] = proxy.HTTPSProxy
 	data.Data["NO_PROXY"] = proxy.NoProxy
+	data.Data["CniSysctlAllowlist"] = "default-cni-sysctl-allowlist"
 
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/multus"), &data)
 	if err != nil {

--- a/pkg/network/multus_test.go
+++ b/pkg/network/multus_test.go
@@ -49,7 +49,7 @@ func TestRenderMultus(t *testing.T) {
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "multus")))
 
 	// It's important that the namespace is first
-	g.Expect(len(objs)).To(Equal(23), "Expected 23 multus related objects")
+	g.Expect(len(objs)).To(Equal(24), "Expected 24 multus related objects")
 	g.Expect(objs[0]).To(HaveKubernetesID("CustomResourceDefinition", "", "network-attachment-definitions.k8s.cni.cncf.io"))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("Namespace", "", "openshift-multus")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "multus")))

--- a/pkg/network/network_metrics_test.go
+++ b/pkg/network/network_metrics_test.go
@@ -49,7 +49,7 @@ func TestRenderNetworkMetricsDaemon(t *testing.T) {
 
 	// Check rendered object
 
-	g.Expect(len(objs)).To(Equal(23), "Expected 23 multus related objects")
+	g.Expect(len(objs)).To(Equal(24), "Expected 24 multus related objects")
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "network-metrics-daemon")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("Service", "openshift-multus", "network-metrics-service")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "metrics-daemon-role")))


### PR DESCRIPTION
A new controller which will watch for changes in the openshift-multus/allowlist config-map, and update the `/etc/cni/tuning/allowlist.conf `file on nodes to reflect changes in the config-map.

The  openshift-multus/allowlist config-map will be created by the multus-admission-controller (no change), as part of the multus installation, but the new controller will take on from there.

If the config-map is deleted, the controller will not delete the `/etc/cni/tuning/allowlist.conf` files on nodes. Should the user want to allow all sysctl's, an appropriate wildcard in the config-map must be added.