### PR TITLE
Jira OCPBUGS-1736: Always set PROXY variables for CNCC

### DIFF
--- a/pkg/controller/operconfig/mtu_probe.go
+++ b/pkg/controller/operconfig/mtu_probe.go
@@ -155,9 +155,14 @@ func renderMTUProber(infra *bootstrap.InfraStatus) ([]*uns.Unstructured, error) 
 	data.Data["KUBERNETES_SERVICE_PORT"] = infra.APIServers[bootstrap.APIServerDefault].Port
 	data.Data["DestNS"] = cmNamespace
 	data.Data["DestName"] = cmName
-	data.Data["HTTP_PROXY"] = infra.Proxy.HTTPProxy
-	data.Data["HTTPS_PROXY"] = infra.Proxy.HTTPSProxy
-	data.Data["NO_PROXY"] = infra.Proxy.NoProxy
+	data.Data["HTTP_PROXY"] = ""
+	data.Data["HTTPS_PROXY"] = ""
+	data.Data["NO_PROXY"] = ""
+	if infra.ControlPlaneTopology == configv1.ExternalTopologyMode {
+		data.Data["HTTP_PROXY"] = infra.Proxy.HTTPProxy
+		data.Data["HTTPS_PROXY"] = infra.Proxy.HTTPSProxy
+		data.Data["NO_PROXY"] = infra.Proxy.NoProxy
+	}
 
 	objs, err := render.RenderDir("bindata/network/mtu-prober", &data)
 	if err != nil {

--- a/pkg/network/cluster_config_test.go
+++ b/pkg/network/cluster_config_test.go
@@ -47,9 +47,11 @@ func TestValidateClusterConfig(t *testing.T) {
 		},
 	}
 	client := fake.NewFakeClient(infrastructure)
+	err := createProxy(client)
+	g.Expect(err).NotTo(HaveOccurred())
 
 	cc := *ClusterConfig.DeepCopy()
-	err := ValidateClusterConfig(cc, client)
+	err = ValidateClusterConfig(cc, client)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	haveError := func(cfg configv1.NetworkSpec, substr string) {
@@ -115,9 +117,11 @@ func TestValidateClusterConfigDualStack(t *testing.T) {
 		},
 	}
 	client := fake.NewFakeClient(infrastructure)
+	err := createProxy(client)
+	g.Expect(err).NotTo(HaveOccurred())
 
 	cc := *ClusterConfig.DeepCopy()
