### PR TITLE
Limit OVN-Kubernetes permissions

### DIFF
--- a/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
+++ b/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
@@ -9,7 +9,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: openshift-ovn-kubernetes-node
+  name: openshift-ovn-kubernetes-node-limited
   namespace: openshift-ovn-kubernetes
 rules:
 - apiGroups: [""]
@@ -31,23 +31,16 @@ rules:
   - get
   - list
   - update
-- apiGroups: [""]
-  resources:
-  - endpoints
-  verbs:
-  - create
-  - update
-  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: openshift-ovn-kubernetes-node
+  name: openshift-ovn-kubernetes-node-limited
   namespace: openshift-ovn-kubernetes
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: openshift-ovn-kubernetes-node
+  name: openshift-ovn-kubernetes-node-limited
 subjects:
 - kind: ServiceAccount
   name: ovn-kubernetes-node
@@ -57,11 +50,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: openshift-ovn-kubernetes-node
+  name: openshift-ovn-kubernetes-node-limited
 rules:
 - apiGroups: [""]
   resources:
   - pods/status
+  - nodes/status
   verbs:
   - patch
   - update
@@ -69,33 +63,11 @@ rules:
   resources:
   - namespaces
   - nodes
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups: [""]
-  resources:
-  - nodes/status
-  verbs:
-  - patch
-  - update
-- apiGroups: [""]
-  resources:
   - pods
   verbs:
   - get
   - list
-  - patch
-  - update
   - watch
-- apiGroups: [""]
-  resources:
-  - pods/status
-  verbs:
-  - patch
-  - update
 - apiGroups: [""]
   resources:
   - endpoints
@@ -109,8 +81,6 @@ rules:
   verbs:
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - discovery.k8s.io
@@ -214,11 +184,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: openshift-ovn-kubernetes-node
+  name: openshift-ovn-kubernetes-node-limited
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: openshift-ovn-kubernetes-node
+  name: openshift-ovn-kubernetes-node-limited
 subjects:
 - kind: ServiceAccount
   name: ovn-kubernetes-node

--- a/bindata/network/ovn-kubernetes/common/003-rbac-controller.yaml
+++ b/bindata/network/ovn-kubernetes/common/003-rbac-controller.yaml
@@ -9,27 +9,14 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: openshift-ovn-kubernetes-controller
+  name: openshift-ovn-kubernetes-controller-limited
 rules:
-- apiGroups: [""]
-  resources:
-  - namespaces
-  - nodes
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups: [""]
   resources:
   - pods
   verbs:
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups: [""]
   resources:
@@ -39,7 +26,7 @@ rules:
   - services/status  
   verbs:
   - patch
-  - update  
+  - update
 - apiGroups: [""]
   resources:
   - configmaps
@@ -51,6 +38,8 @@ rules:
 - apiGroups: [""]
   resources:
   - endpoints
+  - nodes
+  - namespaces
   verbs:
   - get
   - list
@@ -141,11 +130,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: openshift-ovn-kubernetes-controller
+  name: openshift-ovn-kubernetes-controller-limited
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: openshift-ovn-kubernetes-controller
+  name: openshift-ovn-kubernetes-controller-limited
 subjects:
 - kind: ServiceAccount
   name: ovn-kubernetes-controller

--- a/bindata/network/ovn-kubernetes/common/004-rbac-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/common/004-rbac-control-plane.yaml
@@ -9,7 +9,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: openshift-ovn-kubernetes-control-plane
+  name: openshift-ovn-kubernetes-control-plane-limited
 rules:
 - apiGroups: [""]
   resources:
@@ -18,8 +18,6 @@ rules:
   verbs:
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - discovery.k8s.io
@@ -44,7 +42,8 @@ rules:
   - privileged
 - apiGroups: [""]
   resources:
-  - "nodes/status"
+  - nodes/status
+  - pods/status
   verbs:
   - patch
   - update
@@ -103,11 +102,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: openshift-ovn-kubernetes-control-plane
+  name: openshift-ovn-kubernetes-control-plane-limited
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: openshift-ovn-kubernetes-control-plane
+  name: openshift-ovn-kubernetes-control-plane-limited
 subjects:
 - kind: ServiceAccount
   name: ovn-kubernetes-control-plane
@@ -117,7 +116,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: openshift-ovn-kubernetes-control-plane
+  name: openshift-ovn-kubernetes-control-plane-limited
   namespace: openshift-ovn-kubernetes
 rules:
 - apiGroups: [""]
@@ -141,12 +140,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: openshift-ovn-kubernetes-control-plane
+  name: openshift-ovn-kubernetes-control-plane-limited
   namespace: openshift-ovn-kubernetes
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: openshift-ovn-kubernetes-control-plane
+  name: openshift-ovn-kubernetes-control-plane-limited
 subjects:
 - kind: ServiceAccount
   name: ovn-kubernetes-control-plane

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -97,11 +97,11 @@ func TestRenderOVNKubernetes(t *testing.T) {
 
 	// It's important that the namespace is first
 	g.Expect(objs[0]).To(HaveKubernetesID("Namespace", "", "openshift-ovn-kubernetes"))
-	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "openshift-ovn-kubernetes-node")))
-	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "openshift-ovn-kubernetes-controller")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "openshift-ovn-kubernetes-node-limited")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "openshift-ovn-kubernetes-controller-limited")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ServiceAccount", "openshift-ovn-kubernetes", "ovn-kubernetes-node")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ServiceAccount", "openshift-ovn-kubernetes", "ovn-kubernetes-controller")))
-	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRoleBinding", "", "openshift-ovn-kubernetes-node")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRoleBinding", "", "openshift-ovn-kubernetes-node-limited")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("Deployment", "openshift-ovn-kubernetes", "ovnkube-control-plane")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-ovn-kubernetes", "ovnkube-node")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ConfigMap", "openshift-ovn-kubernetes", "ovnkube-config")))


### PR DESCRIPTION
OVN-Kubernetes no longer requires nodes and pods permissions with: https://github.com/ovn-org/ovn-kubernetes/pull/3773

Removed the endpoints creation permission as it was never used downstream.
Removed pod deletion permission from control plane.
Modified status manager garbage collector to avoid removing stale objects from "rbac.authorization.k8s.io" during upgrade. This means that if there is an RBAC file no longer rendered in CNO it will only be removed once the upgrade completes. Using the new names keeps both RBACs during upgrade.
