### PR TITLE
OCPBUGS-15962: Add logic to pick the ovn-k8s-cni-overlay binary from the right dir

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -381,7 +381,49 @@ spec:
             set +o allexport
           fi
           echo "I$(date "+%m%d %H:%M:%S.%N") - waiting for db_ip addresses"
-          cp -f /usr/libexec/cni/ovn-k8s-cni-overlay /cni-bin-dir/
+
+          function log()
+          {
+              echo "$(date --iso-8601=seconds) [cnibincopy] ${1}"
+          }
+          # collect host os information
+          . /host/etc/os-release
+          rhelmajor=
+          # detect which version we're using in order to copy the proper binaries
+          case "${ID}" in
+            rhcos|scos)
+              rhelmajor=$(echo $RHEL_VERSION | sed -E 's/([0-9]+)\.{1}[0-9]+(\.[0-9]+)?/\1/')
+            ;;
+            rhel) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)
+            ;;
+            fedora)
+              if [ "${VARIANT_ID}" == "coreos" ]; then
+                rhelmajor=8
+              else
+                log "FATAL ERROR: Unsupported Fedora variant=${VARIANT_ID}"
+                exit 1
+              fi
+            ;;
+            *) log "FATAL ERROR: Unsupported OS ID=${ID}"; exit 1
+            ;;
+          esac
+
+          # Set which directory we'll copy from, detect if it exists
+          sourcedir=/usr/libexec/cni/
+          case "${rhelmajor}" in
+          8)
+            sourcedir=/usr/libexec/cni/rhel8
+          ;;
+          9)
+            sourcedir=/usr/libexec/cni/rhel9
+          ;;
+          *)
+            log "ERROR: RHEL Major Version Unsupported, rhelmajor=${rhelmajor}"
+          ;;
+          esac
+          
+          cp -f "$sourcedir/ovn-k8s-cni-overlay" /cni-bin-dir/
+
           ovn_config_namespace=openshift-ovn-kubernetes
           echo "I$(date "+%m%d %H:%M:%S.%N") - disable conntrack on geneve port"
           iptables -t raw -A PREROUTING -p udp --dport {{.GenevePort}} -j NOTRACK

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -290,7 +290,49 @@ spec:
             source "/env/${K8S_NODE}"
             set +o allexport
           fi
-          cp -f /usr/libexec/cni/ovn-k8s-cni-overlay /cni-bin-dir/
+
+          function log()
+          {
+              echo "$(date --iso-8601=seconds) [cnibincopy] ${1}"
+          }
+
+          # collect host os information
+          . /host/etc/os-release
+          rhelmajor=
+          # detect which version we're using in order to copy the proper binaries
+          case "${ID}" in
+            rhcos|scos)
+              rhelmajor=$(echo $RHEL_VERSION | sed -E 's/([0-9]+)\.{1}[0-9]+(\.[0-9]+)?/\1/')
+            ;;
+            rhel) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)
+            ;;
+            fedora)
+              if [ "${VARIANT_ID}" == "coreos" ]; then
+                rhelmajor=8
+              else
+                log "FATAL ERROR: Unsupported Fedora variant=${VARIANT_ID}"
+                exit 1
+              fi
+            ;;
+            *) log "FATAL ERROR: Unsupported OS ID=${ID}"; exit 1
+            ;;
+          esac
+
+          # Set which directory we'll copy from, detect if it exists
+          sourcedir=/usr/libexec/cni/
+          case "${rhelmajor}" in
+          8)
+            sourcedir=/usr/libexec/cni/rhel8
+          ;;
+          9)
+            sourcedir=/usr/libexec/cni/rhel9
+          ;;
+          *)
+            log "ERROR: RHEL Major Version Unsupported, rhelmajor=${rhelmajor}"
+          ;;
+          esac
+          
+          cp -f "$sourcedir/ovn-k8s-cni-overlay" /cni-bin-dir/
           ovn_config_namespace=openshift-ovn-kubernetes
           echo "I$(date "+%m%d %H:%M:%S.%N") - disable conntrack on geneve port"
           iptables -t raw -A PREROUTING -p udp --dport {{.GenevePort}} -j NOTRACK


### PR DESCRIPTION
Add logic to pick the ovn-k8s-cni-overlay binary from the right source directory.

This change is required so that we pick the right binary based on the base OS version to not fail glibc linkage for FIPS.