### PR TITLE
ovn-k: Configure dns service namespace and name

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/004-config.yaml
@@ -28,6 +28,8 @@ data:
 {{- end  }}
     platform-type="{{.PlatformType}}"
     healthz-bind-address="0.0.0.0:10256"
+    dns-service-namespace="openshift-dns"
+    dns-service-name="dns-default"
  
     [ovnkubernetesfeature]
     enable-egress-ip=true
@@ -104,6 +106,8 @@ data:
     no-hostsubnet-nodes="kubernetes.io/os=windows"
 {{- end  }}
     platform-type="{{.PlatformType}}"
+    dns-service-namespace="openshift-dns"
+    dns-service-name="dns-default"
 
     [ovnkubernetesfeature]
     enable-egress-ip=true

--- a/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
@@ -28,6 +28,8 @@ data:
 {{- end  }}
     platform-type="{{.PlatformType}}"
     healthz-bind-address="0.0.0.0:10256"
+    dns-service-namespace="openshift-dns"
+    dns-service-name="dns-default"
  
     [ovnkubernetesfeature]
     enable-egress-ip=true

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -202,6 +202,8 @@ apiserver="https://testing.test:8443"
 host-network-namespace="openshift-host-network"
 platform-type="GCP"
 healthz-bind-address="0.0.0.0:10256"
+dns-service-namespace="openshift-dns"
+dns-service-name="dns-default"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
@@ -234,6 +236,8 @@ apiserver="https://testing.test:8443"
 host-network-namespace="openshift-host-network"
 platform-type="GCP"
 healthz-bind-address="0.0.0.0:10256"
+dns-service-namespace="openshift-dns"
+dns-service-name="dns-default"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
@@ -269,6 +273,8 @@ host-network-namespace="openshift-host-network"
 no-hostsubnet-nodes="kubernetes.io/os=windows"
 platform-type="GCP"
 healthz-bind-address="0.0.0.0:10256"
+dns-service-namespace="openshift-dns"
+dns-service-name="dns-default"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
@@ -315,6 +321,8 @@ host-network-namespace="openshift-host-network"
 no-hostsubnet-nodes="kubernetes.io/os=windows"
 platform-type="GCP"
 healthz-bind-address="0.0.0.0:10256"
+dns-service-namespace="openshift-dns"
+dns-service-name="dns-default"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
@@ -364,6 +372,8 @@ host-network-namespace="openshift-host-network"
 no-hostsubnet-nodes="kubernetes.io/os=windows"
 platform-type="GCP"
 healthz-bind-address="0.0.0.0:10256"
+dns-service-namespace="openshift-dns"
+dns-service-name="dns-default"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
@@ -413,6 +423,8 @@ host-network-namespace="openshift-host-network"
 no-hostsubnet-nodes="kubernetes.io/os=windows"
 platform-type="GCP"
 healthz-bind-address="0.0.0.0:10256"
+dns-service-namespace="openshift-dns"
+dns-service-name="dns-default"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
@@ -461,6 +473,8 @@ host-network-namespace="openshift-host-network"
 no-hostsubnet-nodes="kubernetes.io/os=windows"
 platform-type="GCP"
 healthz-bind-address="0.0.0.0:10256"
+dns-service-namespace="openshift-dns"
+dns-service-name="dns-default"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
@@ -498,6 +512,8 @@ apiserver="https://testing.test:8443"
 host-network-namespace="openshift-host-network"
 platform-type="GCP"
 healthz-bind-address="0.0.0.0:10256"
+dns-service-namespace="openshift-dns"
+dns-service-name="dns-default"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
@@ -538,6 +554,8 @@ apiserver="https://testing.test:8443"
 host-network-namespace="openshift-host-network"
 platform-type="GCP"
 healthz-bind-address="0.0.0.0:10256"
+dns-service-namespace="openshift-dns"
+dns-service-name="dns-default"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
@@ -571,6 +589,8 @@ apiserver="https://testing.test:8443"
 host-network-namespace="openshift-host-network"
 platform-type="GCP"
 healthz-bind-address="0.0.0.0:10256"
+dns-service-namespace="openshift-dns"
+dns-service-name="dns-default"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
@@ -603,6 +623,8 @@ apiserver="https://testing.test:8443"
 host-network-namespace="openshift-host-network"
 platform-type="GCP"
 healthz-bind-address="0.0.0.0:10256"
+dns-service-namespace="openshift-dns"
+dns-service-name="dns-default"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true
@@ -637,6 +659,8 @@ apiserver="https://testing.test:8443"
 host-network-namespace="openshift-host-network"
 platform-type="GCP"
 healthz-bind-address="0.0.0.0:10256"
+dns-service-namespace="openshift-dns"
+dns-service-name="dns-default"
 
 [ovnkubernetesfeature]
 enable-egress-ip=true


### PR DESCRIPTION
For the live-migration ovn-kuberntes features [1] CNO need to pass the namespace and name of the dns resolver service.

[1] https://github.com/ovn-org/ovn-kubernetes/pull/3478