### PR TITLE
Adjust memory requests for some containers in multi-zone OVN-IC

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -146,7 +146,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 300Mi
+            memory: 100Mi
       - name: ovn-acl-logging
         image: "{{.OvnImage}}"
         command:
@@ -364,7 +364,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 300Mi
+            memory: 100Mi
         terminationMessagePolicy: FallbackToLogsOnError
 
       # nbdb: the northbound, or logical network object DB. In standalone mode listening on unix socket.
@@ -557,7 +557,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 300Mi
+            memory: 50Mi
         terminationMessagePolicy: FallbackToLogsOnError
 
       # sbdb: the southbound, or flow DB. In standalone mode listening on unix socket
@@ -695,7 +695,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 300Mi
+            memory: 50Mi
         terminationMessagePolicy: FallbackToLogsOnError
 
       - name: kube-rbac-proxy-controller

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -146,7 +146,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 300Mi
+            memory: 100Mi
       - name: ovn-acl-logging
         image: "{{.OvnImage}}"
         command:
@@ -366,7 +366,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 70Mi
+            memory: 100Mi
         terminationMessagePolicy: FallbackToLogsOnError
 
       # nbdb: the northbound, or logical network object DB. In standalone mode listening on unix socket.
@@ -574,7 +574,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 300Mi
+            memory: 50Mi
         terminationMessagePolicy: FallbackToLogsOnError
 
       # sbdb: the southbound, or flow DB. In standalone mode listening on unix socket
@@ -716,7 +716,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 300Mi
+            memory: 50Mi
         terminationMessagePolicy: FallbackToLogsOnError
 
       - name: kube-rbac-proxy-controller


### PR DESCRIPTION
Based on testing conducted that took telemetry data into account to create a representative workload, we see that the max memory usage of certain containers in the ovnkube-node is less than the requests.

Adjust requests based on testing, to avoid wasting unnecessary capacity on the node

Max container memory in MiB during testing:
northd: 85
ovn-controller-95
nbdb: 40
sbdb: 55

This commit only adjusts requests for multi-zone IC and leaves single-zone IC at defaults.