### PR TITLE
CCO-294: Switch azure credentials request to use explicit permissions

### DIFF
--- a/manifests/02-cncc-credentials.yaml
+++ b/manifests/02-cncc-credentials.yaml
@@ -74,8 +74,11 @@ spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: AzureProviderSpec
-    roleBindings:
-      - role: Contributor
+    permissions:
+    - Microsoft.Network/networkInterfaces/read
+    - Microsoft.Network/networkInterfaces/write
+    - Microsoft.Compute/virtualMachines/read
+    - Microsoft.Network/virtualNetworks/read
 ---
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest


### PR DESCRIPTION
xref: [CCO-294](https://issues.redhat.com//browse/CCO-294)

This PR switches from using a blanket role binding to the more granular individual permissions.  A full list can be found here: https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations