### PR TITLE
[release-4.14] OCPBUGS-11550: AUTH: update cluster-reader to include k8s.ovn.org

### DIFF
--- a/bindata/network/ovn-kubernetes/common/007-rbac-cluster-reader.yaml
+++ b/bindata/network/ovn-kubernetes/common/007-rbac-cluster-reader.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+  name: openshift-ovn-kubernetes-cluster-reader
+rules:
+- apiGroups: ["k8s.ovn.org"]
+  resources:
+  - egressfirewalls
+  - egressips
+  - egressqoses
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
API group "k8s.ovn.org" should be included to cluster-reader role. That group has the following resources:
    - EgressFirewall
    - EgressIP
    - EgressQoS