### PR TITLE
OCPBUGS-5306: OVN-Kubernetes: Stop sorting master node addresses

### DIFF
--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -1056,7 +1056,6 @@ func getMasterAddresses(kubeClient crclient.Client, controlPlaneReplicaCount int
 		}
 		ovnMasterAddresses = append(ovnMasterAddresses, ni.address)
 	}
-	sort.Strings(ovnMasterAddresses)
 	klog.V(2).Infof("Preferring %s for database clusters", ovnMasterAddresses)
 
 	return ovnMasterAddresses, timeout, nil


### PR DESCRIPTION
Master nodes are now sorted by creation timestamp so there is no need to sort the IP addresses to get a consistent result.


Signed-off-by: Patryk Diak <pdiak@redhat.com>