### PR TITLE
OCPBUGS-19705: Use port 9108 for ovnkube-control-plane metrics

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/monitor-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/monitor-control-plane.yaml
@@ -65,9 +65,9 @@ spec:
   publishNotReadyAddresses: true
   ports:
     - name: metrics
-      port: 9106
+      port: 9108
       protocol: TCP
-      targetPort: 9106
+      targetPort: 9108
   sessionAffinity: None
   clusterIP: None
   type: ClusterIP

--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-control-plane.yaml
@@ -149,7 +149,7 @@ spec:
             --config-file=/run/ovnkube-config/ovnkube.conf \
             --k8s-token-file=/var/run/secrets/hosted_cluster/token \
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
-            --metrics-bind-address "127.0.0.1:9106" \
+            --metrics-bind-address "127.0.0.1:9108" \
             --metrics-enable-pprof \
             --metrics-enable-config-duration \
             --node-server-privkey ${TLS_PK} \
@@ -188,7 +188,7 @@ spec:
               fieldPath: metadata.name
         ports:
         - name: metrics-port
-          containerPort: 9106
+          containerPort: 9108
         terminationMessagePolicy: FallbackToLogsOnError
 
       - name: socks-proxy

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/monitor-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/monitor-control-plane.yaml
@@ -41,8 +41,8 @@ spec:
   publishNotReadyAddresses: true
   ports:
   - name: metrics
-    port: 9106
+    port: 9108
     protocol: TCP
-    targetPort: 9106
+    targetPort: 9108
   sessionAffinity: None
   type: ClusterIP

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-control-plane.yaml
@@ -70,13 +70,13 @@ spec:
           echo $(date -Iseconds) INFO: ovn-control-plane-metrics-certs mounted, starting kube-rbac-proxy
           exec /usr/bin/kube-rbac-proxy \
             --logtostderr \
-            --secure-listen-address=:9106 \
+            --secure-listen-address=:9108 \
             --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
-            --upstream=http://127.0.0.1:29106/ \
+            --upstream=http://127.0.0.1:29108/ \
             --tls-private-key-file=${TLS_PK} \
             --tls-cert-file=${TLS_CERT}
         ports:
-        - containerPort: 9106
+        - containerPort: 9108
           name: https
         resources:
           requests:
@@ -107,7 +107,7 @@ spec:
             --init-cluster-manager "${K8S_NODE}" \
             --config-file=/run/ovnkube-config/ovnkube.conf \
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
-            --metrics-bind-address "127.0.0.1:29106" \
+            --metrics-bind-address "127.0.0.1:29108" \
             --metrics-enable-pprof \
             --metrics-enable-config-duration
         volumeMounts:
@@ -133,7 +133,7 @@ spec:
               fieldPath: metadata.name
         ports:
         - name: metrics-port
-          containerPort: 29106
+          containerPort: 29108
         terminationMessagePolicy: FallbackToLogsOnError
       nodeSelector:
         node-role.kubernetes.io/master: ""


### PR DESCRIPTION
In order to avoid possible issues with SDN during migration from SDN to OVNK, do not use port 9106 for ovnkube-control-plane metrics, since it's already used by SDN. Use a port that is not used by SDN, such as 9108.
This was a point raised while reviewing the IC upgrade enhancement: https://github.com/openshift/enhancements/pull/1409/files#r1335850394