### PR TITLE
SDN-3597: OVN-K alerts: add OVS overflow alerts

### DIFF
--- a/bindata/network/ovn-kubernetes/common/alert-rules.yaml
+++ b/bindata/network/ovn-kubernetes/common/alert-rules.yaml
@@ -71,3 +71,21 @@ spec:
       expr: increase(ovnkube_resource_retry_failures_total[10m]) > 0
       labels:
         severity: warning
+    - alert: OVNKubernetesNodeOVSOverflowUserspace
+      annotations:
+        summary: OVS vSwitch daemon drops packets due to buffer overflow.
+        description: Netlink messages dropped by OVS vSwitch daemon due to netlink socket buffer overflow.
+          This will result in packet loss.
+      expr: increase(ovs_vswitchd_netlink_overflow[5m]) > 0
+      for: 15m
+      labels:
+        severity: warning
+    - alert: OVNKubernetesNodeOVSOverflowKernel
+      annotations:
+        summary: OVS kernel module drops packets due to buffer overflow.
+        description: Netlink messages dropped by OVS kernel module due to netlink socket buffer overflow.
+          This will result in packet loss.
+      expr: increase(ovs_vswitchd_dp_flows_lookup_lost[5m]) > 0
+      for: 15m
+      labels:
+        severity: warning


### PR DESCRIPTION
OVS vswitchd and kernel module talk via a full duplex link comms using the netlink socket API. Reciever requires a buffer. Buffer overflow will cause packet loss.

Overflows can occur if node is under extreme load and numerous userspace flow lookups. It may also occur if OVS vswitchd is malfunctioning.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>