### PR TITLE
[release-4.10] OCPBUGS-343: Configure ignored namespaces into multus-admission-controller

### DIFF
--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -41,6 +41,7 @@ spec:
         - -tls-cert-file=/etc/webhook/tls.crt
         - -alsologtostderr=true
         - -metrics-listen-address=127.0.0.1:9091
+        - -ignore-namespaces=openshift-etcd,openshift-console,openshift-ingress-canary,{{.IgnoredNamespace}}
         volumeMounts:
         - name: webhook-certs
           mountPath: /etc/webhook

--- a/pkg/apis/network/v1/operatorpki_types.go
+++ b/pkg/apis/network/v1/operatorpki_types.go
@@ -11,12 +11,15 @@ import (
 // a certificate signed by that CA. The certificate has both ClientAuth
 // and ServerAuth extended usages enabled.
 //
-//  More specifically, given an OperatorPKI with <name>, the CNO will manage:
+//	More specifically, given an OperatorPKI with <name>, the CNO will manage:
+//
 // - A Secret called <name>-ca with two data keys:
 //   - tls.key - the private key
 //   - tls.crt - the CA certificate
+//
 // - A ConfigMap called <name>-ca with a single data key:
 //   - cabundle.crt - the CA certificate(s)
+//
 // - A Secret called <name>-cert with two data keys:
 //   - tls.key - the private key
 //   - tls.crt - the certificate, signed by the CA

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -200,16 +200,16 @@ func (c *Client) OperatorHelperClient() operatorv1helpers.OperatorClient {
 // Example for a label-selected ConfigMap watch:
 //
 // c.AddCustomInformer(
-//     v1coreinformers.NewFilteredServiceInformer(
-//          c.Kubernetes(),
-//			kapi.NamespaceAll,
-//			5 * time.Minute, // resync Period
-//			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
-//			func(options *metav1.ListOptions) {
-//				// use k8s.io/apimachinery/pkg/labels for more sophisticated selectors
-//				options.LabelSelector = "operator.example.dev/mylabel=myval"
-//			}))
 //
+//	    v1coreinformers.NewFilteredServiceInformer(
+//	         c.Kubernetes(),
+//				kapi.NamespaceAll,
+//				5 * time.Minute, // resync Period
+//				cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+//				func(options *metav1.ListOptions) {
+//					// use k8s.io/apimachinery/pkg/labels for more sophisticated selectors
+//					options.LabelSelector = "operator.example.dev/mylabel=myval"
+//				}))
 func (c *Client) AddCustomInformer(inf cache.SharedInformer) {
 	c.informers = append(c.informers, inf)
 	if c.started {

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -218,7 +218,7 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 	}
 
 	// Generate the objects
-	objs, err := network.Render(&operConfig.Spec, bootstrapResult, ManifestPath)
+	objs, err := network.Render(&operConfig.Spec, bootstrapResult, ManifestPath, r.client)
 	if err != nil {
 		log.Printf("Failed to render: %v", err)
 		r.status.SetDegraded(statusmanager.OperatorConfig, "RenderError",

--- a/pkg/network/multus_admission_controller.go
+++ b/pkg/network/multus_admission_controller.go
@@ -1,23 +1,64 @@
 package network
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/openshift/cluster-network-operator/pkg/names"
 	"github.com/openshift/cluster-network-operator/pkg/render"
 	"github.com/pkg/errors"
+
+	corev1 "k8s.io/api/core/v1"
+	//metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	//"k8s.io/apimachinery/pkg/labels"
+	//"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// ignoredNamespaces contains the comma separated namespace list that should be ignored
+// to watch by multus admission controller. This only initialized first invocation.
+var ignoredNamespaces string
+
+// getOpenshiftNamespaces collect openshift related namespaces, as comma separate list
+func getOpenshiftNamespaces(kubeClient client.Client) (string, error) {
+	namespaces := []string{}
+
+	// get openshift specific namespaces to add them into ignoreNamespace
+	nsList := &corev1.NamespaceList{}
+	matchingLabels := &client.MatchingLabels{"openshift.io/cluster-monitoring": "true"}
+	err := kubeClient.List(context.TODO(), nsList, matchingLabels)
+
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get namespaces to render multus admission controller manifests")
+	}
+
+	for _, ns := range nsList.Items {
+		namespaces = append(namespaces, ns.Name)
+	}
+	return strings.Join(namespaces, ","), nil
+}
+
 // renderMultusAdmissonControllerConfig returns the manifests of Multus Admisson Controller
-func renderMultusAdmissonControllerConfig(manifestDir string, externalControlPlane bool) ([]*uns.Unstructured, error) {
+func renderMultusAdmissonControllerConfig(manifestDir string, externalControlPlane bool, client client.Client) ([]*uns.Unstructured, error) {
 	objs := []*uns.Unstructured{}
+	var err error
+
+	if ignoredNamespaces == "" {
+		ignoredNamespaces, err = getOpenshiftNamespaces(client)
+		if err != nil {
+			klog.Warningf("failed to get openshift namespaces: %+v", err)
+		}
+	}
 
 	// render the manifests on disk
 	data := render.MakeRenderData()
 	data.Data["ReleaseVersion"] = os.Getenv("RELEASE_VERSION")
 	data.Data["MultusAdmissionControllerImage"] = os.Getenv("MULTUS_ADMISSION_CONTROLLER_IMAGE")
+	data.Data["IgnoredNamespace"] = ignoredNamespaces
 	data.Data["MultusValidatingWebhookName"] = names.MULTUS_VALIDATING_WEBHOOK
 	data.Data["KubeRBACProxyImage"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
 	data.Data["ExternalControlPlane"] = externalControlPlane

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -17,9 +17,10 @@ import (
 
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	utilnet "k8s.io/utils/net"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func Render(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapResult, manifestDir string) ([]*uns.Unstructured, error) {
+func Render(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapResult, manifestDir string, client client.Client) ([]*uns.Unstructured, error) {
 	log.Printf("Starting render phase")
 	objs := []*uns.Unstructured{}
 
@@ -40,7 +41,7 @@ func Render(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapResult
 	objs = append(objs, o...)
 
 	// render MultusAdmissionController
-	o, err = renderMultusAdmissionController(conf, manifestDir, bootstrapResult.Infra.ExternalControlPlane)
+	o, err = renderMultusAdmissionController(conf, manifestDir, bootstrapResult.Infra.ExternalControlPlane, client)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +132,7 @@ func deprecatedCanonicalizeSimpleMacvlanConfig(conf *operv1.SimpleMacvlanConfig)
 // DeprecatedCanonicalize converts configuration to a canonical form for backward
 // compatibility.
 //
-//      *** DO NOT ADD ANY NEW CANONICALIZATION TO THIS FUNCTION! ***
+//	*** DO NOT ADD ANY NEW CANONICALIZATION TO THIS FUNCTION! ***
 //
 // Altering the user-provided configuration from CNO causes problems when other components
 // need to look at the configuration before CNO starts. Users should just write the
@@ -581,7 +582,7 @@ func renderAdditionalNetworks(conf *operv1.NetworkSpec, manifestDir string) ([]*
 }
 
 // renderMultusAdmissionController generates the manifests of Multus Admission Controller
-func renderMultusAdmissionController(conf *operv1.NetworkSpec, manifestDir string, externalControlPlane bool) ([]*uns.Unstructured, error) {
+func renderMultusAdmissionController(conf *operv1.NetworkSpec, manifestDir string, externalControlPlane bool, client client.Client) ([]*uns.Unstructured, error) {
 	if *conf.DisableMultiNetwork {
 		return nil, nil
 	}
@@ -589,7 +590,7 @@ func renderMultusAdmissionController(conf *operv1.NetworkSpec, manifestDir strin
 	var err error
 	out := []*uns.Unstructured{}
 
-	objs, err := renderMultusAdmissonControllerConfig(manifestDir, externalControlPlane)
+	objs, err := renderMultusAdmissonControllerConfig(manifestDir, externalControlPlane, client)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change introduces -ignore-namespace option to multus-admission-controller.