### PR TITLE
Remove the allow_ra sysctl for ipv4 from default systl whitelist

### DIFF
--- a/bindata/network/multus/004-sysctl-configmap.yaml
+++ b/bindata/network/multus/004-sysctl-configmap.yaml
@@ -17,7 +17,6 @@ data:
   # * must not allow to gain CPU or memory resources outside of the resource limit of the pod
   #
   allowlist.conf: |-
-    ^net.ipv4.conf.IFNAME.accept_ra$
     ^net.ipv4.conf.IFNAME.accept_redirects$
     ^net.ipv4.conf.IFNAME.accept_source_route$
     ^net.ipv4.conf.IFNAME.arp_accept$


### PR DESCRIPTION
The allow_ra sysctl controlls router advertisment settings which are an ipv6 thing only. As such it should only be present for ipv6.