### PR TITLE
Set OVN-K north/south bound stale alerts severity to critical

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/alert-rules-control-plane.yaml
@@ -89,7 +89,7 @@ spec:
         time() - max_over_time(ovnkube_master_nb_e2e_timestamp[5m]) > 120
       for: 10m
       labels:
-        severity: warning
+        severity: critical
     - alert: SouthboundStale
       annotations:
         summary: ovn-northd has not successfully synced any changes to the southbound DB for too long.
@@ -104,7 +104,7 @@ spec:
         max_over_time(ovnkube_master_nb_e2e_timestamp[5m]) - max_over_time(ovnkube_master_sb_e2e_timestamp[5m]) > 120
       for: 10m
       labels:
-        severity: warning
+        severity: critical
     - alert: OVNKubernetesNorthboundDatabaseClusterIDError
       annotations:
         summary: Multiple OVN northbound database cluster IDs exist.

--- a/bindata/network/ovn-kubernetes/self-hosted/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/alert-rules-control-plane.yaml
@@ -88,7 +88,7 @@ spec:
         time() - max_over_time(ovnkube_master_nb_e2e_timestamp[5m]) > 120
       for: 10m
       labels:
-        severity: warning
+        severity: critical
     - alert: SouthboundStale
       annotations:
         summary: ovn-northd has not successfully synced any changes to the southbound DB for too long.
@@ -103,7 +103,7 @@ spec:
         max_over_time(ovnkube_master_nb_e2e_timestamp[5m]) - max_over_time(ovnkube_master_sb_e2e_timestamp[5m]) > 120
       for: 10m
       labels:
-        severity: warning
+        severity: critical
     - alert: OVNKubernetesNorthboundDatabaseClusterIDError
       annotations:
         summary: Multiple OVN northbound database cluster IDs exist.


### PR DESCRIPTION
The two alerts highlight connectivity problems
between OVN-K master and NB DB, NB DB and northd,
northd and SB DB and finally SB DB to OVN-K
master.

Networking is a critical component for a
functioning cluster, and without connectivity
between the aforementioned OVN components,
networking can be degraded. Critical
severity correctly highlights the severity
and allows SREs or cluster admins to
investigate.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>

/cc @npinaeva 