### PR TITLE
OCPBUGS-19418: Relax conditions to get IC upgrade started

### DIFF
--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -2420,8 +2420,6 @@ func prepareUpgradeToInterConnect(ovn bootstrap.OVNBootstrapResult, client cnocl
 		!ovn.NodeUpdateStatus.InterConnectEnabled &&
 		!ovn.MasterUpdateStatus.InterConnectEnabled &&
 		doesVersionEnableInterConnect(os.Getenv("RELEASE_VERSION")) &&
-		!ovn.NodeUpdateStatus.Progressing &&
-		!ovn.MasterUpdateStatus.Progressing &&
 		!targetZoneMode.configMapFound {
 
 		klog.Infof("Upgrade to interconnect, phase1: creating IC configmap for single zone")


### PR DESCRIPTION
We've seen cases in which an upgrade to 4.14 was being performed on a 4.13 cluster where one node was in a Ready,SchedulingDisabled state. The ovnkube-node instance on that node had been removed and CNO considered ovnkube-node DaemonSet as progressing (5 out 6 instances were available). This completely bypassed the IC upgrade path and no IC configmap was created. 

Let's relax the conditions on when CNO adds the IC configmap, so we can get IC upgrade started in this case too.