### PR TITLE
Add ovnk alert for resource retry failure

### DIFF
--- a/bindata/network/ovn-kubernetes/common/alert-rules.yaml
+++ b/bindata/network/ovn-kubernetes/common/alert-rules.yaml
@@ -62,3 +62,12 @@ spec:
       for: 15m
       labels:
         severity: warning
+    - alert: OVNKubernetesResourceRetryFailure
+      annotations:
+        summary: OVN Kubernetes failed to apply networking control plane configuration.
+        description: |
+          OVN Kubernetes failed to apply networking control plane configuration after several attempts. This might be because the configuration
+          provided by the user is invalid or because of an internal error. As a consequence, the cluster might have a degraded status.
+      expr: increase(ovnkube_resource_retry_failures_total[10m]) > 0
+      labels:
+        severity: warning


### PR DESCRIPTION
This adds a prometheus alert rule for generating alert for ovnkube_resource_retry_failures_total counter when this keeps happening on cluster over 10 mins period.

Depends on https://github.com/ovn-org/ovn-kubernetes/pull/3314/

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>