### PR TITLE
OCPBUGS-15977: Add logic to pick the openshift-sdn shims from right directories

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -103,9 +103,49 @@ spec:
             set +o allexport
           fi
 
+          function log()
+          {
+              echo "$(date --iso-8601=seconds) [cnibincopy] ${1}"
+          }
+          # collect host os information
+          . /host/etc/os-release
+          rhelmajor=
+          # detect which version we're using in order to copy the proper binaries
+          case "${ID}" in
+            rhcos|scos)
+              rhelmajor=$(echo $RHEL_VERSION | sed -E 's/([0-9]+)\.{1}[0-9]+(\.[0-9]+)?/\1/')
+            ;;
+            rhel) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)
+            ;;
+            fedora)
+              if [ "${VARIANT_ID}" == "coreos" ]; then
+                rhelmajor=8
+              else
+                log "FATAL ERROR: Unsupported Fedora variant=${VARIANT_ID}"
+                exit 1
+              fi
+            ;;
+            *) log "FATAL ERROR: Unsupported OS ID=${ID}"; exit 1
+            ;;
+          esac
+
+          # Set which directory we'll copy from, detect if it exists
+          sourcedir=/opt/cni/bin
+          case "${rhelmajor}" in
+          8)
+            sourcedir=/opt/cni/bin/rhel8
+          ;;
+          9)
+            sourcedir=/opt/cni/bin/rhel9
+          ;;
+          *)
+            log "ERROR: RHEL Major Version Unsupported, rhelmajor=${rhelmajor}"
+          ;;
+          esac
+          
           # Take over network functions on the node
           rm -f /etc/cni/net.d/80-openshift-network.conf
-          cp -f /opt/cni/bin/openshift-sdn /host-cni-bin/
+          cp -f "$sourcedir/openshift-sdn" /host-cni-bin/
 
           mtu_override_flag=
           if [[ -f /config-mtu-migration/mtu.yaml ]]; then


### PR DESCRIPTION
Add logic to pick the sdn shim binaries from the correct source directories based on host os release. This change is required so that we pick the right binary based on the base OS version to not fail glibc linkage for FIPS.