### PR TITLE
CCO-356: Add Infrastructures permission to CNCC cluster role

### DIFF
--- a/bindata/cloud-network-config-controller/common/002-rbac.yaml
+++ b/bindata/cloud-network-config-controller/common/002-rbac.yaml
@@ -25,6 +25,7 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - infrastructures
   - featuregates
   - clusterversions
   verbs:


### PR DESCRIPTION
Necessary for https://github.com/openshift/cloud-network-config-controller/pull/102 to access the cluster infrastructure object

/assign @kyrtapz 
/cc @jcaamano 