### PR TITLE
OCPBUGS-19377: Kuryr: Fix deriving MTU from previous config

### DIFF
--- a/pkg/network/kuryr.go
+++ b/pkg/network/kuryr.go
@@ -262,9 +262,10 @@ func fillKuryrDefaults(conf, previous *operv1.NetworkSpec) {
 			previous.DefaultNetwork.KuryrConfig.MTU != nil {
 			mtu := *previous.DefaultNetwork.KuryrConfig.MTU
 			kc.MTU = &mtu
+		} else {
+			// if it wasn't set, let's make sure we set something
+			var mtu uint32 = 0
+			kc.MTU = &mtu
 		}
-		// if it wasn't set, let's make sure we set something
-		var mtu uint32 = 0
-		kc.MTU = &mtu
 	}
 }


### PR DESCRIPTION
PR https://github.com/openshift/cluster-network-operator/pull/1988 introduced a bug causing upgrades to fail, because even when Kuryr MTU was detected from the previous version of the KuryrConfig, CNO would override it to 0. This commit fixes that.