### PR TITLE
Allow cidr expansion

### DIFF
--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -71,6 +71,10 @@ const NetworkMigrationAnnotation = "networkoperator.openshift.io/network-migrati
 // to indicate the current IP Family mode of the cluster: "single-stack" or "dual-stack"
 const NetworkIPFamilyModeAnnotation = "networkoperator.openshift.io/ip-family-mode"
 
+// ClusterNetworkCIDRsAnnotation is an annotation on the OVN networks.operator.openshift.io daemonsets
+// to indicate the current list of clusterNetwork CIDRs available to the cluster.
+const ClusterNetworkCIDRsAnnotation = "networkoperator.openshift.io/cluster-network-cidr"
+
 // OVNRaftClusterInitiator is an annotation on the networks.operator.openshift.io CR to indicate
 // which node IP was the raft cluster initiator. The NB and SB DB will be initialized by the same member.
 const OVNRaftClusterInitiator = "networkoperator.openshift.io/ovn-cluster-initiator"

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -420,6 +420,17 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 		return nil, progressing, errors.Wrapf(err, "failed to set IP family %s annotation on daemonsets or statefulsets", ipFamilyMode)
 	}
 
+	// logic to pretty print the clusterNetwork CIDR (possibly only one) in its annotation
+	var clusterNetworkCIDRs []string
+	for _, c := range conf.ClusterNetwork {
+		clusterNetworkCIDRs = append(clusterNetworkCIDRs, c.CIDR)
+	}
+
+	err = setOVNObjectAnnotation(objs, names.ClusterNetworkCIDRsAnnotation, strings.Join(clusterNetworkCIDRs, ","))
+	if err != nil {
+		return nil, progressing, errors.Wrapf(err, "failed to set %s annotation on daemonsets or statefulsets", clusterNetworkCIDRs)
+	}
+
 	// don't process upgrades if we are handling a dual-stack conversion.
 	if updateMaster && updateNode {
 		updateNode, updateMaster = shouldUpdateOVNKonUpgrade(bootstrapResult.OVN, os.Getenv("RELEASE_VERSION"))

--- a/pkg/network/render_test.go
+++ b/pkg/network/render_test.go
@@ -2,16 +2,16 @@ package network
 
 import (
 	"fmt"
-	"strings"
-	"testing"
-
 	. "github.com/onsi/gomega"
+	"github.com/openshift/cluster-network-operator/pkg/client/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"strings"
+
 	configv1 "github.com/openshift/api/config/v1"
 	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
-	"github.com/openshift/cluster-network-operator/pkg/client/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
+	"testing"
 )
 
 // NOTE: IsChangeSafe() requires you to have called Validate() beforehand, so we
@@ -20,18 +20,18 @@ import (
 // OpenShiftSDN validation
 // =================================
 func TestDisallowCNAdditionOfSameType(t *testing.T) {
-	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, "sdn", "sdn")
+	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OpenShiftSDNConfig, OpenShiftSDNConfig)
 
 	next.ClusterNetwork = append(next.ClusterNetwork, operv1.ClusterNetworkEntry{
 		CIDR:       "1.2.0.0/16",
 		HostPrefix: 24,
 	})
 	err := IsChangeSafe(prev, next, infra)
-	g.Expect(err).To(MatchError(ContainSubstring("unsupported change to ClusterNetwork")))
+	g.Expect(err).To(MatchError(ContainSubstring("adding/removing clusterNetwork entries of the same type is not supported")))
 }
 
 func TestDisallowServiceNetworkChange(t *testing.T) {
-	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, "sdn", "sdn")
+	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OpenShiftSDNConfig, OpenShiftSDNConfig)
 
 	// It is not supported to change the ServiceNetwork.
 	next.ServiceNetwork = []string{"1.2.3.0/24"}
@@ -40,16 +40,16 @@ func TestDisallowServiceNetworkChange(t *testing.T) {
 }
 
 func TestDisallowHostPrefixChange(t *testing.T) {
-	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, "sdn", "sdn")
+	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OpenShiftSDNConfig, OpenShiftSDNConfig)
 
 	// Changes to the cluster network's prefix are not supported.
 	next.ClusterNetwork[0].HostPrefix = 31
 	err := IsChangeSafe(prev, next, infra)
