### PR TITLE
NP-607: update microshift ovnk manifests

### DIFF
--- a/bindata/network/ovn-kubernetes/microshift/clusterrole.yaml
+++ b/bindata/network/ovn-kubernetes/microshift/clusterrole.yaml
@@ -71,14 +71,6 @@ rules:
 - apiGroups: ['authorization.k8s.io']
   resources: ['subjectaccessreviews']
   verbs: ['create']
-- apiGroups: [certificates.k8s.io]
-  resources: ['certificatesigningrequests']
-  verbs:
-    - create
-    - get
-    - delete
-    - update
-    - list
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/bindata/network/ovn-kubernetes/microshift/configmap.yaml
+++ b/bindata/network/ovn-kubernetes/microshift/configmap.yaml
@@ -27,7 +27,7 @@ data:
     enable-egress-qos=false
 
     [gateway]
-    mode=shared
+    mode=local
     nodeport=true
 
     [masterha]

--- a/bindata/network/ovn-kubernetes/microshift/master/daemonset.yaml
+++ b/bindata/network/ovn-kubernetes/microshift/master/daemonset.yaml
@@ -44,7 +44,7 @@ spec:
       containers:
       # ovn-northd: convert network objects in nbdb to flows in sbdb
       - name: northd
-        image: {{ .ReleaseImage.ovn_kubernetes }}
+        image: {{ .ReleaseImage.ovn_kubernetes_microshift }}
         command:
         - /bin/bash
         - -c
@@ -95,9 +95,9 @@ spec:
             memory: 10Mi
         terminationMessagePolicy: FallbackToLogsOnError
 
-      # nbdb: the northbound, or logical network object DB. In standalone mode
+      # nbdb: the northbound, or logical network object DB. In raft mode
       - name: nbdb
-        image: {{ .ReleaseImage.ovn_kubernetes }}
+        image: {{ .ReleaseImage.ovn_kubernetes_microshift }}
         command:
         - /bin/bash
         - -c
@@ -199,8 +199,7 @@ spec:
                 echo "$(date -Iseconds) - nbdb stopped"
                 rm -f /var/run/ovn/ovnnb_db.pid
         readinessProbe:
-          timeoutSeconds: 10
-          periodSeconds: 600
+          timeoutSeconds: 5
           exec:
             command:
             - /bin/bash
@@ -208,7 +207,6 @@ spec:
             - |
               set -xeo pipefail
               /usr/bin/ovn-appctl -t /var/run/ovn/ovnnb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on 2>/dev/null
-              /usr/bin/ovn-appctl -t /var/run/ovn/ovnnb_db.ctl --timeout=5 ovsdb-server/compact 2>/dev/null
 
         env:
         - name: OVN_LOG_LEVEL
@@ -228,9 +226,9 @@ spec:
             memory: 10Mi
         terminationMessagePolicy: FallbackToLogsOnError
 
-      # sbdb: The southbound, or flow DB. In standalone mode
+      # sbdb: The southbound, or flow DB. In raft mode
       - name: sbdb
-        image: {{ .ReleaseImage.ovn_kubernetes }}
+        image: {{ .ReleaseImage.ovn_kubernetes_microshift }}
         command:
         - /bin/bash
         - -c
@@ -301,8 +299,7 @@ spec:
                 echo "$(date -Iseconds) - sbdb stopped"
                 rm -f /var/run/ovn/ovnsb_db.pid
         readinessProbe:
-          timeoutSeconds: 10
-          periodSeconds: 600
+          timeoutSeconds: 5
           exec:
             command:
             - /bin/bash
@@ -310,8 +307,6 @@ spec:
             - |
               set -xeo pipefail
               /usr/bin/ovn-appctl -t /var/run/ovn/ovnsb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on 2>/dev/null
-              /usr/bin/ovn-appctl -t /var/run/ovn/ovnsb_db.ctl --timeout=5 ovsdb-server/compact 2>/dev/null
-
         env:
         - name: OVN_LOG_LEVEL
           value: info
@@ -330,7 +325,7 @@ spec:
 
       # ovnkube master: convert kubernetes objects in to nbdb logical network components
       - name: ovnkube-master
-        image: {{ .ReleaseImage.ovn_kubernetes }}
+        image: {{ .ReleaseImage.ovn_kubernetes_microshift }}
         command:
         - /bin/bash
         - -c
@@ -355,7 +350,15 @@ spec:
           ip6tables -t raw -A OUTPUT -p udp --dport 6081 -j NOTRACK
           echo "I$(date "+%m%d %H:%M:%S.%N") - starting ovnkube-node"
 
-          gateway_mode_flags="--gateway-mode shared --gateway-interface br-ex"
+          gateway_mode_flags="--gateway-mode local --gateway-interface br-ex"
+
+          gw_interface_flag=
+          # if br-ex1 is configured on the node, we want to use it for external gateway traffic
+          if [ -d /sys/class/net/br-ex1 ]; then
+            gw_interface_flag="--exgw-interface=br-ex1"
+            # the functionality depends on ip_forwarding being enabled
+            sysctl net.ipv4.ip_forward=1
+          fi
 
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-master - start ovnkube --init-master ${K8S_NODE} --init-node ${K8S_NODE}"
           exec /usr/bin/ovnkube \
@@ -364,6 +367,7 @@ spec:
             --config-file=/run/ovnkube-config/ovnkube.conf \
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
             ${gateway_mode_flags} \
+            ${gw_interface_flag} \
             --inactivity-probe="180000" \
             --nb-address "" \
             --sb-address "" \

--- a/bindata/network/ovn-kubernetes/microshift/node/daemonset.yaml
+++ b/bindata/network/ovn-kubernetes/microshift/node/daemonset.yaml
@@ -40,7 +40,7 @@ spec:
       containers:
       # ovn-controller: programs the vswitch with flows from the sbdb
       - name: ovn-controller
-        image: {{ .ReleaseImage.ovn_kubernetes }}
+        image: {{ .ReleaseImage.ovn_kubernetes_microshift }}
         command:
         - /bin/bash
         - -c
@@ -52,7 +52,9 @@ spec:
             set +o allexport
           fi
 
-          echo "$(date -Iseconds) - starting ovn-controller"
+          # K8S_NODE_IP triggers reconcilation of this daemon when node IP changes
+          echo "$(date -Iseconds) - starting ovn-controller, Node: ${K8S_NODE} IP: ${K8S_NODE_IP}"
+
           exec ovn-controller unix:/var/run/openvswitch/db.sock -vfile:off \
             --no-chdir --pidfile=/var/run/ovn/ovn-controller.pid \
             --syslog-method="null" \
@@ -71,6 +73,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         volumeMounts:
         - mountPath: /run/openvswitch
           name: run-openvswitch

--- a/bindata/network/ovn-kubernetes/microshift/role.yaml
+++ b/bindata/network/ovn-kubernetes/microshift/role.yaml
@@ -12,6 +12,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups: [certificates.k8s.io]
+  resources: ['certificatesigningrequests']
+  verbs:
+    - create
+    - get
+    - delete
+    - update
+    - list
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Fixes that went into microshift repo directly needs to be synced
back to CNO repo for consistency in 4.12.
For 4.13+, microshift ovnk manifests will be updated first in CNO
repo, then be picked up by microshift rebase automation.

Details about ovnk maintenance in microshift can be found:
https://docs.google.com/document/d/1xc-CJ8RlmC5dj3CguG5wQC1_rs5DBqKqkpADAeX9qwI/edit#heading=h.m9cxlcfppxur

Signed-off-by: Zenghui Shi <zshi@redhat.com>