### PR TITLE
[ovn-kubernetes] Make APB External Route namespace selector mandatory for a dynamic hop

### DIFF
--- a/bindata/network/ovn-kubernetes/common/001-crd.yaml
+++ b/bindata/network/ovn-kubernetes/common/001-crd.yaml
@@ -668,6 +668,7 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                       required:
+                      - namespaceSelector
                       - podSelector
                       type: object
                     type: array


### PR DESCRIPTION
Depends on this [PR](https://github.com/ovn-org/ovn-kubernetes/pull/3811) from the ovn-kubernetes repository.

@trozet @jcaamano @danwinship PTAL.