### PR TITLE
OCPBUGS-10937: multus-admission-controller mounts secret with mode 0640

### DIFF
--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -213,18 +213,23 @@ spec:
       volumes:
       - name: webhook-certs
         secret:
+{{- if .HyperShiftEnabled}}
+          defaultMode: 0640
+{{- end }}
           secretName: multus-admission-controller-secret
 {{- if .HyperShiftEnabled}}
       - name: hosted-cluster-api-access
         emptyDir: {}
       - name: hosted-ca-cert
         secret:
+          defaultMode: 0640
           secretName: root-ca
           items:
             - key: ca.crt
               path: ca.crt
       - name: admin-kubeconfig
         secret:
+          defaultMode: 0640
           secretName: service-network-admin-kubeconfig
 {{- if not (eq .RunAsUser "")}}
       securityContext:


### PR DESCRIPTION
CNO managed component (multus-admission-controller) to conform to hypershift control plane expectations that All secrets should be mounted to not have global read. change from 420(0644) to 416(0640)