### PR TITLE
always create env.sh when run_vs_existing_cluster

### DIFF
--- a/hack/run-locally.sh
+++ b/hack/run-locally.sh
@@ -40,10 +40,8 @@ function override_install_manifests() {
 
 # Extract environment from a running cluster
 function extract_environment_from_running_cluster() {
-    if [[ ! -e "${CLUSTER_DIR}/env.sh" ]]; then
-        echo "Copying environment variables from manifest to ${CLUSTER_DIR}/env.sh"
-        oc get deployment -n openshift-network-operator network-operator -ojsonpath='{range .spec.template.spec.containers[0].env[?(@.value)]}{.name}{"="}{.value}{"\n"}' > "${CLUSTER_DIR}/env.sh"
-    fi
+    echo "Copying environment variables from manifest to ${CLUSTER_DIR}/env.sh"
+    oc get deployment -n openshift-network-operator network-operator -ojsonpath='{range .spec.template.spec.containers[0].env[?(@.value)]}{.name}{"="}{.value}{"\n"}' > "${CLUSTER_DIR}/env.sh"
     if [[ $EXPORT_ENV_ONLY == true ]]; then
         exit 0
     fi


### PR DESCRIPTION
when working with run-locally.sh on new a new cluster, if that /tmp/env.sh file has not been removed, it will try to use it again and the script hangs waiting for something that will never show up. The 'oc' command to create it from scratch is not overly time consuming, so just run it every time.

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>