### PR TITLE
OCPBUGS-18676: ovnkube: set northd backoff-interval and use a single thread to save CPU

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -506,6 +506,11 @@ spec:
                 if ! retry 20 "ipsec" "${OVN_NB_CTL} set nb_global . ipsec=${ipsec}"; then
                   exit 1
                 fi
+
+                # Tell northd to sleep a bit so it takes less CPU
+                if ! retry 20 "northd-backoff" "${OVN_NB_CTL} set nb_global . options:northd-backoff-interval-ms={{.OVN_NORTHD_BACKOFF_MS}}"; then
+                  exit 1
+                fi
           preStop:
             exec:
               command:

--- a/bindata/network/ovn-kubernetes/managed/single-zone-interconnect/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/single-zone-interconnect/ovnkube-master.yaml
@@ -462,6 +462,11 @@ spec:
                 if ! retry 20 "ipsec" "${OVN_NB_CTL} set nb_global . ipsec=${ipsec}"; then
                   exit 1
                 fi
+
+                # Tell northd to sleep a bit so it takes less CPU
+                if ! retry 20 "northd-backoff" "${OVN_NB_CTL} set nb_global . options:northd-backoff-interval-ms={{.OVN_NORTHD_BACKOFF_MS}}"; then
+                  exit 1
+                fi
           preStop:
             exec:
               command:

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -516,6 +516,11 @@ spec:
                 if ! retry 20 "ipsec" "${OVN_NB_CTL} set nb_global . ipsec=${ipsec} options:ipsec_encapsulation=${ipsec_encapsulation}"; then
                   exit 1
                 fi
+
+                # Tell northd to sleep a bit so it takes less CPU
+                if ! retry 20 "northd-backoff" "${OVN_NB_CTL} set nb_global . options:northd-backoff-interval-ms={{.OVN_NORTHD_BACKOFF_MS}}"; then
+                  exit 1
+                fi
           preStop:
             exec:
               command:

--- a/bindata/network/ovn-kubernetes/self-hosted/single-zone-interconnect/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/single-zone-interconnect/ovnkube-master.yaml
@@ -408,6 +408,11 @@ spec:
                 if ! retry 20 "ipsec" "${OVN_NB_CTL} set nb_global . ipsec=${ipsec} options:ipsec_encapsulation=${ipsec_encapsulation}"; then
                   exit 1
                 fi
+
+                # Tell northd to sleep a bit so it takes less CPU
+                if ! retry 20 "northd-backoff" "${OVN_NB_CTL} set nb_global . options:northd-backoff-interval-ms={{.OVN_NORTHD_BACKOFF_MS}}"; then
+                  exit 1
+                fi
           preStop:
             exec:
               command:

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -391,7 +391,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 		// Less resource constrained clusters can use multiple threads
 		// in northd to improve network operation latency at the cost
 		// of a bit of CPU.
-		data.Data["NorthdThreads"] = 4
+		data.Data["NorthdThreads"] = 1
 	}
 
 	data.Data["OVN_MULTI_NETWORK_ENABLE"] = true

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -191,6 +191,8 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 		nb_inactivity_probe = "60000"
 		klog.Infof("OVN_NB_INACTIVITY_PROBE env var is not defined. Using: %s", nb_inactivity_probe)
 	}
+	// Tell northd to sleep a bit to save CPU
+	data.Data["OVN_NORTHD_BACKOFF_MS"] = "300"
 
 	// Hypershift
 	data.Data["ManagementClusterName"] = names.ManagementClusterName


### PR DESCRIPTION
northd has an option to sleep for a short amount of time after processing changes from NB/SB that allows it to trade off a bit of latency for a lot of CPU savings. Since events from NB come frequently during scale tests northd doesn't have a lot of time to sleep. Until we have more incremental processing, most of that CPU time is burned just recalculating things that haven't changed, so it's mostly wasted.

Letting northd sleep has been shown in density-light and density-cni 120 node scale tests to have almost no adverse effect on P99 PodReady times, but a huge improvement in CPU utilization.

Upstream equivalent is https://github.com/ovn-org/ovn-kubernetes/pull/3877