### PR TITLE
Bug 16136: change whereabouts ip reconciler exec

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -556,7 +556,7 @@ spec:
         args:
           - -c
           - >
-            /usr/src/whereabouts/bin/ip-control-loop -log-level debug
+            /usr/src/whereabouts/bin/entrypoint.sh -log-level debug
         image: {{.WhereaboutsImage}}
         env:
         - name: WHEREABOUTS_NAMESPACE


### PR DESCRIPTION
It changes to invoke entrypoint.sh instead of ip-control-loop directly to run corresponding container base OS version binary.