### PR TITLE
[release-4.12 ] OCPBUGS-11217:use annotation daemonset to update hybrid overlay

### DIFF
--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -71,6 +71,10 @@ const NetworkMigrationAnnotation = "networkoperator.openshift.io/network-migrati
 // to indicate the current IP Family mode of the cluster: "single-stack" or "dual-stack"
 const NetworkIPFamilyModeAnnotation = "networkoperator.openshift.io/ip-family-mode"
 
+// NetworkHybridOverlayAnnotation is an annotation on the OVN networks.operator.io.daemonsets
+// to indicate the current state of of the Hybrid overlay on the cluster: "enabled" or "disabled"
+const NetworkHybridOverlayAnnotation = "networkoperator.openshift.io/hybrid-overlay-status"
+
 // OVNRaftClusterInitiator is an annotation on the networks.operator.openshift.io CR to indicate
 // which node IP was the raft cluster initiator. The NB and SB DB will be initialized by the same member.
 const OVNRaftClusterInitiator = "networkoperator.openshift.io/ovn-cluster-initiator"

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -255,6 +255,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 
 	data.Data["OVN_service_cidr"] = strings.Join(conf.ServiceNetwork, ",")
 
+	hybridOverlayStatus := "disabled"
 	if c.HybridOverlayConfig != nil {
 		if len(c.HybridOverlayConfig.HybridClusterNetwork) > 0 {
 			data.Data["OVNHybridOverlayNetCIDR"] = c.HybridOverlayConfig.HybridClusterNetwork[0].CIDR
@@ -267,6 +268,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 			data.Data["OVNHybridOverlayVXLANPort"] = ""
 		}
 		data.Data["OVNHybridOverlayEnable"] = true
+		hybridOverlayStatus = "enabled"
 	} else {
 		data.Data["OVNHybridOverlayNetCIDR"] = ""
 		data.Data["OVNHybridOverlayEnable"] = false
@@ -367,6 +369,11 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 		return nil, progressing, errors.Wrap(err, "failed to render manifests")
 	}
 	objs = append(objs, manifests...)
+
+	err = setOVNObjectAnnotation(objs, names.NetworkHybridOverlayAnnotation, hybridOverlayStatus)
+	if err != nil {
+		return nil, progressing, errors.Wrapf(err, "failed to set the status of hybrid overlay %s annotation on daemonsets or statefulsets", hybridOverlayStatus)
+	}
 
 	nodeMode := bootstrapResult.OVN.OVNKubernetesConfig.NodeMode
 	if nodeMode == OVN_NODE_MODE_DPU_HOST {


### PR DESCRIPTION
This is a backport of https://github.com/openshift/cluster-network-operator/pull/1709 
the 4.12 cherry-pick did not apply cleanly because of https://github.com/openshift/cluster-network-operator/commit/9d1ccf753f6b62460a73a663a042d168dcbccec6 in names.go but the rest of the cherry-pick applied without issue 

the ability to toggle hybrid overlay has been added to ovn-kubernetes, make the cno automatically rollout changes using an annotation on the daemonsets