### PR TITLE
OCPBUGS-3883: HyperShift: Co-locate OVN-Kubernetes master with other hcp pods

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -26,6 +26,9 @@ metadata:
     kubernetes.io/description: |
       This daemonset launches the ovn-kubernetes controller (master) networking components.
     release.openshift.io/version: "{{.ReleaseVersion}}"
+  labels:
+    # used by PodAffinity to prefer co-locating pods that belong to the same hosted cluster.
+    hypershift.openshift.io/hosted-control-plane: {{.HostedClusterNamespace}}
 spec:
   podManagementPolicy: Parallel
   selector:
@@ -65,6 +68,14 @@ spec:
               matchLabels:
                 app: ovnkube-master
             topologyKey: topology.kubernetes.io/zone
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    hypershift.openshift.io/hosted-control-plane: {{.HostedClusterNamespace}}
+                topologyKey: kubernetes.io/hostname
       priorityClassName: hypershift-api-critical
       initContainers:
       # Remove once https://github.com/kubernetes/kubernetes/issues/85966 is addressed


### PR DESCRIPTION
Co-locate OVN-Kubernetes master with other hcp pods.

This tries to do the same that as: https://github.com/openshift/hypershift/blob/fa7bd17ab5f1bac31a06724cb0a5d53185260f11/support/config/deployment.go#L174

/cc @zshi-redhat @csrwng

To verify it works I created 6 HA hosted clusters and ovn-k is located in the same way as etcd now:
```
oc get po -A -lapp=etcd  --field-selector=metadata.namespace!=openshift-etcd  -o jsonpath='{range .items[*]}{.spec.nodeName}{"\n"}{end}'   | sort | uniq -c
      2 ip-10-0-130-80.ec2.internal
      3 ip-10-0-131-40.ec2.internal
      4 ip-10-0-158-242.ec2.internal
      3 ip-10-0-163-58.ec2.internal
      3 ip-10-0-182-17.ec2.internal
      3 ip-10-0-197-120.ec2.internal
```
```
oc get po -A -lapp=ovnkube-master  --field-selector=metadata.namespace!=openshift-ovn-kubernetes  -o jsonpath='{range .items[*]}{.spec.nodeName}{"\n"}{end}'   | sort | uniq -c
      2 ip-10-0-130-80.ec2.internal
      3 ip-10-0-131-40.ec2.internal
      4 ip-10-0-158-242.ec2.internal
      3 ip-10-0-163-58.ec2.internal
      3 ip-10-0-182-17.ec2.internal
      3 ip-10-0-197-120.ec2.internal
```

Signed-off-by: Patryk Diak <pdiak@redhat.com>