### PR TITLE
SDN-3508: HyperShift: Render cncc with proxy settings of the management cluster

### DIFF
--- a/bindata/cloud-network-config-controller/managed/controller.yaml
+++ b/bindata/cloud-network-config-controller/managed/controller.yaml
@@ -134,6 +134,18 @@ spec:
           value: "{{.KubernetesServicePort}}"
         - name: KUBERNETES_SERVICE_HOST
           value: "{{.KubernetesServiceHost}}"
+{{ if .HTTP_PROXY }}
+        - name: "HTTP_PROXY"
+          value: "{{ .HTTP_PROXY}}"
+{{ end }}
+{{ if .HTTPS_PROXY }}
+        - name: "HTTPS_PROXY"
+          value: "{{ .HTTPS_PROXY}}"
+{{ end }}
+{{ if .NO_PROXY }}
+        - name: "NO_PROXY"
+          value: "{{ .NO_PROXY}}"
+{{ end }}
         resources:
           requests:
             cpu: 10m

--- a/pkg/network/cloud_network.go
+++ b/pkg/network/cloud_network.go
@@ -88,6 +88,14 @@ func renderCloudNetworkConfigController(conf *operv1.NetworkSpec, bootstrapResul
 		data.Data["TokenAudience"] = os.Getenv("TOKEN_AUDIENCE")
 		data.Data["ManagementClusterName"] = names.ManagementClusterName
 		data.Data["HostedClusterNamespace"] = hcpCfg.Namespace
+
+		// In HyperShift CloudNetworkConfigController is deployed as a part of the hosted cluster controlplane
+		// which means that it is created in the management cluster.
+		// CloudNetworkConfigController should use the proxy settings configured by hypershift controlplane operator
+		// on CNO deployment.
+		data.Data["HTTP_PROXY"] = os.Getenv("MGMT_HTTP_PROXY")
+		data.Data["HTTPS_PROXY"] = os.Getenv("MGMT_HTTPS_PROXY")
+		data.Data["NO_PROXY"] = os.Getenv("MGMT_NO_PROXY")
 		caOverride.ObjectMeta = metav1.ObjectMeta{
 			Namespace:   hcpCfg.Namespace,
 			Name:        "cloud-network-config-controller-kube-cloud-config",


### PR DESCRIPTION
In HyperShift CloudNetworkConfigController is deployed as a part of the hosted cluster controlplane
 which means that the deployment is created in the management cluster.
CloudNetworkConfigController should use the proxy settings configured by hypershift controlplane operator
 on CNO deployment.

Signed-off-by: Patryk Diak <pdiak@redhat.com>