### PR TITLE
Revert "Remove oldest ovn acl log files when file limit exceeded"

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -247,7 +247,6 @@ spec:
 
           # Rotate audit log files when then get to max size (in bytes)
           MAXFILESIZE=$(( "{{.OVNPolicyAuditMaxFileSize}}"*1000000 ))
-          MAXLOGFILES="{{.OVNPolicyAuditMaxLogFiles}}"
           LOGFILE=/var/log/ovn/acl-audit-log.log
           CONTROLLERPID=$(cat /run/ovn/ovn-controller.pid)
 
@@ -270,13 +269,6 @@ spec:
               mv ${LOGFILE} /var/log/ovn/acl-audit-log.$timestamp.log
               ovs-appctl -t /run/ovn/ovn-controller.${CONTROLLERPID}.ctl vlog/reopen
               CONTROLLERPID=$(cat /run/ovn/ovn-controller.pid)
-            fi
-
-            # Ensure total number of log files does not exceed the maximum configured from OVNPolicyAuditMaxLogFiles
-            num_files=$(ls -1 $log_dir/acl-audit-log* 2>/dev/null | wc -l)
-            if [ "$num_files" -gt "MAXLOGFILES" ]; then
-              num_to_delete=$(( num_files - ${MAXLOGFILES} ))
-              ls -1t $log_dir/acl-audit-log* 2>/dev/null | tail -$num_to_delete | xargs -I {} rm {}
             fi
 
             # sleep for 30 seconds to avoid wasting CPU

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -244,7 +244,6 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["IPFIXSampling"] = ""
 	data.Data["OVNPolicyAuditRateLimit"] = c.PolicyAuditConfig.RateLimit
 	data.Data["OVNPolicyAuditMaxFileSize"] = c.PolicyAuditConfig.MaxFileSize
-	data.Data["OVNPolicyAuditMaxLogFiles"] = c.PolicyAuditConfig.MaxLogFiles
 	data.Data["OVNPolicyAuditDestination"] = c.PolicyAuditConfig.Destination
 	data.Data["OVNPolicyAuditSyslogFacility"] = c.PolicyAuditConfig.SyslogFacility
 	data.Data["OVN_LOG_PATTERN_CONSOLE"] = OVN_LOG_PATTERN_CONSOLE


### PR DESCRIPTION
This reverts commit abd3596bb843df4b3c950b91eda411e5a245b156.

Caused 4.14 ci release stream to block
https://amd64.ocp.releases.ci.openshift.org/releasestream/4.14.0-0.ci/release/4.14.0-0.ci-2023-07-07-055606

Container `ovn-acl-logging` is crashing with `/bin/bash: line 31: log_dir: unbound variable`