### PR TITLE
OCPBUGS-17391: remove prestop hooks for northd, sbdbd and nbdb

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -338,13 +338,6 @@ spec:
             --n-threads={{.NorthdThreads}} &
 
           wait $!
-        lifecycle:
-          preStop:
-            exec:
-              command:
-                - /bin/bash
-                - -c
-                - OVN_MANAGE_OVSDB=no /usr/share/ovn/scripts/ovn-ctl stop_northd
         env:
         - name: OVN_LOG_LEVEL
           value: info
@@ -511,16 +504,6 @@ spec:
                 if ! retry 20 "northd-backoff" "${OVN_NB_CTL} set nb_global . options:northd-backoff-interval-ms={{.OVN_NORTHD_BACKOFF_MS}}"; then
                   exit 1
                 fi
-          preStop:
-            exec:
-              command:
-                - /bin/bash
-                - -c
-                - |
-                  echo "$(date -Iseconds) - stopping nbdb"
-                  /usr/share/ovn/scripts/ovn-ctl stop_nb_ovsdb
-                  echo "$(date -Iseconds) - nbdb stopped"
-                  rm -f /var/run/ovn/ovnnb_db.pid
         readinessProbe:
           initialDelaySeconds: 90
           timeoutSeconds: 5
@@ -654,16 +637,6 @@ spec:
                 if ! retry 20 "ipsec" "${OVN_SB_CTL} get sb_global . ipsec"; then
                   exit 1
                 fi
-          preStop:
-            exec:
-              command:
-                - /bin/bash
-                - -c
-                - |
-                  echo "$(date -Iseconds) - stopping sbdb"
-                  /usr/share/ovn/scripts/ovn-ctl stop_sb_ovsdb
-                  echo "$(date -Iseconds) - sbdb stopped"
-                  rm -f /var/run/ovn/ovnsb_db.pid
         readinessProbe:
           initialDelaySeconds: 90
           timeoutSeconds: 5

--- a/bindata/network/ovn-kubernetes/managed/single-zone-interconnect/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/single-zone-interconnect/ovnkube-master.yaml
@@ -173,13 +173,6 @@ spec:
             -C /ovn-ca/ca-bundle.crt &
 
           wait $!
-        lifecycle:
-          preStop:
-            exec:
-              command:
-                - /bin/bash
-                - -c
-                - OVN_MANAGE_OVSDB=no /usr/share/ovn/scripts/ovn-ctl stop_northd
         env:
         - name: OVN_LOG_LEVEL
           value: info
@@ -467,16 +460,6 @@ spec:
                 if ! retry 20 "northd-backoff" "${OVN_NB_CTL} set nb_global . options:northd-backoff-interval-ms={{.OVN_NORTHD_BACKOFF_MS}}"; then
                   exit 1
                 fi
-          preStop:
-            exec:
-              command:
-              - /bin/bash
-              - -c
-              - |
-                echo "$(date -Iseconds) - stopping nbdb"
-                /usr/share/ovn/scripts/ovn-ctl stop_nb_ovsdb
-                echo "$(date -Iseconds) - nbdb stopped"
-                rm -f /var/run/ovn/ovnnb_db.pid
         readinessProbe:
           initialDelaySeconds: 90
           timeoutSeconds: 5
@@ -763,16 +746,6 @@ spec:
                 if ! retry 20 "ipsec" "${OVN_SB_CTL} get sb_global . ipsec"; then
                   exit 1
                 fi
-          preStop:
-            exec:
-              command:
-              - /bin/bash
-              - -c
-              - |
-                echo "$(date -Iseconds) - stopping sbdb"
-                /usr/share/ovn/scripts/ovn-ctl stop_sb_ovsdb
-                echo "$(date -Iseconds) - sbdb stopped"
-                rm -f /var/run/ovn/ovnsb_db.pid
         readinessProbe:
           initialDelaySeconds: 90
           timeoutSeconds: 5

--- a/bindata/network/ovn-kubernetes/microshift/master/daemonset.yaml
+++ b/bindata/network/ovn-kubernetes/microshift/master/daemonset.yaml
@@ -72,13 +72,6 @@ spec:
             --pidfile /var/run/ovn/ovn-northd.pid &
 
           wait $!
-        lifecycle:
-          preStop:
-            exec:
-              command:
-                - /bin/bash
-                - -c
-                - OVN_MANAGE_OVSDB=no /usr/share/ovn/scripts/ovn-ctl stop_northd
         env:
         - name: OVN_LOG_LEVEL
           value: info
@@ -187,17 +180,6 @@ spec:
                     fi
                   done
                 fi
-
-          preStop:
-            exec:
-              command:
-              - /bin/bash
-              - -c
-              - |
-                echo "$(date -Iseconds) - stopping nbdb"
-                /usr/share/ovn/scripts/ovn-ctl stop_nb_ovsdb
-                echo "$(date -Iseconds) - nbdb stopped"
-                rm -f /var/run/ovn/ovnnb_db.pid
         readinessProbe:
           timeoutSeconds: 5
           exec:
@@ -288,16 +270,6 @@ spec:
                 set -x
                 rm -f /var/run/ovn/ovnsb_db.pid
 
