### PR TITLE
OCPBUGS-9964: Split out konnectivity certs

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -1012,8 +1012,12 @@ spec:
         volumeMounts:
         - mountPath: /etc/kubernetes/
           name: admin-kubeconfig
-        - mountPath: /etc/konnectivity-proxy-tls
+        - mountPath: /etc/konnectivity/proxy-client
           name: konnectivity-proxy-cert
+          readOnly: true
+        - mountPath: /etc/konnectivity/proxy-ca
+          name: konnectivity-proxy-ca
+          readOnly: true
         resources:
           requests:
             cpu: 10m
@@ -1029,8 +1033,12 @@ spec:
       - name: ovnkube-config
         configMap:
           name: ovnkube-config
+      - name: konnectivity-proxy-ca
+        configMap:
+          name: konnectivity-ca-bundle
       - name: konnectivity-proxy-cert
         secret:
+          defaultMode: 0640
           secretName: konnectivity-client
       - name: env-overrides
         configMap:


### PR DESCRIPTION
konnectivity certs were split out in hypershift: https://github.com/openshift/hypershift/pull/1891
Adapt the proxy to use the new cert.
Additionally make the files read-only.