### PR TITLE
OCPBUGS-15282: Add release version annotation to whereabouts-reconciler

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -528,6 +528,8 @@ kind: DaemonSet
 metadata:
   name: whereabouts-reconciler
   namespace: openshift-multus
+  annotations:
+    release.openshift.io/version: "{{.ReleaseVersion}}"
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
CNO uses it to track whether updates to the daemonset have been done or
not. If not set, CNO won't set the overall operator version to the
target upgrade and the upgrade won't complete.