### PR TITLE
OCPBUGS-17677: [Azure]CNCC failed to assign egressIP to NIC for Azure Workload Identity Cluster

### DIFF
--- a/manifests/02-cncc-credentials.yaml
+++ b/manifests/02-cncc-credentials.yaml
@@ -80,6 +80,7 @@ spec:
     - Microsoft.Compute/virtualMachines/read
     - Microsoft.Network/virtualNetworks/read
     - Microsoft.Network/virtualNetworks/subnets/join/action
+    - Microsoft.Network/loadBalancers/backendAddressPools/join/action
 ---
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest


### PR DESCRIPTION
Adds additional missing permission `Microsoft.Network/loadBalancers/backendAddressPools/join/action`.

OCPBUGS-17677
/cc @huiran0826 