-	err := ValidateClusterConfig(cc, client)
+	err = ValidateClusterConfig(cc, client)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	haveError := func(cfg configv1.NetworkSpec, substr string) {
@@ -168,6 +172,8 @@ func TestValidateClusterConfigDualStack(t *testing.T) {
 	// You can't use dual-stack if this is anything else but BareMetal or NonePlatformType
 	infrastructure.Status.PlatformStatus.Type = configv1.AzurePlatformType
 	client = fake.NewFakeClient(infrastructure)
+	err = createProxy(client)
+	g.Expect(err).NotTo(HaveOccurred())
 	cc = *ClusterConfig.DeepCopy()
 	cc.ServiceNetwork = append(cc.ServiceNetwork, "fd02::/112")
 	cc.ClusterNetwork = append(cc.ClusterNetwork, configv1.ClusterNetworkEntry{

--- a/pkg/network/openshift_sdn.go
+++ b/pkg/network/openshift_sdn.go
@@ -45,9 +45,14 @@ func renderOpenShiftSDN(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Boo
 	data.Data["CNIConfDir"] = pluginCNIConfDir(conf)
 	data.Data["CNIBinDir"] = CNIBinDir
 	data.Data["PlatformType"] = bootstrapResult.Infra.PlatformType
-	data.Data["HTTP_PROXY"] = bootstrapResult.Infra.Proxy.HTTPProxy
-	data.Data["HTTPS_PROXY"] = bootstrapResult.Infra.Proxy.HTTPSProxy
-	data.Data["NO_PROXY"] = bootstrapResult.Infra.Proxy.NoProxy
+	data.Data["HTTP_PROXY"] = ""
+	data.Data["HTTPS_PROXY"] = ""
+	data.Data["NO_PROXY"] = ""
+	if bootstrapResult.Infra.ControlPlaneTopology == configv1.ExternalTopologyMode {
+		data.Data["HTTP_PROXY"] = bootstrapResult.Infra.Proxy.HTTPProxy
+		data.Data["HTTPS_PROXY"] = bootstrapResult.Infra.Proxy.HTTPSProxy
+		data.Data["NO_PROXY"] = bootstrapResult.Infra.Proxy.NoProxy
+	}
 	if bootstrapResult.Infra.PlatformType == configv1.AzurePlatformType {
 		data.Data["SDNPlatformAzure"] = true
 	} else {

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -105,9 +105,14 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["KUBERNETES_SERVICE_PORT"] = apiServer.Port
 	data.Data["K8S_APISERVER"] = "https://" + net.JoinHostPort(apiServer.Host, apiServer.Port)
 	data.Data["K8S_LOCAL_APISERVER"] = "https://" + net.JoinHostPort(localAPIServer.Host, localAPIServer.Port)
-	data.Data["HTTP_PROXY"] = bootstrapResult.Infra.Proxy.HTTPProxy
-	data.Data["HTTPS_PROXY"] = bootstrapResult.Infra.Proxy.HTTPSProxy
-	data.Data["NO_PROXY"] = bootstrapResult.Infra.Proxy.NoProxy
+	data.Data["HTTP_PROXY"] = ""
+	data.Data["HTTPS_PROXY"] = ""
+	data.Data["NO_PROXY"] = ""
+	if bootstrapResult.Infra.ControlPlaneTopology == configv1.ExternalTopologyMode {
+		data.Data["HTTP_PROXY"] = bootstrapResult.Infra.Proxy.HTTPProxy
+		data.Data["HTTPS_PROXY"] = bootstrapResult.Infra.Proxy.HTTPSProxy
+		data.Data["NO_PROXY"] = bootstrapResult.Infra.Proxy.NoProxy
+	}
 
 	data.Data["TokenMinterImage"] = os.Getenv("TOKEN_MINTER_IMAGE")
 	// TOKEN_AUDIENCE is used by token-minter to identify the audience for the service account token which is verified by the apiserver

--- a/pkg/network/render_test.go
+++ b/pkg/network/render_test.go
@@ -253,8 +253,10 @@ func TestRenderUnknownNetwork(t *testing.T) {
 	}
 
 	client := fake.NewFakeClient(infrastructure)
+	err := createProxy(client)
+	g.Expect(err).NotTo(HaveOccurred())
 
-	err := Validate(&config.Spec)
+	err = Validate(&config.Spec)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	prev := config.Spec.DeepCopy()

--- a/pkg/network/testutil_test.go
+++ b/pkg/network/testutil_test.go
@@ -1,11 +1,14 @@
 package network
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/onsi/gomega/types"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
+	"github.com/openshift/cluster-network-operator/pkg/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -72,4 +75,14 @@ func fakeBootstrapResult() *bootstrap.BootstrapResult {
 			},
 		},
 	}
+}
+
+// createProxy creates an empty proxy object.
+func createProxy(client client.Client) error {
+	proxy := &configv1.Proxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+	}
+	return client.Default().CRClient().Create(context.TODO(), proxy)
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -35,15 +35,11 @@ func InfraStatus(client cnoclient.Client) (*bootstrap.InfraStatus, error) {
 		APIServers:             map[string]bootstrap.APIServer{},
 	}
 
-	// If we use hypershift, the components need proxy settings. In selfhosted, they
-	// are always local to the API so there it is never needed.
-	if res.ControlPlaneTopology == configv1.ExternalTopologyMode {
-		proxy := &configv1.Proxy{}
-		if err := client.Default().CRClient().Get(context.TODO(), types.NamespacedName{Name: "cluster"}, proxy); err != nil {
-			return nil, fmt.Errorf("failed to get proxy 'cluster': %w", err)
-		}
-		res.Proxy = proxy.Status
+	proxy := &configv1.Proxy{}
+	if err := client.Default().CRClient().Get(context.TODO(), types.NamespacedName{Name: "cluster"}, proxy); err != nil {
+		return nil, fmt.Errorf("failed to get proxy 'cluster': %w", err)
 	}
+	res.Proxy = proxy.Status
 
 	// Extract apiserver URLs from the kubeconfig(s) passed to the CNO
 	for name, c := range client.Clients() {


### PR DESCRIPTION
Most components such as OVNK, SDN, etc. require PROXY env variables only for hypershift. The CNCC on the other hand must talk to the underlying cloud platform and must respect PROXY settings.

Reported-at: https://issues.redhat.com/browse/OCPBUGS-1736
Signed-off-by: Andreas Karis <ak.karis@gmail.com>