### PR TITLE
ovnkube: trigger updates if ovn-kubernetes images change

### DIFF
--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	configv1 "github.com/openshift/api/config/v1"
+	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 	hyperv1 "github.com/openshift/hypershift/api/v1beta1"
 )
 
@@ -78,9 +79,11 @@ type OVNBootstrapResult struct {
 	// IPsecUpdateStatus is the status of ovn-ipsec daemonset
 	IPsecUpdateStatus *OVNUpdateStatus
 	// PrePullerUpdateStatus is the status of ovnkube-upgrades-prepuller daemonset
-	PrePullerUpdateStatus *OVNUpdateStatus
-	OVNKubernetesConfig   *OVNConfigBoostrapResult
-	FlowsConfig           *FlowsConfig
+	PrePullerUpdateStatus     *OVNUpdateStatus
+	OVNKubernetesConfig       *OVNConfigBoostrapResult
+	FlowsConfig               *FlowsConfig
+	ControlPlaneNamespace     string
+	ControlPlaneClusterClient cnoclient.ClusterClient
 }
 
 type BootstrapResult struct {


### PR DESCRIPTION
The CNO only upgrades ovnk if the cluster version changes. Previously we could force an upgrade by setting a fake RELEASE_VERSION that was newer than the current version (eg, "5.0.0"). But now the CNO checks feature gates and requires that the RELEASE_VERSION be listed in the featuregate resource:

```
I0906 01:08:41.873572       1 operconfig_controller.go:100] Waiting for feature gates initialization...
I0906 01:08:41.873598       1 simple_featuregate_reader.go:171] Starting feature-gate-detector
E0906 01:08:41.902771       1 simple_featuregate_reader.go:290] cluster failed with : unable to determine features: missing desired version "5.0.0" in featuregates.config.openshift.io/cluster
E0906 01:08:41.908422       1 simple_featuregate_reader.go:290] cluster failed with : unable to determine features: missing desired version "5.0.0" in featuregates.config.openshift.io/cluster
E0906 01:08:41.918608       1 simple_featuregate_reader.go:290] cluster failed with : unable to determine features: missing desired version "5.0.0" in featuregates.config.openshift.io/cluster
E0906 01:08:41.938790       1 simple_featuregate_reader.go:290] cluster failed with : unable to determine features: missing desired version "5.0.0" in featuregates.config.openshift.io/cluster
E0906 01:08:41.978976       1 simple_featuregate_reader.go:290] cluster failed with : unable to determine features: missing desired version "5.0.0" in featuregates.config.openshift.io/cluster
E0906 01:08:42.059501       1 simple_featuregate_reader.go:290] cluster failed with : unable to determine features: missing desired version "5.0.0" in featuregates.config.openshift.io/cluster
E0906 01:08:42.219824       1 simple_featuregate_reader.go:290] cluster failed with : unable to determine features: missing desired version "5.0.0" in featuregates.config.openshift.io/cluster
E0906 01:08:42.540748       1 simple_featuregate_reader.go:290] cluster failed with : unable to determine features: missing desired version "5.0.0" in featuregates.config.openshift.io/cluster
E0906 01:08:43.180816       1 simple_featuregate_reader.go:290] cluster failed with : unable to determine features: missing desired version "5.0.0" in featuregates.config.openshift.io/cluster
E0906 01:08:44.461552       1 simple_featuregate_reader.go:290] cluster failed with : unable to determine features: missing desired version "5.0.0" in featuregates.config.openshift.io/cluster
E0906 01:08:47.022344       1 simple_featuregate_reader.go:290] cluster failed with : unable to determine features: missing desired version "5.0.0" in featuregates.config.openshift.io/cluster
E0906 01:08:52.142455       1 simple_featuregate_reader.go:290] cluster failed with : unable to determine features: missing desired version "5.0.0" in featuregates.config.openshift.io/cluster
E0906 01:09:02.383569       1 simple_featuregate_reader.go:290] cluster failed with : unable to determine features: missing desired version "5.0.0" in featuregates.config.openshift.io/cluster
E0906 01:09:22.864017       1 simple_featuregate_reader.go:290] cluster failed with : unable to determine features: missing desired version "5.0.0" in featuregates.config.openshift.io/cluster
W0906 01:09:41.874164       1 builder.go:106] graceful termination failed, controllers failed with error: failed to add controllers to manager: timed out waiting for FeatureGate detection
```

Since we can't override the release version anymore, add a new re-render check that looks at the existing and desired OVNK images and triggers if they are different.