### PR TITLE
Remove references to the hosts kubeconfig

### DIFF
--- a/cmd/cluster-network-operator/main.go
+++ b/cmd/cluster-network-operator/main.go
@@ -4,28 +4,21 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"log"
 	"math/rand"
-	"net/url"
 	"os"
 	"time"
 
 	"github.com/openshift/cluster-network-operator/pkg/names"
 	"github.com/openshift/cluster-network-operator/pkg/operator"
+	"github.com/openshift/cluster-network-operator/pkg/version"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	"k8s.io/client-go/tools/clientcmd"
-
-	_ "github.com/openshift/cluster-network-operator/pkg/client"
-	"github.com/openshift/cluster-network-operator/pkg/version"
 
 	utilflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 )
-
-const ENV_URL_KUBECONFIG = "URL_ONLY_KUBECONFIG"
 
 func main() {
 	rand.Seed(time.Now().UTC().UnixNano())
@@ -38,30 +31,6 @@ func main() {
 
 	command := newNetworkOperatorCommand()
 
-	// Hack: the network operator can't use the apiserver service ip, since there's
-	// no network. We also can't hard-code it to 127.0.0.1, because we run during
-	// bootstrap. Instead, we bind-mount in the kubelet's kubeconfig, but just
-	// use it to get the apiserver url.
-	if kc := os.Getenv(ENV_URL_KUBECONFIG); kc != "" {
-		kubeconfig, err := clientcmd.LoadFromFile(kc)
-		if err != nil {
-			log.Fatal(err)
-		}
-		clusterName := kubeconfig.Contexts[kubeconfig.CurrentContext].Cluster
-		apiURL := kubeconfig.Clusters[clusterName].Server
-
-		url, err := url.Parse(apiURL)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// The kubernetes in-cluster functions don't let you override the apiserver
-		// directly; gotta "pass" it via environment vars.
-		log.Printf("overriding kubernetes api to %s", apiURL)
-		os.Setenv("KUBERNETES_SERVICE_HOST", url.Hostname())
-		os.Setenv("KUBERNETES_SERVICE_PORT", url.Port())
-	}
-
 	if err := command.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
@@ -72,9 +41,7 @@ func newNetworkOperatorCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "network-operator",
 		Short: "Openshift Cluster Network Operator",
-		Long: `Run the network operator.
-This supports an additional environment variable, URL_ONLY_KUBECONFIG,
-which is a kubeconfig from which to take just the URL to the apiserver`,
+		Long:  "Run the network operator",
 		Run: func(cmd *cobra.Command, args []string) {
 			_ = cmd.Help()
 			os.Exit(1)

--- a/hack/run-locally.sh
+++ b/hack/run-locally.sh
@@ -42,7 +42,7 @@ function override_install_manifests() {
 function extract_environment_from_running_cluster() {
     if [[ ! -e "${CLUSTER_DIR}/env.sh" ]]; then
         echo "Copying environment variables from manifest to ${CLUSTER_DIR}/env.sh"
-        oc get deployment -n openshift-network-operator network-operator -ojsonpath='{range .spec.template.spec.containers[0].env[?(@.value)]}{.name}{"="}{.value}{"\n"}' | grep -v URL_ONLY_KUBECONFIG > "${CLUSTER_DIR}/env.sh"
+        oc get deployment -n openshift-network-operator network-operator -ojsonpath='{range .spec.template.spec.containers[0].env[?(@.value)]}{.name}{"="}{.value}{"\n"}' > "${CLUSTER_DIR}/env.sh"
     fi
     if [[ $EXPORT_ENV_ONLY == true ]]; then
         exit 0
@@ -53,7 +53,7 @@ function extract_environment_from_running_cluster() {
 function extract_environment_from_manifests() {
     if [[ manifests/0000_70_cluster-network-operator_03_deployment.yaml -nt "${CLUSTER_DIR}/env.sh" ]]; then
         echo "Copying environment variables from manifest to ${CLUSTER_DIR}/env.sh"
-        oc --kubeconfig=hack/null-kubeconfig patch --local=true -f manifests/0000_70_cluster-network-operator_03_deployment.yaml -p '{}' -ojsonpath='{range .spec.template.spec.containers[0].env[?(@.value)]}{.name}{"="}{.value}{"\n"}' | grep -v URL_ONLY_KUBECONFIG > "${CLUSTER_DIR}/env.sh"
+        oc --kubeconfig=hack/null-kubeconfig patch --local=true -f manifests/0000_70_cluster-network-operator_03_deployment.yaml -p '{}' -ojsonpath='{range .spec.template.spec.containers[0].env[?(@.value)]}{.name}{"="}{.value}{"\n"}' > "${CLUSTER_DIR}/env.sh"
     fi
 }
 

--- a/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
@@ -44,7 +44,8 @@ spec:
           if [[ -f /etc/kubernetes/apiserver-url.env ]]; then
             source /etc/kubernetes/apiserver-url.env
           else
-            URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
+            echo "Error: /etc/kubernetes/apiserver-url.env is missing"
+            exit 1
           fi
           exec /usr/bin/cluster-network-operator start --listen=0.0.0.0:9104
         env:

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -51,7 +51,8 @@ spec:
           if [[ -f /etc/kubernetes/apiserver-url.env ]]; then
             source /etc/kubernetes/apiserver-url.env
           else
-            URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
+            echo "Error: /etc/kubernetes/apiserver-url.env is missing"
+            exit 1
           fi
           exec /usr/bin/cluster-network-operator start --listen=0.0.0.0:9104
         resources:


### PR DESCRIPTION
Since https://github.com/openshift/cluster-network-operator/pull/976 we are no longer using the hosts kubeconfig.

Remove the references to the old approach.

This addresses https://bugzilla.redhat.com/show_bug.cgi?id=2083334, security bugs do not work with the bot:

> When the change merges, the Bugzilla associated with the CVE must be set to MODIFIED. Since the DPTP bugzilla bot is not permitted to scan bugs with the SECURITY group in Bugzilla, The REP will not be able to use the bot's public functionality of moving their bug to MODIFIED.
> https://docs.google.com/document/d/1KuenDafC3Ukw19jY55tkVeH8nNVVAi8TEAfqynoVfzY/edit#heading=h.ikdk6suc575k

Signed-off-by: Patryk Diak <pdiak@redhat.com>
