### PR TITLE
[release-4.13] OCPBUGS-11424: Backport changes to whereabouts reconciler

### DIFF
--- a/bindata/network/multus/002-rbac.yaml
+++ b/bindata/network/multus/002-rbac.yaml
@@ -41,6 +41,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs:
+  - get
 - apiGroups: ["", "events.k8s.io"]
   resources:
   - events

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -537,7 +537,6 @@ spec:
   template:
     metadata:
       labels:
-        tier: node
         app: whereabouts-reconciler
         name: whereabouts-reconciler
     spec:
@@ -568,12 +567,15 @@ spec:
           limits:
             cpu: "50m"
             memory: "100Mi"
-        securityContext:
-          privileged: true
         volumeMounts:
           - name: cni-net-dir
             mountPath: /host/etc/cni/net.d
         env:
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
         - name: KUBERNETES_SERVICE_PORT
           value: "{{.KUBERNETES_SERVICE_PORT}}"
         - name: KUBERNETES_SERVICE_HOST

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -436,6 +436,7 @@ spec:
               "kubernetes": {
                 "kubeconfig": "/etc/kubernetes/cni/net.d/whereabouts.d/whereabouts.kubeconfig"
               },
+              "reconciler_cron_expression": "30 4 * * *",
               "log_level": "debug"
             }
             EOF
@@ -522,49 +523,63 @@ spec:
             defaultMode: 0744
 {{if .RenderIpReconciler}}
 ---
-apiVersion: batch/v1
-kind: CronJob
+apiVersion: apps/v1
+kind: DaemonSet
 metadata:
-  name: ip-reconciler
+  name: whereabouts-reconciler
   namespace: openshift-multus
-  labels:
-    tier: node
-    app: whereabouts
 spec:
-  # reconcile loop every 15 minutes, starting at the top of the hour
-  schedule: "*/15 * * * *"
-  concurrencyPolicy: Replace
-  successfulJobsHistoryLimit: 0
-  jobTemplate:
+  selector:
+    matchLabels:
+      name: whereabouts-reconciler
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: whereabouts-reconciler
+        name: whereabouts-reconciler
     spec:
-      backoffLimit: 0
-      ttlSecondsAfterFinished: 900
-      template:
-        spec:
-          priorityClassName: "system-cluster-critical"
-          serviceAccountName: multus
-          hostNetwork: true
-          containers:
-            - name: whereabouts
-              image: {{.WhereaboutsImage}}
-              resources:
-                requests:
-                  cpu: "25m"
-                  memory: "25Mi"
-              command:
-              - /ip-reconciler
-              - -log-level=verbose
-              volumeMounts:
-                - name: cni-net-dir
-                  mountPath: /host/etc/cni/net.d
-              env:
-              - name: KUBERNETES_SERVICE_PORT
-                value: "{{.KUBERNETES_SERVICE_PORT}}"
-              - name: KUBERNETES_SERVICE_HOST
-                value: "{{.KUBERNETES_SERVICE_HOST}}"
-          volumes:
-            - name: cni-net-dir
-              hostPath:
-                path: {{ .SystemCNIConfDir }}
-          restartPolicy: Never
+      hostNetwork: true      
+      serviceAccountName: multus
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      containers:
+      - name: whereabouts
+        command: [ "/bin/sh" ]
+        args:
+          - -c
+          - >
+            /usr/src/whereabouts/bin/ip-control-loop -log-level debug
+        image: {{.WhereaboutsImage}}
+        env:
+        - name: WHEREABOUTS_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        resources:
+          requests:
+            cpu: "50m"
+            memory: "50Mi"
+          limits:
+            cpu: "50m"
+            memory: "100Mi"
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - name: cni-net-dir
+            mountPath: /host/etc/cni/net.d
+        env:
+        - name: KUBERNETES_SERVICE_PORT
+          value: "{{.KUBERNETES_SERVICE_PORT}}"
+        - name: KUBERNETES_SERVICE_HOST
+          value: "{{.KUBERNETES_SERVICE_HOST}}"
+      volumes:
+        - name: cni-net-dir
+          hostPath:
+            path: {{ .SystemCNIConfDir }}
 {{- end}}

--- a/pkg/network/multus_ipam_test.go
+++ b/pkg/network/multus_ipam_test.go
@@ -226,7 +226,7 @@ func TestRenderWithDHCP(t *testing.T) {
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "dhcp-daemon")))
 }
 
-// TestRenderWithWhereabouts tests a rendering with the ip reconciler
+// TestRenderWithWhereabouts tests a rendering with the whereabouts-reconciler.
 func TestRenderWithWhereabouts(t *testing.T) {
 	g := NewGomegaWithT(t)
 
@@ -236,10 +236,10 @@ func TestRenderWithWhereabouts(t *testing.T) {
 
 	objs, err := renderMultus(config, fakeBootstrapResult(), manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(objs).To(ContainElement(HaveKubernetesID("CronJob", "openshift-multus", "ip-reconciler")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "whereabouts-reconciler")))
 }
 
-// TestRenderWithWhereabouts tests a rendering with the ip reconciler
+// TestRenderWithWhereabouts tests a rendering with the whereabouts-reconciler.
 func TestRenderWithWhereaboutsConflist(t *testing.T) {
 	g := NewGomegaWithT(t)
 
@@ -249,7 +249,7 @@ func TestRenderWithWhereaboutsConflist(t *testing.T) {
 
 	objs, err := renderMultus(config, fakeBootstrapResult(), manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(objs).To(ContainElement(HaveKubernetesID("CronJob", "openshift-multus", "ip-reconciler")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "whereabouts-reconciler")))
 }
 
 // TestRenderNoIPAM tests a rendering WITHOUT an IPAM configured.


### PR DESCRIPTION
Backport changes to whereabouts reconciler

Clean cherry-picks:
~~~
[akaris@linux cluster-network-operator (OCPBUGS-11424)]$ git diff downstream/release-4.14 -- bindata/network/multus/multus.yaml
[akaris@linux cluster-network-operator (OCPBUGS-11424)]$ 
~~~