### PR TITLE
[release-4.13] OCPBUGS-19894: remove prestop hooks for northd, sbdbd and nbdb

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-master.yaml
@@ -171,13 +171,6 @@ spec:
             -C /ovn-ca/ca-bundle.crt &
 
           wait $!
-        lifecycle:
-          preStop:
-            exec:
-              command:
-                - /bin/bash
-                - -c
-                - OVN_MANAGE_OVSDB=no /usr/share/ovn/scripts/ovn-ctl stop_northd
         env:
         - name: OVN_LOG_LEVEL
           value: info
@@ -460,16 +453,6 @@ spec:
                 if ! retry 20 "ipsec" "${OVN_NB_CTL} set nb_global . ipsec=${ipsec}"; then
                   exit 1
                 fi
-          preStop:
-            exec:
-              command:
-              - /bin/bash
-              - -c
-              - |
-                echo "$(date -Iseconds) - stopping nbdb"
-                /usr/share/ovn/scripts/ovn-ctl stop_nb_ovsdb
-                echo "$(date -Iseconds) - nbdb stopped"
-                rm -f /var/run/ovn/ovnnb_db.pid
         readinessProbe:
           initialDelaySeconds: 90
           timeoutSeconds: 5
@@ -756,16 +739,6 @@ spec:
                 if ! retry 20 "ipsec" "${OVN_SB_CTL} get sb_global . ipsec"; then
                   exit 1
                 fi
-          preStop:
-            exec:
-              command:
-              - /bin/bash
-              - -c
-              - |
-                echo "$(date -Iseconds) - stopping sbdb"
-                /usr/share/ovn/scripts/ovn-ctl stop_sb_ovsdb
-                echo "$(date -Iseconds) - sbdb stopped"
-                rm -f /var/run/ovn/ovnsb_db.pid
         readinessProbe:
           initialDelaySeconds: 90
           timeoutSeconds: 5

--- a/bindata/network/ovn-kubernetes/microshift/master/daemonset.yaml
+++ b/bindata/network/ovn-kubernetes/microshift/master/daemonset.yaml
@@ -72,13 +72,6 @@ spec:
             --pidfile /var/run/ovn/ovn-northd.pid &
 
           wait $!
-        lifecycle:
-          preStop:
-            exec:
-              command:
-                - /bin/bash
-                - -c
-                - OVN_MANAGE_OVSDB=no /usr/share/ovn/scripts/ovn-ctl stop_northd
         env:
         - name: OVN_LOG_LEVEL
           value: info
@@ -188,16 +181,6 @@ spec:
                   done
                 fi
 
-          preStop:
-            exec:
-              command:
-              - /bin/bash
-              - -c
-              - |
-                echo "$(date -Iseconds) - stopping nbdb"
-                /usr/share/ovn/scripts/ovn-ctl stop_nb_ovsdb
-                echo "$(date -Iseconds) - nbdb stopped"
-                rm -f /var/run/ovn/ovnnb_db.pid
         readinessProbe:
           timeoutSeconds: 5
           exec:
@@ -286,17 +269,6 @@ spec:
               - -c
               - |
                 set -x
-                rm -f /var/run/ovn/ovnsb_db.pid
-
-          preStop:
-            exec:
-              command:
-              - /bin/bash
-              - -c
-              - |
-                echo "$(date -Iseconds) - stopping sbdb"
-                /usr/share/ovn/scripts/ovn-ctl stop_sb_ovsdb
-                echo "$(date -Iseconds) - sbdb stopped"
                 rm -f /var/run/ovn/ovnsb_db.pid
         readinessProbe:
           timeoutSeconds: 5

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
@@ -93,13 +93,6 @@ spec:
             -C /ovn-ca/ca-bundle.crt &
 
           wait $!
-        lifecycle:
-          preStop:
-            exec:
-              command:
-                - /bin/bash
-                - -c
-                - OVN_MANAGE_OVSDB=no /usr/share/ovn/scripts/ovn-ctl stop_northd
         env:
         - name: OVN_LOG_LEVEL
           value: info 
@@ -384,16 +377,6 @@ spec:
                 if ! retry 20 "ipsec" "${OVN_NB_CTL} set nb_global . ipsec=${ipsec}"; then
                   exit 1
                 fi
-          preStop:
-            exec:
-              command:
-              - /bin/bash
-              - -c
-              - |
-                echo "$(date -Iseconds) - stopping nbdb"
-                /usr/share/ovn/scripts/ovn-ctl stop_nb_ovsdb
-                echo "$(date -Iseconds) - nbdb stopped"
-                rm -f /var/run/ovn/ovnnb_db.pid
         readinessProbe:
 {{ if not .IsSNO }}
           initialDelaySeconds: 90
@@ -736,16 +719,6 @@ spec:
                 if ! retry 20 "ipsec" "${OVN_SB_CTL} get sb_global . ipsec"; then
                   exit 1
                 fi
-          preStop:
-            exec:
-              command:
-              - /bin/bash
-              - -c
-              - |
-                echo "$(date -Iseconds) - stopping sbdb"
-                /usr/share/ovn/scripts/ovn-ctl stop_sb_ovsdb
-                echo "$(date -Iseconds) - sbdb stopped"
-                rm -f /var/run/ovn/ovnsb_db.pid
         readinessProbe:
 {{ if not .IsSNO }}
           initialDelaySeconds: 90


### PR DESCRIPTION
when the prestop hook executes the ovn-ctl stop... command this causes the containers main script to exit which also propagates to the main container (PID 1) process which exits causing the container to exit. This is not neccessarily a problem except that with recent changes in CRI-O [0] there is some problem with how kubelet views this case. the containers are Exited for crio but seen as Ready from kubelet's perspective. Because of this, the pod gets stuck in Terminating state until it times out (~3m) and then containers will restart.

removing the prestop hook let's the SIGTERM reach the configured trap (example [1]) run which effectively does the same thing as what the prestop hook would have done. This prevents the pod from being stuck in Terminating state.

[0] cri-o/cri-o#7168
[1] https://github.com/openshift/cluster-network-operator/blob/c55f19132864a9d8fe347ad6a8280eaa2f60e839/bindata/network/ovn-kubernetes/self-hosted/single-zone-interconnect/ovnkube-master.yaml#L74-L82