### PR TITLE
OCPBUGS-2598: ipsec: Run ovs-monitor-ipsec in the foreground and change probes

### DIFF
--- a/bindata/network/ovn-kubernetes/common/ipsec.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec.yaml
@@ -207,13 +207,13 @@ spec:
           # Start the pluto IKE daemon
           /usr/libexec/ipsec/pluto --leak-detective --config /etc/ipsec.conf --logfile /var/log/openvswitch/libreswan.log
 
-          # Environment variables are for workaround for https://mail.openvswitch.org/pipermail/ovs-dev/2020-October/375734.html
-          # We now start ovs-monitor-ipsec which will monitor for changes in the ovs
+          # Start ovs-monitor-ipsec which will monitor for changes in the ovs
           # tunnelling configuration (for example addition of a node) and configures
           # libreswan appropriately.
-          OVS_LOGDIR=/var/log/openvswitch OVS_RUNDIR=/var/run/openvswitch OVS_PKGDATADIR=/usr/share/openvswitch /usr/share/openvswitch/scripts/ovs-ctl --ike-daemon=libreswan --no-restart-ike-daemon start-ovs-ipsec
-
-          sleep infinity
+          # We are running this in the foreground so that the container will be restarted when ovs-monitor-ipsec fails.
+          /usr/libexec/platform-python /usr/share/openvswitch/scripts/ovs-monitor-ipsec \
+            --pidfile=/var/run/openvswitch/ovs-monitor-ipsec.pid --ike-daemon=libreswan --no-restart-ike-daemon \
+            --log-file --monitor unix:/var/run/openvswitch/db.sock
         env:
         - name: K8S_NODE
           valueFrom:
@@ -236,17 +236,6 @@ spec:
             cpu: 10m
             memory: 100Mi
         terminationMessagePolicy: FallbackToLogsOnError
-        readinessProbe:
-          exec:
-            command:
-            - /bin/bash
-            - -c
-            - |
-              #!/bin/bash
-              ovs-appctl -t ovs-monitor-ipsec ipsec/status && ipsec status
-          initialDelaySeconds: 120
-          periodSeconds: 30
-          timeoutSeconds: 40
         livenessProbe:
           exec:
             command:
@@ -254,8 +243,8 @@ spec:
             - -c
             - |
               #!/bin/bash
-              ovs-appctl -t ovs-monitor-ipsec ipsec/status && ipsec status
-          initialDelaySeconds: 60
+              ipsec status
+          initialDelaySeconds: 15
           periodSeconds: 60
       nodeSelector:
         beta.kubernetes.io/os: "linux"


### PR DESCRIPTION
 ipsec: Run ovs-monitor-ipsec in the foreground and change probes

Up until now, we ran ovs-monitor-ipsec in the background and ran a sleep
infinity after that. We then used the following in our liveness and
readiness probes:
  ovs-appctl -t ovs-monitor-ipsec ipsec/status && ipsec status
We never parsed the output of either of these commands thus the probes
failed only when ovs-monitor-ipsec was down or when pluto failed. Probes
also caused issues in environments with large numbers of IPsec endpoints
as they caused the ovn-ipsec pods to be killed on pod startup.
Optimize this by running ovs-monitor-ipsec in the foreground and by only
keeping `ipsec status` in the probes. Also shorten the
initialDelaySeconds.

Reported-at: https://issues.redhat.com/browse/OCPBUGS-2598
Signed-off-by: Andreas Karis <ak.karis@gmail.com>

---------------------

As discussed with Tim, the current probes are of very little value:
~~~
ovs-appctl -t ovs-monitor-ipsec ipsec/status && ipsec status
~~~
First of all,  `ovs-appctl -t ovs-monitor-ipsec ipsec/status` actually calls `ipsec status` so this was redundant
Secondly, we never parsed the output of either command to make sure that all tunnels were up. So we ran the status commands for the sake of running a status check but never new if everything was o.k. 

ovs-appctl -t ovs-monitor-ipsec ipsec/status actually blocks when a refresh() happens until all tunnels are added. One might argue that this is a valid check to make sure that everything is o.k.; however, this never verified if a tunnel was successfully brought up. All this did is cause liveness probes to fail until the operation is done, thus causing ovn-ipsec pods to be killed in large environments: https://issues.redhat.com/browse/OCPBUGS-2598 

Our new plan consists of 3 parts:
a) run in foreground and drop the probes
b) look into adding probes that check if all of the tunnels are actually up; while in the process of adding tunnels, add a taint to the node to make it unschedulable; if something goes wrong, the probe can still kill the pod if that's needed; either way, the probe must become way smarter
c) fix ovs-monitor-ipsec to come up faster -----> @mheib ttps://bugzilla.redhat.com/show_bug.cgi?id=2138135

This PR addresses a) so that we can close https://issues.redhat.com/browse/OCPBUGS-2598
