### PR TITLE
OCPBUGS-10647: multus-admission-controller should not run as root under Hypershift

### DIFF
--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -212,6 +212,10 @@ spec:
       - name: admin-kubeconfig
         secret:
           secretName: service-network-admin-kubeconfig
+{{- if not (eq .RunAsUser "")}}
+      securityContext:
+        runAsUser: {{.RunAsUser}}
+{{- end }}
       tolerations:
         - key: "hypershift.openshift.io/control-plane"
           operator: "Equal"

--- a/pkg/network/hypershift.go
+++ b/pkg/network/hypershift.go
@@ -31,6 +31,7 @@ var (
 	routeHost      = os.Getenv("OVN_SBDB_ROUTE_HOST")
 	routeLabels    = map[string]string{}
 	routeLabelsRaw = os.Getenv("OVN_SBDB_ROUTE_LABELS")
+	runAsUser      = os.Getenv("RUN_AS_USER")
 )
 
 const (
@@ -53,6 +54,7 @@ type HyperShiftConfig struct {
 	Name               string
 	Namespace          string
 	OVNSbDbRouteHost   string
+	RunAsUser          string
 	OVNSbDbRouteLabels map[string]string
 	RelatedObjects     []RelatedObject
 }
@@ -62,6 +64,7 @@ func NewHyperShiftConfig() *HyperShiftConfig {
 		Enabled:            hyperShiftEnabled(),
 		Name:               name,
 		Namespace:          namespace,
+		RunAsUser:          runAsUser,
 		OVNSbDbRouteHost:   routeHost,
 		OVNSbDbRouteLabels: routeLabels,
 	}

--- a/pkg/network/multus_admission_controller.go
+++ b/pkg/network/multus_admission_controller.go
@@ -81,6 +81,7 @@ func renderMultusAdmissonControllerConfig(manifestDir string, externalControlPla
 		data.Data["CLIImage"] = os.Getenv("CLI_IMAGE")
 		data.Data["TokenMinterImage"] = os.Getenv("TOKEN_MINTER_IMAGE")
 		data.Data["TokenAudience"] = os.Getenv("TOKEN_AUDIENCE")
+		data.Data["RunAsUser"] = hsc.RunAsUser
 
 		// Get serving CA from the management cluster since the service resides there
 		serviceCA := &corev1.ConfigMap{}


### PR DESCRIPTION
This PR changes pod security context of `multus-admission-controller` to run with a specific user ID when under Hypershift management.

Instead of duplicating code from Hypershift CPO to detect management cluster capabilities https://github.com/openshift/hypershift/blob/9d04882e2e6896d5f9e04551331ecd2129355ecd/support/capabilities/management_cluster_capabilities.go#L102-L109 (which possibly requires additional permissions assigned to CNO service account), user ID to run with is passed from Hypershift as an env variable.