### PR TITLE
Remove northbound DB on schema downgrade

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -382,22 +382,6 @@ spec:
                   if ! retry 60 "inactivity-probe" "ovn-nbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_NB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_NB_INACTIVITY_PROBE}}"; then
                     exit 1
                   fi
-
-                  # Upgrade the db if required.
-                  DB_SCHEMA="/usr/share/ovn/ovn-nb.ovsschema"
-                  DB_SERVER="unix:/var/run/ovn/ovnnb_db.sock"
-                  schema_name=$(ovsdb-tool schema-name $DB_SCHEMA)
-                  db_version=$(ovsdb-client -t 10 get-schema-version "$DB_SERVER" "$schema_name")
-                  target_version=$(ovsdb-tool schema-version "$DB_SCHEMA")
-
-                  if ovsdb-tool compare-versions "$db_version" == "$target_version"; then
-                    :
-                  elif ovsdb-tool compare-versions "$db_version" ">" "$target_version"; then
-                      echo "Database $schema_name has newer schema version ($db_version) than our local schema ($target_version), possibly an upgrade is partially complete?"
-                  else
-                      echo "Upgrading database $schema_name from schema version $db_version to $target_version"
-                      ovsdb-client -t 30 convert "$DB_SERVER" "$DB_SCHEMA"
-                  fi
                 fi
 
                 # read the current northd_probe_interval from the DB
@@ -702,23 +686,6 @@ spec:
                   if ! retry 60 "inactivity-probe" "ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_CONTROLLER_INACTIVITY_PROBE}}"; then
                     exit 1
                   fi
-
-                  # Upgrade the db if required.
-                  DB_SCHEMA="/usr/share/ovn/ovn-sb.ovsschema"
-                  DB_SERVER="unix:/var/run/ovn/ovnsb_db.sock"
-                  schema_name=$(ovsdb-tool schema-name $DB_SCHEMA)
-                  db_version=$(ovsdb-client -t 10 get-schema-version "$DB_SERVER" "$schema_name")
-                  target_version=$(ovsdb-tool schema-version "$DB_SCHEMA")
-
-                  if ovsdb-tool compare-versions "$db_version" == "$target_version"; then
-                    :
-                  elif ovsdb-tool compare-versions "$db_version" ">" "$target_version"; then
-                      echo "Database $schema_name has newer schema version ($db_version) than our local schema ($target_version), possibly an upgrade is partially complete?"
-                  else
-                      echo "Upgrading database $schema_name from schema version $db_version to $target_version"
-                      ovsdb-client -t 30 convert "$DB_SERVER" "$DB_SCHEMA"
-                  fi
-                fi
 
                 # Kill some time while the cluster converges by checking IPsec status
                 OVN_SB_CTL="ovn-sbctl -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt --db "{{.OVN_SB_DB_LIST}}""

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -384,6 +384,28 @@ spec:
                   fi
                 fi
 
+                # Remove the nbdb on schema downgrade
+                DB_SCHEMA="/usr/share/ovn/ovn-nb.ovsschema"
+                DB_SERVER="unix:/var/run/ovn/ovnnb_db.sock"
+                retries=0
+                while [[ "${retries}" -lt 10 ]]; do
+                  schema_name=$(ovsdb-tool schema-name $DB_SCHEMA)
+                  db_version=$(ovsdb-client -t 10 get-schema-version "$DB_SERVER" "$schema_name")
+                  if [[ $? != 0 ]]; then
+                    sleep 2
+                    (( retries += 1 ))
+                    continue
+                  fi
+                
+                  target_version=$(ovsdb-tool schema-version "$DB_SCHEMA")
+                  if ovsdb-tool compare-versions "$db_version" ">" "$target_version"; then
+                    # Schema conversion should happen in ovndbchecker
+                    echo "Removing nbdb database, schema is being downgraded from $db_version to $target_version"
+                    rm -f /etc/ovn/ovnnb_db.db
+                  fi
+                  break
+                done
+                
                 # read the current northd_probe_interval from the DB
                 OVN_NB_CTL="ovn-nbctl -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt --db "{{.OVN_NB_DB_LIST}}""
                 northd_probe_interval=${OVN_NORTHD_PROBE_INTERVAL:-10000}

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
@@ -334,7 +334,29 @@ spec:
                     exit 1
                   fi
                 fi
