### PR TITLE
Fix CNO crashing when Kuryr without MTU is set

### DIFF
--- a/pkg/network/kuryr.go
+++ b/pkg/network/kuryr.go
@@ -112,6 +112,7 @@ func renderKuryr(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapR
 
 	// Pods Network MTU
 	data.Data["PodsNetworkMTU"] = b.PodsNetworkMTU
+	c.MTU = &b.PodsNetworkMTU
 
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/kuryr"), &data)
 	if err != nil {


### PR DESCRIPTION
2cb56d8176756e57dd95d4940c620e88cae02342 moved around code setting default value for MTU when Kuryr is configured. The problem is that it also stopped to set it, which made CNO unable to update the .status on Network CR and the kube-apiserver-operator from correctly populating API IP in the certs.

This commit makes sure we always populate KuryrConfig.MTU with a value.