### PR TITLE
OCPBUGS-5027: Make the operator degraded on panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	k8s.io/kube-proxy v0.26.1
 	k8s.io/utils v0.0.0-20230209194617-a36077c30491
 	sigs.k8s.io/cluster-api-provider-openstack v0.6.3
-	sigs.k8s.io/controller-runtime v0.14.4
+	sigs.k8s.io/controller-runtime v0.14.6
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1140,6 +1140,8 @@ sigs.k8s.io/cluster-api-provider-ibmcloud v0.2.4 h1:w+2d3XjWzlLw5seYmven6bDHsFQ1
 sigs.k8s.io/cluster-api-provider-ibmcloud v0.2.4/go.mod h1:ZynNCZIFZx80I9n4PyzssF8rE3ewmLgMUlPUl90BWx4=
 sigs.k8s.io/controller-runtime v0.14.4 h1:Kd/Qgx5pd2XUL08eOV2vwIq3L9GhIbJ5Nxengbd4/0M=
 sigs.k8s.io/controller-runtime v0.14.4/go.mod h1:WqIdsAY6JBsjfc/CqO0CORmNtoCtE4S6qbPc9s68h+0=
+sigs.k8s.io/controller-runtime v0.14.6 h1:oxstGVvXGNnMvY7TAESYk+lzr6S3V5VFxQ6d92KcwQA=
+sigs.k8s.io/controller-runtime v0.14.6/go.mod h1:WqIdsAY6JBsjfc/CqO0CORmNtoCtE4S6qbPc9s68h+0=
 sigs.k8s.io/controller-tools v0.2.8/go.mod h1:9VKHPszmf2DHz/QmHkcfZoewO6BL7pPs9uAiBVsaJSE=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=

--- a/pkg/controller/operconfig/cluster.go
+++ b/pkg/controller/operconfig/cluster.go
@@ -86,6 +86,8 @@ func (r *ReconcileOperConfig) ClusterNetworkStatus(ctx context.Context, operConf
 	// Update the cluster config status
 	status := network.StatusFromOperatorConfig(&operConfig.Spec, &clusterConfig.Status)
 	if status == nil || reflect.DeepEqual(*status, clusterConfig.Status) {
+		// clusterConfig is already updated
+		r.status.SetConfigUpdated(true)
 		return nil, nil
 	}
 	clusterConfig.Status = *status

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -468,6 +468,7 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 				fmt.Sprintf("Could not update cluster configuration status: %v", err))
 			return reconcile.Result{}, err
 		}
+		r.status.SetConfigUpdated(true)
 	}
 
 	r.status.SetNotDegraded(statusmanager.OperatorConfig)

--- a/pkg/controller/statusmanager/pod_status.go
+++ b/pkg/controller/statusmanager/pod_status.go
@@ -262,7 +262,8 @@ func (status *StatusManager) SetFromPods() {
 		status.unsetProgressing(PodDeployment)
 	}
 
-	if reachedAvailableLevel {
+	// set the operator as available only after it rolled out all resources and the operator config was updated
+	if reachedAvailableLevel && status.configUpdated {
 		status.set(reachedAvailableLevel, operv1.OperatorCondition{
 			Type:   operv1.OperatorStatusTypeAvailable,
 			Status: operv1.ConditionTrue})

--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -39,7 +39,8 @@ import (
 type StatusLevel int
 
 const (
-	ClusterConfig StatusLevel = iota
+	PanicLevel StatusLevel = iota // Special StatusLevel used when recovering from a panic
+	ClusterConfig
 	OperatorConfig
 	OperatorRender
 	ProxyConfig

--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -87,6 +87,7 @@ type StatusManager struct {
 
 	failing         [maxStatusLevel]*operv1.OperatorCondition
 	installComplete bool
+	configUpdated   bool
 
 	// All our informers and listers
 	dsInformers map[string]cache.SharedIndexInformer
@@ -531,6 +532,12 @@ func (status *StatusManager) SetNotDegraded(statusLevel StatusLevel) {
 	status.Lock()
 	defer status.Unlock()
 	status.setNotDegraded(statusLevel)
+}
+
+func (status *StatusManager) SetConfigUpdated(updated bool) {
+	status.Lock()
+	defer status.Unlock()
+	status.configUpdated = updated
 }
 
 // syncProgressing syncs the current Progressing status

--- a/pkg/controller/statusmanager/status_manager_test.go
+++ b/pkg/controller/statusmanager/status_manager_test.go
@@ -339,6 +339,7 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 	no := &operv1.Network{ObjectMeta: metav1.ObjectMeta{Name: names.OPERATOR_CONFIG}}
 	set(t, client, no)
 
+	status.SetConfigUpdated(true)
 	status.SetFromPods()
 	co, oc, err := getStatuses(client, "testing")
 	if err != nil {
@@ -376,6 +377,7 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 		},
 	}
 	set(t, client, dsB)
+	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	// Since the DaemonSet.Status reports no pods Available, the status should be Progressing
@@ -432,6 +434,7 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 	for dsA.Status.NumberUnavailable > 0 || dsB.Status.NumberUnavailable > 0 {
 		set(t, client, dsA)
 		set(t, client, dsB)
+		status.SetConfigUpdated(true)
 		status.SetFromPods()
 
 		co, oc, err = getStatuses(client, "testing")
@@ -486,6 +489,7 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 	set(t, client, dsA)
 	set(t, client, dsB)
 	time.Sleep(1 * time.Second) // minimum transition time fidelity
+	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -530,6 +534,7 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 	// that we enter Progressing state but otherwise stay Available
 	dsA.Generation = 2
 	set(t, client, dsA)
+	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -571,6 +576,7 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 		ObservedGeneration:     2,
 	}
 	set(t, client, dsA)
+	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -611,6 +617,7 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 		ObservedGeneration:     2,
 	}
 	set(t, client, dsA)
+	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -655,6 +662,7 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 
 	t0 := time.Now()
 	time.Sleep(time.Second / 10)
+	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -716,6 +724,7 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 		}
 	}
 	setLastPodState(t, client, "testing", ps)
+	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -767,6 +776,7 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 		UpdatedNumberScheduled: 1,
 	}
 	set(t, client, dsA)
+	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	// see that the pod state is sensible
@@ -824,6 +834,7 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 		},
 	}
 	set(t, client, dsNC)
+	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	// We should now be Progressing, but not un-Available
@@ -865,6 +876,7 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 		}
 	}
 	setLastPodState(t, client, "testing", ps)
+	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -901,6 +913,7 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 	dsNC.Status.DesiredNumberScheduled = 1
 	dsNC.Status.UpdatedNumberScheduled = 1
 	set(t, client, dsNC)
+	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -939,6 +952,7 @@ func TestStatusManagerSetFromDeployments(t *testing.T) {
 	no := &operv1.Network{ObjectMeta: metav1.ObjectMeta{Name: names.OPERATOR_CONFIG}}
 	set(t, client, no)
 
+	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err := getStatuses(client, "testing")
@@ -964,6 +978,7 @@ func TestStatusManagerSetFromDeployments(t *testing.T) {
 	depA := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "one", Name: "alpha", Labels: sl}}
 	set(t, client, depA)
 
