### PR TITLE
OCPBUGS-14833: Fixes lint issues

### DIFF
--- a/pkg/controller/proxyconfig/controller.go
+++ b/pkg/controller/proxyconfig/controller.go
@@ -232,8 +232,7 @@ func (r *ReconcileProxyConfig) Reconcile(ctx context.Context, request reconcile.
 		}
 
 		// Create a configmap containing the merged proxy.trustedCA/system bundles.
-		//nolint:staticcheck // TODO:danehans maybe remove this line?
-		trustBundle, err = r.mergeTrustBundlesToConfigMap(proxyData, systemData)
+		_, err = r.mergeTrustBundlesToConfigMap(proxyData, systemData)
 		if err != nil {
 			log.Printf("Failed to merge trustedCA and system bundles for proxy '%s': %v", names.PROXY_CONFIG, err)
 			r.status.SetDegraded(statusmanager.ProxyConfig, "EnsureProxyConfigFailure",

--- a/pkg/controller/signer/signer-controller.go
+++ b/pkg/controller/signer/signer-controller.go
@@ -134,8 +134,7 @@ func (r *ReconcileCSR) Reconcile(ctx context.Context, request reconcile.Request)
 			Reason:  "AutoApproved",
 			Message: "Automatically approved by " + signerName})
 		// Update status to "Approved"
-		//nolint:staticcheck
-		csr, err = r.clientset.CertificatesV1().CertificateSigningRequests().UpdateApproval(ctx, request.Name, csr, metav1.UpdateOptions{})
+		_, err = r.clientset.CertificatesV1().CertificateSigningRequests().UpdateApproval(ctx, request.Name, csr, metav1.UpdateOptions{})
 		if err != nil {
 			log.Printf("Unable to approve certificate for %v and signer %v: %v", request.Name, signerName, err)
 			return reconcile.Result{}, err


### PR DESCRIPTION
This was preventing us from bumping to golangci-lint 1.53.1 in CI.