### PR TITLE
ovn-k, multi-homing: enable the feature

### DIFF
--- a/bindata/network/ovn-kubernetes/common/003-rbac-controller.yaml
+++ b/bindata/network/ovn-kubernetes/common/003-rbac-controller.yaml
@@ -117,6 +117,11 @@ rules:
 - apiGroups: ['authorization.k8s.io']
   resources: ['subjectaccessreviews']
   verbs: ['create']
+- apiGroups:
+  - k8s.cni.cncf.io
+  resources:
+  - network-attachment-definitions
+  verbs: ["list", "get", "watch"]
 
 
 ---

--- a/bindata/network/ovn-kubernetes/managed/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/004-config.yaml
@@ -35,6 +35,9 @@ data:
 {{- if .ReachabilityNodePort }}
     egressip-node-healthcheck-port={{.ReachabilityNodePort}}
 {{- end }}
+{{- if .OVN_MULTI_NETWORK_ENABLE }}
+    enable-multi-network=true
+{{- end }}
 
     [gateway]
     mode={{.OVN_GATEWAY_MODE}}

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -849,6 +849,11 @@ spec:
             fi
           done
 
+          multi_network_enabled_flag=
+          if [[ "{{.OVN_MULTI_NETWORK_ENABLE}}" == "true" ]]; then
+            multi_network_enabled_flag="--enable-multi-network"
+          fi
+
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-master - start ovnkube --init-master ${K8S_NODE}"
           exec /usr/bin/ovnkube \
             --init-master "${K8S_NODE}" \
@@ -874,6 +879,7 @@ spec:
             --disable-snat-multiple-gws \
             --node-server-privkey ${TLS_PK} \
             --node-server-cert ${TLS_CERT} \
+            ${multi_network_enabled_flag} \
             --acl-logging-rate-limit "{{.OVNPolicyAuditRateLimit}}"
         volumeMounts:
         - mountPath: /etc/ovn

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -431,6 +431,11 @@ spec:
             node_mgmt_port_netdev_flags="--ovnkube-node-mgmt-port-netdev ${OVNKUBE_NODE_MGMT_PORT_NETDEV}"
           fi
 
+          multi_network_enabled_flag=
+          if [[ "{{.OVN_MULTI_NETWORK_ENABLE}}" == "true" ]]; then
+            multi_network_enabled_flag="--enable-multi-network"
+          fi
+
           exec /usr/bin/ovnkube --init-node "${K8S_NODE}" \
             --nb-address "{{.OVN_NB_DB_ENDPOINT}}" \
             --sb-address "{{.OVN_SB_DB_ENDPOINT}}" \
@@ -456,6 +461,7 @@ spec:
             --export-ovs-metrics \
             --disable-snat-multiple-gws \
             ${export_network_flows_flags} \
+            ${multi_network_enabled_flag} \
             ${gw_interface_flag}
         env:
         # for kubectl

--- a/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
@@ -38,6 +38,9 @@ data:
 {{- if .ReachabilityNodePort }}
     egressip-node-healthcheck-port={{.ReachabilityNodePort}}
 {{- end }}
+{{- if .OVN_MULTI_NETWORK_ENABLE }}
+    enable-multi-network=true
+{{- end }}
 
     [gateway]
     mode={{.OVN_GATEWAY_MODE}}

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
@@ -828,6 +828,11 @@ spec:
             exit 1
           fi
 
+          multi_network_enabled_flag=
+          if [[ "{{.OVN_MULTI_NETWORK_ENABLE}}" == "true" ]]; then
+            multi_network_enabled_flag="--enable-multi-network"
+          fi
+
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-master - start ovnkube --init-master ${K8S_NODE}"
           exec /usr/bin/ovnkube \
             --init-master "${K8S_NODE}" \
@@ -850,6 +855,7 @@ spec:
             --nb-cert-common-name "{{.OVN_CERT_CN}}" \
             --enable-multicast \
             --disable-snat-multiple-gws \
+            ${multi_network_enabled_flag} \
             --acl-logging-rate-limit "{{.OVNPolicyAuditRateLimit}}"
         volumeMounts:
         # for checking ovs-configuration service

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -338,6 +338,11 @@ spec:
             node_mgmt_port_netdev_flags="--ovnkube-node-mgmt-port-netdev ${OVNKUBE_NODE_MGMT_PORT_NETDEV}"
           fi
 
+          multi_network_enabled_flag=
+          if [[ "{{.OVN_MULTI_NETWORK_ENABLE}}" == "true" ]]; then
+            multi_network_enabled_flag="--enable-multi-network"
+          fi
+
           exec /usr/bin/ovnkube --init-node "${K8S_NODE}" \
             --nb-address "{{.OVN_NB_DB_LIST}}" \
             --sb-address "{{.OVN_SB_DB_LIST}}" \
@@ -363,6 +368,7 @@ spec:
             --export-ovs-metrics \
             --disable-snat-multiple-gws \
             ${export_network_flows_flags} \
+            ${multi_network_enabled_flag} \
             ${gw_interface_flag}
         env:
         # for kubectl

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -351,6 +351,11 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 		data.Data["NorthdThreads"] = 4
 	}
 
