### PR TITLE
OCPBUGS-3916: SDN alerts: Add `$labels.node` to `SDNPodNotRady` metric

### DIFF
--- a/bindata/network/openshift-sdn/alert-rules.yaml
+++ b/bindata/network/openshift-sdn/alert-rules.yaml
@@ -72,7 +72,7 @@ spec:
         summary: OpenShift SDN pod {{"{{"}} $labels.pod {{"}}"}} on node {{"{{"}} $labels.node {{"}}"}} is not ready.
         description: Network control plane configuration on the node could be degraded.
       expr: |
-        kube_pod_status_ready{namespace='openshift-sdn', condition='true'} == 0
+        sum by(pod, namespace) (kube_pod_status_ready{condition="true",namespace="openshift-sdn"}) * on(pod, namespace) group_right() kube_pod_info == 0
       for: 10m
       labels:
         severity: warning


### PR DESCRIPTION
`kube_pod_status_ready` metric has no label called `node`: https://github.com/kubernetes/kube-state-metrics/blob/master/docs/pod-metrics.md

Adding node name value from `kube_pod_info` metric, as it was done for kuryr in
- https://github.com/openshift/cluster-network-operator/pull/1176


Ref: https://issues.redhat.com/browse/OCPBUGS-3916

