### PR TITLE
OCPBUGS-17391: do not run ovn-ctl stop... in preStop hook

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -338,13 +338,6 @@ spec:
             --n-threads={{.NorthdThreads}} &
 
           wait $!
-        lifecycle:
-          preStop:
-            exec:
-              command:
-                - /bin/bash
-                - -c
-                - OVN_MANAGE_OVSDB=no /usr/share/ovn/scripts/ovn-ctl stop_northd
         env:
         - name: OVN_LOG_LEVEL
           value: info
@@ -512,9 +505,6 @@ spec:
                 - /bin/bash
                 - -c
                 - |
-                  echo "$(date -Iseconds) - stopping nbdb"
-                  /usr/share/ovn/scripts/ovn-ctl stop_nb_ovsdb
-                  echo "$(date -Iseconds) - nbdb stopped"
                   rm -f /var/run/ovn/ovnnb_db.pid
         readinessProbe:
           initialDelaySeconds: 90
@@ -655,9 +645,6 @@ spec:
                 - /bin/bash
                 - -c
                 - |
-                  echo "$(date -Iseconds) - stopping sbdb"
-                  /usr/share/ovn/scripts/ovn-ctl stop_sb_ovsdb
-                  echo "$(date -Iseconds) - sbdb stopped"
                   rm -f /var/run/ovn/ovnsb_db.pid
         readinessProbe:
           initialDelaySeconds: 90

--- a/bindata/network/ovn-kubernetes/managed/single-zone-interconnect/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/single-zone-interconnect/ovnkube-master.yaml
@@ -173,13 +173,6 @@ spec:
             -C /ovn-ca/ca-bundle.crt &
 
           wait $!
-        lifecycle:
-          preStop:
-            exec:
-              command:
-                - /bin/bash
-                - -c
-                - OVN_MANAGE_OVSDB=no /usr/share/ovn/scripts/ovn-ctl stop_northd
         env:
         - name: OVN_LOG_LEVEL
           value: info
@@ -468,9 +461,6 @@ spec:
               - /bin/bash
               - -c
               - |
-                echo "$(date -Iseconds) - stopping nbdb"
-                /usr/share/ovn/scripts/ovn-ctl stop_nb_ovsdb
-                echo "$(date -Iseconds) - nbdb stopped"
                 rm -f /var/run/ovn/ovnnb_db.pid
         readinessProbe:
           initialDelaySeconds: 90
@@ -764,9 +754,6 @@ spec:
               - /bin/bash
               - -c
               - |
-                echo "$(date -Iseconds) - stopping sbdb"
-                /usr/share/ovn/scripts/ovn-ctl stop_sb_ovsdb
-                echo "$(date -Iseconds) - sbdb stopped"
                 rm -f /var/run/ovn/ovnsb_db.pid
         readinessProbe:
           initialDelaySeconds: 90

--- a/bindata/network/ovn-kubernetes/microshift/master/daemonset.yaml
+++ b/bindata/network/ovn-kubernetes/microshift/master/daemonset.yaml
@@ -72,13 +72,6 @@ spec:
             --pidfile /var/run/ovn/ovn-northd.pid &
 
           wait $!
-        lifecycle:
-          preStop:
-            exec:
-              command:
-                - /bin/bash
-                - -c
-                - OVN_MANAGE_OVSDB=no /usr/share/ovn/scripts/ovn-ctl stop_northd
         env:
         - name: OVN_LOG_LEVEL
           value: info
@@ -194,9 +187,6 @@ spec:
               - /bin/bash
               - -c
               - |
-                echo "$(date -Iseconds) - stopping nbdb"
-                /usr/share/ovn/scripts/ovn-ctl stop_nb_ovsdb
-                echo "$(date -Iseconds) - nbdb stopped"
                 rm -f /var/run/ovn/ovnnb_db.pid
         readinessProbe:
           timeoutSeconds: 5
@@ -294,9 +284,6 @@ spec:
               - /bin/bash
               - -c
               - |
-                echo "$(date -Iseconds) - stopping sbdb"
-                /usr/share/ovn/scripts/ovn-ctl stop_sb_ovsdb
-                echo "$(date -Iseconds) - sbdb stopped"
                 rm -f /var/run/ovn/ovnsb_db.pid
         readinessProbe:
           timeoutSeconds: 5

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -338,13 +338,6 @@ spec:
             --pidfile /var/run/ovn/ovn-northd.pid \
             --n-threads={{.NorthdThreads}} &
           wait $!
-        lifecycle:
-          preStop:
-            exec:
-              command:
-                - /bin/bash
-                - -c
-                - OVN_MANAGE_OVSDB=no /usr/share/ovn/scripts/ovn-ctl stop_northd
         env:
         - name: OVN_LOG_LEVEL
           value: info
@@ -522,9 +515,6 @@ spec:
                 - /bin/bash
                 - -c
                 - |
-                  echo "$(date -Iseconds) - stopping nbdb"
-                  /usr/share/ovn/scripts/ovn-ctl stop_nb_ovsdb
-                  echo "$(date -Iseconds) - nbdb stopped"
                   rm -f /var/run/ovn/ovnnb_db.pid
         readinessProbe:
 {{ if not .IsSNO }}
@@ -671,9 +661,6 @@ spec:
                 - /bin/bash
                 - -c
                 - |
-                  echo "$(date -Iseconds) - stopping sbdb"
-                  /usr/share/ovn/scripts/ovn-ctl stop_sb_ovsdb
-                  echo "$(date -Iseconds) - sbdb stopped"
                   rm -f /var/run/ovn/ovnsb_db.pid
         readinessProbe:
 {{ if not .IsSNO }}

--- a/bindata/network/ovn-kubernetes/self-hosted/single-zone-interconnect/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/single-zone-interconnect/ovnkube-master.yaml
@@ -93,13 +93,6 @@ spec:
             -C /ovn-ca/ca-bundle.crt &
 
           wait $!
-        lifecycle:
-          preStop:
-            exec:
-              command:
-                - /bin/bash
-                - -c
-                - OVN_MANAGE_OVSDB=no /usr/share/ovn/scripts/ovn-ctl stop_northd
         env:
         - name: OVN_LOG_LEVEL
           value: info
@@ -414,9 +407,6 @@ spec:
               - /bin/bash
               - -c
               - |
-                echo "$(date -Iseconds) - stopping nbdb"
-                /usr/share/ovn/scripts/ovn-ctl stop_nb_ovsdb
-                echo "$(date -Iseconds) - nbdb stopped"
                 rm -f /var/run/ovn/ovnnb_db.pid
         readinessProbe:
 {{ if not .IsSNO }}
@@ -766,9 +756,6 @@ spec:
               - /bin/bash
               - -c
               - |
-                echo "$(date -Iseconds) - stopping sbdb"
-                /usr/share/ovn/scripts/ovn-ctl stop_sb_ovsdb
-                echo "$(date -Iseconds) - sbdb stopped"
                 rm -f /var/run/ovn/ovnsb_db.pid
         readinessProbe:
 {{ if not .IsSNO }}


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/OCPBUGS-17391

it's killing the container and due to recent changes somewhere in openshift (possibly these cri-o stop handling changes [0]), deleting the ovnkube pods will see them stuck in Terminating state with the containers all Exited but kubelet showing them as Running. Eventually (~3m) the pod will finally restart, but if we let cri-o sigterm kill the containers instead the pod will restart normally right away.

[0] https://github.com/cri-o/cri-o/pull/7168