### PR TITLE
OCPBUGS-17916: Fix IC configmap lookup in pod_status.go

### DIFF
--- a/pkg/controller/statusmanager/pod_status.go
+++ b/pkg/controller/statusmanager/pod_status.go
@@ -256,9 +256,9 @@ func (status *StatusManager) SetFromPods() {
 	// hack for 2-phase upgrade from non-IC to IC ovnk:
 	// don't update the version field until phase 2 is over
 	if icConfigMap, err := util.GetInterConnectConfigMap(status.client.ClientFor("").Kubernetes()); err == nil {
-		// When an upgrade from <= 4.13 is ongoing, the IC configmap exists and exhibits ongoing-upgrade=true.
+		// When an upgrade from <= 4.13 is ongoing, the IC configmap exists and exhibits ongoing-upgrade=''.
 		// When multizone control-plane and node have been rolled out (end of phase 2), the configmap is deleted.
-		if ongoingUpgrade, ok := icConfigMap.Data["ongoing-upgrade"]; ok && ongoingUpgrade == "true" {
+		if _, ok := icConfigMap.Data["ongoing-upgrade"]; ok {
 			reachedAvailableLevel = false
 		}
 	} else if !apierrors.IsNotFound(err) {

--- a/pkg/controller/statusmanager/pod_status.go
+++ b/pkg/controller/statusmanager/pod_status.go
@@ -263,6 +263,8 @@ func (status *StatusManager) SetFromPods() {
 		}
 	} else if !apierrors.IsNotFound(err) {
 		log.Printf("Failed to retrieve interconnect configmap: %v", err)
+		// don't risk reporting new version during zone mode migration until configmap retrieval is successful
+		reachedAvailableLevel = false
 	}
 
 	status.setNotDegraded(PodDeployment)

--- a/pkg/controller/statusmanager/pod_watcher.go
+++ b/pkg/controller/statusmanager/pod_watcher.go
@@ -117,6 +117,10 @@ func (s *StatusManager) AddPodWatcher(mgr manager.Manager) error {
 // Reconcile triggers a re-update of Status.
 func (p *PodWatcher) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	defer utilruntime.HandleCrash(p.status.SetDegradedOnPanicAndCrash)
+	if p.status.isOVNKubernetes == nil {
+		val := p.status.isClusterRunningOVNKubernetes()
+		p.status.isOVNKubernetes = &val
+	}
 	p.status.SetFromPods()
 	return reconcile.Result{}, nil
 }

--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -101,6 +101,10 @@ type StatusManager struct {
 	labelSelector labels.Selector
 
 	relatedObjects []configv1.ObjectReference
+
+	// used only for upgrades from <=4.13 to 4.14 with ovn-kubernetes
+	// TODO: remove in 4.15
+	isOVNKubernetes *bool
 }
 
 func New(client cnoclient.Client, name, cluster string) *StatusManager {

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -2450,7 +2450,7 @@ func prepareUpgradeToInterConnect(ovn bootstrap.OVNBootstrapResult, client cnocl
 		// if node and master DaemonSets have already upgraded to >= 4.14 single zone and
 		// we previously pushed a configmap for temporary single zone,
 		// patch the configmap and proceed with the migration to multizone.
-		klog.Infof("Upgrade to interconnect, phase2: patching tmp configmap for multizone")
+		klog.Infof("Upgrade to interconnect, phase2: patching IC configmap for multizone")
 
 		patch := []map[string]interface{}{
 			{


### PR DESCRIPTION
 During an upgrade from non-IC to IC, the CNO status logic looks up a well-known configmap that indicates whether the an upgrade to IC is ongoing in order not to report the new operator version (4.14) until the second and final phase of the IC upgrade is done.

The following corrections are needed:

 - CNO shouldn't report a new version if IC configmap can't be retrieved for whatever reason, as suggested in a review to the CNO PR that enabled IC support: https://github.com/openshift/cluster-network-operator/pull/1874#pullrequestreview-1560616992
- looking up the key "ongoing-upgrade" inside the IC configmap is enough; checking for its value to be "true" is not correct, since after code reviews it was decided not to set the value to "true", but to set it to an empty string;
- (optimization) CNO shouldn't look up the IC configmap if the cluster is not running ovn kubernetes 