### PR TITLE
Bug 1896533: moved SetDegraded call out of object loop to process all items first

### DIFF
--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -370,6 +370,7 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 	r.status.SetRelatedClusterObjects(relatedClusterObjects)
 
 	// Apply the objects to the cluster
+	setDegraded := false
 	for _, obj := range objs {
 		// TODO: OwnerRef for non default clusters. For HyperShift this should probably be HostedControlPlane CR
 		if apply.GetClusterName(obj) == "" {
@@ -402,10 +403,14 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 					continue
 				}
 			}
-			r.status.SetDegraded(statusmanager.OperatorConfig, "ApplyOperatorConfig",
-				fmt.Sprintf("Error while updating operator configuration: %v", err))
-			return reconcile.Result{}, err
+			setDegraded = true
 		}
+	}
+
+	if setDegraded {
+		r.status.SetDegraded(statusmanager.OperatorConfig, "ApplyOperatorConfig",
+			fmt.Sprintf("Error while updating operator configuration: %v", err))
+		return reconcile.Result{}, err
 	}
 
 	if operConfig.Spec.Migration != nil && operConfig.Spec.Migration.NetworkType != "" {

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -371,6 +371,7 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 
 	// Apply the objects to the cluster
 	setDegraded := false
+	var degradedErr error
 	for _, obj := range objs {
 		// TODO: OwnerRef for non default clusters. For HyperShift this should probably be HostedControlPlane CR
 		if apply.GetClusterName(obj) == "" {
@@ -404,12 +405,13 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 				}
 			}
 			setDegraded = true
+			degradedErr = err
 		}
 	}
 
 	if setDegraded {
 		r.status.SetDegraded(statusmanager.OperatorConfig, "ApplyOperatorConfig",
-			fmt.Sprintf("Error while updating operator configuration: %v", err))
+			fmt.Sprintf("Error while updating operator configuration: %v", degradedErr))
 		return reconcile.Result{}, err
 	}
 


### PR DESCRIPTION
This is a follow up to #1128, for this bug: https://bugzilla.redhat.com/show_bug.cgi?id=1896533

Signed-off-by: nicklesimba <simha.nikhil@gmail.com>