### PR TITLE
OCPBUGS-10765: Remove oldest ovn acl log files when file limit exceeded

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -247,6 +247,7 @@ spec:
 
           # Rotate audit log files when then get to max size (in bytes)
           MAXFILESIZE=$(( "{{.OVNPolicyAuditMaxFileSize}}"*1000000 ))
+          MAXLOGFILES="{{.OVNPolicyAuditMaxLogFiles}}"
           LOGFILE=/var/log/ovn/acl-audit-log.log
           CONTROLLERPID=$(cat /run/ovn/ovn-controller.pid)
 
@@ -271,6 +272,13 @@ spec:
               CONTROLLERPID=$(cat /run/ovn/ovn-controller.pid)
             fi
 
+            # Ensure total number of log files does not exceed the maximum configured from OVNPolicyAuditMaxLogFiles
+            num_files=$(ls -1 $log_dir/acl-audit-log* 2>/dev/null | wc -l)
+            if [ "$num_files" -gt "MAXLOGFILES" ]; then
+              num_to_delete=$(( num_files - ${MAXLOGFILES} ))
+              ls -1t $log_dir/acl-audit-log* 2>/dev/null | tail -$num_to_delete | xargs -I {} rm {}
+            fi
+          
             # sleep for 30 seconds to avoid wasting CPU
             sleep 30
           done

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -243,7 +243,8 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["IPFIXCacheActiveTimeout"] = ""
 	data.Data["IPFIXSampling"] = ""
 	data.Data["OVNPolicyAuditRateLimit"] = c.PolicyAuditConfig.RateLimit
-	data.Data["OVNPolicyAuditMaxFileSize"] = c.PolicyAuditConfig.MaxFileSize
+	data.Data["OVNPolicyAuditMaxLogFiles"] = c.PolicyAuditConfig.MaxLogFiles
+	data.Data["OVNPolicyAuditMaxTotalStorage"] = c.PolicyAuditConfig.MaxFileSize
 	data.Data["OVNPolicyAuditDestination"] = c.PolicyAuditConfig.Destination
 	data.Data["OVNPolicyAuditSyslogFacility"] = c.PolicyAuditConfig.SyslogFacility
 	data.Data["OVN_LOG_PATTERN_CONSOLE"] = OVN_LOG_PATTERN_CONSOLE


### PR DESCRIPTION
adds new api config for max total storage with a default of 5GB. once the /var/log/ovn/ folder has exceeded that limit, the oldest files will be removed (one at a time) to keep within the limit.