### PR TITLE
Jira OCPBUGS-3777: IPsec: Fix broken counter++ expression

### DIFF
--- a/bindata/network/ovn-kubernetes/common/ipsec.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec.yaml
@@ -105,7 +105,7 @@ spec:
             counter=0
             until [ ! -z $(kubectl get csr/$(hostname) -o jsonpath='{.status.certificate}' 2>/dev/null) ]
             do
-              ((counter++))
+              counter=$((counter+1))
               sleep 1
               if [ $counter -gt 60 ];
               then
@@ -180,7 +180,7 @@ spec:
           counter=0
           until [ -f /etc/cni/net.d/10-ovn-kubernetes.conf ]
           do
-            ((counter++))
+            counter=$((counter+1))
             sleep 1
             if [ $counter -gt 300 ];
             then


### PR DESCRIPTION
((counter++)) does not always work - the ovn-keys init container dies
when hitting that line under certain cicumstances.
I discovered upstream that changing this to counter=$[counter+1] will
fix this.

Reported-at: https://issues.redhat.com/browse/OCPBUGS-3777
Signed-off-by: Andreas Karis <ak.karis@gmail.com>

context, I implemented the ipsec pods in kind upstream and I had noticed that the expression was broken
So I already ported it this way upstream:
https://github.com/ovn-org/ovn-kubernetes/blob/master/dist/templates/ovn-ipsec.yaml.j2#L107
I think those loop counter increments likely never worked but that in most cases, the until always returned true so we never had to get into the loop.
Due to another fix for IPsec, Anurag started deploying and testing ovnk ipsec with dualstack all the way down to 4.9 and said that all of his tests failed for dualstack (on those loop counters, it seems from the logs)

Bash reproducer:
~~~
[akaris@linux ~]$ ./test.sh
+ counter=0
+ false
+ (( counter++ ))
[akaris@linux ~]$ cat test.sh
#!/bin/bash

set -eux

counter=0
until false; do
    ((counter++))
    echo $counter
    sleep 1
done
~~~

And after fixing it:
~~~
$ cat test.sh
#!/bin/bash

set -ux

counter=0
until false; do
    counter=$((counter+1))
    echo $counter
    sleep 1
done
[akaris@linux ~]$ ./test.sh
+ counter=0
+ false
+ counter=1
+ echo 1
1
+ sleep 1
+ false
+ counter=2
+ echo 2
2
+ sleep 1
+ false
+ counter=3
+ echo 3
3
+ sleep 1
^C
~~~

The script is `set -e` but `(( counter++))` returns `1` for the 0 -> 1 transition:
~~~
[akaris@linux ~]$ counter=0
[akaris@linux ~]$ (( counter++))
[akaris@linux ~]$ echo $?
1
[akaris@linux ~]$ echo $counter
1
[akaris@linux ~]$ (( counter++))
[akaris@linux ~]$ echo $?
0
[akaris@linux ~]$ echo $counter
2
~~~

Also see https://stackoverflow.com/questions/10515964/counter-increment-in-bash-loop-not-working
~~~
As explained to me by Ilkka Virta (who answers questions addressed to bug-bash@gnu.org), this is not the inc/dec operators, but rather the ((...)) construct. If the result of the expression is zero, ((...)) returns a status of 1, which makes it useful for conditional expressions: if (( 100-100 )); then echo true; else echo false; fi If your counter starts at zero, you can use ((++x)), which returns the value after the expression is evaluated, whereas ((x++)) returns the value of x before it's incremented, resulting in an "false/error" return value. – 
[Bill Jetzer](https://stackoverflow.com/users/12859753/bill-jetzer)
[Nov 24, 2020 at 14:16](https://stackoverflow.com/questions/10515964/counter-increment-in-bash-loop-not-working#comment114895103_59775569)
~~~