### PR TITLE
OCPBUGS-18114: Update node selector in various YAMLs

### DIFF
--- a/bindata/network-diagnostics/network-check-source.yaml
+++ b/bindata/network-diagnostics/network-check-source.yaml
@@ -65,7 +65,7 @@ spec:
             memory: 40Mi
             cpu: 10m
       nodeSelector:
-        beta.kubernetes.io/os: "linux"
+        kubernetes.io/os: "linux"
 
 ---
 apiVersion: v1

--- a/bindata/network-diagnostics/network-check-target.yaml
+++ b/bindata/network-diagnostics/network-check-target.yaml
@@ -64,7 +64,7 @@ spec:
       tolerations:
       - operator: "Exists"
       nodeSelector:
-        beta.kubernetes.io/os: "linux"
+        kubernetes.io/os: "linux"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/bindata/network/openshift-sdn/controller.yaml
+++ b/bindata/network/openshift-sdn/controller.yaml
@@ -116,8 +116,9 @@ spec:
             mountPath: /etc/pki/tls/metrics-certs
             readOnly: True
       hostNetwork: true
-{{- if not .ExternalControlPlane }}
       nodeSelector:
+        kubernetes.io/os: "linux"
+{{- if not .ExternalControlPlane }}
         node-role.kubernetes.io/master: ""
 {{- end }}
       priorityClassName: "system-cluster-critical"

--- a/bindata/network/ovn-kubernetes/common/ipsec-containerized.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-containerized.yaml
@@ -268,7 +268,7 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 60
       nodeSelector:
-        beta.kubernetes.io/os: "linux"
+        kubernetes.io/os: "linux"
       terminationGracePeriodSeconds: 10
       volumes:
       - name: host-var-log-ovs

--- a/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
@@ -283,7 +283,7 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 60
       nodeSelector:
-        beta.kubernetes.io/os: "linux"
+        kubernetes.io/os: "linux"
       terminationGracePeriodSeconds: 10
       volumes:
       - hostPath:

--- a/bindata/network/ovn-kubernetes/common/pre-puller.yaml
+++ b/bindata/network/ovn-kubernetes/common/pre-puller.yaml
@@ -36,6 +36,6 @@ spec:
           echo "$(date -Iseconds) - finished pulling ovnkube-node image."
           sleep infinity
       nodeSelector:
-        beta.kubernetes.io/os: "linux"
+        kubernetes.io/os: "linux"
       tolerations:
       - operator: "Exists"

--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -1049,7 +1049,7 @@ spec:
               fieldPath: spec.nodeName
       {{- end}}
       nodeSelector:
-        beta.kubernetes.io/os: "linux"
+        kubernetes.io/os: "linux"
       volumes:
       # for checking ovs-configuration service
       - name: systemd-units

--- a/bindata/network/ovn-kubernetes/managed/single-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/single-zone-interconnect/ovnkube-node.yaml
@@ -747,7 +747,7 @@ spec:
               fieldPath: spec.nodeName
       {{- end}}
       nodeSelector:
-        beta.kubernetes.io/os: "linux"
+        kubernetes.io/os: "linux"
       volumes:
       # for checking ovs-configuration service
       - name: systemd-units

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-control-plane.yaml
@@ -137,7 +137,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
       nodeSelector:
         node-role.kubernetes.io/master: ""
-        beta.kubernetes.io/os: "linux"
+        kubernetes.io/os: "linux"
       volumes:
       - name: ovnkube-config
         configMap:

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -1071,7 +1071,7 @@ spec:
               fieldPath: spec.nodeName
       {{- end}}
       nodeSelector:
-        beta.kubernetes.io/os: "linux"
+        kubernetes.io/os: "linux"
       volumes:
       # for checking ovs-configuration service
       - name: systemd-units

--- a/bindata/network/ovn-kubernetes/self-hosted/single-zone-interconnect/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/single-zone-interconnect/ovnkube-master.yaml
@@ -1007,7 +1007,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
       nodeSelector:
         node-role.kubernetes.io/master: ""
-        beta.kubernetes.io/os: "linux"
+        kubernetes.io/os: "linux"
       volumes:
       # for checking ovs-configuration service
       - name: systemd-units

--- a/bindata/network/ovn-kubernetes/self-hosted/single-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/single-zone-interconnect/ovnkube-node.yaml
@@ -642,7 +642,7 @@ spec:
               fieldPath: spec.nodeName
       {{- end}}
       nodeSelector:
-        beta.kubernetes.io/os: "linux"
+        kubernetes.io/os: "linux"
       volumes:
       # for checking ovs-configuration service
       - name: systemd-units


### PR DESCRIPTION
- Replace deprecated `beta.kubernetes.io/os` node selector with `kubernetes.io/os`
https://kubernetes.io/docs/reference/labels-annotations-taints/#beta-kubernetes-io-os-deprecated
- Add linux node selector to openshift-sdn/sdn-controller daemonset