### PR TITLE
[WIP] 4.13 Use encapsulation=true for IBM Cloud

### DIFF
--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
@@ -385,7 +385,7 @@ spec:
                 if [ "${ipsec}" == "true" ]; then
                     # IBMCloud does not forward ESP (IP proto 50)
                     # Instead, force IBMCloud IPsec to always use NAT-T
-                    if [ "{{.PlatformType}}" == "IBMCloud" ]; then
+                    if [ "{{.PlatformType}}" == "Azure" ]; then
                         ipsec_encapsulation=true
                     fi
                 fi

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
@@ -381,7 +381,15 @@ spec:
                 {{ else }}
                 ipsec=false
                 {{ end }}
-                if ! retry 20 "ipsec" "${OVN_NB_CTL} set nb_global . ipsec=${ipsec}"; then
+                ipsec_encapsulation=false
+                if [ "${ipsec}" == "true" ]; then
+                    # IBMCloud does not forward ESP (IP proto 50)
+                    # Instead, force IBMCloud IPsec to always use NAT-T
+                    if [ "{{.PlatformType}}" == "IBMCloud" ]; then
+                        ipsec_encapsulation=true
+                    fi
+                fi
+                if ! retry 20 "ipsec" "${OVN_NB_CTL} set nb_global . ipsec=${ipsec} options:ipsec_encapsulation=${ipsec_encapsulation}"; then
                   exit 1
                 fi
           preStop:


### PR DESCRIPTION

Use encapsulation=true for IBM Cloud

e.g. ovn-nbctl set nb_global . options:ipsec_encapsulation=true

4.13 testing