### PR TITLE
Jira OCPBUGS-7774: Print RawCNIConfig in its string representation

### DIFF
--- a/pkg/network/additional_networks.go
+++ b/pkg/network/additional_networks.go
@@ -56,7 +56,7 @@ func validateRaw(conf *operv1.AdditionalNetworkDefinition) []error {
 	confBytes := []byte(conf.RawCNIConfig)
 	err = json.Unmarshal(confBytes, &rawConfig)
 	if err != nil {
-		out = append(out, errors.Errorf("Failed to Unmarshal RawCNIConfig: %v", confBytes))
+		out = append(out, errors.Errorf("Failed to Unmarshal RawCNIConfig: %s", string(confBytes)))
 	}
 
 	return out


### PR DESCRIPTION
Error message Failed to Unmarshal RawCNIConfig showed the raw byte output which is not very helpful in the status conditions of the network.operator (it's not human readable). Convert the output to its string representation.