### PR TITLE
OCPBUGS-15544: Enable multi-external-gateway feature by default for managed and hosted clusters

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -904,7 +904,8 @@ spec:
             --node-server-cert ${TLS_CERT} \
             ${multi_network_enabled_flag} \
             ${multi_network_policy_enabled_flag} \
-            --acl-logging-rate-limit "{{.OVNPolicyAuditRateLimit}}"
+            --acl-logging-rate-limit "{{.OVNPolicyAuditRateLimit}}" \
+            --enable-multi-external-gateway=true
         volumeMounts:
         - mountPath: /etc/ovn
           name: datadir

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -493,7 +493,8 @@ spec:
             ${export_network_flows_flags} \
             ${multi_network_enabled_flag} \
             ${multi_network_policy_enabled_flag} \
-            ${gw_interface_flag}
+            ${gw_interface_flag} \
+            --enable-multi-external-gateway=true
         env:
         # for kubectl
         - name: KUBERNETES_SERVICE_PORT

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
@@ -862,7 +862,8 @@ spec:
             --disable-snat-multiple-gws \
             ${multi_network_enabled_flag} \
             ${multi_network_policy_enabled_flag} \
-            --acl-logging-rate-limit "{{.OVNPolicyAuditRateLimit}}"
+            --acl-logging-rate-limit "{{.OVNPolicyAuditRateLimit}}" \
+            --enable-multi-external-gateway=true
         volumeMounts:
         # for checking ovs-configuration service
         - mountPath: /etc/systemd/system

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -400,7 +400,8 @@ spec:
             ${export_network_flows_flags} \
             ${multi_network_enabled_flag} \
             ${multi_network_policy_enabled_flag} \
-            ${gw_interface_flag}
+            ${gw_interface_flag} \
+            --enable-multi-external-gateway=true
         env:
         # for kubectl
         - name: KUBERNETES_SERVICE_PORT


### PR DESCRIPTION
Add --enable-multi-external-gateway flag, since we disabled this feature on ovn-k by default. Don't enable this feature for microshift.