### PR TITLE
OCPBUGS-4350: Fix handling of deployment and statefulset updates

### DIFF
--- a/pkg/controller/statusmanager/pod_status.go
+++ b/pkg/controller/statusmanager/pod_status.go
@@ -148,6 +148,9 @@ func (status *StatusManager) SetFromPods() {
 		if isNonCritical(ss) && ss.Status.ReadyReplicas == 0 && !status.installComplete {
 			progressing = append(progressing, fmt.Sprintf("StatefulSet %q is waiting for other operators to become ready", ssName.String()))
 			ssProgressing = true
+		} else if ss.Status.UpdatedReplicas < ss.Status.Replicas {
+			progressing = append(progressing, fmt.Sprintf("StatefulSet %q update is rolling out (%d out of %d updated)", ssName.String(), ss.Status.UpdatedReplicas, ss.Status.Replicas))
+			ssProgressing = true
 		} else if ss.Status.ReadyReplicas > 0 && ss.Status.ReadyReplicas < ss.Status.Replicas {
 			progressing = append(progressing, fmt.Sprintf("StatefulSet %q is not available (awaiting %d nodes)", ssName.String(), (ss.Status.Replicas-ss.Status.ReadyReplicas)))
 			ssProgressing = true
@@ -199,6 +202,9 @@ func (status *StatusManager) SetFromPods() {
 
 		if isNonCritical(dep) && dep.Status.UnavailableReplicas > 0 && !status.installComplete {
 			progressing = append(progressing, fmt.Sprintf("Deployment %q is waiting for other operators to become ready", depName.String()))
+			depProgressing = true
+		} else if dep.Status.UpdatedReplicas < dep.Status.Replicas {
+			progressing = append(progressing, fmt.Sprintf("Deployment %q update is rolling out (%d out of %d updated)", depName.String(), dep.Status.UpdatedReplicas, dep.Status.Replicas))
 			depProgressing = true
 		} else if dep.Status.UnavailableReplicas > 0 {
 			progressing = append(progressing, fmt.Sprintf("Deployment %q is not available (awaiting %d nodes)", depName.String(), dep.Status.UnavailableReplicas))

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -1546,10 +1546,9 @@ func daemonSetProgressing(ds *appsv1.DaemonSet, allowHung bool) bool {
 func statefulSetProgressing(ss *appsv1.StatefulSet) bool {
 	status := ss.Status
 
-	// Copy-pasted from status_manager: Determine if a DaemonSet is progressing
-	progressing := (status.ReadyReplicas < status.Replicas ||
-		status.AvailableReplicas == 0 ||
-		ss.Generation > status.ObservedGeneration)
+	progressing := status.UpdatedReplicas < status.Replicas ||
+		status.AvailableReplicas < status.Replicas ||
+		ss.Generation > status.ObservedGeneration
 
 	s := "progressing"
 	if !progressing {

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -107,7 +106,7 @@ func RenderTemplate(path string, d *RenderData) ([]*unstructured.Unstructured, e
 	tmpl.Funcs(template.FuncMap{"getOr": getOr, "isSet": isSet, "iniEscapeCharacters": iniEscapeCharacters})
 	tmpl.Funcs(sprig.TxtFuncMap())
 
-	source, err := ioutil.ReadFile(path)
+	source, err := os.ReadFile(path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read manifest %s", path)
 	}


### PR DESCRIPTION
When a deployment or a statefulset is being updated `UpdatedReplicas` indicates how many replicas are on the latest version. When the field was not taken into account all statefulsets and deployments were considered ready prematurely during upgrades.

cc: @zshi-redhat 
/assign @jcaamano 

Signed-off-by: Patryk Diak <pdiak@redhat.com>