### PR TITLE
OCPBUGS-10652: ovnkube: disable conntrack on hybrid overlay VXLAN ports

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/single-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/single-zone-interconnect/ovnkube-node.yaml
@@ -462,6 +462,11 @@ spec:
           iptables -t raw -A OUTPUT -p udp --dport {{.GenevePort}} -j NOTRACK
           ip6tables -t raw -A PREROUTING -p udp --dport {{.GenevePort}} -j NOTRACK
           ip6tables -t raw -A OUTPUT -p udp --dport {{.GenevePort}} -j NOTRACK
+          {{- if .OVNHybridOverlayVXLANPort}}
+          echo "I$(date "+%m%d %H:%M:%S.%N") - disable conntrack on hybrid overlay VXLAN port"
+          iptables -t raw -A PREROUTING -p udp --dport {{.OVNHybridOverlayVXLANPort}} -j NOTRACK
+          iptables -t raw -A OUTPUT -p udp --dport {{.OVNHybridOverlayVXLANPort}} -j NOTRACK
+          {{- end}}
           retries=0
 
           echo "I$(date "+%m%d %H:%M:%S.%N") - starting ovnkube-node db_ip ${db_ip}"

--- a/bindata/network/ovn-kubernetes/self-hosted/single-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/single-zone-interconnect/ovnkube-node.yaml
@@ -371,6 +371,11 @@ spec:
           iptables -t raw -A OUTPUT -p udp --dport {{.GenevePort}} -j NOTRACK
           ip6tables -t raw -A PREROUTING -p udp --dport {{.GenevePort}} -j NOTRACK
           ip6tables -t raw -A OUTPUT -p udp --dport {{.GenevePort}} -j NOTRACK
+          {{- if .OVNHybridOverlayVXLANPort}}
+          echo "I$(date "+%m%d %H:%M:%S.%N") - disable conntrack on hybrid overlay VXLAN port"
+          iptables -t raw -A PREROUTING -p udp --dport {{.OVNHybridOverlayVXLANPort}} -j NOTRACK
+          iptables -t raw -A OUTPUT -p udp --dport {{.OVNHybridOverlayVXLANPort}} -j NOTRACK
+          {{- end}}
           echo "I$(date "+%m%d %H:%M:%S.%N") - starting ovnkube-node"
 
           if [ "{{.OVN_GATEWAY_MODE}}" == "shared" ]; then


### PR DESCRIPTION
Like GENEVE we don't need to conntrack the hybrid overlay VXLAN traffic.

Resolves: https://issues.redhat.com/browse/OCPBUGS-10652