-	g.Expect(err).To(MatchError(ContainSubstring("unsupported change to ClusterNetwork")))
+	g.Expect(err).To(MatchError(ContainSubstring("network type is OpenShiftSDN. changing clusterNetwork entries is only supported for OVNKubernetes")))
 }
 
 func TestNoErrorOnIdenticalConfigs(t *testing.T) {
-	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, "sdn", "sdn")
+	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OpenShiftSDNConfig, OpenShiftSDNConfig)
 
 	// No error should occur when prev equals next.
 	err := IsChangeSafe(prev, next, infra)
@@ -59,7 +59,7 @@ func TestNoErrorOnIdenticalConfigs(t *testing.T) {
 // Migration from OpenShiftSDN to OVNKubernetes validation
 // =================================
 func TestClusterNetworkChangeOkOnMigration(t *testing.T) {
-	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, "sdn", "ovn")
+	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OpenShiftSDNConfig, OVNKubernetesConfig)
 
 	prev.Migration = &operv1.NetworkMigration{NetworkType: "OVNKubernetes"}
 
@@ -78,7 +78,7 @@ func TestClusterNetworkChangeOkOnMigration(t *testing.T) {
 // Invalid miscellaneous migration validation
 // =================================
 func TestServiceNetworkChangeNotOkOnMigration(t *testing.T) {
-	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, "sdn", "sdn")
+	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OpenShiftSDNConfig, OpenShiftSDNConfig)
 
 	prev.Migration = &operv1.NetworkMigration{NetworkType: "OVNKubernetes"}
 
@@ -89,7 +89,7 @@ func TestServiceNetworkChangeNotOkOnMigration(t *testing.T) {
 }
 
 func TestDisallowNetworkTypeChangeWithoutMigration(t *testing.T) {
-	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, "sdn", "sdn")
+	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OpenShiftSDNConfig, OpenShiftSDNConfig)
 
 	// You can't change default network type when not doing migration.
 	next.DefaultNetwork.Type = "Kuryr"
@@ -98,7 +98,7 @@ func TestDisallowNetworkTypeChangeWithoutMigration(t *testing.T) {
 }
 
 func TestDisallowNonTargetTypeForMigration(t *testing.T) {
-	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, "sdn", "sdn")
+	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OpenShiftSDNConfig, OpenShiftSDNConfig)
 
 	// You can't change default network type to non-target migration network type.
 	prev.Migration = &operv1.NetworkMigration{NetworkType: "OVNKubernetes"}
@@ -108,7 +108,7 @@ func TestDisallowNonTargetTypeForMigration(t *testing.T) {
 }
 
 func TestDisallowMigrationTypeChangeWhenNotNull(t *testing.T) {
-	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, "sdn", "ovn")
+	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OpenShiftSDNConfig, OVNKubernetesConfig)
 
 	// You can't change the migration network type when it is not null.
 	next.Migration = &operv1.NetworkMigration{NetworkType: "OVNKubernetes"}
@@ -120,10 +120,10 @@ func TestDisallowMigrationTypeChangeWhenNotNull(t *testing.T) {
 // OVNKubernetes DualStack validation
 // =================================
 func TestSingleToDualStackIsOk(t *testing.T) {
-	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, "ovn", "ovn")
+	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OVNKubernetesConfig, OVNKubernetesConfig)
 
 	infra.PlatformType = configv1.BareMetalPlatformType
-	
+
 	// You can change a single-stack config to dual-stack ...
 	next.ServiceNetwork = append(next.ServiceNetwork, "fd02::/112")
 	next.ClusterNetwork = append(next.ClusterNetwork, operv1.ClusterNetworkEntry{
@@ -138,7 +138,7 @@ func TestSingleToDualStackIsOk(t *testing.T) {
 }
 
 func TestDisallowServiceNetworkChangeV4toV6(t *testing.T) {
-	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, "ovn", "ovn")
+	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OVNKubernetesConfig, OVNKubernetesConfig)
 
 	infra.PlatformType = configv1.BareMetalPlatformType
 
@@ -156,7 +156,7 @@ func TestDisallowServiceNetworkChangeV4toV6(t *testing.T) {
 }
 
 func TestDisallowClusterNetworkChangeV4toV6(t *testing.T) {
-	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, "ovn", "ovn")
+	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OVNKubernetesConfig, OVNKubernetesConfig)
 
 	infra.PlatformType = configv1.BareMetalPlatformType
 
