### PR TITLE
OCPBUGS-6651: HyperShift: Add .hypershift.local to no proxy list

### DIFF
--- a/pkg/util/proxyconfig/no_proxy.go
+++ b/pkg/util/proxyconfig/no_proxy.go
@@ -8,9 +8,8 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-
 	configv1 "github.com/openshift/api/config/v1"
-
+	cnonetwork "github.com/openshift/cluster-network-operator/pkg/network"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -55,6 +54,10 @@ func mergeUserSystemNoProxy(proxy *configv1.Proxy, infra *configv1.Infrastructur
 		".svc",
 		".cluster.local",
 	)
+	if hcpCfg := cnonetwork.NewHyperShiftConfig(); hcpCfg.Enabled {
+		set.Insert(".hypershift.local")
+	}
+
 	if ic.Networking.MachineCIDR != "" {
 		if _, _, err := net.ParseCIDR(ic.Networking.MachineCIDR); err != nil {
 			return "", fmt.Errorf("MachineCIDR has an invalid CIDR: %s", ic.Networking.MachineCIDR)


### PR DESCRIPTION
Currently in a PublicAndPrivate setup behind a proxy, nodes remain unready because ovn-node pods fail to talk to the control plane osdb and api endpoints. This is because the connection to .hypershift.local tries to go through the proxy.

This PR https://github.com/openshift/hypershift/pull/2081 should make hypershift.local to be set in NO_PROXY via
https://github.com/openshift/cluster-network-operator/blob/8db9a00429dd4a5e4123b1217da93419557645eb/pkg/util/proxyconfig/no_proxy.go#L76
and
https://github.com/openshift/hypershift/blob/117c87f271ad7dc7cab875afb17769795fb7d117/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go#L248

Additionally we also want to let the CNO set .hypershift.local in NO_PROXY unconditionally as this is a design invariant

https://issues.redhat.com/browse/OCPBUGS-6651