### PR TITLE
Test 4.12: IPsec: Fix broken counter++ expression

### DIFF
--- a/bindata/network/ovn-kubernetes/common/ipsec.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec.yaml
@@ -105,7 +105,7 @@ spec:
             counter=0
             until [ ! -z $(kubectl get csr/$(hostname) -o jsonpath='{.status.certificate}' 2>/dev/null) ]
             do
-              ((counter++))
+              counter=$[counter+1]
               sleep 1
               if [ $counter -gt 60 ];
               then
@@ -180,7 +180,7 @@ spec:
           counter=0
           until [ -f /etc/cni/net.d/10-ovn-kubernetes.conf ]
           do
-            ((counter++))
+            counter=$[counter+1]
             sleep 1
             if [ $counter -gt 300 ];
             then


### PR DESCRIPTION
((counter++)) does not work in under all circumstances - the ovn-ipsec init container dies when hitting that step under certain cicumstances. I discovered upstream that changing this to counter=$[counter+1] will fix this.

Reported-at: https://issues.redhat.com/browse/OCPBUGS-3777
Signed-off-by: Andreas Karis <ak.karis@gmail.com>