### PR TITLE
OCPBUGS-10649: HyperShift: Add POD_NAME env to ovnkube-node

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -513,6 +513,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
         ports:
         - name: metrics-port
           containerPort: 29103


### PR DESCRIPTION
This is a followup to https://github.com/openshift/cluster-network-operator/pull/1715

POD_NAME is now required for ovnkube-node, it was missing for managed deployments.
Without it ovnkube-node won't start in hypershift.
/cc @ricky-rav 