### PR TITLE
OCPBUGS-13922: Revert "Do not set the operator as available before updating the network config"

### DIFF
--- a/pkg/controller/operconfig/cluster.go
+++ b/pkg/controller/operconfig/cluster.go
@@ -86,8 +86,6 @@ func (r *ReconcileOperConfig) ClusterNetworkStatus(ctx context.Context, operConf
 	// Update the cluster config status
 	status := network.StatusFromOperatorConfig(&operConfig.Spec, &clusterConfig.Status)
 	if status == nil || reflect.DeepEqual(*status, clusterConfig.Status) {
-		// clusterConfig is already updated
-		r.status.SetConfigUpdated(true)
 		return nil, nil
 	}
 	clusterConfig.Status = *status

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -470,7 +470,6 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 				fmt.Sprintf("Could not update cluster configuration status: %v", err))
 			return reconcile.Result{}, err
 		}
-		r.status.SetConfigUpdated(true)
 	}
 
 	r.status.SetNotDegraded(statusmanager.OperatorConfig)

--- a/pkg/controller/statusmanager/pod_status.go
+++ b/pkg/controller/statusmanager/pod_status.go
@@ -262,8 +262,7 @@ func (status *StatusManager) SetFromPods() {
 		status.unsetProgressing(PodDeployment)
 	}
 
-	// set the operator as available only after it rolled out all resources and the operator config was updated
-	if reachedAvailableLevel && status.configUpdated {
+	if reachedAvailableLevel {
 		status.set(reachedAvailableLevel, operv1.OperatorCondition{
 			Type:   operv1.OperatorStatusTypeAvailable,
 			Status: operv1.ConditionTrue})

--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -87,7 +87,6 @@ type StatusManager struct {
 
 	failing         [maxStatusLevel]*operv1.OperatorCondition
 	installComplete bool
-	configUpdated   bool
 
 	// All our informers and listers
 	dsInformers map[string]cache.SharedIndexInformer
@@ -532,12 +531,6 @@ func (status *StatusManager) SetNotDegraded(statusLevel StatusLevel) {
 	status.Lock()
 	defer status.Unlock()
 	status.setNotDegraded(statusLevel)
-}
-
-func (status *StatusManager) SetConfigUpdated(updated bool) {
-	status.Lock()
-	defer status.Unlock()
-	status.configUpdated = updated
 }
 
 // syncProgressing syncs the current Progressing status

--- a/pkg/controller/statusmanager/status_manager_test.go
+++ b/pkg/controller/statusmanager/status_manager_test.go
@@ -339,7 +339,6 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 	no := &operv1.Network{ObjectMeta: metav1.ObjectMeta{Name: names.OPERATOR_CONFIG}}
 	set(t, client, no)
 
-	status.SetConfigUpdated(true)
 	status.SetFromPods()
 	co, oc, err := getStatuses(client, "testing")
 	if err != nil {
@@ -377,7 +376,6 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 		},
 	}
 	set(t, client, dsB)
-	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	// Since the DaemonSet.Status reports no pods Available, the status should be Progressing
@@ -434,7 +432,6 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 	for dsA.Status.NumberUnavailable > 0 || dsB.Status.NumberUnavailable > 0 {
 		set(t, client, dsA)
 		set(t, client, dsB)
-		status.SetConfigUpdated(true)
 		status.SetFromPods()
 
 		co, oc, err = getStatuses(client, "testing")
@@ -489,7 +486,6 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 	set(t, client, dsA)
 	set(t, client, dsB)
 	time.Sleep(1 * time.Second) // minimum transition time fidelity
-	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -534,7 +530,6 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 	// that we enter Progressing state but otherwise stay Available
 	dsA.Generation = 2
 	set(t, client, dsA)
-	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -576,7 +571,6 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 		ObservedGeneration:     2,
 	}
 	set(t, client, dsA)
-	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -617,7 +611,6 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 		ObservedGeneration:     2,
 	}
 	set(t, client, dsA)
-	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -662,7 +655,6 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 
 	t0 := time.Now()
 	time.Sleep(time.Second / 10)
-	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -724,7 +716,6 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 		}
 	}
 	setLastPodState(t, client, "testing", ps)
-	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -776,7 +767,6 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 		UpdatedNumberScheduled: 1,
 	}
 	set(t, client, dsA)
-	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	// see that the pod state is sensible
@@ -834,7 +824,6 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 		},
 	}
 	set(t, client, dsNC)
-	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	// We should now be Progressing, but not un-Available
@@ -876,7 +865,6 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 		}
 	}
 	setLastPodState(t, client, "testing", ps)
-	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -913,7 +901,6 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 	dsNC.Status.DesiredNumberScheduled = 1
 	dsNC.Status.UpdatedNumberScheduled = 1
 	set(t, client, dsNC)
