### PR TITLE
[release-4.13] OCPBUGS-13920: add Hypershift release-image annotation to multus

### DIFF
--- a/bindata/cloud-network-config-controller/managed/controller.yaml
+++ b/bindata/cloud-network-config-controller/managed/controller.yaml
@@ -22,6 +22,7 @@ spec:
     metadata:
       name: cloud-network-config-controller
       annotations:
+        hypershift.openshift.io/release-image: {{.ReleaseImage}}
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: cloud-network-config-controller

--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -27,6 +27,9 @@ spec:
   template:
     metadata:
       annotations:
+{{- if .HyperShiftEnabled}}
+        hypershift.openshift.io/release-image: {{.ReleaseImage}}
+{{- end }}      
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: multus-admission-controller

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -51,6 +51,7 @@ spec:
   template:
     metadata:
       annotations:
+        hypershift.openshift.io/release-image: {{.ReleaseImage}}
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: ovnkube-master

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -35,6 +35,7 @@ type OVNHyperShiftBootstrapResult struct {
 	OVNSbDbRouteLabels        map[string]string
 	HCPNodeSelector           map[string]string
 	ControlPlaneReplicas      int
+	ReleaseImage              string
 }
 
 type OVNConfigBoostrapResult struct {

--- a/pkg/network/cloud_network.go
+++ b/pkg/network/cloud_network.go
@@ -89,6 +89,7 @@ func renderCloudNetworkConfigController(conf *operv1.NetworkSpec, bootstrapResul
 		data.Data["TokenAudience"] = os.Getenv("TOKEN_AUDIENCE")
 		data.Data["ManagementClusterName"] = names.ManagementClusterName
 		data.Data["HostedClusterNamespace"] = hcpCfg.Namespace
+		data.Data["ReleaseImage"] = hcpCfg.ReleaseImage
 		data.Data["HCPNodeSelector"] = cloudBootstrapResult.HostedControlPlane.Spec.NodeSelector
 		// In HyperShift CloudNetworkConfigController is deployed as a part of the hosted cluster controlplane
 		// which means that it is created in the management cluster.

--- a/pkg/network/multus_admission_controller.go
+++ b/pkg/network/multus_admission_controller.go
@@ -99,6 +99,8 @@ func renderMultusAdmissonControllerConfig(manifestDir string, externalControlPla
 		data.Data["ClusterIDLabel"] = platform.ClusterIDLabel
 		data.Data["ClusterID"] = bootstrapResult.Infra.HostedControlPlane.Spec.ClusterID
 		data.Data["HCPNodeSelector"] = bootstrapResult.Infra.HostedControlPlane.Spec.NodeSelector
+
+		data.Data["ReleaseImage"] = hsc.ReleaseImage
 	}
 
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/multus-admission-controller"), &data)

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -168,6 +168,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	// Hypershift
 	data.Data["ManagementClusterName"] = names.ManagementClusterName
 	data.Data["HostedClusterNamespace"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.Namespace
+	data.Data["ReleaseImage"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.ReleaseImage
 	data.Data["ClusterID"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.ClusterID
 	data.Data["ClusterIDLabel"] = platform.ClusterIDLabel
 	data.Data["OVNDbServiceType"] = corev1.ServiceTypeClusterIP
@@ -532,6 +533,7 @@ func bootstrapOVNHyperShiftConfig(hc *platform.HyperShiftConfig, kubeClient cnoc
 		Namespace:          hc.Namespace,
 		OVNSbDbRouteHost:   hc.OVNSbDbRouteHost,
 		OVNSbDbRouteLabels: hc.OVNSbDbRouteLabels,
+		ReleaseImage:       hc.ReleaseImage,
 	}
 
 	if !hc.Enabled {

--- a/pkg/platform/hypershift.go
+++ b/pkg/platform/hypershift.go
@@ -32,6 +32,7 @@ var (
 	routeLabels    = map[string]string{}
 	routeLabelsRaw = os.Getenv("OVN_SBDB_ROUTE_LABELS")
 	runAsUser      = os.Getenv("RUN_AS_USER")
+	releaseImage   = os.Getenv("OPENSHIFT_RELEASE_IMAGE")
 )
 
 const (
@@ -57,6 +58,7 @@ type HyperShiftConfig struct {
 	RunAsUser          string
 	OVNSbDbRouteLabels map[string]string
 	RelatedObjects     []RelatedObject
+	ReleaseImage       string
 }
 
 func NewHyperShiftConfig() *HyperShiftConfig {
@@ -67,6 +69,7 @@ func NewHyperShiftConfig() *HyperShiftConfig {
 		RunAsUser:          runAsUser,
 		OVNSbDbRouteHost:   routeHost,
 		OVNSbDbRouteLabels: routeLabels,
+		ReleaseImage:       releaseImage,
 	}
 }
 


### PR DESCRIPTION
This PR is to back-port change https://github.com/openshift/cluster-network-operator/pull/1770 to release-4.13 branch.