### PR TITLE
OCPBUGS-11565: High API requests due to allowlist and operconfig reconcilers running too often

### DIFF
--- a/pkg/controller/allowlist/allowlist_controller.go
+++ b/pkg/controller/allowlist/allowlist_controller.go
@@ -2,7 +2,6 @@ package allowlist
 
 import (
 	"context"
-	"log"
 	"os"
 	"strings"
 	"time"
@@ -94,10 +93,10 @@ func (r *ReconcileAllowlist) Reconcile(ctx context.Context, request reconcile.Re
 		return reconcile.Result{}, err
 	}
 
-	if request.Namespace != names.MULTUS_NAMESPACE || request.Name != names.ALLOWLIST_CONFIG_NAME {
+	if request.Name != names.ALLOWLIST_CONFIG_NAME {
 		return reconcile.Result{}, nil
 	}
-	log.Printf("Reconcile allowlist for %s/%s", request.Namespace, request.Name)
+	klog.Infof("Reconcile allowlist for %s/%s", request.Namespace, request.Name)
 
 	configMap, err := getConfig(ctx, r.client, request.NamespacedName)
 	if err != nil {

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -480,8 +480,9 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 
 func reconcileOperConfig(obj crclient.Object) []reconcile.Request {
 	log.Printf("%s %s/%s changed, triggering operconf reconciliation", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName())
+	// Update reconcile.Request object to align with unnamespaced default network,
+	// to ensure we don't have multiple requeueing reconcilers running
 	return []reconcile.Request{{NamespacedName: types.NamespacedName{
-		Name:      names.OPERATOR_CONFIG,
-		Namespace: names.APPLIED_NAMESPACE,
+		Name: names.OPERATOR_CONFIG,
 	}}}
 }


### PR DESCRIPTION
The allowlist and operconfig reconcilers are running too often, which significantly drives up the cluster-network-operator kube-apiserver requests.

The allowlist controller creates a watcher that triggers the reconciler for any configmap change in any namespace. The first thing the reconciler does is a GET request for the 1 configmap it manages to check existence, creating it if it doesn't already exist. The second thing is to exit if the object being reconciled is not the configmap it manages. This results in the reconciler being run almost constantly, up to a few thousand times per hour, with a configmap GET request every time. By changing the controller to use a cmInformer to limit the watcher to a specific namespace, as is done with other controllers watching configmaps, the reconciler is run only when needed.

The operconfig reconciler accesses and manages a larger number of resources, and requeues itself every 3 minutes in order to update node status if needed. The requeue functionality is reliant on the uniqueness of the reconcile request object, ie. namespace and name. Originally, the controller launched this recurring reconciler with just a watcher on the network type. A later update added configmap and node watchers as additional triggers, with a request object transformer to set the request name to match the default network name. However, this transformer also set the namespace, where the network reconcile request was unnamespaced. This created a second unique recurring reconciler, as can be seen in the logs by pairing the timestamps of "Operconfig Controller complete" logs with the subsequent requeued reconciler start log "Reconciling Network.operator.openshift.io cluster" three minutes later. As a result, the reconciler is now run twice every three minutes, rather than once. By updating the request object transformer to leave the namespace unset, the reconcile requests triggered by configmap and node changes now match the network request object, and the requeue sees these as the same trigger, leaving a single recurring reconciler requeued.