### PR TITLE
ovnkube: simplify northd threading and SNO templating

### DIFF
--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -382,17 +382,9 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 		}
 	}
 	renderOVNFlowsConfig(bootstrapResult, &data)
-	if len(bootstrapResult.OVN.MasterAddresses) == 1 {
-		data.Data["IsSNO"] = true
-		data.Data["NorthdThreads"] = 1
-	} else {
-		data.Data["IsSNO"] = false
-		// OVN 22.06 and later support multiple northd threads.
-		// Less resource constrained clusters can use multiple threads
-		// in northd to improve network operation latency at the cost
-		// of a bit of CPU.
-		data.Data["NorthdThreads"] = 1
-	}
+
+	data.Data["NorthdThreads"] = 1
+	data.Data["IsSNO"] = len(bootstrapResult.OVN.MasterAddresses) == 1
 
 	data.Data["OVN_MULTI_NETWORK_ENABLE"] = true
 	data.Data["OVN_MULTI_NETWORK_POLICY_ENABLE"] = false


### PR DESCRIPTION
It's all single thread now, plus we don't need an if/else block for SNO anymore since it's just a single boolean now.