-          preStop:
-            exec:
-              command:
-              - /bin/bash
-              - -c
-              - |
-                echo "$(date -Iseconds) - stopping sbdb"
-                /usr/share/ovn/scripts/ovn-ctl stop_sb_ovsdb
-                echo "$(date -Iseconds) - sbdb stopped"
-                rm -f /var/run/ovn/ovnsb_db.pid
         readinessProbe:
           timeoutSeconds: 5
           exec:

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -338,13 +338,6 @@ spec:
             --pidfile /var/run/ovn/ovn-northd.pid \
             --n-threads={{.NorthdThreads}} &
           wait $!
-        lifecycle:
-          preStop:
-            exec:
-              command:
-                - /bin/bash
-                - -c
-                - OVN_MANAGE_OVSDB=no /usr/share/ovn/scripts/ovn-ctl stop_northd
         env:
         - name: OVN_LOG_LEVEL
           value: info
@@ -521,16 +514,6 @@ spec:
                 if ! retry 20 "northd-backoff" "${OVN_NB_CTL} set nb_global . options:northd-backoff-interval-ms={{.OVN_NORTHD_BACKOFF_MS}}"; then
                   exit 1
                 fi
-          preStop:
-            exec:
-              command:
-                - /bin/bash
-                - -c
-                - |
-                  echo "$(date -Iseconds) - stopping nbdb"
-                  /usr/share/ovn/scripts/ovn-ctl stop_nb_ovsdb
-                  echo "$(date -Iseconds) - nbdb stopped"
-                  rm -f /var/run/ovn/ovnnb_db.pid
         readinessProbe:
 {{ if not .IsSNO }}
           initialDelaySeconds: 90
@@ -670,16 +653,6 @@ spec:
                 if ! retry 20 "ipsec" "${OVN_SB_CTL} get sb_global . ipsec"; then
                   exit 1
                 fi
-          preStop:
-            exec:
-              command:
-                - /bin/bash
-                - -c
-                - |
-                  echo "$(date -Iseconds) - stopping sbdb"
-                  /usr/share/ovn/scripts/ovn-ctl stop_sb_ovsdb
-                  echo "$(date -Iseconds) - sbdb stopped"
-                  rm -f /var/run/ovn/ovnsb_db.pid
         readinessProbe:
 {{ if not .IsSNO }}
           initialDelaySeconds: 90

--- a/bindata/network/ovn-kubernetes/self-hosted/single-zone-interconnect/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/single-zone-interconnect/ovnkube-master.yaml
@@ -93,13 +93,6 @@ spec:
             -C /ovn-ca/ca-bundle.crt &
 
           wait $!
-        lifecycle:
-          preStop:
-            exec:
-              command:
-                - /bin/bash
-                - -c
-                - OVN_MANAGE_OVSDB=no /usr/share/ovn/scripts/ovn-ctl stop_northd
         env:
         - name: OVN_LOG_LEVEL
           value: info
@@ -413,16 +406,6 @@ spec:
                 if ! retry 20 "northd-backoff" "${OVN_NB_CTL} set nb_global . options:northd-backoff-interval-ms={{.OVN_NORTHD_BACKOFF_MS}}"; then
                   exit 1
                 fi
-          preStop:
-            exec:
-              command:
-              - /bin/bash
-              - -c
-              - |
-                echo "$(date -Iseconds) - stopping nbdb"
-                /usr/share/ovn/scripts/ovn-ctl stop_nb_ovsdb
-                echo "$(date -Iseconds) - nbdb stopped"
-                rm -f /var/run/ovn/ovnnb_db.pid
         readinessProbe:
 {{ if not .IsSNO }}
           initialDelaySeconds: 90
@@ -765,16 +748,6 @@ spec:
                 if ! retry 20 "ipsec" "${OVN_SB_CTL} get sb_global . ipsec"; then
                   exit 1
                 fi
-          preStop:
-            exec:
-              command:
-              - /bin/bash
-              - -c
-              - |
-                echo "$(date -Iseconds) - stopping sbdb"
-                /usr/share/ovn/scripts/ovn-ctl stop_sb_ovsdb
-                echo "$(date -Iseconds) - sbdb stopped"
-                rm -f /var/run/ovn/ovnsb_db.pid
         readinessProbe:
 {{ if not .IsSNO }}
           initialDelaySeconds: 90


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/OCPBUGS-17391

when the prestop hook executes the ovn-ctl stop... command this causes the containers main script to exit which also propagates to the main container (PID 1) process which exits causing the container to exit. This is not neccessarily a problem except that with recent changes in CRI-O [0] there is some problem with how kubelet views this case. the containers are Exited for crio but seen as Ready from kubelet's perspective. Because of this, the pod gets stuck in Terminating state until it times out (~3m) and then containers will restart.

removing the prestop hook let's the SIGTERM reach the configured trap (example [1]) run which effectively does the same thing as what the prestop hook would have done. This prevents the pod from being stuck in Terminating state.

[0] https://github.com/cri-o/cri-o/pull/7168
[1] https://github.com/openshift/cluster-network-operator/blob/c55f19132864a9d8fe347ad6a8280eaa2f60e839/bindata/network/ovn-kubernetes/self-hosted/single-zone-interconnect/ovnkube-master.yaml#L74-L82