### PR TITLE
OCPBUGS-13219: Use `IfNotPresent` instead of `Always` in OVNK upgrades pre-puller

### DIFF
--- a/bindata/network/ovn-kubernetes/common/pre-puller.yaml
+++ b/bindata/network/ovn-kubernetes/common/pre-puller.yaml
@@ -28,7 +28,7 @@ spec:
         # ovnkube-upgrades-prepuller: no-op container that simply pulls the new image during upgrades
       - name: ovnkube-upgrades-prepuller
         image: "{{.OvnImage}}"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command:
         - /bin/bash
         - -c


### PR DESCRIPTION
Currently the `ovnkube-upgrades-prepuller` daemon set uses the `Always` image pull policy. As a result this pod requires the presence of working image registry server. That is not really needed, and complicates upgrades in environments where the registry is not available at the time this pod runs. To avoid that this patch chages the image pull policy to `IfNotPresent`.

Related: https://issues.redhat.com/browse/OCPBUGS-13219
Related: https://issues.redhat.com/browse/MGMT-13733