+	data.Data["OVN_MULTI_NETWORK_ENABLE"] = true
+	if conf.DisableMultiNetwork != nil && *conf.DisableMultiNetwork {
+		data.Data["OVN_MULTI_NETWORK_ENABLE"] = false
+	}
+
 	var manifestSubDir string
 	manifestDirs := make([]string, 0, 2)
 	manifestDirs = append(manifestDirs, filepath.Join(manifestDir, "network/ovn-kubernetes/common"))

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -171,6 +171,7 @@ func TestRenderedOVNKubernetesConfig(t *testing.T) {
 		masterIPs           []string
 		v4InternalSubnet    string
 		disableGRO          bool
+		disableMultiNet     bool
 	}
 	testcases := []testcase{
 		{
@@ -196,6 +197,7 @@ enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
 egressip-node-healthcheck-port=9107
+enable-multi-network=true
 
 [gateway]
 mode=shared
@@ -225,6 +227,7 @@ enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
 egressip-node-healthcheck-port=9107
+enable-multi-network=true
 
 [gateway]
 mode=shared
@@ -257,6 +260,7 @@ enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
 egressip-node-healthcheck-port=9107
+enable-multi-network=true
 
 [gateway]
 mode=local
@@ -301,6 +305,7 @@ enable-egress-firewall=true
 enable-egress-qos=true
 egressip-reachability-total-timeout=3
 egressip-node-healthcheck-port=9107
+enable-multi-network=true
 
 [gateway]
 mode=local
@@ -347,6 +352,7 @@ enable-egress-firewall=true
 enable-egress-qos=true
 egressip-reachability-total-timeout=0
 egressip-node-healthcheck-port=9107
+enable-multi-network=true
 
 [gateway]
 mode=local
@@ -392,6 +398,7 @@ enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
 egressip-node-healthcheck-port=9107
+enable-multi-network=true
 
 [gateway]
 mode=local
@@ -437,6 +444,7 @@ enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
 egressip-node-healthcheck-port=9107
+enable-multi-network=true
 
 [gateway]
 mode=shared
@@ -471,6 +479,7 @@ enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
 egressip-node-healthcheck-port=9107
+enable-multi-network=true
 
 [gateway]
 mode=shared
@@ -508,12 +517,43 @@ enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
 egressip-node-healthcheck-port=9107
+enable-multi-network=true
 
 [gateway]
 mode=shared
 nodeport=true`,
 			masterIPs:  []string{"1.2.3.4", "2.3.4.5"},
 			disableGRO: true,
+		},
+		{
+			desc: "disabled multi-network",
+			expected: `
+[default]
+mtu="1500"
+cluster-subnets="10.128.0.0/15/23,10.0.0.0/14/24"
+encap-port="8061"
+enable-lflow-cache=true
+lflow-cache-limit-kb=1048576
+enable-udp-aggregation=true
+
+[kubernetes]
+service-cidrs="172.30.0.0/16"
+ovn-config-namespace="openshift-ovn-kubernetes"
+apiserver="https://testing.test:8443"
+host-network-namespace="openshift-host-network"
+platform-type="GCP"
+
+[ovnkubernetesfeature]
+enable-egress-ip=true
+enable-egress-firewall=true
+enable-egress-qos=true
+egressip-node-healthcheck-port=9107
+
+[gateway]
+mode=shared
+nodeport=true`,
+			masterIPs:       []string{"1.2.3.4", "2.3.4.5"},
+			disableMultiNet: true,
 		},
 	}
 	g := NewGomegaWithT(t)
@@ -536,6 +576,8 @@ nodeport=true`,
 			if tc.v4InternalSubnet != "" {
 				OVNKubeConfig.Spec.DefaultNetwork.OVNKubernetesConfig.V4InternalSubnet = tc.v4InternalSubnet
 			}
+
+			OVNKubeConfig.Spec.DisableMultiNetwork = &tc.disableMultiNet
 
 			crd := OVNKubeConfig.DeepCopy()
 			config := &crd.Spec


### PR DESCRIPTION
The OVN-Kubernetes feature will be enabled whenever the `conf.DisableMultiNetwork` knob is disabled.

Manually testing deploying this PR w/ the following YAML gets us two pods interconnected via this cluster-wide logical switch on upcoming openshift-4.13:
```yaml
---
apiVersion: k8s.cni.cncf.io/v1
kind: NetworkAttachmentDefinition
metadata:
  name: flatl2
spec:
    config: '{                                                                           
        "cniVersion": "0.4.0",
        "name": "flatl2",
        "netAttachDefName": "default/flatl2",
        "topology": "layer2",
        "type": "ovn-k8s-cni-overlay",                                          
        "subnets": "192.168.100.0/24",                                                          
        "logFile": "/var/log/ovn-kubernetes/ovn-k8s-cni-overlay.log",           
        "logLevel": "5",                                                        
        "logfile-maxsize": 100,                                                 
        "logfile-maxbackups": 5,                                                
        "logfile-maxage": 5                                                     
    }'
---
apiVersion: v1
kind: Pod
metadata:
  name: pod1
  annotations:
    k8s.v1.cni.cncf.io/networks: 'flatl2'
spec:
  containers:
  - name: pod1
    image: k8s.gcr.io/e2e-test-images/agnhost:2.26
    command: ["/bin/ash", "-c", "trap : TERM INT; sleep infinity & wait"]
    securityContext:
      runAsUser: 1000
      privileged: false
      seccompProfile:
        type: RuntimeDefault
      capabilities:
        drop: ["ALL"]
      runAsNonRoot: true
      allowPrivilegeEscalation: false
---
apiVersion: v1
kind: Pod
metadata:
  name: pod2
  annotations:
    k8s.v1.cni.cncf.io/networks: 'flatl2'
spec:
  containers:
  - name: pod2
    image: k8s.gcr.io/e2e-test-images/agnhost:2.26
    command: ["/bin/ash", "-c", "trap : TERM INT; sleep infinity & wait"]
    securityContext:
      runAsUser: 1000
      privileged: false
      seccompProfile:
        type: RuntimeDefault
      capabilities:
        drop: ["ALL"]
      runAsNonRoot: true
      allowPrivilegeEscalation: false
```