@@ -175,7 +175,7 @@ func TestDisallowClusterNetworkChangeV4toV6(t *testing.T) {
 }
 
 func TestAllowMultipleClusterNetworksOfNewIPFamily(t *testing.T) {
-	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, "ovn", "ovn")
+	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OVNKubernetesConfig, OVNKubernetesConfig)
 
 	infra.PlatformType = configv1.BareMetalPlatformType
 
@@ -199,7 +199,7 @@ func TestAllowMultipleClusterNetworksOfNewIPFamily(t *testing.T) {
 }
 
 func TestDisallowMultipleClusterNetworksOfOldIPFamily(t *testing.T) {
-	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, "ovn", "ovn")
+	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OVNKubernetesConfig, OVNKubernetesConfig)
 
 	infra.PlatformType = configv1.BareMetalPlatformType
 
@@ -220,7 +220,7 @@ func TestDisallowMultipleClusterNetworksOfOldIPFamily(t *testing.T) {
 }
 
 func TestAllowMigrationOnlyForBareMetalOrNoneType(t *testing.T) {
-	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, "ovn", "ovn")
+	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OVNKubernetesConfig, OVNKubernetesConfig)
 
 	// You can't migrate from single-stack to dual-stack if this is anything else but
 	// BareMetal or NonePlatformType
