### PR TITLE
OCPBUGS-14714: Do not rely on ControlPlaneTopology do determine if running in HyperShift

### DIFF
--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -206,7 +206,8 @@ spec:
 {{- if not .ExternalControlPlane }}
       nodeSelector:
         node-role.kubernetes.io/master: ""
-{{- else }}
+{{- end }}
+{{- if .HyperShiftEnabled}}
       {{ if .HCPNodeSelector }}
       nodeSelector:
         {{ range $key, $value := .HCPNodeSelector }}

--- a/pkg/controller/operconfig/mtu_probe.go
+++ b/pkg/controller/operconfig/mtu_probe.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	operv1 "github.com/openshift/api/operator/v1"
-
 	"github.com/openshift/cluster-network-operator/pkg/apply"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
 	"github.com/openshift/cluster-network-operator/pkg/render"
@@ -39,7 +38,8 @@ const (
 // If, for whatever reason, it takes longer for the MTU to be detected,
 // it will adopt an existing job.
 func (r *ReconcileOperConfig) probeMTU(ctx context.Context, oc *operv1.Network, infra *bootstrap.InfraStatus) (int, error) {
-	if infra.ControlPlaneTopology == configv1.ExternalTopologyMode {
+	// infra.HostedControlPlane is not nil only when HyperShift is enabled
+	if infra.HostedControlPlane != nil {
 		if infra.PlatformType == configv1.AWSPlatformType {
 			klog.Infof("AWS cluster, omitting MTU probing and using default of %d", awsMTU)
 			return awsMTU, nil

--- a/pkg/controller/operconfig/mtu_probe_test.go
+++ b/pkg/controller/operconfig/mtu_probe_test.go
@@ -7,6 +7,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
+	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,8 +24,12 @@ func TestProbeMTU(t *testing.T) {
 		expectedMTU int
 	}{
 		{
-			name:        "AWS on Hypershift, hardcoded value is used",
-			infra:       &bootstrap.InfraStatus{PlatformType: configv1.AWSPlatformType, ControlPlaneTopology: configv1.ExternalTopologyMode},
+			name: "AWS on Hypershift, hardcoded value is used",
+			infra: &bootstrap.InfraStatus{
+				PlatformType:         configv1.AWSPlatformType,
+				ControlPlaneTopology: configv1.ExternalTopologyMode,
+				HostedControlPlane:   &hyperv1.HostedControlPlane{},
+			},
 			expectedMTU: 9001,
 		},
 		{
@@ -37,8 +42,12 @@ func TestProbeMTU(t *testing.T) {
 			expectedMTU: 5000,
 		},
 		{
-			name:        "Azure on hypershift, hardcoded value is used",
-			infra:       &bootstrap.InfraStatus{PlatformType: configv1.AzurePlatformType, ControlPlaneTopology: configv1.ExternalTopologyMode},
+			name: "Azure on hypershift, hardcoded value is used",
+			infra: &bootstrap.InfraStatus{
+				PlatformType:         configv1.AzurePlatformType,
+				ControlPlaneTopology: configv1.ExternalTopologyMode,
+				HostedControlPlane:   &hyperv1.HostedControlPlane{},
+			},
 			expectedMTU: 1500,
 		},
 		{
@@ -52,7 +61,7 @@ func TestProbeMTU(t *testing.T) {
 		},
 		{
 			name:  "Unknown platform on Hypershift, value from configmap is used",
-			infra: &bootstrap.InfraStatus{ControlPlaneTopology: configv1.ExternalTopologyMode},
+			infra: &bootstrap.InfraStatus{ControlPlaneTopology: configv1.ExternalTopologyMode, HostedControlPlane: &hyperv1.HostedControlPlane{}},
 			objects: []crclient.Object{&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Namespace: cmNamespace, Name: cmName},
 				Data:       map[string]string{"mtu": "5000"},


### PR DESCRIPTION
When the `ControlPlaneTopology` is set to `External` it does not always mean that HyperShift is also enabled. Instead of relying on `ControlPlaneTopology` value, always check if HyperShift is directly enabled.

It looks like in IBM ROKS  `ControlPlaneTopology` is always set to `External` triggering the bug in CNO: https://github.com/openshift/ibm-roks-toolkit/blob/master/assets/cluster-bootstrap/cluster-infrastructure-02-config.yaml#L16

/cc @jcaamano 