### PR TITLE
OCPBUGS-8692: HyperShift: Set affinity, tolerations and co-location for all hcp resources created by CNO

### DIFF
--- a/bindata/cloud-network-config-controller/managed/controller.yaml
+++ b/bindata/cloud-network-config-controller/managed/controller.yaml
@@ -54,6 +54,7 @@ spec:
                   matchLabels:
                     hypershift.openshift.io/hosted-control-plane: {{.HostedClusterNamespace}}
                 topologyKey: kubernetes.io/hostname
+      priorityClassName: hypershift-control-plane
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/bindata/cloud-network-config-controller/managed/controller.yaml
+++ b/bindata/cloud-network-config-controller/managed/controller.yaml
@@ -9,6 +9,9 @@ metadata:
     release.openshift.io/version: "{{.ReleaseVersion}}"
     networkoperator.openshift.io/non-critical: ""
     network.operator.openshift.io/cluster-name:  {{.ManagementClusterName}}
+  labels:
+    # used by PodAffinity to prefer co-locating pods that belong to the same hosted cluster.
+    hypershift.openshift.io/hosted-control-plane: {{.HostedClusterNamespace}}
 spec:
   selector:
     matchLabels:
@@ -26,6 +29,15 @@ spec:
         type: infra
         openshift.io/component: network
     spec:
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    hypershift.openshift.io/hosted-control-plane: {{.HostedClusterNamespace}}
+                topologyKey: kubernetes.io/hostname
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/bindata/cloud-network-config-controller/managed/controller.yaml
+++ b/bindata/cloud-network-config-controller/managed/controller.yaml
@@ -30,6 +30,22 @@ spec:
         openshift.io/component: network
     spec:
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 50
+              preference:
+                matchExpressions:
+                  - key: hypershift.openshift.io/control-plane
+                    operator: In
+                    values:
+                      - "true"
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: hypershift.openshift.io/cluster
+                    operator: In
+                    values:
+                      - {{.HostedClusterNamespace}}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -178,8 +194,13 @@ spec:
           readOnly: true
         terminationMessagePolicy: FallbackToLogsOnError
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
+      - key: "hypershift.openshift.io/control-plane"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+      - key: "hypershift.openshift.io/cluster"
+        operator: "Equal"
+        value: {{.HostedClusterNamespace}}
         effect: "NoSchedule"
       volumes:
       - name: hosted-cluster-api-access

--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -37,6 +37,22 @@ spec:
     spec:
 {{- if .HyperShiftEnabled}}
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 50
+              preference:
+                matchExpressions:
+                  - key: hypershift.openshift.io/control-plane
+                    operator: In
+                    values:
+                      - "true"
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: hypershift.openshift.io/cluster
+                    operator: In
+                    values:
+                      - {{.AdmissionControllerNamespace}}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -196,8 +212,18 @@ spec:
       - name: admin-kubeconfig
         secret:
           secretName: service-network-admin-kubeconfig
-{{- end }}
+      tolerations:
+        - key: "hypershift.openshift.io/control-plane"
+          operator: "Equal"
+          value: "true"
+          effect: "NoSchedule"
+        - key: "hypershift.openshift.io/cluster"
+          operator: "Equal"
+          value: {{.AdmissionControllerNamespace}}
+          effect: "NoSchedule"
+{{- else }}
       tolerations:
       - key: "node-role.kubernetes.io/master"
         operator: Exists
         effect: NoSchedule
+{{- end }}

--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{.AdmissionControllerNamespace}}
   labels:
     app: multus-admission-controller
+{{- if .HyperShiftEnabled}}
+    # used by PodAffinity to prefer co-locating pods that belong to the same hosted cluster.
+    hypershift.openshift.io/hosted-control-plane: {{.AdmissionControllerNamespace}}
+{{- end }}
   annotations:
     kubernetes.io/description: |
       This deployment launches the Multus admisson controller component.
@@ -32,6 +36,15 @@ spec:
         openshift.io/component: network
     spec:
 {{- if .HyperShiftEnabled}}
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    hypershift.openshift.io/hosted-control-plane: {{.AdmissionControllerNamespace}}
+                topologyKey: kubernetes.io/hostname
       initContainers:
         - name: hosted-cluster-kubecfg-setup
           image: "{{.CLIImage}}"

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -62,6 +62,22 @@ spec:
         kubernetes.io/os: "linux"
     spec:
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            preference:
+              matchExpressions:
+                - key: hypershift.openshift.io/control-plane
+                  operator: In
+                  values:
+                    - "true"
+          - weight: 100
+            preference:
+              matchExpressions:
+                - key: hypershift.openshift.io/cluster
+                  operator: In
+                  values:
+                    - {{.HostedClusterNamespace}}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1056,3 +1072,12 @@ spec:
           items:
             - key: ca.crt
               path: ca.crt
+      tolerations:
+        - key: "hypershift.openshift.io/control-plane"
+          operator: "Equal"
+          value: "true"
+          effect: "NoSchedule"
+        - key: "hypershift.openshift.io/cluster"
+          operator: "Equal"
+          value: {{.HostedClusterNamespace}}
+          effect: "NoSchedule"


### PR DESCRIPTION
This duplicates the following funcionality of HyperShift control-plane operator:
https://github.com/openshift/hypershift/blob/main/support/config/deployment.go#L264-L265
https://hypershift-docs.netlify.app/how-to/distribute-hosted-cluster-workloads/

I will work on [nodeSelector](https://github.com/openshift/hypershift/blob/main/support/config/deployment.go#L255) implementation in CNO as a follow up PR.

/cc @jcaamano @zshi-redhat @enxebre @csrwng 