### PR TITLE
Bug OCPBUGS-736: Kuryr: If set use MTU from Config for svc net

### DIFF
--- a/pkg/network/kuryr.go
+++ b/pkg/network/kuryr.go
@@ -110,16 +110,7 @@ func renderKuryr(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapR
 	data.Data["ConfigMapHash"] = hash
 
 	// Pods Network MTU
-	mtu := b.PodsNetworkMTU
-	if c.MTU != nil {
-		if mtu >= *c.MTU {
-			mtu = *c.MTU
-		} else {
-			return nil, progressing, errors.Errorf("Configured MTU (%d) is incompatible with OpenShift nodes network MTU (%d).", *c.MTU, mtu)
-		}
-	}
-	c.MTU = &mtu
-	data.Data["PodsNetworkMTU"] = mtu
+	data.Data["PodsNetworkMTU"] = b.PodsNetworkMTU
 
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/kuryr"), &data)
 	if err != nil {

--- a/pkg/platform/openstack/kuryr_bootstrap.go
+++ b/pkg/platform/openstack/kuryr_bootstrap.go
@@ -412,6 +412,16 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient crclient.Client) (*boot
 	}
 	log.Printf("Found Nodes Network MTU %d", mtu)
 
+	// Check the MTU. Basically if MTU is configured on KuryrConfig, then we need it to be lower or equal to nodes
+	// network MTU. Use configured value if it is, error out if it isn't.
+	if kc.MTU != nil {
+		if mtu >= *kc.MTU {
+			mtu = *kc.MTU
+		} else {
+			return nil, errors.Errorf("Configured MTU (%d) is incompatible with OpenShift nodes network MTU (%d).", *kc.MTU, mtu)
+		}
+	}
+
 	log.Print("Ensuring services network")
 	svcNetId, err := ensureOpenStackNetwork(client, generateName("kuryr-service-network", clusterID), tag, mtu)
 	if err != nil {


### PR DESCRIPTION
This commit fixes #1545 to make sure that Kuryr bootstrap honors the MTU set in KuryrConfig when creating the network for services. The MTU logic had to be moved from rendering to the bootstrap phase.