### PR TITLE
IBMCloud specific: patch out management workload for dataplane component thats needed for bootstrapping

### DIFF
--- a/profile-patches/ibm-cloud-managed/0000_70_cluster-network-operator_03_deployment.yaml-patch
+++ b/profile-patches/ibm-cloud-managed/0000_70_cluster-network-operator_03_deployment.yaml-patch
@@ -4,3 +4,5 @@
     include.release.openshift.io/ibm-cloud-managed: "true"
 - op: remove
   path: /spec/template/spec/nodeSelector
+- op: remove
+  path: /spec/template/metadata/annotations/target.workload.openshift.io~1management


### PR DESCRIPTION
openshift-network-operator runs in the dataplane for IBM Cloud. 
4.13 introduced some changes that require worker nodes to be present on the cluster for deployments with this annotation to schedule: `target.workload.openshift.io/management`.
While this annotation is "preferred" it delays initial provisioning by ~5-15 minutes.

CNO is required for bootstrapping of worker nodes in openshift clusters. 

Removing this annotation on the CNO to allow for it to immediately schedule on a node to allow it complete provisioning. 

Slack Thread: https://ibm-argonauts.slack.com/archives/C015MKYUVSR/p1691784810280779

Concept doc that introduced this change for 4.13: https://github.com/dhellmann/openshift-enhancements/blob/f2faf86f757269fa1c0bf39023c3ae0911f0d413/enhancements/management-workload-partitioning.md