### PR TITLE
OCPBUGS-17379: HyperShift: Use K8S_POD_IP to determine whether to listen on dual-stack in nbdb/sbdb

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/single-zone-interconnect/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/single-zone-interconnect/ovnkube-master.yaml
@@ -407,8 +407,12 @@ spec:
                 if [[ "${pod_dns_name}" == "${CLUSTER_INITIATOR_IP}" ]]; then
                   echo "$(date -Iseconds) - nbdb - postStart - waiting for master to be selected"
 
+                  listen_dual_stack=""
+                  if [[ "${K8S_POD_IP}" == *":"* ]]; then
+                    listen_dual_stack=":[::]"
+                  fi
                   # set the connection and inactivity probe
-                  if ! retry 60 "inactivity-probe" "ovn-nbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_NB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_NB_INACTIVITY_PROBE}}"; then
+                  if ! retry 60 "inactivity-probe" "ovn-nbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_NB_PORT}}${listen_dual_stack} -- set connection . inactivity_probe={{.OVN_NB_INACTIVITY_PROBE}}"; then
                     exit 1
                   fi
 
@@ -731,8 +735,12 @@ spec:
                 if [[ "${pod_dns_name}" == "${CLUSTER_INITIATOR_IP}" ]]; then
                   echo "$(date -Iseconds) - sdb - postStart - waiting for master to be selected"
 
+                  listen_dual_stack=""
+                  if [[ "${K8S_POD_IP}" == *":"* ]]; then
+                    listen_dual_stack=":[::]"
+                  fi
                   # set the connection and inactivity probe
-                  if ! retry 60 "inactivity-probe" "ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_CONTROLLER_INACTIVITY_PROBE}}"; then
+                  if ! retry 60 "inactivity-probe" "ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}}${listen_dual_stack} -- set connection . inactivity_probe={{.OVN_CONTROLLER_INACTIVITY_PROBE}}"; then
                     exit 1
                   fi
 


### PR DESCRIPTION
`LISTEN_DUAL_STACK` is not calculated properly for HyperShift since ovnMasterAddresses are not IP addresses.
Use K8S_POD_IP to dynamically figure out the stack as we do for RAFT.