### PR TITLE
OCPBUGS-18396: Fix config status MTU migration not being updated

### DIFF
--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -343,8 +343,13 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 		}
 	}
 
-	// Generate the objects
-	objs, progressing, err := network.Render(&newOperConfig.Spec, bootstrapResult, ManifestPath, r.client, r.featureGates)
+	// once updated, use the new config
+	operConfig = newOperConfig
+
+	// Generate the objects.
+	// Note that Render might have side effects in the passed in operConfig that
+	// will be reflected later on in the updated status.
+	objs, progressing, err := network.Render(&operConfig.Spec, bootstrapResult, ManifestPath, r.client, r.featureGates)
 	if err != nil {
 		log.Printf("Failed to render: %v", err)
 		r.status.SetDegraded(statusmanager.OperatorConfig, "RenderError",


### PR DESCRIPTION
Render has side effects in the passed in operConfig that are reflected later on in the status when it is being updated. This stopped working when the the passed in operConfig was changed to a copy that was not then used when applying the status.

It makes sense to use the updated operConfig for everything that comes after, not just Render, so change that to fix the issue.

Fixes: https://github.com/openshift/cluster-network-operator/pull/1952