### PR TITLE
OCPBUGS-5954: Backport Added missing API field podref to OverlappingRangeIPReservation CRD

### DIFF
--- a/bindata/network/additional-networks/crd/001-crd.yaml
+++ b/bindata/network/additional-networks/crd/001-crd.yaml
@@ -143,6 +143,8 @@ spec:
             properties:
               containerid:
                 type: string
+              podref:
+                type: string
             required:
             - containerid
             type: object


### PR DESCRIPTION
The OverlappingRangeIPReservation CRD was missing the podref field. Because of this, an issue occurs when the ip-reconciler code from whereabouts get executed, where the ip-reconciler will incorrectly view a pod as not alive, and consequently incorrectly delete the OverlappingRangeIPReservation object from kubernetes.

I updated the CRD to include the podref field.

Signed-off-by: nicklesimba [simha.nikhil@gmail.com](mailto:simha.nikhil@gmail.com)