### PR TITLE
OCPBUGS-2947: Disable the drop-icmp container 'oc' pprof webserver on Azure

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -310,7 +310,7 @@ spec:
           iptables -F AZURE_ICMP_ACTION
           iptables -A AZURE_ICMP_ACTION -j LOG
           iptables -A AZURE_ICMP_ACTION -j DROP
-          /host/usr/bin/oc observe pods -n openshift-sdn -l app=sdn -a '{ .status.hostIP }' -- /var/run/add_iptables.sh
+          /host/usr/bin/oc observe pods -n openshift-sdn --listen-addr='' -l app=sdn -a '{ .status.hostIP }' -- /var/run/add_iptables.sh
         lifecycle:
           preStop:
             exec:

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -613,8 +613,8 @@ spec:
           ip route show
           iptables -nvL
           iptables -nvL -t nat
-          oc observe pods -n openshift-ovn-kubernetes -l app=ovnkube-node -a '{ .status.hostIP }' -- /var/run/ovn/add_iptables.sh
-          #systemd-run -qPG -- oc observe pods -n openshift-ovn-kubernetes -l app=ovnkube-node -a '{ .status.hostIP }' -- /var/run/ovn/add_iptables.sh
+          oc observe pods -n openshift-ovn-kubernetes --listen-addr='' -l app=ovnkube-node -a '{ .status.hostIP }' -- /var/run/ovn/add_iptables.sh
+          #systemd-run -qPG -- oc observe pods -n openshift-ovn-kubernetes --listen-addr='' -l app=ovnkube-node -a '{ .status.hostIP }' -- /var/run/ovn/add_iptables.sh
         lifecycle:
           preStop:
             exec:

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -508,8 +508,8 @@ spec:
           ip route show
           iptables -nvL
           iptables -nvL -t nat
-          oc observe pods -n openshift-ovn-kubernetes -l app=ovnkube-node -a '{ .status.hostIP }' -- /var/run/ovn/add_iptables.sh
-          #systemd-run -qPG -- oc observe pods -n openshift-ovn-kubernetes -l app=ovnkube-node -a '{ .status.hostIP }' -- /var/run/ovn/add_iptables.sh
+          oc observe pods -n openshift-ovn-kubernetes --listen-addr='' -l app=ovnkube-node -a '{ .status.hostIP }' -- /var/run/ovn/add_iptables.sh
+          #systemd-run -qPG -- oc observe pods -n openshift-ovn-kubernetes --listen-addr='' -l app=ovnkube-node -a '{ .status.hostIP }' -- /var/run/ovn/add_iptables.sh
         lifecycle:
           preStop:
             exec:


### PR DESCRIPTION
- `oc describe` commands should be executed with the `--listen-addr=''` command line argument to keep the go profiling web server