### PR TITLE
Enable EgressService controller

### DIFF
--- a/bindata/network/ovn-kubernetes/common/001-crd.yaml
+++ b/bindata/network/ovn-kubernetes/common/001-crd.yaml
@@ -728,3 +728,128 @@ spec:
     storage: true
     subresources:
       status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
+  name: egressservices.k8s.ovn.org
+spec:
+  group: k8s.ovn.org
+  names:
+    kind: EgressService
+    listKind: EgressServiceList
+    plural: egressservices
+    singular: egressservice
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: EgressService is a CRD that allows the user to request that the
+          source IP of egress packets originating from all of the pods that are endpoints
+          of the corresponding LoadBalancer Service would be its ingress IP. In addition,
+          it allows the user to request that egress packets originating from all of
+          the pods that are endpoints of the LoadBalancer service would use a different
+          network than the main one.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EgressServiceSpec defines the desired state of EgressService
+            properties:
+              network:
+                description: The network which this service should send egress and
+                  corresponding ingress replies to. This is typically implemented
+                  as VRF mapping, representing a numeric id or string name of a routing
+                  table which by omission uses the default host routing.
+                type: string
+              nodeSelector:
+                description: Allows limiting the nodes that can be selected to handle
+                  the service's traffic when sourceIPBy=LoadBalancerIP. When present
+                  only a node whose labels match the specified selectors can be selected
+                  for handling the service's traffic. When it is not specified any
+                  node in the cluster can be chosen to manage the service's traffic.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              sourceIPBy:
+                description: Determines the source IP of egress traffic originating
+                  from the pods backing the LoadBalancer Service. When `LoadBalancerIP`
+                  the source IP is set to its LoadBalancer ingress IP. When `Network`
+                  the source IP is set according to the interface of the Network,
+                  leveraging the masquerade rules that are already in place. Typically
+                  these rules specify SNAT to the IP of the outgoing interface, which
+                  means the packet will typically leave with the IP of the node.
+                enum:
+                - LoadBalancerIP
+                - Network
+                type: string
+            type: object
+          status:
+            description: EgressServiceStatus defines the observed state of EgressService
+            properties:
+              host:
+                description: The name of the node selected to handle the service's
+                  traffic. In case sourceIPBy=Network the field will be set to "ALL".
+                type: string
+            required:
+            - host
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bindata/network/ovn-kubernetes/common/002-rbac.yaml
+++ b/bindata/network/ovn-kubernetes/common/002-rbac.yaml
@@ -92,6 +92,7 @@ rules:
 - apiGroups: ["k8s.ovn.org"]
   resources:
   - egressips
+  - egressservices
   - adminpolicybasedexternalroutes
   verbs:
   - get

--- a/bindata/network/ovn-kubernetes/common/003-rbac-controller.yaml
+++ b/bindata/network/ovn-kubernetes/common/003-rbac-controller.yaml
@@ -88,6 +88,8 @@ rules:
   - egressips
   - egressqoses
   - adminpolicybasedexternalroutes
+  - egressservices
+  - egressservices/status
   verbs:
   - get
   - list

--- a/bindata/network/ovn-kubernetes/common/007-rbac-cluster-reader.yaml
+++ b/bindata/network/ovn-kubernetes/common/007-rbac-cluster-reader.yaml
@@ -11,6 +11,7 @@ rules:
   - egressfirewalls
   - egressips
   - egressqoses
+  - egressservices
   - adminpolicybasedexternalroutes
   verbs:
   - get

--- a/bindata/network/ovn-kubernetes/managed/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/004-config.yaml
@@ -33,6 +33,7 @@ data:
     enable-egress-ip=true
     enable-egress-firewall=true
     enable-egress-qos=true
+    enable-egress-service=true
 {{- if .ReachabilityNodePort }}
     egressip-node-healthcheck-port={{.ReachabilityNodePort}}
 {{- end }}
@@ -108,6 +109,7 @@ data:
     enable-egress-ip=true
     enable-egress-firewall=true
     enable-egress-qos=true
+    enable-egress-service=true
 {{- if .ReachabilityNodePort }}
     egressip-node-healthcheck-port={{.ReachabilityNodePort}}
 {{- end }}

