### PR TITLE
OCPBUGS-18517: Kuryr: Set MTU on Bootstrap, not Render phase

### DIFF
--- a/pkg/network/kuryr.go
+++ b/pkg/network/kuryr.go
@@ -112,7 +112,6 @@ func renderKuryr(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapR
 
 	// Pods Network MTU
 	data.Data["PodsNetworkMTU"] = b.PodsNetworkMTU
-	c.MTU = &b.PodsNetworkMTU
 
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/kuryr"), &data)
 	if err != nil {
@@ -219,7 +218,7 @@ func isKuryrChangeSafe(prev, next *operv1.NetworkSpec) []error {
 		errs = append(errs, errors.Errorf("cannot change kuryr openStackServiceNetwork"))
 	}
 
-	if !reflect.DeepEqual(pn.MTU, nn.MTU) {
+	if pn.MTU != nil && *pn.MTU != 0 && !reflect.DeepEqual(pn.MTU, nn.MTU) {
 		errs = append(errs, errors.Errorf("cannot change mtu for the Pods Network"))
 	}
 
@@ -257,12 +256,15 @@ func fillKuryrDefaults(conf, previous *operv1.NetworkSpec) {
 		var batchPorts uint = 3
 		kc.PoolBatchPorts = &batchPorts
 	}
-	// MTU  is currently the only field we pull from previous.
+	// MTU is currently the only field we pull from previous.
 	if kc.MTU == nil {
 		if previous != nil && previous.DefaultNetwork.KuryrConfig != nil &&
 			previous.DefaultNetwork.KuryrConfig.MTU != nil {
 			mtu := *previous.DefaultNetwork.KuryrConfig.MTU
 			kc.MTU = &mtu
 		}
+		// if it wasn't set, let's make sure we set something
+		var mtu uint32 = 0
+		kc.MTU = &mtu
 	}
 }

--- a/pkg/network/kuryr_test.go
+++ b/pkg/network/kuryr_test.go
@@ -164,6 +164,7 @@ func TestFillKuryrDefaults(t *testing.T) {
 	c := uint32(8091)
 	d := uint32(8090)
 	batch := uint(3)
+	mtu := uint32(0)
 	expected := operv1.NetworkSpec{
 		ServiceNetwork: []string{"172.30.0.0/16"},
 		ClusterNetwork: []operv1.ClusterNetworkEntry{
@@ -182,6 +183,7 @@ func TestFillKuryrDefaults(t *testing.T) {
 				PoolMaxPorts:                 0,
 				PoolMinPorts:                 1,
 				PoolBatchPorts:               &batch,
+				MTU:                          &mtu,
 			},
 		},
 	}

--- a/pkg/platform/openstack/kuryr_bootstrap.go
+++ b/pkg/platform/openstack/kuryr_bootstrap.go
@@ -417,12 +417,14 @@ func BootstrapKuryr(conf *operv1.NetworkSpec, kubeClient crclient.Client) (*boot
 
 	// Check the MTU. Basically if MTU is configured on KuryrConfig, then we need it to be lower or equal to nodes
 	// network MTU. Use configured value if it is, error out if it isn't.
-	if kc.MTU != nil {
+	if kc.MTU != nil && *kc.MTU != 0 {
 		if mtu >= *kc.MTU {
 			mtu = *kc.MTU
 		} else {
 			return nil, errors.Errorf("Configured MTU (%d) is incompatible with OpenShift nodes network MTU (%d).", *kc.MTU, mtu)
 		}
+	} else {
+		kc.MTU = &mtu
 	}
 
 	log.Print("Ensuring services network")


### PR DESCRIPTION
Since #1952 `network.Render` is no longer supplied with operConfig used later, but a copy of it. This means that MTU set by Kuryr's render phase won't be used for setting the Network.Status and will lead to panic.

We have this issue because for Kuryr default MTU is detected on bootstrap phase and there's no fixed value.

This commit solves this by making "0" a default value for Kuryr's MTU. Having 0 means that Kuryr will attempt to autodetect the MTU. Moreover the MTU on KuryrConfig will now be set on bootstrap phase, so update of the OperConfig done after the bootstrap phase will make sure to update it too.