### PR TITLE
use sleep instead of wait

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -160,7 +160,7 @@ spec:
           trap quit TERM INT
 
           echo "$(date -Iseconds) - starting ovn-northd"
-          exec ovn-northd \
+          nohup ovn-northd \
             --no-chdir "-vconsole:${OVN_LOG_LEVEL}" -vfile:off "-vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
             --ovnnb-db "{{.OVN_NB_DB_LIST}}" \
             --ovnsb-db "{{.OVN_SB_DB_LIST}}" \
@@ -170,7 +170,7 @@ spec:
             -c /ovn-cert/tls.crt \
             -C /ovn-ca/ca-bundle.crt &
 
-          wait $!
+          while true; do sleep 10; done
         lifecycle:
           preStop:
             exec:
@@ -321,14 +321,14 @@ spec:
             if ${cluster_found}; then
               echo "Cluster already exists for DB: ${db}"
               # join existing cluster
-              exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
+              nohup /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
               --db-nb-cluster-remote-port={{.OVN_NB_RAFT_PORT}} \
               --db-nb-cluster-remote-addr=${init_ip} \
               --db-nb-cluster-remote-proto=ssl \
               --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
               run_nb_ovsdb &
 
-              wait $!
+              while true; do sleep 10; done
             else
               # either we need to initialize a new cluster or wait for master to create it
               if [[ "${pod_dns_name}" == "${CLUSTER_INITIATOR_IP}" ]]; then
@@ -338,30 +338,30 @@ spec:
                   election_timer="--db-nb-election-timer=$(({{.OVN_NB_RAFT_ELECTION_TIMER}}*1000))"
                 fi
 
-                exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
+                nohup /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
                 --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
                 ${election_timer} \
                 run_nb_ovsdb &
 
-                wait $!
+                while true; do sleep 10; done
               else
                 echo "Joining the nbdb cluster with init_ip=${init_ip}..."
-                exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
+                nohup /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
                 --db-nb-cluster-remote-port={{.OVN_NB_RAFT_PORT}} \
                 --db-nb-cluster-remote-addr=${init_ip} \
                 --db-nb-cluster-remote-proto=ssl \
                 --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
                 run_nb_ovsdb &
 
-                wait $!
+                while true; do sleep 10; done
               fi
             fi
           else
-            exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
+            nohup /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
               --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
               run_nb_ovsdb &
 
-              wait $!
+              while true; do sleep 10; done
           fi
 
         lifecycle:
@@ -647,14 +647,14 @@ spec:
             if ${cluster_found}; then
               echo "Cluster already exists for DB: ${db}"
               # join existing cluster
-              exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
+              nohup /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
               --db-sb-cluster-remote-port={{.OVN_SB_RAFT_PORT}} \
               --db-sb-cluster-remote-addr=${init_ip} \
               --db-sb-cluster-remote-proto=ssl \
               --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
               run_sb_ovsdb &
 
-              wait $!
+              while true; do sleep 10; done
             else
               # either we need to initialize a new cluster or wait for master to create it
               if [[ "${pod_dns_name}" == "${CLUSTER_INITIATOR_IP}" ]]; then
@@ -664,29 +664,29 @@ spec:
                   election_timer="--db-sb-election-timer=$(({{.OVN_SB_RAFT_ELECTION_TIMER}}*1000))"
                 fi
 
-                exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
+                nohup /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
                 --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
                 ${election_timer} \
                 run_sb_ovsdb &
 
-                wait $!
+                while true; do sleep 10; done
               else
-                exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
+                nohup /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
                 --db-sb-cluster-remote-port={{.OVN_SB_RAFT_PORT}} \
                 --db-sb-cluster-remote-addr=${init_ip} \
                 --db-sb-cluster-remote-proto=ssl \
                 --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
                 run_sb_ovsdb &
 
-                wait $!
+                while true; do sleep 10; done
               fi
             fi
           else
-            exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
+            nohup /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
             --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
             run_sb_ovsdb &
 
-            wait $!
+            while true; do sleep 10; done
           fi
         lifecycle:
           postStart:

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
@@ -82,7 +82,7 @@ spec:
           trap quit TERM INT
 
           echo "$(date -Iseconds) - starting ovn-northd"