-
+                
+                # Remove the nbdb on schema downgrade
+                DB_SCHEMA="/usr/share/ovn/ovn-nb.ovsschema"
+                DB_SERVER="unix:/var/run/ovn/ovnnb_db.sock"
+                retries=0
+                while [[ "${retries}" -lt 10 ]]; do
+                  schema_name=$(ovsdb-tool schema-name $DB_SCHEMA)
+                  db_version=$(ovsdb-client -t 10 get-schema-version "$DB_SERVER" "$schema_name")
+                  if [[ $? != 0 ]]; then
+                    sleep 2
+                    (( retries += 1 ))
+                    continue
+                  fi
+                
+                  target_version=$(ovsdb-tool schema-version "$DB_SCHEMA")
+                  if ovsdb-tool compare-versions "$db_version" ">" "$target_version"; then
+                    # Schema conversion should happen in ovndbchecker
+                    echo "Removing nbdb database, schema is being downgraded from $db_version to $target_version"
+                    rm -f /etc/ovn/ovnnb_db.db
+                  fi
+                  break
+                done
+                
                 # read the current northd_probe_interval from the DB
                 OVN_NB_CTL="ovn-nbctl -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt --db "{{.OVN_NB_DB_LIST}}""
                 northd_probe_interval=${OVN_NORTHD_PROBE_INTERVAL:-10000}

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
@@ -333,22 +333,6 @@ spec:
                   if ! retry 60 "inactivity-probe" "ovn-nbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_NB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_NB_INACTIVITY_PROBE}}"; then
                     exit 1
                   fi
-
-                  # Upgrade the db if required.
-                  DB_SCHEMA="/usr/share/ovn/ovn-nb.ovsschema"
-                  DB_SERVER="unix:/var/run/ovn/ovnnb_db.sock"
-                  schema_name=$(ovsdb-tool schema-name $DB_SCHEMA)
-                  db_version=$(ovsdb-client -t 10 get-schema-version "$DB_SERVER" "$schema_name")
-                  target_version=$(ovsdb-tool schema-version "$DB_SCHEMA")
-
-                  if ovsdb-tool compare-versions "$db_version" == "$target_version"; then
-                    :
-                  elif ovsdb-tool compare-versions "$db_version" ">" "$target_version"; then
-                      echo "Database $schema_name has newer schema version ($db_version) than our local schema ($target_version), possibly an upgrade is partially complete?"
-                  else
-                      echo "Upgrading database $schema_name from schema version $db_version to $target_version"
-                      ovsdb-client -t 30 convert "$DB_SERVER" "$DB_SCHEMA"
-                  fi
                 fi
 
                 # read the current northd_probe_interval from the DB
@@ -709,23 +693,6 @@ spec:
                   if ! retry 60 "inactivity-probe" "ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_CONTROLLER_INACTIVITY_PROBE}}"; then
                     exit 1
                   fi
-
-                  # Upgrade the db if required.
-                  DB_SCHEMA="/usr/share/ovn/ovn-sb.ovsschema"
-                  DB_SERVER="unix:/var/run/ovn/ovnsb_db.sock"
-                  schema_name=$(ovsdb-tool schema-name $DB_SCHEMA)
-                  db_version=$(ovsdb-client -t 10 get-schema-version "$DB_SERVER" "$schema_name")
-                  target_version=$(ovsdb-tool schema-version "$DB_SCHEMA")
-
-                  if ovsdb-tool compare-versions "$db_version" == "$target_version"; then
-                    :
-                  elif ovsdb-tool compare-versions "$db_version" ">" "$target_version"; then
-                      echo "Database $schema_name has newer schema version ($db_version) than our local schema ($target_version), possibly an upgrade is partially complete?"
-                  else
-                      echo "Upgrading database $schema_name from schema version $db_version to $target_version"
-                      ovsdb-client -t 30 convert "$DB_SERVER" "$DB_SCHEMA"
-                  fi
-                fi
 
                 # Kill some time while the cluster converges by checking IPsec status
                 OVN_SB_CTL="ovn-sbctl -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt --db "{{.OVN_SB_DB_LIST}}""


### PR DESCRIPTION
To avoid dealing with stale data on downgrades remove the northbound database so it gets rebuilt from k8s API