### PR TITLE
OCPBUGS-16051, OCPBUGS-3176: Enables IP Forwarding config in CNO

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -961,6 +961,15 @@ spec:
             multi_network_policy_enabled_flag="--enable-multi-networkpolicy"
           fi
 
+          # If IP Forwarding mode is global set it in the host here.
+          ip_forwarding_flag=
+          if [ "{{.IP_FORWARDING_MODE}}" == "Global" ]; then
+            sysctl -w net.ipv4.ip_forward=1
+            sysctl -w net.ipv6.conf.all.forwarding=1
+          else
+            ip_forwarding_flag="--disable-forwarding"
+          fi
+
           exec /usr/bin/ovnkube --init-node "${K8S_NODE}" \
             --config-file=/run/ovnkube-config/ovnkube.conf \
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
@@ -981,7 +990,8 @@ spec:
             --zone ${K8S_NODE} \
             --enable-interconnect \
             ${gw_interface_flag} \
-            --enable-multi-external-gateway=true
+            --enable-multi-external-gateway=true  \
+            ${ip_forwarding_flag}
         env:
         # for kubectl
         - name: KUBERNETES_SERVICE_PORT

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -983,6 +983,15 @@ spec:
             multi_network_policy_enabled_flag="--enable-multi-networkpolicy"
           fi
 
+          # If IP Forwarding mode is global set it in the host here.
+          ip_forwarding_flag=
+          if [ "{{.IP_FORWARDING_MODE}}" == "Global" ]; then
+            sysctl -w net.ipv4.ip_forward=1
+            sysctl -w net.ipv6.conf.all.forwarding=1
+          else
+            ip_forwarding_flag="--disable-forwarding"
+          fi
+
           exec /usr/bin/ovnkube --init-node "${K8S_NODE}" \
             --config-file=/run/ovnkube-config/ovnkube.conf \
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
@@ -1003,7 +1012,8 @@ spec:
             --zone ${K8S_NODE} \
             --enable-interconnect \
             ${gw_interface_flag} \
-            --enable-multi-external-gateway=true
+            --enable-multi-external-gateway=true \
+            ${ip_forwarding_flag}
         env:
         # for kubectl
         - name: KUBERNETES_SERVICE_PORT

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -344,7 +344,7 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 	}
 
 	// Generate the objects
-	objs, progressing, err := network.Render(&operConfig.Spec, bootstrapResult, ManifestPath, r.client, r.featureGates)
+	objs, progressing, err := network.Render(&newOperConfig.Spec, bootstrapResult, ManifestPath, r.client, r.featureGates)
 	if err != nil {
 		log.Printf("Failed to render: %v", err)
 		r.status.SetDegraded(statusmanager.OperatorConfig, "RenderError",


### PR DESCRIPTION
CNO will detect an upgrade scenario from 4.13->4.14. In this case, IP Forwarding is set in the API to Global mode. This is desired to not break users during upgrade who have features enabled that rely on this behavior (like Metal LB). In 4.13 IP Forwarding is set via MCO. During upgrade, CNO upgrades first and will detect the upgrade, and enable global IP forwarding. Upon node reboot during upgrade, MCO will remove the forwarding files, but the ovnkube-node container will re-enable forwarding at start up.

For non 4.13->4.14 upgrade scenarios, whatever the setting in the API is will be used (by default this is restricted forwarding).