### PR TITLE
[release-4.11] OCPBUGS-10487: Enable configuration of node healthz server on ovnkube

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/004-config.yaml
@@ -26,6 +26,7 @@ data:
     no-hostsubnet-nodes="kubernetes.io/os=windows"
 {{- end  }}
     platform-type="{{.PlatformType}}"
+    healthz-bind-address="0.0.0.0:10256"
  
     [ovnkubernetesfeature]
     enable-egress-ip=true

--- a/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
@@ -26,6 +26,7 @@ data:
     no-hostsubnet-nodes="kubernetes.io/os=windows"
 {{- end  }}
     platform-type="{{.PlatformType}}"
+    healthz-bind-address="0.0.0.0:10256"
  
     [ovnkubernetesfeature]
     enable-egress-ip=true

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -402,6 +402,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
         ports:
         - name: metrics-port
           containerPort: 29103

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -186,6 +186,7 @@ ovn-config-namespace="openshift-ovn-kubernetes"
 apiserver="https://testing.test:8443"
 host-network-namespace="openshift-host-network"
 platform-type="GCP"
+healthz-bind-address="0.0.0.0:10256"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
@@ -214,6 +215,7 @@ apiserver="https://testing.test:8443"
 host-network-namespace="openshift-host-network"
 no-hostsubnet-nodes="kubernetes.io/os=windows"
 platform-type="GCP"
+healthz-bind-address="0.0.0.0:10256"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
@@ -254,6 +256,7 @@ apiserver="https://testing.test:8443"
 host-network-namespace="openshift-host-network"
 no-hostsubnet-nodes="kubernetes.io/os=windows"
 platform-type="GCP"
+healthz-bind-address="0.0.0.0:10256"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
@@ -297,6 +300,7 @@ apiserver="https://testing.test:8443"
 host-network-namespace="openshift-host-network"
 no-hostsubnet-nodes="kubernetes.io/os=windows"
 platform-type="GCP"
+healthz-bind-address="0.0.0.0:10256"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
@@ -329,6 +333,7 @@ ovn-config-namespace="openshift-ovn-kubernetes"
 apiserver="https://testing.test:8443"
 host-network-namespace="openshift-host-network"
 platform-type="GCP"
+healthz-bind-address="0.0.0.0:10256"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true


### PR DESCRIPTION
4.11 backport for:

- Set healthz-bind-address to 0.0.0.0:10256 for ovnk to match what we have in SDN
- Pass POD_NAME to ovnkube node for node healthz server checks (this goes hand in hand with https://github.com/ovn-org/ovn-kubernetes/pull/3469)
closes #OCPBUGS-10487