### PR TITLE
OCPBUGS-18392: notify when /etc/openvswitch path changes

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -1059,6 +1059,8 @@ spec:
         hostPath:
           path: /var/lib/openvswitch/data
       - name: etc-openvswitch
+        # used by cluster-node-tuning-operator to enable /etc/openvswitch/enable_dynamic_cpu_affinity.
+        # See OCPBUGS-18392. Notify cluster-node-tuning-operator when this changes.
         hostPath:
           path: /var/lib/ovn-ic/etc  # different path than 4.13 and single-zone 4.14 to avoid collision during upgrade
       - name: run-openvswitch

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -1082,6 +1082,8 @@ spec:
           path: /var/lib/openvswitch/data
       - name: etc-openvswitch
         hostPath:
+          # used by cluster-node-tuning-operator to enable /etc/openvswitch/enable_dynamic_cpu_affinity.
+          # See OCPBUGS-18392. Notify cluster-node-tuning-operator when this changes.
           path: /var/lib/ovn-ic/etc  # different path than 4.13 and single-zone 4.14 to avoid collision during upgrade
       - name: run-openvswitch
         hostPath:


### PR DESCRIPTION
OVK-Kubernetes `ovspinning.go` monitors `/etc/openvswitch/enable_dynamic_cpu_affinity`

cluster-node-tuning-operator enables the feature, so we have to notify that component when the path changs on the host.