### PR TITLE
OVN-Kubernetes ipsec: Do not try to remove CSRs

### DIFF
--- a/bindata/network/ovn-kubernetes/common/ipsec.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec.yaml
@@ -114,8 +114,6 @@ spec:
             # Decode the signed certificate.
             kubectl get csr -lk8s.ovn.org/ipsec-csr=$(hostname) --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1:].status.certificate}' | base64 -d | openssl x509 -outform pem -text -out /etc/openvswitch/keys/ipsec-cert.pem
 
-            kubectl delete csr/$(hostname)
-
             # Get the CA certificate so we can authenticate peer nodes.
             cat /signer-ca/ca-bundle.crt | openssl x509 -outform pem -text > /etc/openvswitch/keys/ipsec-cacert.pem
           fi


### PR DESCRIPTION
Follow up to https://github.com/openshift/cluster-network-operator/pull/1928/ in which the ipsec daemonset starting using a randomized name for CSRs. 
It should not try to remove the CSR at the end since it doesn't have the permissions to do so and CSRs are automatically garbage collected anyway.

/cc @jcaamano 