-	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -952,7 +939,6 @@ func TestStatusManagerSetFromDeployments(t *testing.T) {
 	no := &operv1.Network{ObjectMeta: metav1.ObjectMeta{Name: names.OPERATOR_CONFIG}}
 	set(t, client, no)
 
-	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err := getStatuses(client, "testing")
@@ -978,7 +964,6 @@ func TestStatusManagerSetFromDeployments(t *testing.T) {
 	depA := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "one", Name: "alpha", Labels: sl}}
 	set(t, client, depA)
 
-	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -1017,7 +1002,6 @@ func TestStatusManagerSetFromDeployments(t *testing.T) {
 	depA.Status.UnavailableReplicas = 0
 	depA.Status.AvailableReplicas = depA.Status.Replicas
 	set(t, client, depA)
-	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -1074,7 +1058,6 @@ func TestStatusManagerSetFromDeployments(t *testing.T) {
 
 	t0 := time.Now()
 	time.Sleep(time.Second / 10)
-	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -1141,7 +1124,6 @@ func TestStatusManagerSetFromDeployments(t *testing.T) {
 	depB.Status.AvailableReplicas = depB.Status.Replicas
 
 	set(t, client, depB)
-	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -1183,7 +1165,6 @@ func TestStatusManagerSetFromDeployments(t *testing.T) {
 		}
 	}
 	setLastPodState(t, client, "testing", ps)
-	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -1226,7 +1207,6 @@ func TestStatusManagerSetFromDeployments(t *testing.T) {
 	depB.Status.UnavailableReplicas = 0
 	depB.Status.AvailableReplicas = depB.Status.Replicas
 	set(t, client, depB)
-	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	co, oc, err = getStatuses(client, "testing")
@@ -1422,7 +1402,6 @@ func TestStatusManagerCheckCrashLoopBackOffPods(t *testing.T) {
 	}
 	set(t, client, podnC)
 
-	status.SetConfigUpdated(true)
 	status.SetFromPods()
 
 	oc, err := getOC(client)
@@ -1490,7 +1469,6 @@ func TestStatusManagerCheckCrashLoopBackOffPods(t *testing.T) {
 	}
 	set(t, client, podC)
 
-	status.SetConfigUpdated(true)
 	status.SetFromPods()
 	oc, err = getOC(client)
 	if err != nil {
@@ -1568,115 +1546,10 @@ func TestStatusManagerHyperShift(t *testing.T) {
 		}}
 	set(t, mgmtClient, depHCP)
 
-	mgmtStatus.SetConfigUpdated(true)
 	mgmtStatus.SetFromPods()
 
 	// mgmt conditions should not reflect the failures in hosted clusters namespace
 	oc, err := getOC(mgmtClient)
-	if err != nil {
-		t.Fatalf("error getting ClusterOperator: %v", err)
-	}
-	if !conditionsInclude(oc.Status.Conditions, []operv1.OperatorCondition{
-		{
-			Type:   operv1.OperatorStatusTypeDegraded,
-			Status: operv1.ConditionFalse,
-		},
-		{
-			Type:   operv1.OperatorStatusTypeProgressing,
-			Status: operv1.ConditionFalse,
-		},
-		{
-			Type:   operv1.OperatorStatusTypeUpgradeable,
-			Status: operv1.ConditionTrue,
-		},
-		{
-			Type:   operv1.OperatorStatusTypeAvailable,
-			Status: operv1.ConditionTrue,
-		},
-	}) {
-		t.Fatalf("unexpected Status.Conditions: %#v", oc.Status.Conditions)
-	}
-}
-
-func TestStatusManagerSetConfigUpdated(t *testing.T) {
-	client := fake.NewFakeClient()
-	status := New(client, "testing", "")
-	setFakeListers(status)
-	no := &operv1.Network{ObjectMeta: metav1.ObjectMeta{Name: names.OPERATOR_CONFIG}}
-	set(t, client, no)
-
-	status.SetFromPods()
-	co, oc, err := getStatuses(client, "testing")
-	if err != nil {
-		t.Fatalf("error getting ClusterOperator: %v", err)
-	}
-	if !conditionsInclude(oc.Status.Conditions, []operv1.OperatorCondition{
-		{
-			Type:   operv1.OperatorStatusTypeProgressing,
-			Status: operv1.ConditionTrue,
-			Reason: "Deploying",
-		},
-	}) {
-		t.Fatalf("unexpected Status.Conditions: %#v", oc.Status.Conditions)
-	}
-	if len(co.Status.Versions) > 0 {
-		t.Fatalf("Status.Versions unexpectedly already set: %#v", co.Status.Versions)
-	}
-
-	// Create minimal Deployment
-	depA := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "one", Name: "alpha", Labels: sl},
-		Status: appsv1.DeploymentStatus{
-			Replicas:          1,
-			UpdatedReplicas:   1,
-			AvailableReplicas: 1,
-		},
-		Spec: appsv1.DeploymentSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"app": "gamma"},
-			},
-		},
-	}
-	set(t, client, depA)
-
-	// Even though the deployment is done the operator should not be Available if the config is not updated
-	status.SetConfigUpdated(false)
-	status.SetFromPods()
-
-	co, oc, err = getStatuses(client, "testing")
-	if err != nil {
-		t.Fatalf("error getting ClusterOperator: %v", err)
-	}
-	if !conditionsInclude(oc.Status.Conditions, []operv1.OperatorCondition{
-		{
-			Type:   operv1.OperatorStatusTypeDegraded,
-			Status: operv1.ConditionFalse,
-		},
-		{
-			Type:   operv1.OperatorStatusTypeProgressing,
-			Status: operv1.ConditionFalse,
-		},
-		{
-			Type:   operv1.OperatorStatusTypeUpgradeable,
-			Status: operv1.ConditionTrue,
-		},
-		{
-			Type:   operv1.OperatorStatusTypeAvailable,
-			Status: operv1.ConditionFalse,
-			Reason: "Startup",
-		},
-	}) {
-		t.Fatalf("unexpected Status.Conditions: %#v", oc.Status.Conditions)
-	}
-	if len(co.Status.Versions) > 0 {
-		t.Fatalf("Status.Versions unexpectedly already set: %#v", co.Status.Versions)
-	}
-
-	// Operator should be available when the deployment is done and the config is updated
-	status.SetConfigUpdated(true)
-	status.SetFromPods()
-
-	oc, err = getOC(client)
 	if err != nil {
 		t.Fatalf("error getting ClusterOperator: %v", err)
 	}