+	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -1002,6 +1017,7 @@ func TestStatusManagerSetFromDeployments(t *testing.T) {
 	depA.Status.UnavailableReplicas = 0
 	depA.Status.AvailableReplicas = depA.Status.Replicas
 	set(t, client, depA)
+	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -1058,6 +1074,7 @@ func TestStatusManagerSetFromDeployments(t *testing.T) {
 
 	t0 := time.Now()
 	time.Sleep(time.Second / 10)
+	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -1124,6 +1141,7 @@ func TestStatusManagerSetFromDeployments(t *testing.T) {
 	depB.Status.AvailableReplicas = depB.Status.Replicas
 
 	set(t, client, depB)
+	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -1165,6 +1183,7 @@ func TestStatusManagerSetFromDeployments(t *testing.T) {
 		}
 	}
 	setLastPodState(t, client, "testing", ps)
+	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -1207,6 +1226,7 @@ func TestStatusManagerSetFromDeployments(t *testing.T) {
 	depB.Status.UnavailableReplicas = 0
 	depB.Status.AvailableReplicas = depB.Status.Replicas
 	set(t, client, depB)
+	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -1402,6 +1422,7 @@ func TestStatusManagerCheckCrashLoopBackOffPods(t *testing.T) {
 	}
 	set(t, client, podnC)
 
+	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	oc, err := getOC(client)
@@ -1469,6 +1490,7 @@ func TestStatusManagerCheckCrashLoopBackOffPods(t *testing.T) {
 	}
 	set(t, client, podC)
 
+	status.SetConfigUpdated(true)
 	status.SetFromPods()
 	oc, err = getOC(client)
 	if err != nil {
@@ -1546,10 +1568,115 @@ func TestStatusManagerHyperShift(t *testing.T) {
 		}}
 	set(t, mgmtClient, depHCP)
 
+	mgmtStatus.SetConfigUpdated(true)
 	mgmtStatus.SetFromPods()
 
 	// mgmt conditions should not reflect the failures in hosted clusters namespace
 	oc, err := getOC(mgmtClient)
+	if err != nil {
+		t.Fatalf("error getting ClusterOperator: %v", err)
+	}
+	if !conditionsInclude(oc.Status.Conditions, []operv1.OperatorCondition{
+		{
+			Type:   operv1.OperatorStatusTypeDegraded,
+			Status: operv1.ConditionFalse,
+		},
+		{
+			Type:   operv1.OperatorStatusTypeProgressing,
+			Status: operv1.ConditionFalse,
+		},
+		{
+			Type:   operv1.OperatorStatusTypeUpgradeable,
+			Status: operv1.ConditionTrue,
+		},
+		{
+			Type:   operv1.OperatorStatusTypeAvailable,
+			Status: operv1.ConditionTrue,
+		},
+	}) {
+		t.Fatalf("unexpected Status.Conditions: %#v", oc.Status.Conditions)
+	}
+}
+
+func TestStatusManagerSetConfigUpdated(t *testing.T) {
+	client := fake.NewFakeClient()
+	status := New(client, "testing", "")
+	setFakeListers(status)
+	no := &operv1.Network{ObjectMeta: metav1.ObjectMeta{Name: names.OPERATOR_CONFIG}}
+	set(t, client, no)
+
+	status.SetFromPods()
+	co, oc, err := getStatuses(client, "testing")
+	if err != nil {
+		t.Fatalf("error getting ClusterOperator: %v", err)
+	}
+	if !conditionsInclude(oc.Status.Conditions, []operv1.OperatorCondition{
+		{
+			Type:   operv1.OperatorStatusTypeProgressing,
+			Status: operv1.ConditionTrue,
+			Reason: "Deploying",
+		},
+	}) {
+		t.Fatalf("unexpected Status.Conditions: %#v", oc.Status.Conditions)
+	}
+	if len(co.Status.Versions) > 0 {
+		t.Fatalf("Status.Versions unexpectedly already set: %#v", co.Status.Versions)
+	}
+
+	// Create minimal Deployment
+	depA := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "one", Name: "alpha", Labels: sl},
+		Status: appsv1.DeploymentStatus{
+			Replicas:          1,
+			UpdatedReplicas:   1,
+			AvailableReplicas: 1,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "gamma"},
+			},
+		},
+	}
+	set(t, client, depA)
+
+	// Even though the deployment is done the operator should not be Available if the config is not updated
+	status.SetConfigUpdated(false)
+	status.SetFromPods()
+
+	co, oc, err = getStatuses(client, "testing")
+	if err != nil {
+		t.Fatalf("error getting ClusterOperator: %v", err)
+	}
+	if !conditionsInclude(oc.Status.Conditions, []operv1.OperatorCondition{
+		{
+			Type:   operv1.OperatorStatusTypeDegraded,
+			Status: operv1.ConditionFalse,
+		},
+		{
+			Type:   operv1.OperatorStatusTypeProgressing,
+			Status: operv1.ConditionFalse,
+		},
+		{
+			Type:   operv1.OperatorStatusTypeUpgradeable,
+			Status: operv1.ConditionTrue,
+		},
+		{
+			Type:   operv1.OperatorStatusTypeAvailable,
+			Status: operv1.ConditionFalse,
+			Reason: "Startup",
+		},
+	}) {
+		t.Fatalf("unexpected Status.Conditions: %#v", oc.Status.Conditions)
+	}
+	if len(co.Status.Versions) > 0 {
+		t.Fatalf("Status.Versions unexpectedly already set: %#v", co.Status.Versions)
+	}
+
+	// Operator should be available when the deployment is done and the config is updated
+	status.SetConfigUpdated(true)
+	status.SetFromPods()
+
+	oc, err = getOC(client)
 	if err != nil {
 		t.Fatalf("error getting ClusterOperator: %v", err)
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1502,7 +1502,7 @@ sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta1
 # sigs.k8s.io/cluster-api-provider-openstack v0.6.3 => github.com/openshift/cluster-api-provider-openstack v0.0.0-20220209101310-a384cbe0dfa0
 ## explicit; go 1.17
 sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1
-# sigs.k8s.io/controller-runtime v0.14.4
+# sigs.k8s.io/controller-runtime v0.14.6
 ## explicit; go 1.19
 sigs.k8s.io/controller-runtime
 sigs.k8s.io/controller-runtime/pkg/builder

--- a/vendor/sigs.k8s.io/controller-runtime/alias.go
+++ b/vendor/sigs.k8s.io/controller-runtime/alias.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
-	cfg "sigs.k8s.io/controller-runtime/pkg/config" //nolint:staticcheck
+	cfg "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -99,8 +99,7 @@ var (
 	// ConfigFile returns the cfg.File function for deferred config file loading,
 	// this is passed into Options{}.From() to populate the Options fields for
 	// the manager.
-	// Deprecated: This is deprecated in favor of using Options directly.
-	ConfigFile = cfg.File //nolint:staticcheck
+	ConfigFile = cfg.File
 
 	// NewControllerManagedBy returns a new controller builder that will be started by the provided Manager.
 	NewControllerManagedBy = builder.ControllerManagedBy

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/builder/controller.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/builder/controller.go
@@ -285,7 +285,7 @@ func (blder *Builder) getControllerName(gvk schema.GroupVersionKind, hasGVK bool
 }
 
 func (blder *Builder) doController(r reconcile.Reconciler) error {
-	globalOpts := blder.mgr.GetControllerOptions() //nolint:staticcheck
+	globalOpts := blder.mgr.GetControllerOptions()
 
 	ctrlOptions := blder.ctrlOptions
 	if ctrlOptions.Reconciler == nil {

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/cache/cache.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/cache/cache.go
@@ -452,6 +452,7 @@ func convertToByObject[T any](byGVK map[schema.GroupVersionKind]T, scheme *runti
 		if !ok {
 			return nil, def, fmt.Errorf("object %T for GVK %q does not implement client.Object", obj, gvk)
 		}
+		cObj.GetObjectKind().SetGroupVersionKind(gvk)
 		if byObject == nil {
 			byObject = map[client.Object]T{}
 		}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/apiutil/apimachinery.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/apiutil/apimachinery.go
@@ -95,6 +95,7 @@ func GVKForObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersi
 		return gvk, nil
 	}
 
+	// Use the given scheme to retrieve all the GVKs for the object.
 	gvks, isUnversioned, err := scheme.ObjectKinds(obj)
 	if err != nil {
 		return schema.GroupVersionKind{}, err
@@ -103,16 +104,39 @@ func GVKForObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersi
 		return schema.GroupVersionKind{}, fmt.Errorf("cannot create group-version-kind for unversioned type %T", obj)
 	}
 
-	if len(gvks) < 1 {
-		return schema.GroupVersionKind{}, fmt.Errorf("no group-version-kinds associated with type %T", obj)
-	}
-	if len(gvks) > 1 {
-		// this should only trigger for things like metav1.XYZ --
-		// normal versioned types should be fine
+	switch {
+	case len(gvks) < 1:
+		// If the object has no GVK, the object might not have been registered with the scheme.
+		// or it's not a valid object.
+		return schema.GroupVersionKind{}, fmt.Errorf("no GroupVersionKind associated with Go type %T, was the type registered with the Scheme?", obj)
+	case len(gvks) > 1:
+		err := fmt.Errorf("multiple GroupVersionKinds associated with Go type %T within the Scheme, this can happen when a type is registered for multiple GVKs at the same time", obj)
+
+		// We've found multiple GVKs for the object.
+		currentGVK := obj.GetObjectKind().GroupVersionKind()
+		if !currentGVK.Empty() {
+			// If the base object has a GVK, check if it's in the list of GVKs before using it.
+			for _, gvk := range gvks {
+				if gvk == currentGVK {
+					return gvk, nil
+				}
+			}
+
+			return schema.GroupVersionKind{}, fmt.Errorf(
+				"%w: the object's supplied GroupVersionKind %q was not found in the Scheme's list; refusing to guess at one: %q", err, currentGVK, gvks)
+		}
+
+		// This should only trigger for things like metav1.XYZ --
+		// normal versioned types should be fine.
+		//
+		// See https://github.com/kubernetes-sigs/controller-runtime/issues/362
+		// for more information.
 		return schema.GroupVersionKind{}, fmt.Errorf(
-			"multiple group-version-kinds associated with type %T, refusing to guess at one", obj)
+			"%w: callers can either fix their type registration to only register it once, or specify the GroupVersionKind to use for object passed in; refusing to guess at one: %q", err, gvks)
+	default:
+		// In any other case, we've found a single GVK for the object.
+		return gvks[0], nil
 	}
-	return gvks[0], nil
 }
 
 // RESTClientForGVK constructs a new rest.Interface capable of accessing the resource associated

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/apiutil/lazyrestmapper.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/apiutil/lazyrestmapper.go
@@ -33,7 +33,7 @@ type lazyRESTMapper struct {
 	mapper      meta.RESTMapper
 	client      *discovery.DiscoveryClient
 	knownGroups map[string]*restmapper.APIGroupResources
-	apiGroups   *metav1.APIGroupList
+	apiGroups   []metav1.APIGroup
 
 	// mutex to provide thread-safe mapper reloading.
 	mu sync.Mutex
@@ -45,6 +45,7 @@ func newLazyRESTMapperWithClient(discoveryClient *discovery.DiscoveryClient) (me
 		mapper:      restmapper.NewDiscoveryRESTMapper([]*restmapper.APIGroupResources{}),
 		client:      discoveryClient,
 		knownGroups: map[string]*restmapper.APIGroupResources{},
+		apiGroups:   []metav1.APIGroup{},
 	}, nil
 }
 
@@ -147,7 +148,7 @@ func (m *lazyRESTMapper) addKnownGroupAndReload(groupName string, versions ...st
 	// This operation requires 2 requests: /api and /apis, but only once. For all subsequent calls
 	// this data will be taken from cache.
 	if len(versions) == 0 {
-		apiGroup, err := m.findAPIGroupByName(groupName)
+		apiGroup, err := m.findAPIGroupByNameLocked(groupName)
 		if err != nil {
 			return err
 		}
@@ -176,11 +177,22 @@ func (m *lazyRESTMapper) addKnownGroupAndReload(groupName string, versions ...st
 	}
 
 	// Update information for group resources about the API group by adding new versions.
+	// Ignore the versions that are already registered.
 	for _, version := range versions {
-		groupResources.Group.Versions = append(groupResources.Group.Versions, metav1.GroupVersionForDiscovery{
-			GroupVersion: metav1.GroupVersion{Group: groupName, Version: version}.String(),
-			Version:      version,
-		})
+		found := false
+		for _, v := range groupResources.Group.Versions {
+			if v.Version == version {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			groupResources.Group.Versions = append(groupResources.Group.Versions, metav1.GroupVersionForDiscovery{
+				GroupVersion: metav1.GroupVersion{Group: groupName, Version: version}.String(),
+				Version:      version,
+			})
+		}
 	}
 
 	// Update data in the cache.
@@ -197,28 +209,34 @@ func (m *lazyRESTMapper) addKnownGroupAndReload(groupName string, versions ...st
 	return nil
 }
 
-// findAPIGroupByName returns API group by its name.
-func (m *lazyRESTMapper) findAPIGroupByName(groupName string) (metav1.APIGroup, error) {
-	// Ensure that required info about existing API groups is received and stored in the mapper.
-	// It will make 2 API calls to /api and /apis, but only once.
-	if m.apiGroups == nil {
-		apiGroups, err := m.client.ServerGroups()
-		if err != nil {
-			return metav1.APIGroup{}, fmt.Errorf("failed to get server groups: %w", err)
-		}
-		if len(apiGroups.Groups) == 0 {
-			return metav1.APIGroup{}, fmt.Errorf("received an empty API groups list")
-		}
-
-		m.apiGroups = apiGroups
-	}
-
-	for i := range m.apiGroups.Groups {
-		if groupName == (&m.apiGroups.Groups[i]).Name {
-			return m.apiGroups.Groups[i], nil
+// findAPIGroupByNameLocked returns API group by its name.
+func (m *lazyRESTMapper) findAPIGroupByNameLocked(groupName string) (metav1.APIGroup, error) {
+	// Looking in the cache first.
+	for _, apiGroup := range m.apiGroups {
+		if groupName == apiGroup.Name {
+			return apiGroup, nil
 		}
 	}
 
+	// Update the cache if nothing was found.
+	apiGroups, err := m.client.ServerGroups()
+	if err != nil {
+		return metav1.APIGroup{}, fmt.Errorf("failed to get server groups: %w", err)
+	}
+	if len(apiGroups.Groups) == 0 {
+		return metav1.APIGroup{}, fmt.Errorf("received an empty API groups list")
+	}
+
+	m.apiGroups = apiGroups.Groups
+
+	// Looking in the cache again.
+	for _, apiGroup := range m.apiGroups {
+		if groupName == apiGroup.Name {
+			return apiGroup, nil
+		}
+	}
+
+	// If there is still nothing, return an error.
 	return metav1.APIGroup{}, fmt.Errorf("failed to find API group %s", groupName)
 }
 

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/config/config.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/config/config.go
@@ -24,24 +24,20 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1" //nolint:staticcheck
+	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
 )
 
 // ControllerManagerConfiguration defines the functions necessary to parse a config file
 // and to configure the Options struct for the ctrl.Manager.
-//
-// Deprecated: This package has been deprecated and will be removed in a future release.
 type ControllerManagerConfiguration interface {
 	runtime.Object
 
 	// Complete returns the versioned configuration
-	Complete() (v1alpha1.ControllerManagerConfigurationSpec, error) //nolint:staticcheck
+	Complete() (v1alpha1.ControllerManagerConfigurationSpec, error)
 }
 
 // DeferredFileLoader is used to configure the decoder for loading controller
 // runtime component config types.
-//
-// Deprecated: This package has been deprecated and will be removed in a future release.
 type DeferredFileLoader struct {
 	ControllerManagerConfiguration
 	path   string
@@ -56,8 +52,6 @@ type DeferredFileLoader struct {
 // Defaults:
 // * Path: "./config.yaml"
 // * Kind: GenericControllerManagerConfiguration
-//
-// Deprecated: This package has been deprecated and will be removed in a future release.
 func File() *DeferredFileLoader {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
@@ -69,8 +63,6 @@ func File() *DeferredFileLoader {
 }
 
 // Complete will use sync.Once to set the scheme.
-//
-// Deprecated: This package has been deprecated and will be removed in a future release.
 func (d *DeferredFileLoader) Complete() (v1alpha1.ControllerManagerConfigurationSpec, error) {
 	d.once.Do(d.loadFile)
 	if d.err != nil {
@@ -79,33 +71,25 @@ func (d *DeferredFileLoader) Complete() (v1alpha1.ControllerManagerConfiguration
 	return d.ControllerManagerConfiguration.Complete()
 }
 
-// AtPath will set the path to load the file for the decoder
-//
-// Deprecated: This package has been deprecated and will be removed in a future release.
+// AtPath will set the path to load the file for the decoder.
 func (d *DeferredFileLoader) AtPath(path string) *DeferredFileLoader {
 	d.path = path
 	return d
 }
 
 // OfKind will set the type to be used for decoding the file into.
-//
-// Deprecated: This package has been deprecated and will be removed in a future release.
 func (d *DeferredFileLoader) OfKind(obj ControllerManagerConfiguration) *DeferredFileLoader {
 	d.ControllerManagerConfiguration = obj
 	return d
 }
 
 // InjectScheme will configure the scheme to be used for decoding the file.
-//
-// Deprecated: This package has been deprecated and will be removed in a future release.
 func (d *DeferredFileLoader) InjectScheme(scheme *runtime.Scheme) error {
 	d.scheme = scheme
 	return nil
 }
 
 // loadFile is used from the mutex.Once to load the file.
-//
-// Deprecated: This package has been deprecated and will be removed in a future release.
 func (d *DeferredFileLoader) loadFile() {
 	if d.scheme == nil {
 		d.err = fmt.Errorf("scheme not supplied to controller configuration loader")

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/config/doc.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/config/doc.go
@@ -22,6 +22,4 @@ limitations under the License.
 // This uses a deferred file decoding allowing you to chain your configuration
 // setup. You can pass this into manager.Options#File and it will load your
 // config.
-//
-// Deprecated: This package has been deprecated and will be removed in a future release.
 package config

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/config/v1alpha1/doc.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/config/v1alpha1/doc.go
@@ -17,6 +17,4 @@ limitations under the License.
 // Package v1alpha1 provides the ControllerManagerConfiguration used for
 // configuring ctrl.Manager
 // +kubebuilder:object:generate=true
-//
-// Deprecated: This package has been deprecated and will be removed in a future release.
 package v1alpha1

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/config/v1alpha1/register.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/config/v1alpha1/register.go
@@ -23,18 +23,12 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects.
-	//
-	// Deprecated: This package has been deprecated and will be removed in a future release.
 	GroupVersion = schema.GroupVersion{Group: "controller-runtime.sigs.k8s.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
-	//
-	// Deprecated: This package has been deprecated and will be removed in a future release.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.
-	//
-	// Deprecated: This package has been deprecated and will be removed in a future release.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
 

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/config/v1alpha1/types.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/config/v1alpha1/types.go
@@ -25,8 +25,6 @@ import (
 )
 
 // ControllerManagerConfigurationSpec defines the desired state of GenericControllerManagerConfiguration.
-//
-// Deprecated: This package has been deprecated and will be removed in a future release.
 type ControllerManagerConfigurationSpec struct {
 	// SyncPeriod determines the minimum frequency at which watched resources are
 	// reconciled. A lower period will correct entropy more quickly, but reduce
@@ -77,8 +75,6 @@ type ControllerManagerConfigurationSpec struct {
 
 // ControllerConfigurationSpec defines the global configuration for
 // controllers registered with the manager.
-//
-// Deprecated: This package has been deprecated and will be removed in a future release.
 type ControllerConfigurationSpec struct {
 	// GroupKindConcurrency is a map from a Kind to the number of concurrent reconciliation
 	// allowed for that controller.
@@ -153,20 +149,14 @@ type ControllerWebhook struct {
 // +kubebuilder:object:root=true
 
 // ControllerManagerConfiguration is the Schema for the GenericControllerManagerConfigurations API.
-//
-// Deprecated: This package has been deprecated and will be removed in a future release.
 type ControllerManagerConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 
 	// ControllerManagerConfiguration returns the contfigurations for controllers
-	//
-	// Deprecated: This package has been deprecated and will be removed in a future release.
 	ControllerManagerConfigurationSpec `json:",inline"`
 }
 
 // Complete returns the configuration for controller-runtime.
-//
-// Deprecated: This package has been deprecated and will be removed in a future release.
 func (c *ControllerManagerConfigurationSpec) Complete() (ControllerManagerConfigurationSpec, error) {
 	return *c, nil
 }

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controller.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controller.go
@@ -141,7 +141,7 @@ func NewUnmanaged(name string, mgr manager.Manager, options Options) (Controller
 	}
 
 	if options.RecoverPanic == nil {
-		options.RecoverPanic = mgr.GetControllerOptions().RecoverPanic //nolint:staticcheck
+		options.RecoverPanic = mgr.GetControllerOptions().RecoverPanic
 	}
 
 	// Create controller with dependencies set

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/manager/manager.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/manager/manager.go
@@ -36,8 +36,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
-	"sigs.k8s.io/controller-runtime/pkg/config"          //nolint:staticcheck
-	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1" //nolint:staticcheck
+	"sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	intrec "sigs.k8s.io/controller-runtime/pkg/internal/recorder"
 	"sigs.k8s.io/controller-runtime/pkg/leaderelection"
@@ -94,11 +94,7 @@ type Manager interface {
 	GetLogger() logr.Logger
 
 	// GetControllerOptions returns controller global configuration options.
-	//
-	// Deprecated: In a future version, the returned value is going to be replaced with a
-	// different type that doesn't rely on component configuration types.
-	// This is a temporary warning, and no action is needed as of today.
-	GetControllerOptions() v1alpha1.ControllerConfigurationSpec //nolint:staticcheck
+	GetControllerOptions() v1alpha1.ControllerConfigurationSpec
 }
 
 // Options are the arguments for creating a new Manager.
@@ -301,11 +297,7 @@ type Options struct {
 	// Controller contains global configuration options for controllers
 	// registered within this manager.
 	// +optional
-	//
-	// Deprecated: In a future version, the type of this field is going to be replaced with a
-	// different struct that doesn't rely on component configuration types.
-	// This is a temporary warning, and no action is needed as of today.
-	Controller v1alpha1.ControllerConfigurationSpec //nolint:staticcheck
+	Controller v1alpha1.ControllerConfigurationSpec
 
 	// makeBroadcaster allows deferring the creation of the broadcaster to
 	// avoid leaking goroutines if we never call Start on this manager.  It also
@@ -464,8 +456,6 @@ func New(config *rest.Config, options Options) (Manager, error) {
 // AndFrom will use a supplied type and convert to Options
 // any options already set on Options will be ignored, this is used to allow
 // cli flags to override anything specified in the config file.
-//
-// Deprecated: This method will be removed in a future release.
 func (o Options) AndFrom(loader config.ControllerManagerConfiguration) (Options, error) {
 	if inj, wantsScheme := loader.(inject.Scheme); wantsScheme {
 		err := inj.InjectScheme(o.Scheme)
@@ -531,8 +521,6 @@ func (o Options) AndFrom(loader config.ControllerManagerConfiguration) (Options,
 }
 
 // AndFromOrDie will use options.AndFrom() and will panic if there are errors.
-//
-// Deprecated: This method will be removed in a future release.
 func (o Options) AndFromOrDie(loader config.ControllerManagerConfiguration) Options {
 	o, err := o.AndFrom(loader)
 	if err != nil {
@@ -541,7 +529,7 @@ func (o Options) AndFromOrDie(loader config.ControllerManagerConfiguration) Opti
 	return o
 }
 
-func (o Options) setLeaderElectionConfig(obj v1alpha1.ControllerManagerConfigurationSpec) Options { //nolint:staticcheck
+func (o Options) setLeaderElectionConfig(obj v1alpha1.ControllerManagerConfigurationSpec) Options {
 	if obj.LeaderElection == nil {
 		// The source does not have any configuration; noop
 		return o


### PR DESCRIPTION
This PR introduces two changes to:
- Make the Operator/ClusterOperator degraded on panic if any of the controllers crashes
- Do not set the Operator as available if the network config status is not set
   I am not sure if this could be done better but I am open to suggestions, CNO sets the `Available` condition once it is done deploying all of the pods, I added an additional condition that it also has to wait for the config to get updated.