### PR TITLE
Do not enable node admission webhook if the CNI is not OVN-Kubernetes

### DIFF
--- a/bindata/network/node-identity/managed/node-identity-webhook.yaml
+++ b/bindata/network/node-identity/managed/node-identity-webhook.yaml
@@ -3,6 +3,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: network-node-identity.openshift.io
 webhooks:
+{{ if .ConfigureNodeAdmissionWebhook }}
   - name: node.network-node-identity.openshift.io
     clientConfig:
       url: https://network-node-identity.{{.HostedClusterNamespace}}.svc:{{.NetworkNodeIdentityPort}}/node
@@ -15,6 +16,7 @@ webhooks:
         apiVersions: ["*"]
         resources: ["nodes/status"]
         scope: "*"
+{{ end }}
   - name: pod.network-node-identity.openshift.io
     clientConfig:
       url: https://network-node-identity.{{.HostedClusterNamespace}}.svc:{{.NetworkNodeIdentityPort}}/pod

--- a/bindata/network/node-identity/self-hosted/node-identity-webhook.yaml
+++ b/bindata/network/node-identity/self-hosted/node-identity-webhook.yaml
@@ -3,6 +3,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: network-node-identity.openshift.io
 webhooks:
+{{ if .ConfigureNodeAdmissionWebhook }}
   - name: node.network-node-identity.openshift.io
     clientConfig:
       url: https://{{.NetworkNodeIdentityAddress}}:{{.NetworkNodeIdentityPort}}/node
@@ -15,6 +16,7 @@ webhooks:
         apiVersions: ["*"]
         resources: ["nodes/status"]
         scope: "*"
+{{ end }}
   - name: pod.network-node-identity.openshift.io
     clientConfig:
       url: https://{{.NetworkNodeIdentityAddress}}:{{.NetworkNodeIdentityPort}}/pod

--- a/pkg/network/node_identity.go
+++ b/pkg/network/node_identity.go
@@ -71,6 +71,11 @@ func renderNetworkNodeIdentity(conf *operv1.NetworkSpec, bootstrapResult *bootst
 	webhookCALookup := types.NamespacedName{Name: "network-node-identity-ca", Namespace: NetworkNodeIdentityNamespace}
 	caKey := "ca-bundle.crt"
 
+	data.Data["ConfigureNodeAdmissionWebhook"] = false
+	if conf.DefaultNetwork.Type == operv1.NetworkTypeOVNKubernetes {
+		data.Data["ConfigureNodeAdmissionWebhook"] = true
+	}
+
 	webhookReady := false
 	// HyperShift specific
 	if hcpCfg := platform.NewHyperShiftConfig(); hcpCfg.Enabled {


### PR DESCRIPTION
SDN is not modifying node objects and there is no need to configure the node webhook.