### PR TITLE
Jira OCPBUGS-3744: Fix mount for /var/run/netns for egress-router

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -150,7 +150,7 @@ spec:
           readOnly: true
           mountPropagation: HostToContainer
         - name: host-var-run-netns
-          mountPath: /host/var/run/netns
+          mountPath: /var/run/netns
           mountPropagation: HostToContainer
           readOnly: true
         # We mount our socket here


### PR DESCRIPTION
Commit 62cefe43a9963f386c2831f5296116f8ba62e257 mounted the wrong dir We must mount the host's /var/run/netns with a HostToContainer mount / rslave into the SDN container's /var/run/netns to correctly propagate everything.

Reported-at: https://issues.redhat.com/browse/OCPBUGS-3744
Signed-off-by: Andreas Karis <ak.karis@gmail.com>