### PR TITLE
SDN-2591: allow hybrid overlay to be enabled post install

### DIFF
--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -838,10 +838,7 @@ func isOVNKubernetesChangeSafe(prev, next *operv1.NetworkSpec) []error {
 	if !reflect.DeepEqual(pn.GenevePort, nn.GenevePort) {
 		errs = append(errs, errors.Errorf("cannot change ovn-kubernetes genevePort"))
 	}
-	if pn.HybridOverlayConfig == nil && nn.HybridOverlayConfig != nil {
-		errs = append(errs, errors.Errorf("cannot start a hybrid overlay network after install time"))
-	}
-	if pn.HybridOverlayConfig != nil {
+	if pn.HybridOverlayConfig != nil && nn.HybridOverlayConfig != nil {
 		if !reflect.DeepEqual(pn.HybridOverlayConfig, nn.HybridOverlayConfig) {
 			errs = append(errs, errors.Errorf("cannot edit a running hybrid overlay network"))
 		}

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -810,8 +810,7 @@ func TestOVNKubernetesIsSafe(t *testing.T) {
 	next.DefaultNetwork.OVNKubernetesConfig.HybridOverlayConfig = &hybridOverlayConfigNext
 
 	errs = isOVNKubernetesChangeSafe(prev, next)
-	g.Expect(errs).To(HaveLen(1))
-	g.Expect(errs[0]).To(MatchError("cannot start a hybrid overlay network after install time"))
+	g.Expect(errs).To(BeEmpty())
 
 	//try to change a previous hybrid overlay
 	hybridOverlayConfigPrev :=
@@ -827,6 +826,13 @@ func TestOVNKubernetesIsSafe(t *testing.T) {
 
 	prev.DefaultNetwork.OVNKubernetesConfig.HybridOverlayConfig = nil
 	next.DefaultNetwork.OVNKubernetesConfig.HybridOverlayConfig = nil
+
+	//try to disable a running hybrid overlay
+	prev.DefaultNetwork.OVNKubernetesConfig.HybridOverlayConfig = &hybridOverlayConfigPrev
+	next.DefaultNetwork.OVNKubernetesConfig.HybridOverlayConfig = nil
+
+	errs = isOVNKubernetesChangeSafe(prev, next)
+	g.Expect(errs).To(BeEmpty())
 
 	// change the mtu without migration
 	next.DefaultNetwork.OVNKubernetesConfig.MTU = ptrToUint32(70000)


### PR DESCRIPTION
after the last downstream merge of ovn-kube we can enable and disable hybrid overlay post install 