### PR TITLE
OCPBUGS-11882: Added another volume to safe-to-evict-local-volume annotation

### DIFF
--- a/bindata/cloud-network-config-controller/managed/controller.yaml
+++ b/bindata/cloud-network-config-controller/managed/controller.yaml
@@ -23,7 +23,7 @@ spec:
       name: cloud-network-config-controller
       annotations:
         hypershift.openshift.io/release-image: {{.ReleaseImage}}
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: "cloud-token,hosted-ca-cert"
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: "hosted-cluster-api-access,cloud-token,hosted-ca-cert"
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: cloud-network-config-controller


### PR DESCRIPTION
This PR fixes part of this bug: https://issues.redhat.com/browse/OCPBUGS-11882.

Basically adding this annotation to the pods which contains volumes or emptyDirs will allow the ClusterAutoscaler to drain the pods properly.