### PR TITLE
OCPBUGS-19550: multus: set MULTUS_NODE_NAME to filter pods to local node

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -232,6 +232,10 @@ spec:
           value: "{{.KUBERNETES_SERVICE_PORT}}"
         - name: KUBERNETES_SERVICE_HOST
           value: "{{.KUBERNETES_SERVICE_HOST}}"
+        - name: MULTUS_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
 {{ if .HTTP_PROXY }}
         - name: "HTTP_PROXY"
           value: "{{ .HTTP_PROXY}}"


### PR DESCRIPTION
This allows multus to set an apiserver filter to only watch pods on its own node. Should reduce memory usage as multus doesn't care about pods on other nodes.

Clusters with ~60,000 pods show multus using around 1.8G of RSS which seems fairly unnecessary.

QE: can be verified by looking at the top of `kube-multus` container logs in multus pods:

```
$ oc logs -n openshift-multus -c kube-multus multus-llgcj | grep "Filtering pod"
2023-09-21T12:44:11Z [verbose] Filtering pod watch for node "ci-op-fvc0qy12-b3a20-dkw5b-worker-b-m7qmq"
```