### PR DESCRIPTION
In https://github.com/openshift/cluster-network-operator/pull/1786 I introduced a change that addressed a corner case in which CNO would set the `Available` status even if the `network.config` was not set. The introduced fix sets a flag in the status marking whether the `network.config` was updated or not.

It was found in [CI](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.14-e2e-aws-sdn-upgrade/1658645249297223680) that there is a chance for the status controller to settle(all new pods are running and ready) before the flag is set:

1. Status manager sets the conditions of the operator, it won't update the the version because `SetConfigUpdated` was not called yet
https://github.com/openshift/cluster-network-operator/blob/master/pkg/controller/statusmanager/status_manager.go#L451
```
2023-05-17T02:22:06.755541499Z I0517 02:22:06.755499       1 log.go:194] Set ClusterOperator conditions:
...
2023-05-17T02:22:09.156877165Z I0517 02:22:09.156642       1 log.go:194] Set ClusterOperator conditions:
...
2023-05-17T02:22:10.357949905Z I0517 02:22:10.357459       1 log.go:194] Set ClusterOperator conditions:
...
2023-05-17T02:22:12.556214901Z I0517 02:22:12.556175       1 log.go:194] Set ClusterOperator conditions:
2023-05-17T02:22:12.556214901Z   message: Deployment "/openshift-multus/multus-admission-controller" update is rolling
2023-05-17T02:22:12.556214901Z     out (2 out of 3 updated)
2023-05-17T02:22:12.556214901Z   reason: Deploying
2023-05-17T02:22:12.556214901Z   status: "True"
2023-05-17T02:22:12.556214901Z   type: Progressing
2023-05-17T02:22:13.760833339Z I0517 02:22:13.760773       1 log.go:194] Set ClusterOperator conditions:
2023-05-17T02:22:13.760833339Z - lastTransitionTime: "2023-05-17T01:56:22Z"
2023-05-17T02:22:13.760833339Z   status: "False"
2023-05-17T02:22:13.760833339Z   type: Degraded
2023-05-17T02:22:13.760833339Z - lastTransitionTime: "2023-05-17T01:48:28Z"
2023-05-17T02:22:13.760833339Z   status: "False"
2023-05-17T02:22:13.760833339Z   type: ManagementStateDegraded
2023-05-17T02:22:13.760833339Z - lastTransitionTime: "2023-05-17T01:48:28Z"
2023-05-17T02:22:13.760833339Z   status: "True"
2023-05-17T02:22:13.760833339Z   type: Upgradeable
2023-05-17T02:22:13.760833339Z - lastTransitionTime: "2023-05-17T02:22:13Z"
2023-05-17T02:22:13.760833339Z   status: "False"
2023-05-17T02:22:13.760833339Z   type: Progressing
2023-05-17T02:22:13.760833339Z - lastTransitionTime: "2023-05-17T01:49:17Z"
2023-05-17T02:22:13.760833339Z   status: "True"
2023-05-17T02:22:13.760833339Z   type: Available
```

2. [SetConfigUpdated](https://github.com/openshift/cluster-network-operator/blob/7df32ec5213e2abfcff18cd22a63e7f20a5cccdc/pkg/controller/operconfig/cluster.go#L90) gets called after the status manager settles:
```
2023-05-17T02:22:16.149920367Z I0517 02:22:16.149868       1 log.go:194] Operconfig Controller complete
```
Status manager won't reconcile unless there is a change to the pods state.
Lets revert the introduced change to give us time to work on a better fix.