### PR TITLE
ovn-kubernetes: Allow node_mgmt_port_netdev_flags for non-DPU modes

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -446,9 +446,9 @@ spec:
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
             --inactivity-probe="${OVN_CONTROLLER_INACTIVITY_PROBE}" \
             ${gateway_mode_flags} \
+            ${node_mgmt_port_netdev_flags} \
             {{- if eq .OVN_NODE_MODE "dpu-host" }}
             --ovnkube-node-mode dpu-host \
-            ${node_mgmt_port_netdev_flags} \
             {{- end }}
             --metrics-bind-address "127.0.0.1:29103" \
             --ovn-metrics-bind-address "127.0.0.1:29105" \

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -353,9 +353,9 @@ spec:
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
             --inactivity-probe="${OVN_CONTROLLER_INACTIVITY_PROBE}" \
             ${gateway_mode_flags} \
+            ${node_mgmt_port_netdev_flags} \
             {{- if eq .OVN_NODE_MODE "dpu-host" }}
             --ovnkube-node-mode dpu-host \
-            ${node_mgmt_port_netdev_flags} \
             {{- end }}
             --metrics-bind-address "127.0.0.1:29103" \
             --ovn-metrics-bind-address "127.0.0.1:29105" \


### PR DESCRIPTION
The node_mgmt_port_netdev_flags is a feature flag of ovn-kubernetes and shouldn't be restricted to any particular modes of operation.

Signed-off-by: William Zhao <wizhao@redhat.com>