### PR TITLE
OCPBUGS-15945: Stop using utilruntime.PanicHandlers to handle reconciliation panics

### DIFF
--- a/pkg/controller/allowlist/allowlist_controller.go
+++ b/pkg/controller/allowlist/allowlist_controller.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	v1coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -82,6 +83,7 @@ type ReconcileAllowlist struct {
 }
 
 func (r *ReconcileAllowlist) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	defer utilruntime.HandleCrash(r.status.SetDegradedOnPanicAndCrash)
 	if exists, err := daemonsetConfigExists(ctx, r.client); !exists {
 		err = createObjects(ctx, r.client, allowlistManifestDir)
 		if err != nil {

--- a/pkg/controller/clusterconfig/clusterconfig_controller.go
+++ b/pkg/controller/clusterconfig/clusterconfig_controller.go
@@ -16,6 +16,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -64,6 +65,7 @@ type ReconcileClusterConfig struct {
 // In other words, it watches Network.config.openshift.io/v1/cluster and updates
 // Network.operator.openshift.io/v1/cluster.
 func (r *ReconcileClusterConfig) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	defer utilruntime.HandleCrash(r.status.SetDegradedOnPanicAndCrash)
 	log.Printf("Reconciling Network.config.openshift.io %s\n", request.Name)
 
 	// We won't create more than one network

--- a/pkg/controller/configmap_ca_injector/controller.go
+++ b/pkg/controller/configmap_ca_injector/controller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/util/validation"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -115,6 +116,7 @@ type ReconcileConfigMapInjector struct {
 // 2. a configmap in any namespace with the label config.openshift.io/inject-trusted-cabundle = true and will insure that it contains the ca-bundle.crt
 // entry in the configmap named trusted-ca-bundle in namespace openshift-config-managed.
 func (r *ReconcileConfigMapInjector) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	defer utilruntime.HandleCrash(r.status.SetDegradedOnPanicAndCrash)
 	log.Printf("Reconciling configmap from  %s/%s\n", request.Namespace, request.Name)
 
 	trustedCAbundleConfigMap, err := r.nsLister.ConfigMaps(names.TRUSTED_CA_BUNDLE_CONFIGMAP_NS).Get(names.TRUSTED_CA_BUNDLE_CONFIGMAP)

--- a/pkg/controller/egress_router/egress_router_controller.go
+++ b/pkg/controller/egress_router/egress_router_controller.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
 
 	netopv1 "github.com/openshift/api/networkoperator/v1"
@@ -88,6 +89,7 @@ func newEgressRouterReconciler(mgr manager.Manager, status *statusmanager.Status
 }
 
 func (r EgressRouterReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	defer utilruntime.HandleCrash(r.status.SetDegradedOnPanicAndCrash)
 	klog.Infof("Reconciling egressrouter.network.operator.openshift.io %s\n", request.NamespacedName)
 
 	obj := &netopv1.EgressRouter{}

--- a/pkg/controller/infrastructureconfig/infrastructureconfig_controller.go
+++ b/pkg/controller/infrastructureconfig/infrastructureconfig_controller.go
@@ -11,6 +11,7 @@ import (
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 	"github.com/openshift/cluster-network-operator/pkg/controller/statusmanager"
 	"github.com/openshift/cluster-network-operator/pkg/names"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,6 +66,7 @@ type ReconcileInfrastructureConfig struct {
 // new and deprecated API & Ingress VIP fields to have consistent APIs between
 // versions.
 func (r *ReconcileInfrastructureConfig) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	defer utilruntime.HandleCrash(r.status.SetDegradedOnPanicAndCrash)
 	log.Printf("Reconciling Infrastructure.config.openshift.io %s\n", request.Name)
 
 	// Only check on the default infrastructure config

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	v1coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -157,6 +158,8 @@ type ReconcileOperConfig struct {
 // Reconcile updates the state of the cluster to match that which is desired
 // in the operator configuration (Network.operator.openshift.io)
 func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	defer utilruntime.HandleCrash(r.status.SetDegradedOnPanicAndCrash)
+
 	log.Printf("Reconciling Network.operator.openshift.io %s\n", request.Name)
 
 	// We won't create more than one network

--- a/pkg/controller/pki/pki_controller.go
+++ b/pkg/controller/pki/pki_controller.go
@@ -27,6 +27,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -101,6 +102,7 @@ func newPKIReconciler(mgr manager.Manager, status *statusmanager.StatusManager) 
 
 // Reconcile configures a CertRotationController from a PKI object
 func (r *PKIReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	defer utilruntime.HandleCrash(r.status.SetDegradedOnPanicAndCrash)
 	log.Printf("Reconciling pki.network.operator.openshift.io %s\n", request.NamespacedName)
 
 	obj := &netopv1.OperatorPKI{}

--- a/pkg/controller/proxyconfig/controller.go
+++ b/pkg/controller/proxyconfig/controller.go
@@ -14,6 +14,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	v1coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
 
@@ -93,6 +94,7 @@ type ReconcileProxyConfig struct {
 // named "cluster" or a configmap object in namespace "openshift-config"
 // and will ensure either object is in the desired state.
 func (r *ReconcileProxyConfig) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	defer utilruntime.HandleCrash(r.status.SetDegradedOnPanicAndCrash)
 	validate := true
 	trustBundle := &corev1.ConfigMap{}
 

--- a/pkg/controller/signer/signer-controller.go
+++ b/pkg/controller/signer/signer-controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/library-go/pkg/crypto"
 	csrv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"k8s.io/client-go/kubernetes"
 
@@ -95,6 +96,7 @@ type ReconcileCSR struct {
 
 // Reconcile CSR
 func (r *ReconcileCSR) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	defer utilruntime.HandleCrash(r.status.SetDegradedOnPanicAndCrash)
 	csr := &csrv1.CertificateSigningRequest{}
 	err := r.client.Get(ctx, request.NamespacedName, csr)
 	if err != nil {

--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -527,6 +527,13 @@ func (status *StatusManager) SetDegraded(statusLevel StatusLevel, reason, messag
 	status.setDegraded(statusLevel, reason, message)
 }
 
+func (status *StatusManager) SetDegradedOnPanicAndCrash(panicVal interface{}) {
+	status.Lock()
+	defer status.Unlock()
+	status.setDegraded(PanicLevel, "ReconcileError", fmt.Sprintf("Panic detected: %v", panicVal))
+	panic(panicVal)
+}
+
 func (status *StatusManager) SetNotDegraded(statusLevel StatusLevel) {
 	status.Lock()
 	defer status.Unlock()


### PR DESCRIPTION
`utilruntime.PanicHandlers` is a global slice of fuctions that can be ran when a panic occurs. One of the places this happens is:
https://github.com/openshift/cluster-network-operator/blob/db57a477b10f517bc4ae501d95cc7b8398a8755c/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission/webhook.go#L157 If the panic handlers are ran in a http handler any panics that happen will get supressed: https://github.com/golang/go/blob/49d42128fd8594c172162961ead19ac95e247d24/src/net/http/server.go#L1865-L1870
This means CNO cannot just add a `panic()` to a handler in utilruntime.PanicHandlers because it can result in it setting the degraded status without exiting the process.

Use `utilruntime.HandleCrash` with an additional handler for each reconciler to avoid affecting other components and dependencies.
I opted to forward the panic in `SetDegradedOnPanicAndCrash` instead of using `OPENSHIFT_ON_PANIC=crash` because the latter makes it so any panic handled with `utilruntime.HandleCrash` (in any module) will cause a further panic: https://github.com/openshift/cluster-network-operator/blob/75af28f15ab7ae91cb5834c955bdac4601e8b007/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go#L56
I think the approach proposed here gives us more granular control over how we handle the panics in each of the controllers and is more suited for future changes.


Synthetic reproducer: https://github.com/openshift/cluster-network-operator/pull/1892
Failure in the reproducer: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_cluster-network-operator/1892/pull-ci-openshift-cluster-network-operator-master-e2e-gcp-sdn/1681235354356551680/artifacts/e2e-gcp-sdn/gather-extra/artifacts/pods/openshift-network-operator_network-operator-57886b94cc-pqp9p_network-operator.log
Example failure in CI: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.14-e2e-gcp-sdn/1681059506030645248/artifacts/e2e-gcp-sdn/gather-extra/artifacts/pods/openshift-network-operator_network-operator-78b9f5cb94-55zpc_network-operator.log