### PR TITLE
OCPBUGS-14384: Remove nodeSelector for architecture in whereabouts daemonset

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -542,8 +542,6 @@ spec:
     spec:
       hostNetwork: true      
       serviceAccountName: multus
-      nodeSelector:
-        kubernetes.io/arch: amd64
       tolerations:
       - operator: Exists
         effect: NoSchedule


### PR DESCRIPTION
This change removes nodeSelector for architecture in whereabouts daemonset yaml becuase it is no longer for specific architecture, not only for amd64, also arm64.