### PR TITLE
sdn: stop mounting host's / in sdn container

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -151,10 +151,6 @@ spec:
         # We mount our socket here
         - mountPath: /var/run/openshift-sdn
           name: host-var-run-openshift-sdn
-        - mountPath: /host
-          name: host-slash
-          readOnly: true
-          mountPropagation: HostToContainer
         # CNI related mounts which we take over
         - mountPath: /host-cni-bin
           name: host-cni-bin


### PR DESCRIPTION
With https://github.com/openshift/sdn/pull/496 merged we no longer need host's / in the container.