### PR TITLE
OCPBUGS-7777: use --template instead of -a for 'oc observe'

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -305,7 +305,7 @@ spec:
           iptables -F AZURE_ICMP_ACTION
           iptables -A AZURE_ICMP_ACTION -j LOG
           iptables -A AZURE_ICMP_ACTION -j DROP
-          oc observe pods -n openshift-sdn --listen-addr='' -l app=sdn -a '{ .status.hostIP }' -- /var/run/add_iptables.sh
+          oc observe pods -n openshift-sdn --listen-addr='' -l app=sdn --template '{ .status.hostIP }' -- /var/run/add_iptables.sh
         lifecycle:
           preStop:
             exec:


### PR DESCRIPTION
The -a (--argument) flag is deprecated in favor of --template. It is currently causing a warning message. Fix that:

+ oc observe pods -n openshift-sdn --listen-addr= -l app=sdn -a '{ .status.hostIP }' -- /var/run/add_iptables.sh Flag --argument has been deprecated, and will be removed in a future release. Use --template instead.