### PR TITLE
OSASINFRA-3075 - sync_vips: allow external LB on OpenStack platform

### DIFF
--- a/pkg/controller/infrastructureconfig/sync_vips.go
+++ b/pkg/controller/infrastructureconfig/sync_vips.go
@@ -37,7 +37,7 @@ func (*apiAndIngressVipsSynchronizer) VipsSynchronize(infraConfig *configv1.Infr
 		ingressVIPs = &updatedInfraConfig.Status.PlatformStatus.VSphere.IngressIPs
 		ingressVIP = &updatedInfraConfig.Status.PlatformStatus.VSphere.IngressIP
 
-	case updatedInfraConfig.Status.Platform == configv1.OpenStackPlatformType:
+	case updatedInfraConfig.Status.Platform == configv1.OpenStackPlatformType && updatedInfraConfig.Status.PlatformStatus.OpenStack != nil: // if an External LB is being used, this field isn't populated
 		apiVIPs = &updatedInfraConfig.Status.PlatformStatus.OpenStack.APIServerInternalIPs
 		apiVIP = &updatedInfraConfig.Status.PlatformStatus.OpenStack.APIServerInternalIP
 		ingressVIPs = &updatedInfraConfig.Status.PlatformStatus.OpenStack.IngressIPs

--- a/pkg/controller/infrastructureconfig/sync_vips_test.go
+++ b/pkg/controller/infrastructureconfig/sync_vips_test.go
@@ -166,8 +166,10 @@ func Test_apiAndIngressVipsSynchronizer_VipsSynchronize(t *testing.T) {
 				Platform: configv1.OpenStackPlatformType,
 				PlatformStatus: &configv1.PlatformStatus{
 					OpenStack: &configv1.OpenStackPlatformStatus{
-						APIServerInternalIP: "fooA",
-						IngressIP:           "fooI",
+						APIServerInternalIP:  "fooA",
+						APIServerInternalIPs: []string{"fooA"},
+						IngressIP:            "fooI",
+						IngressIPs:           []string{"fooI"},
 					},
 				},
 			},
@@ -277,6 +279,19 @@ func Test_apiAndIngressVipsSynchronizer_VipsSynchronize(t *testing.T) {
 			},
 			wantStatus: configv1.InfrastructureStatus{
 				Platform:       configv1.VSpherePlatformType,
+				PlatformStatus: &configv1.PlatformStatus{},
+			},
+		},
+		{
+			name: "should not panic on empty PlatformStatus.OpenStack field (if an External LB is being used, this field isn't populated)",
+			givenStatus: configv1.InfrastructureStatus{
+				Platform: configv1.OpenStackPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					OpenStack: nil,
+				},
+			},
+			wantStatus: configv1.InfrastructureStatus{
+				Platform:       configv1.OpenStackPlatformType,
 				PlatformStatus: &configv1.PlatformStatus{},
 			},
 		},


### PR DESCRIPTION
If the VIPs aren't defined in the PlatformStatus, don't try to sync the
vips, they don't exist.
