### PR TITLE
multinetworkpolicy: allow Neighbor Discovery Protocol traffic

### DIFF
--- a/bindata/network/multus-networkpolicy/custom-iptables-rules.yaml
+++ b/bindata/network/multus-networkpolicy/custom-iptables-rules.yaml
@@ -1,0 +1,17 @@
+---
+# Following rules are applied to every pod with an MultiNetworkPolicy working on it, allowing 
+# a base networking that couldn't be expressed by the policy syntax.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: multi-networkpolicy-custom-rules
+  namespace: openshift-multus
+data:
+  
+  custom-v6-rules.txt: |
+    # accept NDP
+    -p icmpv6 --icmpv6-type neighbor-solicitation -j ACCEPT
+    -p icmpv6 --icmpv6-type neighbor-advertisement -j ACCEPT
+    # accept RA/RS
+    -p icmpv6 --icmpv6-type router-solicitation -j ACCEPT
+    -p icmpv6 --icmpv6-type router-advertisement -j ACCEPT

--- a/bindata/network/multus-networkpolicy/multus-networkpolicy.yaml
+++ b/bindata/network/multus-networkpolicy/multus-networkpolicy.yaml
@@ -35,6 +35,8 @@ spec:
         - "--container-runtime-endpoint=/run/crio/crio.sock"
         - "--pod-iptables=/var/lib/multi-networkpolicy/iptables"
         - "--network-plugins=macvlan,sriov"
+        - "--custom-v6-ingress-rule-file=/etc/multi-networkpolicy/rules/custom-v6-rules.txt"
+        - "--custom-v6-egress-rule-file=/etc/multi-networkpolicy/rules/custom-v6-rules.txt"
         resources:
           requests:
             cpu: "100m"
@@ -48,6 +50,9 @@ spec:
           mountPath: /host
         - name: var-lib-multinetworkpolicy
           mountPath: /var/lib/multi-networkpolicy
+        - name: multi-networkpolicy-custom-rules
+          mountPath: /etc/multi-networkpolicy/rules
+          readOnly: true
       hostNetwork: true
       nodeSelector:
         kubernetes.io/os: linux
@@ -63,3 +68,6 @@ spec:
         - name: var-lib-multinetworkpolicy
           hostPath:
             path: /var/lib/multi-networkpolicy
+        - name: multi-networkpolicy-custom-rules
+          configMap:
+            name: multi-networkpolicy-custom-rules

--- a/pkg/network/multi_network_policy_test.go
+++ b/pkg/network/multi_network_policy_test.go
@@ -48,9 +48,10 @@ func TestRenderMultiNetworkPolicy(t *testing.T) {
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "multus-networkpolicy")))
 
 	// Check rendered object
-	g.Expect(len(objs)).To(Equal(4))
+	g.Expect(len(objs)).To(Equal(5))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("CustomResourceDefinition", "", "multi-networkpolicies.k8s.cni.cncf.io")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "openshift-multus-networkpolicy")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRoleBinding", "", "openshift-multus-networkpolicy")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "multus-networkpolicy")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ConfigMap", "openshift-multus", "multi-networkpolicy-custom-rules")))
 }


### PR DESCRIPTION
MultusNetworkPolicy iptables implementation denies all traffic that is not specified by policy rules. This can bring to some unexpected scenario, especially when working with IPv6.

Unlike ARP in IPv4, Neighbor Discovery Protocol (NDP) uses IP packets to exchange information between peers, so they are affected by iptables rules. In a scenario where a server is the subject of a MultiNetworkPolicy and a client is the only one who can send traffic to the server, the latter should be able to send the neighbor advertisements, otherwise the client will never know the link-layer address of the server.

multus-networkpolicy doc: https://github.com/openshift/multus-networkpolicy/blob/master/docs/configurations.md#add-custom-iptablesip6tables-rules