### PR TITLE
OCPBUGS-11046: Fix allowlist ds template

### DIFF
--- a/bindata/allowlist/daemonset/daemonset.yaml
+++ b/bindata/allowlist/daemonset/daemonset.yaml
@@ -44,4 +44,4 @@ spec:
           name: tuning-conf-dir
         - name: ready
           emptyDir: { }
-     priorityClassName: "system-user-critical"
+      priorityClassName: "system-user-critical"


### PR DESCRIPTION
This issue does not allow the allowlist controller to update the sysctl allowlist file of the nodes.