### PR TITLE
update 'make install.tools' for golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ golangci-lint:
 .PHONY: golangci-lint
 
 install.tools:
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b ${GOPATH}/bin
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b ${GOPATH}/bin
 .PHONY: install.tools
 
 


### PR DESCRIPTION
looks like the godownloader [0] wasn't updated for a while and no longer works, so install.goreleaser.com is no longer working.

new way to install was found here [1]

[0] https://goreleaser.com/deprecations/#godownloader [1] https://golangci-lint.run/usage/install/

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>