### PR TITLE
[wip] Do a rolling update of ovn control plane only if it's not SNO

### DIFF
--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-control-plane.yaml
@@ -13,11 +13,13 @@ spec:
   selector:
     matchLabels:
       app: ovnkube-control-plane
+{{ if not .IsSNO }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 1
       maxSurge: 0
+{{ end }}
   template:
     metadata:
       annotations:


### PR DESCRIPTION
In SNO we only have one copy of ovnkube-control-plane. If we keep the rolling update with `maxSurge=0` and `maxUnavailable=1`, upon upgrade the API server would delete the existing control plane pod and create a new one. This would result in a short window of time without any cluster manager pod running. Let's solve that by removing the rolling update all together for SNO.