### PR TITLE
OCPBUGS-7992: Sets ovn-ofctrl-wait-before-clear for ovnkube-node

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -462,7 +462,8 @@ spec:
             --disable-snat-multiple-gws \
             ${export_network_flows_flags} \
             ${multi_network_enabled_flag} \
-            ${gw_interface_flag}
+            ${gw_interface_flag} \
+            --ofctrl-wait-before-clear 10000
         env:
         # for kubectl
         - name: KUBERNETES_SERVICE_PORT

--- a/bindata/network/ovn-kubernetes/microshift/master/daemonset.yaml
+++ b/bindata/network/ovn-kubernetes/microshift/master/daemonset.yaml
@@ -373,7 +373,8 @@ spec:
             --sb-address "" \
             --enable-multicast \
             --disable-snat-multiple-gws \
-            --acl-logging-rate-limit "20"
+            --acl-logging-rate-limit "20" \
+            --ofctrl-wait-before-clear 5000
         lifecycle:
           preStop:
             exec:

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -369,7 +369,8 @@ spec:
             --disable-snat-multiple-gws \
             ${export_network_flows_flags} \
             ${multi_network_enabled_flag} \
-            ${gw_interface_flag}
+            ${gw_interface_flag} \
+            --ofctrl-wait-before-clear 10000
         env:
         # for kubectl
         - name: KUBERNETES_SERVICE_PORT


### PR DESCRIPTION
This will add some delay (10s in managed and self hosted, 5 in microshift) to the time before ovn-controller will wipe flows in OVS and program new flows. Previously ovn-controller would connect to OVS and wipe its flows, then after a long period of time (10 seconds or so) ovn-controller would finally reprogram OVS flows.

This causes total dataplane downtime during these 10 seconds. By adding this new setting the consequence is that new pods or other control plane changes will be delayed by 10 seconds. However, it is better to overcompensate here rather than undercompensate as traffic stability for existing pods should be prioritized over new changes during restart.

It's hard to predict what the typical outage time will be given that it depends on a variety of factors (processor speed, network speed, scale of cluster). So for now lets start with a high value and then we can decide to lower it after a full perf/scale investigation. Potentially with IC the number can be reduced.

Note: Nvidia is currently using 10 seconds as well. From their commit message:

"Tested with ~200k ovs flows generated by ovn-controller on a system with 8 Armv8 A72 cores, with ovn-ofctrl-wait-before-clear set to 8000.

Without this patch, there were ~5 seconds ping failures during ovn-controller restart.

With this patch, there is no ping failure observed with 100ms interval (ping -i 0.1)."