### PR TITLE
OCPBUGS-6651: HyperShift: Do not use proxy for internal routes

### DIFF
--- a/pkg/network/hypershift.go
+++ b/pkg/network/hypershift.go
@@ -9,6 +9,8 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 )
 
+const HyperShiftInternalRouteLabel = "hypershift.openshift.io/internal-route"
+
 func init() {
 	for _, label := range strings.Split(routeLabelsRaw, ",") {
 		if label == "" {

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -186,7 +186,9 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	}
 
 	// Hypershift proxy
-	if bootstrapResult.Infra.Proxy.HTTPProxy == "" {
+	// proxy should not be used for internal routes
+	if bootstrapResult.Infra.Proxy.HTTPProxy == "" ||
+		bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.OVNSbDbRouteLabels[HyperShiftInternalRouteLabel] == "true" {
 		data.Data["ENABLE_OVN_NODE_PROXY"] = false
 	} else {
 		data.Data["ENABLE_OVN_NODE_PROXY"] = true


### PR DESCRIPTION
ovn-kube node should connect to the sbdb through a proxy only if the route is not an internal one.

Signed-off-by: Patryk Diak <pdiak@redhat.com>