### PR TITLE
[release-4.13] OVN-Kubernetes ipsec: create random CSR instead of removing the previous one

### DIFF
--- a/bindata/network/ovn-kubernetes/common/002-rbac.yaml
+++ b/bindata/network/ovn-kubernetes/common/002-rbac.yaml
@@ -114,8 +114,6 @@ rules:
   verbs:
     - create
     - get
-    - delete
-    - update
     - list
 
 ---

--- a/bindata/network/ovn-kubernetes/common/ipsec.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec.yaml
@@ -79,31 +79,28 @@ spec:
 
             csr_64=$(cat /etc/openvswitch/keys/ipsec-req.pem | base64 | tr -d "\n")
 
-            # The signer controller does not allow re-signing a key. We will
-            # delete the old key to be sure it is not there
-            kubectl delete --ignore-not-found=true csr/$(hostname)
-
             # Request that our generated certificate signing request is
             # signed by the "network.openshift.io/signer" signer that is
             # implemented by the CNO signer controller. This will sign the
             # certificate signing request using the signer-ca which has been
             # set up by the OperatorPKI. In this way, we have a signed certificate
             # and our private key has remained private on this host.
-            cat <<EOF | kubectl apply -f -
+            cat <<EOF | kubectl create -f -
             apiVersion: certificates.k8s.io/v1
             kind: CertificateSigningRequest
             metadata:
-              name: $(hostname)
+              generateName: ipsec-csr-$(hostname)-
+              labels:
+                k8s.ovn.org/ipsec-csr: $(hostname)
             spec:
               request: ${csr_64}
               signerName: network.openshift.io/signer
               usages:
               - ipsec tunnel
           EOF
-
             # Wait until the certificate signing request has been signed.
             counter=0
-            until [ ! -z $(kubectl get csr/$(hostname) -o jsonpath='{.status.certificate}' 2>/dev/null) ]
+            until [ ! -z $(kubectl get csr -lk8s.ovn.org/ipsec-csr=$(hostname) --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1:].status.certificate}' 2>/dev/null) ]
             do
               counter=$((counter+1))
               sleep 1
@@ -115,9 +112,7 @@ spec:
             done
 
             # Decode the signed certificate.
-            kubectl get csr/$(hostname) -o jsonpath='{.status.certificate}' | base64 -d | openssl x509 -outform pem -text -out /etc/openvswitch/keys/ipsec-cert.pem
-
-            kubectl delete csr/$(hostname)
+            kubectl get csr -lk8s.ovn.org/ipsec-csr=$(hostname) --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1:].status.certificate}' | base64 -d | openssl x509 -outform pem -text -out /etc/openvswitch/keys/ipsec-cert.pem
 
             # Get the CA certificate so we can authenticate peer nodes.
             cat /signer-ca/ca-bundle.crt | openssl x509 -outform pem -text > /etc/openvswitch/keys/ipsec-cacert.pem


### PR DESCRIPTION
CSR is a cluster scoped resource and it is not great to have the permission to delete it.
CSRs are garbage collected so instead of removing the previous one, always create the CSR with a randomized name.

Includes https://github.com/openshift/cluster-network-operator/pull/1934
Additionally addressed https://github.com/openshift/cluster-network-operator/issues/1960. 
(cherry picked from commit 10dd8c57a98558c03f6aa72a6e8d90292db890ba)