### PR TITLE
[wip] multus: set MULTUS_NODE_NAME to filter pods to local node

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -231,6 +231,10 @@ spec:
           value: "{{.KUBERNETES_SERVICE_PORT}}"
         - name: KUBERNETES_SERVICE_HOST
           value: "{{.KUBERNETES_SERVICE_HOST}}"
+        - name: MULTUS_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
 {{ if .HTTP_PROXY }}
         - name: "HTTP_PROXY"
           value: "{{ .HTTP_PROXY}}"


### PR DESCRIPTION
This allows multus to set an apiserver filter to only watch pods on its own node. Should reduce memory usage as multus doesn't care about pods on other nodes.

Clusters with ~60,000 pods show multus using around 1.8G of RSS which seems fairly unecessary.