### PR TITLE
ovn-kube: move back to unsuffixed RHEL9 images

### DIFF
--- a/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
@@ -72,7 +72,7 @@ spec:
         - name: MULTUS_NETWORKPOLICY_IMAGE
           value: quay.io/openshift/origin-multus-networkpolicy:latest
         - name: OVN_IMAGE
-          value: quay.io/openshift/origin-ovn-kubernetes-rhel-9:latest
+          value: quay.io/openshift/origin-ovn-kubernetes:latest
         - name: OVN_NB_RAFT_ELECTION_TIMER
           value: "10"
         - name: OVN_SB_RAFT_ELECTION_TIMER

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -83,7 +83,7 @@ spec:
         - name: MULTUS_NETWORKPOLICY_IMAGE
           value: "quay.io/openshift/origin-multus-networkpolicy:latest"
         - name: OVN_IMAGE
-          value: "quay.io/openshift/origin-ovn-kubernetes-rhel-9:latest"
+          value: "quay.io/openshift/origin-ovn-kubernetes:latest"
         - name: OVN_NB_RAFT_ELECTION_TIMER
           value: "10"
         - name: OVN_SB_RAFT_ELECTION_TIMER

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -42,14 +42,14 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-container-networking-plugins:latest
-  - name: ovn-kubernetes-rhel-9
+  - name: ovn-kubernetes
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-ovn-kubernetes-rhel-9:latest
-  - name: ovn-kubernetes-microshift-rhel-9
+      name: quay.io/openshift/origin-ovn-kubernetes:latest
+  - name: ovn-kubernetes-microshift
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-ovn-kubernetes-microshift-rhel-9:latest
+      name: quay.io/openshift/origin-ovn-kubernetes-microshift:latest
   - name: egress-router-cni
     from:
       kind: DockerImage


### PR DESCRIPTION
Now that we're building the unsuffixed images with RHEL9 we can move back to them.