### PR TITLE
OCPBUGS-15794: fix: add missing annotation for workload partitioning

### DIFF
--- a/bindata/allowlist/daemonset/daemonset.yaml
+++ b/bindata/allowlist/daemonset/daemonset.yaml
@@ -12,6 +12,8 @@ spec:
     metadata:
       labels:
         app: cni-sysctl-allowlist-ds
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
         - name: kube-multus-additional-cni-plugins


### PR DESCRIPTION
To support the workload partitioning we need to add this required annotations
(https://github.com/openshift/enhancements/pull/703).