### PR TITLE
Allow SDN migration from Kuryr to OVNKubernetes

### DIFF
--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -423,26 +423,29 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 			err = fmt.Errorf("Error: operConfig.Spec.Migration.NetworkType: %s is not equal to either \"OpenshiftSDN\" or \"OVNKubernetes\"", operConfig.Spec.Migration.NetworkType)
 			return reconcile.Result{}, err
 		}
-		migration := operConfig.Spec.Migration
-		if migration.Features == nil || migration.Features.EgressFirewall {
-			err = migrateEgressFirewallCRs(ctx, operConfig, r.client)
-			if err != nil {
-				log.Printf("Could not migrate EgressFirewall CRs: %v", err)
-				return reconcile.Result{}, err
+
+		if operConfig.Spec.DefaultNetwork.Type != operv1.NetworkTypeKuryr { // Kuryr does not support these features, we can't migrate them from it.
+			migration := operConfig.Spec.Migration
+			if migration.Features == nil || migration.Features.EgressFirewall {
+				err = migrateEgressFirewallCRs(ctx, operConfig, r.client)
+				if err != nil {
+					log.Printf("Could not migrate EgressFirewall CRs: %v", err)
+					return reconcile.Result{}, err
+				}
 			}
-		}
-		if migration.Features == nil || migration.Features.Multicast {
-			err = migrateMulticastEnablement(ctx, operConfig, r.client)
-			if err != nil {
-				log.Printf("Could not migrate Multicast settings: %v", err)
-				return reconcile.Result{}, err
+			if migration.Features == nil || migration.Features.Multicast {
+				err = migrateMulticastEnablement(ctx, operConfig, r.client)
+				if err != nil {
+					log.Printf("Could not migrate Multicast settings: %v", err)
+					return reconcile.Result{}, err
+				}
 			}
-		}
-		if migration.Features == nil || migration.Features.EgressIP {
-			err = migrateEgressIpCRs(ctx, operConfig, r.client)
-			if err != nil {
-				log.Printf("Could not migrate EgressIP CRs: %v", err)
-				return reconcile.Result{}, err
+			if migration.Features == nil || migration.Features.EgressIP {
+				err = migrateEgressIpCRs(ctx, operConfig, r.client)
+				if err != nil {
+					log.Printf("Could not migrate EgressIP CRs: %v", err)
+					return reconcile.Result{}, err
+				}
 			}
 		}
 	}

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -427,18 +427,21 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 		if migration.Features == nil || migration.Features.EgressFirewall {
 			err = migrateEgressFirewallCRs(ctx, operConfig, r.client)
 			if err != nil {
+				log.Printf("Could not migrate EgressFirewall CRs: %v", err)
 				return reconcile.Result{}, err
 			}
 		}
 		if migration.Features == nil || migration.Features.Multicast {
 			err = migrateMulticastEnablement(ctx, operConfig, r.client)
 			if err != nil {
+				log.Printf("Could not migrate Multicast settings: %v", err)
 				return reconcile.Result{}, err
 			}
 		}
 		if migration.Features == nil || migration.Features.EgressIP {
 			err = migrateEgressIpCRs(ctx, operConfig, r.client)
 			if err != nil {
+				log.Printf("Could not migrate EgressIP CRs: %v", err)
 				return reconcile.Result{}, err
 			}
 		}


### PR DESCRIPTION
This PR aims to unblock checks that currently block Kuryr->OVNKubernetes migrations. Interestingly that worked just fine in 4.11, but feature migrations introduced in 4.12 started to block that. Also a validateMigration function is introduced that will
block Kuryr->OpenShiftSDN migrations that are considered not supported.

I also added error logging to feature migration code as these are not printed and I spent quite a while trying to figure out why the migration isn't progressing as it did in 4.11.