### PR TITLE
Support RHOBS monitoring for HyperShift

### DIFF
--- a/bindata/network/multus-admission-controller/monitor.yaml
+++ b/bindata/network/multus-admission-controller/monitor.yaml
@@ -1,5 +1,9 @@
 ---
+{{- if eq .RHOBSMonitoring "1" }}
+apiVersion: monitoring.rhobs/v1
+{{- else }}
 apiVersion: monitoring.coreos.com/v1
+{{- end }}
 kind: ServiceMonitor
 metadata:
   labels:

--- a/bindata/network/ovn-kubernetes/managed/monitor-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/monitor-master.yaml
@@ -1,5 +1,9 @@
 ---
+{{- if eq .RHOBSMonitoring "1" }}
+apiVersion: monitoring.rhobs/v1
+{{- else }}
 apiVersion: monitoring.coreos.com/v1
+{{- end }}
 kind: ServiceMonitor
 metadata:
   labels:

--- a/pkg/network/multus_admission_controller.go
+++ b/pkg/network/multus_admission_controller.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 	"os"
 	"path/filepath"
 	"strings"
+
+	hyperv1 "github.com/openshift/hypershift/api/v1alpha1"
 
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
@@ -72,6 +73,7 @@ func renderMultusAdmissonControllerConfig(manifestDir string, externalControlPla
 	data.Data["HyperShiftEnabled"] = hsc.Enabled
 	data.Data["ManagementClusterName"] = names.ManagementClusterName
 	data.Data["AdmissionControllerNamespace"] = "openshift-multus"
+	data.Data["RHOBSMonitoring"] = os.Getenv("RHOBS_MONITORING")
 	if hsc.Enabled {
 		data.Data["AdmissionControllerNamespace"] = hsc.Namespace
 		data.Data["KubernetesServiceHost"] = bootstrapResult.Infra.APIServers[bootstrap.APIServerDefaultLocal].Host

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -310,6 +310,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 		klog.Infof("OVN_EGRESSIP_HEALTHCHECK_PORT env var is not defined. Using: %s", reachability_node_port)
 	}
 	data.Data["ReachabilityNodePort"] = reachability_node_port
+	data.Data["RHOBSMonitoring"] = os.Getenv("RHOBS_MONITORING")
 
 	exportNetworkFlows := conf.ExportNetworkFlows
 	if exportNetworkFlows != nil {


### PR DESCRIPTION
When running in HyperShift mode and the RHOBS_MONITORING=1 environment variable is set, renders service monitors in the control plane namespace using the RHOBS group/version (monitoring.rhobs/v1) instead of the default monitoring.coreos.com/v1.

This is needed by the service delivery implementation of monitoring where the monitoring stack requires the use of the monitoring.rhobs/v1 group version in resources it discovers for scraping.

Fixes: #[HOSTEDCP-624](https://issues.redhat.com//browse/HOSTEDCP-624)