### PR TITLE
OCPBUGS-6736: Remove nbctl logfile

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -750,13 +750,12 @@ spec:
           export OVN_NB_DAEMON=$(ovn-nbctl --pidfile=/var/run/ovn/ovn-nbctl.pid \
             --detach \
             -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt \
-            --db "{{.OVN_NB_DB_LIST}}" --log-file=/run/ovn/ovn-nbctl.log \
+            --db "{{.OVN_NB_DB_LIST}}"  \
             --monitor \
             --unixctl=/var/run/ovn/ovn-nbctl.ctl \
             -vreconnect:file:info)
 
-          # include nbctl daemon logging, allow for ovn-nbctl to create the log file
-          tail -F /run/ovn/ovn-nbctl.log &
+        
 
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-master - start ovnkube --init-master ${K8S_NODE}"
           exec /usr/bin/ovnkube \


### PR DESCRIPTION
Problem: The ovn-nbctl logs were never rotated and are stored in a logfile that continually grows.
The nbctl daemon is run in detatched mode, which disables the file-descriptors, so we cannot just log to stdout

Solution: Simplest solution is to just remove the logs, especially since nbctl is not used in newer versions 

Signed-off-by: Ben Pickard <bpickard@redhat.com>