### PR TITLE
Remove certificatesigningrequests/update permission from ovnkubenode

### DIFF
--- a/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
+++ b/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
@@ -152,7 +152,6 @@ rules:
     - create
     - get
     - list
-    - update
 - apiGroups: ["security.openshift.io"]
   resources:
   - securitycontextconstraints


### PR DESCRIPTION
ovnkube-node creates and reads `certificatesigningrequests`, there is no need for it to have the update permission.
Upstream docs: https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/#authorization

/cc @jcaamano 