### PR TITLE
ipsec: Run ovs-monitor-ipsec in the foreground and drop probes

### DIFF
--- a/bindata/network/ovn-kubernetes/common/ipsec.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec.yaml
@@ -207,13 +207,13 @@ spec:
           # Start the pluto IKE daemon
           /usr/libexec/ipsec/pluto --leak-detective --config /etc/ipsec.conf --logfile /var/log/openvswitch/libreswan.log
 
-          # Environment variables are for workaround for https://mail.openvswitch.org/pipermail/ovs-dev/2020-October/375734.html
-          # We now start ovs-monitor-ipsec which will monitor for changes in the ovs
+          # Start ovs-monitor-ipsec which will monitor for changes in the ovs
           # tunnelling configuration (for example addition of a node) and configures
           # libreswan appropriately.
-          OVS_LOGDIR=/var/log/openvswitch OVS_RUNDIR=/var/run/openvswitch OVS_PKGDATADIR=/usr/share/openvswitch /usr/share/openvswitch/scripts/ovs-ctl --ike-daemon=libreswan --no-restart-ike-daemon start-ovs-ipsec
-
-          sleep infinity
+          # We are running this in the foreground so that the container will be restarted when ovs-monitor-ipsec fails.
+          /usr/libexec/platform-python /usr/share/openvswitch/scripts/ovs-monitor-ipsec \
+            --pidfile=/var/run/openvswitch/ovs-monitor-ipsec.pid --ike-daemon=libreswan --no-restart-ike-daemon \
+            --log-file --monitor unix:/var/run/openvswitch/db.sock
         env:
         - name: K8S_NODE
           valueFrom:
@@ -236,27 +236,6 @@ spec:
             cpu: 10m
             memory: 100Mi
         terminationMessagePolicy: FallbackToLogsOnError
-        readinessProbe:
-          exec:
-            command:
-            - /bin/bash
-            - -c
-            - |
-              #!/bin/bash
-              ovs-appctl -t ovs-monitor-ipsec ipsec/status && ipsec status
-          initialDelaySeconds: 120
-          periodSeconds: 30
-          timeoutSeconds: 40
-        livenessProbe:
-          exec:
-            command:
-            - /bin/bash
-            - -c
-            - |
-              #!/bin/bash
-              ovs-appctl -t ovs-monitor-ipsec ipsec/status && ipsec status
-          initialDelaySeconds: 60
-          periodSeconds: 60
       nodeSelector:
         beta.kubernetes.io/os: "linux"
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Up until now, we ran ovs-monitor-ipsec in the background and ran a sleep infinity after that. We then used the following in our liveness and readiness probes:
  ovs-appctl -t ovs-monitor-ipsec ipsec/status && ipsec status
However, we never parsed the output of either of these commands thus the probes would only ever fail when ovs-monitor-ipsec was down. By running ovs-monitor-ipsec in the foreground, we can hence drop the probes. Probes also caused issues in environments with large numbers of IPsec endpoints as they caused the ovn-ipsec pods to be killed on pod startup.

Reported-at: https://issues.redhat.com/browse/OCPBUGS-2598
Signed-off-by: Andreas Karis <ak.karis@gmail.com>