### PR TITLE
OCPBUGS-3744: SDN: /var/run mount cleanup

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -130,10 +130,9 @@ spec:
           readOnly: true
         - mountPath: /env
           name: env-overrides
-        # Mount the entire run directory for socket access for Docker or CRI-o
-        # TODO: remove
-        - mountPath: /var/run
-          name: host-var-run
+        # Mount CRI-o run directory for socket access
+        - mountPath: /var/run/crio
+          name: host-var-run-crio
         # Run directories where we need to be able to access sockets
         - mountPath: /var/run/dbus/
           name: host-var-run-dbus
@@ -346,10 +345,9 @@ spec:
       - name: host-modules
         hostPath:
           path: /lib/modules
-      # TODO: access to the docker socket should be replaced by CRI socket
-      - name: host-var-run
+      - name: host-var-run-crio
         hostPath:
-          path: /var/run
+          path: /var/run/crio
       - name: host-run-netns
         hostPath:
           path: /run/netns

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -149,10 +149,6 @@ spec:
           name: host-run-netns
           readOnly: true
           mountPropagation: HostToContainer
-        - name: host-var-run-netns
-          mountPath: /host/var/run/netns
-          mountPropagation: HostToContainer
-          readOnly: true
         # We mount our socket here
         - mountPath: /var/run/openshift-sdn
           name: host-var-run-openshift-sdn
@@ -357,9 +353,6 @@ spec:
       - name: host-run-netns
         hostPath:
           path: /run/netns
-      - name: host-var-run-netns
-        hostPath:
-          path: /var/run/netns
       - name: host-var-run-dbus
         hostPath:
           path: /var/run/dbus


### PR DESCRIPTION
This PR reverts https://github.com/openshift/cluster-network-operator/pull/787 which no longer helps with the `unknown FS magic on "/var/run/netns/...": 1021994(TMPFS_MAGIC)`.
Additionally limit the `/var/run` mount to `/var/run/crio` as we no longer need to access the docker socket since: https://github.com/openshift/sdn/commit/153a756be0d73fac06db7b17fc023393633c6fb2.

/cc @andreaskaris 
/assign @danwinship 