### PR TITLE
OCPBUGS-16019: prevent creation of multiple cni-sysctl-allowlist-ds pods

### DIFF
--- a/pkg/controller/allowlist/allowlist_controller.go
+++ b/pkg/controller/allowlist/allowlist_controller.go
@@ -2,6 +2,7 @@ package allowlist
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/names"
 	"github.com/openshift/cluster-network-operator/pkg/render"
 	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -114,12 +116,14 @@ func (r *ReconcileAllowlist) Reconcile(ctx context.Context, request reconcile.Re
 	defer cleanup(ctx, r.client)
 
 	// If daemonset still exists, delete it and reconcile again
-	if daemonsetExists, err := daemonsetExists(ctx, r.client); daemonsetExists {
-		klog.Errorln("Allowlist daemonset already exists: deleting and retrying")
-		return reconcile.Result{}, errors.New("retrying")
-	} else if err != nil {
+	ds, err := getDaemonSet(ctx, r.client)
+	if err != nil {
 		klog.Errorf("Failed to look up allowlist daemonset: %v", err)
 		return reconcile.Result{}, err
+	}
+	if ds != nil {
+		klog.Errorln("Allowlist daemonset already exists: deleting and retrying")
+		return reconcile.Result{}, errors.New("retrying")
 	}
 
 	err = createObjects(ctx, r.client, manifestDir)
@@ -184,6 +188,14 @@ func createObject(ctx context.Context, client cnoclient.Client, obj *unstructure
 
 func checkDsPodsReady(ctx context.Context, client cnoclient.Client) error {
 	return wait.PollUntilContextTimeout(ctx, time.Second, time.Minute, false, func(ctx context.Context) (done bool, err error) {
+		ds, err := getDaemonSet(ctx, client)
+		if err != nil {
+			return false, err
+		}
+		if ds == nil || ds.GetUID() == "" {
+			return false, fmt.Errorf("failed to get UID of daemon set")
+		}
+
 		podList, err := client.Default().Kubernetes().CoreV1().Pods(names.MULTUS_NAMESPACE).List(
 			ctx, metav1.ListOptions{LabelSelector: allowlistAnnotation})
 		if err != nil {
@@ -195,6 +207,11 @@ func checkDsPodsReady(ctx context.Context, client cnoclient.Client) error {
 		}
 
 		for _, pod := range podList.Items {
+			// Ignore pods that are not owned by current daemon set.
+			if len(pod.GetOwnerReferences()) == 0 || pod.GetOwnerReferences()[0].UID != ds.GetUID() {
+				continue
+			}
+
 			if len(pod.Status.ContainerStatuses) == 0 || !pod.Status.ContainerStatuses[0].Ready {
 				return false, nil
 			}
@@ -204,17 +221,20 @@ func checkDsPodsReady(ctx context.Context, client cnoclient.Client) error {
 }
 
 func cleanup(ctx context.Context, client cnoclient.Client) {
-	if exists, err := daemonsetExists(ctx, client); exists {
-		err = deleteDeamonSet(ctx, client)
+	ds, err := getDaemonSet(ctx, client)
+	if err != nil {
+		klog.Errorf("Error looking up allowlist daemonset : %+v", err)
+		return
+	}
+	if ds != nil {
+		err = deleteDaemonSet(ctx, client)
 		if err != nil {
 			klog.Errorf("Error cleaning up allow list daemonset: %+v", err)
 		}
-	} else if err != nil && !apierrors.IsNotFound(err) {
-		klog.Errorf("Error looking up allowlist daemonset : %+v", err)
 	}
 }
 
-func deleteDeamonSet(ctx context.Context, client cnoclient.Client) error {
+func deleteDaemonSet(ctx context.Context, client cnoclient.Client) error {
 	err := client.Default().Kubernetes().AppsV1().DaemonSets(names.MULTUS_NAMESPACE).Delete(
 		ctx, allowlistDsName, metav1.DeleteOptions{})
 	if err != nil {
@@ -223,16 +243,16 @@ func deleteDeamonSet(ctx context.Context, client cnoclient.Client) error {
 	return nil
 }
 
-func daemonsetExists(ctx context.Context, client cnoclient.Client) (bool, error) {
+func getDaemonSet(ctx context.Context, client cnoclient.Client) (*appsv1.DaemonSet, error) {
 	ds, err := client.Default().Kubernetes().AppsV1().DaemonSets(names.MULTUS_NAMESPACE).Get(
 		ctx, allowlistDsName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return false, nil
+			return nil, nil
 		}
-		return false, err
+		return nil, err
 	}
-	return ds != nil, nil
+	return ds, nil
 }
 
 func daemonsetConfigExists(ctx context.Context, client cnoclient.Client) (bool, error) {

--- a/pkg/controller/allowlist/allowlist_controller.go
+++ b/pkg/controller/allowlist/allowlist_controller.go
@@ -134,7 +134,7 @@ func (r *ReconcileAllowlist) Reconcile(ctx context.Context, request reconcile.Re
 		return reconcile.Result{}, err
 	}
 
-	klog.Errorln("Successfully updated sysctl allowlist")
+	klog.Infoln("Successfully updated sysctl allowlist")
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/controller/allowlist/allowlist_controller.go
+++ b/pkg/controller/allowlist/allowlist_controller.go
@@ -128,10 +128,15 @@ func (r *ReconcileAllowlist) Reconcile(ctx context.Context, request reconcile.Re
 		return reconcile.Result{}, err
 	}
 
+	// Do not retry when pods are not ready. The daemonset has a BestEffort QoS which
+	// means that in some cases, the pods won't ever be scheduled.
+	// This also prevents unwanted retries when one or more pods are not ready due to
+	// issues with the cluster.
+	// https://issues.redhat.com/browse/OCPBUGS-15818
 	err = checkDsPodsReady(ctx, r.client)
 	if err != nil {
 		klog.Errorf("Failed to verify ready status on allowlist daemonset pods: %v", err)
-		return reconcile.Result{}, err
+		return reconcile.Result{}, nil
 	}
 
 	klog.Infoln("Successfully updated sysctl allowlist")


### PR DESCRIPTION
The daemonset has a BestEffort QoS which  means that in some cases, the pods won't ever be scheduled.
This also prevents unwanted retries when one or more pods are not ready due to issues with the cluster.
https://issues.redhat.com/browse/OCPBUGS-15818 (BestEffort Daemonset cni-sysctl-allowlist-ds)

When there are issues with the cluster such as in https://issues.redhat.com/browse/OCPBUGS-15284, some pods are stuck in the terminating state which affects subsequent reconciliations of the allowlist controller.



