### PR TITLE
OCPBUGS-13067: Fix tier label, privileged, HOSTNAME/NODENAME in whereabouts reconciler [backport 4.12]

### DIFF
--- a/bindata/network/multus/002-rbac.yaml
+++ b/bindata/network/multus/002-rbac.yaml
@@ -41,6 +41,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs:
+  - get
 - apiGroups: ["", "events.k8s.io"]
   resources:
   - events

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -537,7 +537,6 @@ spec:
   template:
     metadata:
       labels:
-        tier: node
         app: whereabouts-reconciler
         name: whereabouts-reconciler
     spec:
@@ -568,12 +567,15 @@ spec:
           limits:
             cpu: "50m"
             memory: "100Mi"
-        securityContext:
-          privileged: true
         volumeMounts:
           - name: cni-net-dir
             mountPath: /host/etc/cni/net.d
         env:
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
         - name: KUBERNETES_SERVICE_PORT
           value: "{{.KUBERNETES_SERVICE_PORT}}"
         - name: KUBERNETES_SERVICE_HOST


### PR DESCRIPTION
Fix tier label.
Remove privileged security Context.
Retrieve node name from the downward API.
Grant multus clusterrole the right to get nodes.