### PR TITLE
OCPBUGS-6730, SDN-3221: ovn-kubernetes: use RHEL9-based images

### DIFF
--- a/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
@@ -72,7 +72,7 @@ spec:
         - name: MULTUS_NETWORKPOLICY_IMAGE
           value: quay.io/openshift/origin-multus-networkpolicy:latest
         - name: OVN_IMAGE
-          value: quay.io/openshift/origin-ovn-kubernetes:latest
+          value: quay.io/openshift/origin-ovn-kubernetes-rhel-9:latest
         - name: OVN_NB_RAFT_ELECTION_TIMER
           value: "10"
         - name: OVN_SB_RAFT_ELECTION_TIMER

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -83,7 +83,7 @@ spec:
         - name: MULTUS_NETWORKPOLICY_IMAGE
           value: "quay.io/openshift/origin-multus-networkpolicy:latest"
         - name: OVN_IMAGE
-          value: "quay.io/openshift/origin-ovn-kubernetes:latest"
+          value: "quay.io/openshift/origin-ovn-kubernetes-rhel-9:latest"
         - name: OVN_NB_RAFT_ELECTION_TIMER
           value: "10"
         - name: OVN_SB_RAFT_ELECTION_TIMER

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -42,14 +42,14 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-container-networking-plugins:latest
-  - name: ovn-kubernetes
+  - name: ovn-kubernetes-rhel-9
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-ovn-kubernetes:latest
-  - name: ovn-kubernetes-microshift
+      name: quay.io/openshift/origin-ovn-kubernetes-rhel-9:latest
+  - name: ovn-kubernetes-microshift-rhel-9
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-ovn-kubernetes-microshift:latest
+      name: quay.io/openshift/origin-ovn-kubernetes-microshift-rhel-9:latest
   - name: egress-router-cni
     from:
       kind: DockerImage


### PR DESCRIPTION
This PR flips ovn-kubernetes over to use RHEL9-based container images which include OVS 3.1. This brings us the following important fixes:

- Support for custom tunnel options (eg, NAT-T) for https://issues.redhat.com/browse/SDN-3221
- ovsdb-server writing snapshots in a separate thread for https://issues.redhat.com/browse/OCPBUGS-6730