### PR TITLE
SDN-3515: HyperShift: multus admission controller: expose metrics over HTTPs

### DIFF
--- a/bindata/network/multus-admission-controller/001-service.yaml
+++ b/bindata/network/multus-admission-controller/001-service.yaml
@@ -18,6 +18,10 @@ spec:
     targetPort: 6443
   - name: metrics
     port: 8443
+{{- if .HyperShiftEnabled}}
+    targetPort: metrics-port
+{{- else }}
     targetPort: https
+{{- end }}
   selector:
     app: multus-admission-controller

--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -102,8 +102,13 @@ spec:
             -port=6443 \
             -tls-private-key-file=/etc/webhook/tls.key \
             -tls-cert-file=/etc/webhook/tls.crt \
-            -alsologtostderr=true \
+{{- if .HyperShiftEnabled}}
+            -encrypt-metrics=true \
+            -metrics-listen-address=:9091 \
+{{- else }}
             -metrics-listen-address=127.0.0.1:9091 \
+{{- end }}
+            -alsologtostderr=true \
             -ignore-namespaces=openshift-etcd,openshift-console,openshift-ingress-canary,{{.IgnoredNamespace}}
         volumeMounts:
         - name: webhook-certs
@@ -127,6 +132,7 @@ spec:
         ports:
         - name: metrics-port
           containerPort: 9091
+{{- if not .HyperShiftEnabled}}
       - name: kube-rbac-proxy
         image: {{.KubeRBACProxyImage}}
         args:
@@ -148,7 +154,6 @@ spec:
         - name: webhook-certs
           mountPath: /etc/webhook
           readOnly: True
-{{- if not .HyperShiftEnabled}}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/bindata/network/multus-admission-controller/monitor.yaml
+++ b/bindata/network/multus-admission-controller/monitor.yaml
@@ -32,6 +32,14 @@ spec:
         key: tls.key
         name: multus-admission-controller-secret
       serverName: multus-admission-controller.{{.AdmissionControllerNamespace}}.svc
+    metricRelabelings:
+      - action: replace
+        replacement: {{.ClusterID}}
+        targetLabel: {{.ClusterIDLabel}}
+    relabelings:
+      - action: replace
+        replacement: {{.ClusterID}}
+        targetLabel: {{.ClusterIDLabel}}
 {{ else }}
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     tlsConfig:


### PR DESCRIPTION
The usage of kube-rbac-proxy is not supported in hosted clusters control namespace as it required a clusterrole binding.
Follow the example of other components and expose encrypted metrics directly.
Additionally, replace metrics id for multus admission controller.

Signed-off-by: Patryk Diak <pdiak@redhat.com>