--- a/bindata/network/ovn-kubernetes/microshift/clusterrole.yaml
+++ b/bindata/network/ovn-kubernetes/microshift/clusterrole.yaml
@@ -55,6 +55,7 @@ rules:
 - apiGroups: ["k8s.ovn.org"]
   resources:
   - egressips
+  - egressservices
   verbs:
   - get
   - list
@@ -154,6 +155,8 @@ rules:
   - egressfirewalls
   - egressips
   - egressqoses
+  - egressservices
+  - egressservices/status
   verbs:
   - get
   - list

--- a/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
@@ -33,6 +33,7 @@ data:
     enable-egress-ip=true
     enable-egress-firewall=true
     enable-egress-qos=true
+    enable-egress-service=true
     {{- if .ReachabilityTotalTimeoutSeconds }}
     egressip-reachability-total-timeout={{.ReachabilityTotalTimeoutSeconds}}
     {{- end }}

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -207,6 +207,7 @@ healthz-bind-address="0.0.0.0:10256"
 enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
+enable-egress-service=true
 egressip-node-healthcheck-port=9107
 enable-multi-network=true
 
@@ -238,6 +239,7 @@ healthz-bind-address="0.0.0.0:10256"
 enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
+enable-egress-service=true
 egressip-node-healthcheck-port=9107
 enable-multi-network=true
 
@@ -272,6 +274,7 @@ healthz-bind-address="0.0.0.0:10256"
 enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
+enable-egress-service=true
 egressip-node-healthcheck-port=9107
 enable-multi-network=true
 
@@ -317,6 +320,7 @@ healthz-bind-address="0.0.0.0:10256"
 enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
+enable-egress-service=true
 egressip-reachability-total-timeout=3
 egressip-node-healthcheck-port=9107
 enable-multi-network=true
@@ -365,6 +369,7 @@ healthz-bind-address="0.0.0.0:10256"
 enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
+enable-egress-service=true
 egressip-reachability-total-timeout=0
 egressip-node-healthcheck-port=9107
 enable-multi-network=true
@@ -413,6 +418,7 @@ healthz-bind-address="0.0.0.0:10256"
 enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
+enable-egress-service=true
 egressip-node-healthcheck-port=9107
 enable-multi-network=true
 
@@ -460,6 +466,7 @@ healthz-bind-address="0.0.0.0:10256"
 enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
+enable-egress-service=true
 egressip-node-healthcheck-port=9107
 enable-multi-network=true
 
@@ -496,6 +503,7 @@ healthz-bind-address="0.0.0.0:10256"
 enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
+enable-egress-service=true
 egressip-node-healthcheck-port=9107
 enable-multi-network=true
 
@@ -535,6 +543,7 @@ healthz-bind-address="0.0.0.0:10256"
 enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
+enable-egress-service=true
 egressip-node-healthcheck-port=9107
 enable-multi-network=true
 
@@ -567,6 +576,7 @@ healthz-bind-address="0.0.0.0:10256"
 enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
+enable-egress-service=true
 egressip-node-healthcheck-port=9107
 
 [gateway]
@@ -598,6 +608,7 @@ healthz-bind-address="0.0.0.0:10256"
 enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
+enable-egress-service=true
 egressip-node-healthcheck-port=9107
 enable-multi-network=true
 enable-multi-networkpolicy=true
@@ -631,6 +642,7 @@ healthz-bind-address="0.0.0.0:10256"
 enable-egress-ip=true
 enable-egress-firewall=true
 enable-egress-qos=true
+enable-egress-service=true
 egressip-node-healthcheck-port=9107
 
 [gateway]


### PR DESCRIPTION
This PR cherry-picks changes from https://github.com/openshift/cluster-network-operator/pull/1844 since Ori is out and there were conflicts. 

I resolved conflicts in:
- `bindata/network/ovn-kubernetes/common/001-crd.yaml`
- `bindata/network/ovn-kubernetes/common/003-rbac-controller.yaml`

Since https://github.com/ovn-org/ovn-kubernetes/pull/3567 got downstream [here](https://github.com/openshift/ovn-kubernetes/pull/1718) this PR should be ready to go in as well.