### PR TITLE
[wip][poc] HyperShift: run ovnkube-master on two nodes

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -64,6 +64,13 @@ spec:
     spec:
       affinity:
         nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: hypershift.openshift.io/test
+                    operator: In
+                    values:
+                      - test
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 50
             preference:
@@ -72,7 +79,7 @@ spec:
                   operator: In
                   values:
                     - "true"
-          - weight: 100
+          - weight: 60
             preference:
               matchExpressions:
                 - key: hypershift.openshift.io/cluster
@@ -80,14 +87,16 @@ spec:
                   values:
                     - {{.HostedClusterNamespace}}
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                app: ovnkube-master
-            topologyKey: topology.kubernetes.io/zone
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: ovnkube-master
+              topologyKey: topology.kubernetes.io/zone
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
+            - weight: 50
               podAffinityTerm:
                 labelSelector:
                   matchLabels:
@@ -871,9 +880,9 @@ spec:
             multi_network_enabled_flag="--enable-multi-network"
           fi
 
-          echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-master - start ovnkube --init-master ${K8S_NODE}"
+          echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-master - start ovnkube --init-master "${K8S_POD_NAME}.ovnkube-master-internal.{{.HostedClusterNamespace}}.svc.cluster.local""
           exec /usr/bin/ovnkube \
-            --init-master "${K8S_NODE}" \
+            --init-master "${K8S_POD_NAME}.ovnkube-master-internal.{{.HostedClusterNamespace}}.svc.cluster.local" \
             --config-file=/run/ovnkube-config/ovnkube.conf \
             --k8s-token-file=/var/run/secrets/hosted_cluster/token \
             --ovn-empty-lb-events \
@@ -925,6 +934,10 @@ spec:
         env:
         - name: OVN_KUBE_LOG_LEVEL
           value: "4"
+        - name: K8S_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: K8S_NODE
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Removed the required podAntiAffinity so ovnkube-master pods can share a node.
Added `nodeAffinity/requiredDuringSchedulingIgnoredDuringExecution` just to limit the list of nodes ovnkube-master can be scheduled on.
Added `podAntiAffinity/preferredDuringSchedulingIgnoredDuringExecution` to do a best effort spread between available nodes.
Changed `init-master` since this is our `holderIdentity` for the leader lease, nodeName won't work anymore.