### PR TITLE
Fix tier label, privileged, HOSTNAME/NODENAME in whereabouts reconciler 

### DIFF
--- a/bindata/network/multus/002-rbac.yaml
+++ b/bindata/network/multus/002-rbac.yaml
@@ -41,6 +41,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs:
+  - get
 - apiGroups: ["", "events.k8s.io"]
   resources:
   - events

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -537,7 +537,6 @@ spec:
   template:
     metadata:
       labels:
-        tier: node
         app: whereabouts-reconciler
         name: whereabouts-reconciler
     spec:
@@ -568,12 +567,15 @@ spec:
           limits:
             cpu: "50m"
             memory: "100Mi"
-        securityContext:
-          privileged: true
         volumeMounts:
           - name: cni-net-dir
             mountPath: /host/etc/cni/net.d
         env:
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
         - name: KUBERNETES_SERVICE_PORT
           value: "{{.KUBERNETES_SERVICE_PORT}}"
         - name: KUBERNETES_SERVICE_HOST


### PR DESCRIPTION
Fix tier label - it's not needed to run the whereabouts-reconciler downstream
Remove privileged security Context - elevated privileges are not needed to run the whereabouts-reconciler downstream
Retrieve node name from the downward API - this is needed to accomodate a recent bugfix in the whereabouts-reconciler
Grant multus clusterrole the right to get nodes - this is needed to accomodate the same bugfix in the whereabouts-reconciler