### PR TITLE
OCPBUGS-17964: ovn-k, managed: Align join subnet configuration

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/common/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/common/004-config.yaml
@@ -52,6 +52,12 @@ data:
     [gateway]
     mode={{.OVN_GATEWAY_MODE}}
     nodeport=true
+{{- if (index . "V4JoinSubnet") }}
+    v4-join-subnet="{{.V4JoinSubnet}}"
+{{- end }}
+{{- if (index . "V6JoinSubnet") }}
+    v6-join-subnet="{{.V6JoinSubnet}}"
+{{- end }}
 {{- if .OVNHybridOverlayEnable }}
 
     [hybridoverlay]


### PR DESCRIPTION
At ovn-k managed config template both control plane and workers should have the same join subnet configuration.

Closes: https://issues.redhat.com/browse/OCPBUGS-17964