### PR TITLE
OCPBUGS-10433: Hypershift: Add RollingUpdate parameters to multus-admission-controller

### DIFF
--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -24,6 +24,13 @@ spec:
     matchLabels:
       app: multus-admission-controller
       namespace: {{.AdmissionControllerNamespace}}
+{{- if and .HyperShiftEnabled (gt .Replicas 1)}}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+{{- end }}
   template:
     metadata:
       annotations:


### PR DESCRIPTION
This PR adds missing deployment rolling update parameters to multus-admission-controller 
```
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxSurge: 0
      maxUnavailable: 1
```

This duplicates the following funcionality of HyperShift https://github.com/openshift/hypershift/blob/646bcef53e4ecb9ec01a05408bb2da8ffd832a14/support/config/deployment.go#L81

/cc @enxebre @csrwng