### PR TITLE
[release-4.13] OCPBUGS-14888: Added safe-to-evict annotation to CNO components

### DIFF
--- a/bindata/cloud-network-config-controller/managed/controller.yaml
+++ b/bindata/cloud-network-config-controller/managed/controller.yaml
@@ -23,7 +23,7 @@ spec:
       name: cloud-network-config-controller
       annotations:
         hypershift.openshift.io/release-image: {{.ReleaseImage}}
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: "cloud-token,hosted-ca-cert"
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: "hosted-cluster-api-access,cloud-token,hosted-ca-cert"
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: cloud-network-config-controller

--- a/bindata/cloud-network-config-controller/managed/controller.yaml
+++ b/bindata/cloud-network-config-controller/managed/controller.yaml
@@ -23,6 +23,7 @@ spec:
       name: cloud-network-config-controller
       annotations:
         hypershift.openshift.io/release-image: {{.ReleaseImage}}
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: "cloud-token,hosted-ca-cert"
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: cloud-network-config-controller

--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -36,7 +36,8 @@ spec:
       annotations:
 {{- if .HyperShiftEnabled}}
         hypershift.openshift.io/release-image: {{.ReleaseImage}}
-{{- end }}      
+{{- end }}
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: "hosted-cluster-api-access"
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: multus-admission-controller

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -53,6 +53,7 @@ spec:
       annotations:
         hypershift.openshift.io/release-image: {{.ReleaseImage}}
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: "hosted-cluster-api-access"
       labels:
         app: ovnkube-master
         ovn-db-pod: "true"


### PR DESCRIPTION
Manual cherry pick from:

- https://github.com/openshift/cluster-network-operator/pull/1822
- https://github.com/openshift/cluster-network-operator/pull/1830

Which includes the annotations for safe eviction of local volumes by the autoscaler.