### PR TITLE
Revert "OCPBUGS-5842: Use pods oc vs host"

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -305,7 +305,7 @@ spec:
           iptables -F AZURE_ICMP_ACTION
           iptables -A AZURE_ICMP_ACTION -j LOG
           iptables -A AZURE_ICMP_ACTION -j DROP
-          oc observe pods -n openshift-sdn --listen-addr='' -l app=sdn -a '{ .status.hostIP }' -- /var/run/add_iptables.sh
+          /host/usr/bin/oc observe pods -n openshift-sdn --listen-addr='' -l app=sdn -a '{ .status.hostIP }' -- /var/run/add_iptables.sh
         lifecycle:
           preStop:
             exec:


### PR DESCRIPTION
Reverts openshift/cluster-network-operator#1681 ; tracked by [TRT-848](https://issues.redhat.com//browse/TRT-848)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Example failing job: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.13-upgrade-from-stable-4.12-e2e-azure-sdn-upgrade/1625040515592359936

Since this merged, azure micro upgrades are failing with the drop-icmp container crashlooping with errors like this;


```
2023-02-13T11:33:43.533651259Z + touch /var/run/add_iptables.sh
2023-02-13T11:33:43.536071373Z + chmod 0755 /var/run/add_iptables.sh
2023-02-13T11:33:43.538207086Z + cat
2023-02-13T11:33:43.541084503Z ++ date '+%m%d %H:%M:%S.%N'
2023-02-13T11:33:43.543265915Z + echo 'I0213 11:33:43.542734312 - drop-icmp - start drop-icmp ci-op-jqc4wgr6-7cadb-wfmh5-worker-centralus1-xvccc'
2023-02-13T11:33:43.543322816Z I0213 11:33:43.542734312 - drop-icmp - start drop-icmp ci-op-jqc4wgr6-7cadb-wfmh5-worker-centralus1-xvccc
2023-02-13T11:33:43.543334916Z + iptables -X AZURE_CHECK_ICMP_SOURCE
2023-02-13T11:33:43.550656359Z iptables v1.8.4 (nf_tables):  CHAIN_USER_DEL failed (Device or resource busy): chain AZURE_CHECK_ICMP_SOURCE
2023-02-13T11:33:43.550990161Z + true
2023-02-13T11:33:43.551027861Z + iptables -N AZURE_CHECK_ICMP_SOURCE
2023-02-13T11:33:43.553045373Z iptables: Chain already exists.
2023-02-13T11:33:43.553270874Z + true
2023-02-13T11:33:43.553297674Z + iptables -F AZURE_CHECK_ICMP_SOURCE
2023-02-13T11:33:43.555586788Z + iptables -D INPUT -p icmp --icmp-type fragmentation-needed -j AZURE_CHECK_ICMP_SOURCE
2023-02-13T11:33:43.558080002Z + iptables -I INPUT -p icmp --icmp-type fragmentation-needed -j AZURE_CHECK_ICMP_SOURCE
2023-02-13T11:33:43.565565646Z + iptables -N AZURE_ICMP_ACTION
2023-02-13T11:33:43.567562758Z iptables: Chain already exists.
2023-02-13T11:33:43.567818259Z + true
2023-02-13T11:33:43.567851159Z + iptables -F AZURE_ICMP_ACTION
2023-02-13T11:33:43.570072272Z + iptables -A AZURE_ICMP_ACTION -j LOG
2023-02-13T11:33:43.576384010Z + iptables -A AZURE_ICMP_ACTION -j DROP
2023-02-13T11:33:43.578980725Z + oc observe pods -n openshift-sdn --listen-addr= -l app=sdn -a '{ .status.hostIP }' -- /var/run/add_iptables.sh
2023-02-13T11:33:43.579079025Z /bin/bash: line 30: oc: command not found
```


To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result to confirm the fix has corrected the problem:

`/payload 4.13 nightly blocking`

CC: @mccv1r0 