@@ -238,6 +238,92 @@ func TestAllowMigrationOnlyForBareMetalOrNoneType(t *testing.T) {
 	// ... but the migration in the other direction should work
 	err = IsChangeSafe(next, prev, infra)
 	g.Expect(err).NotTo(HaveOccurred())
+}
+
+// ClusterNetwork CIDR tests
+func TestAllowExpandingClusterNetworkCIDRMaskForOVN(t *testing.T) {
+	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OVNKubernetesConfig, OVNKubernetesConfig)
+
+	// original is 10.128.0.0/15, so expanding the ip range with a /14 mask should be allowed.
+	next.ClusterNetwork[0].CIDR = "10.128.0.0/14"
+	err := IsChangeSafe(prev, next, infra)
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+func TestDisallowExpandingClusterNetworkCIDRMaskForSDN(t *testing.T) {
+	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OpenShiftSDNConfig, OpenShiftSDNConfig)
+
+	// Changes to the cluster network's CIDR mask is not allowed for OpenShiftSDN.
+	next.ClusterNetwork[0].CIDR = "10.128.0.0/14"
+	err := IsChangeSafe(prev, next, infra)
+	g.Expect(err).To(MatchError(ContainSubstring("network type is OpenShiftSDN. changing clusterNetwork entries is only supported for OVNKubernetes")))
+}
+
+func TestDisallowShrinkingClusterNetworkCIDRMaskForOVN(t *testing.T) {
+	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OVNKubernetesConfig, OVNKubernetesConfig)
+
+	// original is 10.128.0.0/15, but shrinking the ip range with a /16 mask should not be allowed.
+	next.ClusterNetwork[0].CIDR = "10.128.0.0/16"
+	err := IsChangeSafe(prev, next, infra)
+	g.Expect(err).To(MatchError(ContainSubstring("reducing IP range with a larger CIDR mask for clusterNetwork CIDR is unsupported")))
+}
+
+func TestDisallowShrinkingClusterNetworkCIDRMaskForSDN(t *testing.T) {
+	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OpenShiftSDNConfig, OpenShiftSDNConfig)
+
+	// Changes to the cluster network's CIDR mask is not allowed for OpenShiftSDN.
+	next.ClusterNetwork[0].CIDR = "10.128.0.0/16"
+	err := IsChangeSafe(prev, next, infra)
+	g.Expect(err).To(MatchError(ContainSubstring("network type is OpenShiftSDN. changing clusterNetwork entries is only supported for OVNKubernetes")))
+}
+
+func TestDisallowRemovalOfAllClusterNetworkCIDREntries(t *testing.T) {
+	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OVNKubernetesConfig, OVNKubernetesConfig)
+
+	// negative test case to ensure no ill effects when trying to apply a blank CusterNetwork CIDR config
+	next.ClusterNetwork[0].CIDR = ""
+	err := IsChangeSafe(prev, next, infra)
+	g.Expect(err).To(MatchError(ContainSubstring("error parsing CIDR from ClusterNetwork entry : invalid CIDR address: ")))
+}
+
+func TestAllowExpandingClusterNetworkCIDRAfterEntriesReordered(t *testing.T) {
+	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OVNKubernetesConfig, OVNKubernetesConfig)
+
+	// multiple clusterNetwork entries can exist and expanding one of them is supported even if the
+	// entries have been re-ordered in the change. original 0th element was 10.128.0.0/15 and 1st
+	// element is 10.0.0.0/14. Swapping those and modifying the CIDR mask on one of them
+	next.ClusterNetwork[0].CIDR = "10.0.0.0/14"
+	next.ClusterNetwork[0].HostPrefix = prev.ClusterNetwork[1].HostPrefix
+	next.ClusterNetwork[1].CIDR = "10.128.0.0/14"
+	next.ClusterNetwork[1].HostPrefix = prev.ClusterNetwork[0].HostPrefix
+	err := IsChangeSafe(prev, next, infra)
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+func TestDisallowCIDRMaskChangeInDualStackUpdate(t *testing.T) {
+	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OVNKubernetesConfig, OVNKubernetesConfig)
+
+	infra.PlatformType = configv1.BareMetalPlatformType
+
+	// You can add multiple ClusterNetworks of the new IP family, but cannot also change
+	// the previously existing clusternetwork CIDR mask at the same time.
+	next.ServiceNetwork = append(next.ServiceNetwork, "fd02::/112")
+	next.ClusterNetwork = append(next.ClusterNetwork,
+		operv1.ClusterNetworkEntry{
+			CIDR:       "fd01::/48",
+			HostPrefix: 64,
+		},
+		operv1.ClusterNetworkEntry{
+			CIDR:       "fd02::/48",
+			HostPrefix: 64,
+		},
+		operv1.ClusterNetworkEntry{
+			CIDR:       "10.128.0.0/14",
+			HostPrefix: 23,
+		},
+	)
+	err := IsChangeSafe(prev, next, infra)
+	g.Expect(err).To(MatchError(ContainSubstring("cannot add additional ClusterNetwork values of original IP family when migrating to dual stack")))
 }
 
 func TestRenderUnknownNetwork(t *testing.T) {
@@ -402,7 +488,7 @@ func fillDefaults(conf, previous *operv1.NetworkSpec) {
 	FillDefaults(conf, previous, 1400)
 }
 
-func setupTestInfraAndBasicRenderConfigs(t *testing.T, prevType, nextType string) (
+func setupTestInfraAndBasicRenderConfigs(t *testing.T, prevType, nextType operv1.Network) (
 	*GomegaWithT,
 	*bootstrap.InfraStatus,
 	*operv1.NetworkSpec,
@@ -411,17 +497,8 @@ func setupTestInfraAndBasicRenderConfigs(t *testing.T, prevType, nextType string
 	g := NewGomegaWithT(t)
 	infra := &fakeBootstrapResult().Infra
 
-	var prev, next *operv1.NetworkSpec
-	if prevType == "sdn" {
-		prev = OpenShiftSDNConfig.Spec.DeepCopy()
-	} else if prevType == "ovn" {
-		prev = OVNKubernetesConfig.Spec.DeepCopy()
-	}
-	if nextType == "sdn" {
-		next = OpenShiftSDNConfig.Spec.DeepCopy()
-	} else if nextType == "ovn" {
-		next = OVNKubernetesConfig.Spec.DeepCopy()
-	}
+	prev := prevType.Spec.DeepCopy()
+	next := nextType.Spec.DeepCopy()
 
 	fillDefaults(prev, nil)
 	fillDefaults(next, nil)


### PR DESCRIPTION
- only the mask can change and must become smaller (allowing for more
  ip addresses across the entire cluster)
- only supported for OVNKuberentes