-          exec ovn-northd \
+          nohup ovn-northd \
             --no-chdir "-vconsole:${OVN_LOG_LEVEL}" -vfile:off "-vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
             --ovnnb-db "{{.OVN_NB_DB_LIST}}" \
             --ovnsb-db "{{.OVN_SB_DB_LIST}}" \
@@ -92,7 +92,7 @@ spec:
             -c /ovn-cert/tls.crt \
             -C /ovn-ca/ca-bundle.crt &
 
-          wait $!
+          while true; do sleep 10; done
         lifecycle:
           preStop:
             exec:
@@ -247,14 +247,14 @@ spec:
             if ${cluster_found}; then
               echo "Cluster already exists for DB: ${db}"
               # join existing cluster
-              exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
+              nohup /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
               --db-nb-cluster-remote-port={{.OVN_NB_RAFT_PORT}} \
               --db-nb-cluster-remote-addr=${init_ip} \
               --db-nb-cluster-remote-proto=ssl \
               --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
               run_nb_ovsdb &
 
-              wait $!
+              while true; do sleep 10; done
             else
               # either we need to initialize a new cluster or wait for master to create it
               if [[ "${K8S_NODE_IP}" == "${CLUSTER_INITIATOR_IP}" ]]; then
@@ -264,30 +264,30 @@ spec:
                   election_timer="--db-nb-election-timer=$(({{.OVN_NB_RAFT_ELECTION_TIMER}}*1000))"
                 fi
 
-                exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
+                nohup /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
                 --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
                 ${election_timer} \
                 run_nb_ovsdb &
 
-                wait $!
+                while true; do sleep 10; done
               else
                 echo "Joining the nbdb cluster with init_ip=${init_ip}..."
-                exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
+                nohup /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
                 --db-nb-cluster-remote-port={{.OVN_NB_RAFT_PORT}} \
                 --db-nb-cluster-remote-addr=${init_ip} \
                 --db-nb-cluster-remote-proto=ssl \
                 --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
                 run_nb_ovsdb &
 
-                wait $!
+                while true; do sleep 10; done
               fi
             fi
           else
-            exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
+            nohup /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
               --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
               run_nb_ovsdb &
 
-              wait $!
+              while true; do sleep 10; done
           fi
 
         lifecycle:
@@ -629,14 +629,14 @@ spec:
             if ${cluster_found}; then
               echo "Cluster already exists for DB: ${db}"
               # join existing cluster
-              exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
+              nohup /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
               --db-sb-cluster-remote-port={{.OVN_SB_RAFT_PORT}} \
               --db-sb-cluster-remote-addr=${init_ip} \
               --db-sb-cluster-remote-proto=ssl \
               --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
               run_sb_ovsdb &
 
-              wait $!
+              while true; do sleep 10; done
             else
               # either we need to initialize a new cluster or wait for master to create it
               if [[ "${K8S_NODE_IP}" == "${CLUSTER_INITIATOR_IP}" ]]; then
@@ -646,29 +646,29 @@ spec:
                   election_timer="--db-sb-election-timer=$(({{.OVN_SB_RAFT_ELECTION_TIMER}}*1000))"
                 fi
 
-                exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
+                nohup /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
                 --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
                 ${election_timer} \
                 run_sb_ovsdb &
 
-                wait $!
+                while true; do sleep 10; done
               else
-                exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
+                nohup /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
                 --db-sb-cluster-remote-port={{.OVN_SB_RAFT_PORT}} \
                 --db-sb-cluster-remote-addr=${init_ip} \
                 --db-sb-cluster-remote-proto=ssl \
                 --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
                 run_sb_ovsdb &
 
-                wait $!
+                while true; do sleep 10; done
               fi
             fi
           else
-            exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
+            nohup /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
             --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
             run_sb_ovsdb &
 
-            wait $!
+            while true; do sleep 10; done
           fi
         lifecycle:
           postStart:


### PR DESCRIPTION
wait will end up killing the parent PID after the current process ends and that will be PID 1 which exits the container. This happens when the prestop hook runs the ovn-ctl stop command. Because of this and new changes in cri-o the container is in exit state, but kubelet believes it's still running.

this allows the prestop hook to execute all it's steps and it's intention is not to stop the container anyway.