### PR TITLE
OCPBUGS-18089,OCPBUGS-18088: ovnkube: container scripts cleanup

### DIFF
--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -367,3 +367,182 @@ data:
         exit 1
       fi
     }
+
+    function log()
+    {
+        echo "$(date --iso-8601=seconds) [{$1}] ${2}"
+    }
+
+    # cni-bin-copy() detects the host OS and copies the correct shim binary to
+    # the CNI binary directory.
+    #
+    # Requires the following volume mounts:
+    #   /host
+    #   /cni-bin-dir
+    cni-bin-copy()
+    {
+      # collect host os information
+      . /host/etc/os-release
+      rhelmajor=
+      # detect which version we're using in order to copy the proper binaries
+      case "${ID}" in
+        rhcos|scos)
+          RHEL_VERSION=$(echo "${CPE_NAME}" | cut -f 5 -d :)
+          rhelmajor=$(echo $RHEL_VERSION | sed -E 's/([0-9]+)\.{1}[0-9]+(\.[0-9]+)?/\1/')
+        ;;
+        rhel) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)
+        ;;
+        fedora)
+          if [ "${VARIANT_ID}" == "coreos" ]; then
+            rhelmajor=8
+          else
+            log "cnibincopy" "FATAL ERROR: Unsupported Fedora variant=${VARIANT_ID}"
+            exit 1
+          fi
+        ;;
+        *) log "cnibincopy" "FATAL ERROR: Unsupported OS ID=${ID}"; exit 1
+        ;;
+      esac
+
+      # Set which directory we'll copy from, detect if it exists
+      sourcedir=/usr/libexec/cni/
+      case "${rhelmajor}" in
+        8)
+          sourcedir=/usr/libexec/cni/rhel8
+        ;;
+        9)
+          sourcedir=/usr/libexec/cni/rhel9
+        ;;
+        *)
+          log "cnibincopy" "ERROR: RHEL Major Version Unsupported, rhelmajor=${rhelmajor}"
+        ;;
+      esac
+
+      cp -f "$sourcedir/ovn-k8s-cni-overlay" /cni-bin-dir/
+    }
+
+    # start-ovnkube-node starts the ovnkube-node process. This function does not
+    # return.
+    start-ovnkube-node()
+    {
+      local log_level=$1
+      local metrics_port=$2
+      local ovn_metrics_port=$3
+
+      # copy the right CNI shim for the host OS
+      cni-bin-copy
+
+      ovn_config_namespace=openshift-ovn-kubernetes
+      echo "I$(date "+%m%d %H:%M:%S.%N") - disable conntrack on geneve port"
+      iptables -t raw -A PREROUTING -p udp --dport {{.GenevePort}} -j NOTRACK
+      iptables -t raw -A OUTPUT -p udp --dport {{.GenevePort}} -j NOTRACK
+      ip6tables -t raw -A PREROUTING -p udp --dport {{.GenevePort}} -j NOTRACK
+      ip6tables -t raw -A OUTPUT -p udp --dport {{.GenevePort}} -j NOTRACK
+      echo "I$(date "+%m%d %H:%M:%S.%N") - starting ovnkube-node"
+
+      if [ "{{.OVN_GATEWAY_MODE}}" == "shared" ]; then
+        gateway_mode_flags="--gateway-mode shared --gateway-interface br-ex"
+      elif [ "{{.OVN_GATEWAY_MODE}}" == "local" ]; then
+        gateway_mode_flags="--gateway-mode local --gateway-interface br-ex"
+      else
+        echo "Invalid OVN_GATEWAY_MODE: \"{{.OVN_GATEWAY_MODE}}\". Must be \"local\" or \"shared\"."
+        exit 1
+      fi
+
+      export_network_flows_flags=
+      if [[ -n "${NETFLOW_COLLECTORS}" ]] ; then
+        export_network_flows_flags="--netflow-targets ${NETFLOW_COLLECTORS}"
+      fi
+      if [[ -n "${SFLOW_COLLECTORS}" ]] ; then
+        export_network_flows_flags="$export_network_flows_flags --sflow-targets ${SFLOW_COLLECTORS}"
+      fi
+      if [[ -n "${IPFIX_COLLECTORS}" ]] ; then
+        export_network_flows_flags="$export_network_flows_flags --ipfix-targets ${IPFIX_COLLECTORS}"
+      fi
+      if [[ -n "${IPFIX_CACHE_MAX_FLOWS}" ]] ; then
+        export_network_flows_flags="$export_network_flows_flags --ipfix-cache-max-flows ${IPFIX_CACHE_MAX_FLOWS}"
+      fi
+      if [[ -n "${IPFIX_CACHE_ACTIVE_TIMEOUT}" ]] ; then
+        export_network_flows_flags="$export_network_flows_flags --ipfix-cache-active-timeout ${IPFIX_CACHE_ACTIVE_TIMEOUT}"
+      fi
+      if [[ -n "${IPFIX_SAMPLING}" ]] ; then
+        export_network_flows_flags="$export_network_flows_flags --ipfix-sampling ${IPFIX_SAMPLING}"
+      fi
+      gw_interface_flag=
+      # if br-ex1 is configured on the node, we want to use it for external gateway traffic
+      if [ -d /sys/class/net/br-ex1 ]; then
+        gw_interface_flag="--exgw-interface=br-ex1"
+      fi
+
+      node_mgmt_port_netdev_flags=
+      if [[ -n "${OVNKUBE_NODE_MGMT_PORT_NETDEV}" ]] ; then
+        node_mgmt_port_netdev_flags="--ovnkube-node-mgmt-port-netdev ${OVNKUBE_NODE_MGMT_PORT_NETDEV}"
+      fi
+      if [[ -n "${OVNKUBE_NODE_MGMT_PORT_DP_RESOURCE_NAME}" ]] ; then
+        node_mgmt_port_netdev_flags="$node_mgmt_port_netdev_flags --ovnkube-node-mgmt-port-dp-resource-name ${OVNKUBE_NODE_MGMT_PORT_DP_RESOURCE_NAME}"
+      fi
+
+      multi_network_enabled_flag=
+      if [[ "{{.OVN_MULTI_NETWORK_ENABLE}}" == "true" ]]; then
+        multi_network_enabled_flag="--enable-multi-network"
+      fi
+
+      multi_network_policy_enabled_flag=
+      if [[ "{{.OVN_MULTI_NETWORK_POLICY_ENABLE}}" == "true" ]]; then
+        multi_network_policy_enabled_flag="--enable-multi-networkpolicy"
+      fi
+
+      admin_network_policy_enabled_flag=
+      if [[ "{{.OVN_ADMIN_NETWORK_POLICY_ENABLE}}" == "true" ]]; then
+        admin_network_policy_enabled_flag="--enable-admin-network-policy"
+      fi
+
+      # If IP Forwarding mode is global set it in the host here.
+      ip_forwarding_flag=
+      if [ "{{.IP_FORWARDING_MODE}}" == "Global" ]; then
+        sysctl -w net.ipv4.ip_forward=1
+        sysctl -w net.ipv6.conf.all.forwarding=1
+      else
+        ip_forwarding_flag="--disable-forwarding"
+      fi
+
+      NETWORK_NODE_IDENTITY_ENABLE=
+      if [[ "{{.NETWORK_NODE_IDENTITY_ENABLE}}" == "true" ]]; then
+        NETWORK_NODE_IDENTITY_ENABLE="
+          --bootstrap-kubeconfig=/var/lib/kubelet/kubeconfig
+          --cert-dir=/etc/ovn/ovnkube-node-certs
+          --cert-duration={{.NodeIdentityCertDuration}}
+        "
+      fi
+
+      exec /usr/bin/ovnkube \
+        --init-ovnkube-controller "${K8S_NODE}" \
+        --init-node "${K8S_NODE}" \
+        --config-file=/run/ovnkube-config/ovnkube.conf \
+        --ovn-empty-lb-events \
+        --loglevel "${log_level}" \
+        --inactivity-probe="${OVN_CONTROLLER_INACTIVITY_PROBE}" \
+        ${gateway_mode_flags} \
+        ${node_mgmt_port_netdev_flags} \
+{{- if eq .OVN_NODE_MODE "dpu-host" }}
+        --ovnkube-node-mode dpu-host \
+{{- end }}
+        --metrics-bind-address "127.0.0.1:${metrics_port}" \
+        --ovn-metrics-bind-address "127.0.0.1:${ovn_metrics_port}" \
+        --metrics-enable-pprof \
+        --metrics-enable-config-duration \
+        --export-ovs-metrics \
+        --disable-snat-multiple-gws \
+        ${export_network_flows_flags} \
+        ${multi_network_enabled_flag} \
+        ${multi_network_policy_enabled_flag} \
+        ${admin_network_policy_enabled_flag} \
+        --enable-multicast \
+        --zone ${K8S_NODE} \
+        --enable-interconnect \
+        --acl-logging-rate-limit "{{.OVNPolicyAuditRateLimit}}" \
+        ${gw_interface_flag} \
+        --enable-multi-external-gateway=true \
+        ${ip_forwarding_flag} \
+        ${NETWORK_NODE_IDENTITY_ENABLE}
+    }

--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ovnkube-script-lib
+  namespace: openshift-ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This is a script used by the ovn-kubernetes daemonset
+    release.openshift.io/version: "{{.ReleaseVersion}}"
+data:
+  ovnkube-lib.sh: |-
+    #!/bin/bash
+    set -x
+
+    # Add node-specific overrides if the container has mounted any
+    K8S_NODE=${K8S_NODE:-}
+    if [[ -n "${K8S_NODE}" && -f "/env/${K8S_NODE}" ]]; then
+      set -o allexport
+      source "/env/${K8S_NODE}"
+      set +o allexport
+    fi
+
+    controller_pidfile="/var/run/ovn/ovn-controller.pid"
+    vswitch_dbsock="/var/run/openvswitch/db.sock"
+
+    # start-ovn-controller() starts ovn-controller and does not return until
+    # ovn-controller exits
+    #
+    # Requires the following volume mounts:
+    #   /run/openvswitch
+    #   /run/ovn/
+    #   /etc/openvswitch
+    #   /etc/ovn/
+    #   /var/lib/openvswitch
+    #   /var/log/ovn/
+    #   /dev/log
+    start-ovn-controller()
+    {
+      local log_level=$1
+
+      echo "$(date -Iseconds) - starting ovn-controller"
+      exec ovn-controller \
+        unix:${vswitch_dbsock} \
+        -vfile:off \
+        --no-chdir \
+        --pidfile=${controller_pidfile} \
+        --syslog-method="{{.OVNPolicyAuditDestination}}" \
+        --log-file=/var/log/ovn/acl-audit-log.log \
+        -vFACILITY:"{{.OVNPolicyAuditSyslogFacility}}" \
+        -vconsole:"${log_level}" \
+        -vconsole:"acl_log:off" \
+        -vPATTERN:console:"{{.OVN_LOG_PATTERN_CONSOLE}}" \
+        -vsyslog:"acl_log:info" \
+        -vfile:"acl_log:info"
+    }

--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -20,6 +20,7 @@ data:
       set +o allexport
     fi
 
+    northd_pidfile="/var/run/ovn/ovn-northd.pid"
     controller_pidfile="/var/run/ovn/ovn-controller.pid"
     vswitch_dbsock="/var/run/openvswitch/db.sock"
 
@@ -52,4 +53,41 @@ data:
         -vPATTERN:console:"{{.OVN_LOG_PATTERN_CONSOLE}}" \
         -vsyslog:"acl_log:info" \
         -vfile:"acl_log:info"
+    }
+
+    # quit-ovn-northd() will cleanly shut down ovn-northd. It is intended
+    # to be run from a bash 'trap' like so:
+    #
+    #    trap quit-ovn-northd TERM INT
+    quit-ovn-northd()
+    {
+      echo "$(date -Iseconds) - stopping ovn-northd"
+      OVN_MANAGE_OVSDB=no /usr/share/ovn/scripts/ovn-ctl stop_northd
+      echo "$(date -Iseconds) - ovn-northd stopped"
+      rm -f ${northd_pidfile}
+      exit 0
+    }
+
+    # run-ovn-northd() starts ovn-northd and does not return until
+    # northd exits.
+    #
+    # Requires the following volume mounts:
+    #   /etc/openvswitch/
+    #   /var/lib/openvswitch/
+    #   /run/openvswitch/
+    #   /run/ovn/
+    #   /var/log/ovn/
+    start-ovn-northd()
+    {
+      local log_level=$1
+
+      echo "$(date -Iseconds) - starting ovn-northd"
+      exec ovn-northd \
+        --no-chdir \
+        -vconsole:"${log_level}" \
+        -vfile:off \
+        -vPATTERN:console:"{{.OVN_LOG_PATTERN_CONSOLE}}" \
+        --pidfile ${northd_pidfile} \
+        --n-threads={{.NorthdThreads}} &
+      wait $!
     }

--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -22,6 +22,7 @@ data:
 
     northd_pidfile="/var/run/ovn/ovn-northd.pid"
     controller_pidfile="/var/run/ovn/ovn-controller.pid"
+    controller_logfile="/var/log/ovn/acl-audit-log.log"
     vswitch_dbsock="/var/run/openvswitch/db.sock"
 
     # start-ovn-controller() starts ovn-controller and does not return until
@@ -46,7 +47,7 @@ data:
         --no-chdir \
         --pidfile=${controller_pidfile} \
         --syslog-method="{{.OVNPolicyAuditDestination}}" \
-        --log-file=/var/log/ovn/acl-audit-log.log \
+        --log-file=${controller_logfile} \
         -vFACILITY:"{{.OVNPolicyAuditSyslogFacility}}" \
         -vconsole:"${log_level}" \
         -vconsole:"acl_log:off" \
@@ -90,4 +91,52 @@ data:
         --pidfile ${northd_pidfile} \
         --n-threads={{.NorthdThreads}} &
       wait $!
+    }
+
+    # start-audit-log-rotation() continuously watches ovn-controller's audit
+    # log directory and deletes old logs to ensure the total size of the logs
+    # does not exceed a given threshold. This function does not return.
+    #
+    # Requires the following volume mounts:
+    #   /var/log/ovn/
+    #   /run/ovn/
+    start-audit-log-rotation()
+    {
+      # Rotate audit log files when then get to max size (in bytes)
+      MAXFILESIZE=$(( "{{.OVNPolicyAuditMaxFileSize}}"*1000000 ))
+      MAXLOGFILES="{{.OVNPolicyAuditMaxLogFiles}}"
+      LOGDIR=$(dirname ${controller_logfile})
+      CONTROLLERPID=$(cat ${controller_pidfile})
+
+      # Redirect err to null so no messages are shown upon rotation
+      tail -F ${controller_logfile} 2> /dev/null &
+
+      while true
+      do
+        # Make sure ovn-controller's logfile exists, and get current size in bytes
+        if [ -f "${controller_logfile}" ]; then
+          file_size=`du -b ${controller_logfile} | tr -s '\t' ' ' | cut -d' ' -f1`
+        else
+          ovs-appctl -t /var/run/ovn/ovn-controller.${CONTROLLERPID}.ctl vlog/reopen
+          file_size=`du -b ${controller_logfile} | tr -s '\t' ' ' | cut -d' ' -f1`
+        fi
+
+        if [ $file_size -gt $MAXFILESIZE ];then
+          echo "Rotating OVN ACL Log File"
+          timestamp=`date '+%Y-%m-%dT%H-%M-%S'`
+          mv ${controller_logfile} ${LOGDIR}/acl-audit-log.$timestamp.log
+          ovs-appctl -t /run/ovn/ovn-controller.${CONTROLLERPID}.ctl vlog/reopen
+          CONTROLLERPID=$(cat ${controller_pidfile})
+        fi
+
+        # Ensure total number of log files does not exceed the maximum configured from OVNPolicyAuditMaxLogFiles
+        num_files=$(ls -1 ${LOGDIR}/acl-audit-log* 2>/dev/null | wc -l)
+        if [ "$num_files" -gt "$MAXLOGFILES" ]; then
+          num_to_delete=$(( num_files - ${MAXLOGFILES} ))
+          ls -1t ${LOGDIR}/acl-audit-log* 2>/dev/null | tail -$num_to_delete | xargs -I {} rm {}
+        fi
+
+        # sleep for 30 seconds to avoid wasting CPU
+        sleep 30
+      done
     }

--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -140,3 +140,55 @@ data:
         sleep 30
       done
     }
+
+    wait-for-certs()
+    {
+      local detail=$1
+      local privkey=$2
+      local clientcert=$3
+
+      retries=0
+      TS=$(date +%s)
+      WARN_TS=$(( ${TS} + $(( 20 * 60)) ))
+      HAS_LOGGED_INFO=0
+      while [[ ! -f "${privkey}" ||  ! -f "${clientcert}" ]] ; do
+        CUR_TS=$(date +%s)
+        if [[ "${CUR_TS}" -gt "WARN_TS"  ]]; then
+          echo "$(date -Iseconds) WARN: ${detail} certs not mounted after 20 minutes."
+        elif [[ "${HAS_LOGGED_INFO}" -eq 0 ]] ; then
+          echo "$(date -Iseconds) INFO: ${detail} certs not mounted. Waiting one hour."
+          HAS_LOGGED_INFO=1
+        fi
+        sleep 5
+      done
+    }
+
+    # start-rbac-proxy() starts the kube-rbac-proxy to expose ovnkube metrics to
+    # Prometheus on the given listen_port, proxying from upstream_port. This
+    # function does not return.
+    #
+    # Requires the following volume mounts:
+    #   /etc/pki/tls/metrics-cert
+    start-rbac-proxy-node()
+    {
+      local detail=$1
+      local listen_port=$2
+      local upstream_port=$3
+      local privkey=$4
+      local clientcert=$5
+
+      # As the secret mount is optional we must wait for the files to be present.
+      # The service is created in monitor.yaml and this is created in sdn.yaml.
+      # If it isn't created there is probably an issue so we want to crashloop.
+      echo "$(date -Iseconds) INFO: waiting for ${detail} certs to be mounted"
+      wait-for-certs "${detail}" "${privkey}" "${clientcert}"
+
+      echo "$(date -Iseconds) INFO: ${detail} certs mounted, starting kube-rbac-proxy"
+      exec /usr/bin/kube-rbac-proxy \
+        --logtostderr \
+        --secure-listen-address=:${listen_port} \
+        --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
+        --upstream=http://127.0.0.1:${upstream_port}/ \
+        --tls-private-key-file=${privkey} \
+        --tls-cert-file=${clientcert}
+    }

--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -27,6 +27,9 @@ data:
     nbdb_pidfile="/var/run/ovn/ovnnb_db.pid"
     nbdb_sock="/var/run/ovn/ovnnb_db.sock"
     nbdb_ctl="/var/run/ovn/ovnnb_db.ctl"
+    sbdb_pidfile="/var/run/ovn/ovnsb_db.pid"
+    sbdb_sock="/var/run/ovn/ovnsb_db.sock"
+    sbdb_ctl="/var/run/ovn/ovnsb_db.ctl"
 
     # start-ovn-controller() starts ovn-controller and does not return until
     # ovn-controller exits
@@ -314,6 +317,53 @@ data:
       status=$(/usr/bin/ovn-appctl -t ${ctlfile} --timeout=3 ovsdb-server/sync-status  2>/dev/null | { grep "state: active" || false; })
       if [[ -z "${status}" ]]; then
         echo "${dbname} DB is not running or active."
+        exit 1
+      fi
+    }
+
+    # quit-sbdb() will cleanly shut down the southbound dbserver. It is intended
+    # to be run from a bash 'trap' like so:
+    #
+    #    trap quit-sbdb TERM INT
+    quit-sbdb()
+    {
+      echo "$(date -Iseconds) - stopping sbdb"
+      /usr/share/ovn/scripts/ovn-ctl stop_sb_ovsdb
+      echo "$(date -Iseconds) - sbdb stopped"
+      rm -f ${sbdb_pidfile}
+      exit 0
+    }
+
+    # start-sbdb() starts the OVN southbound database. This function does not
+    # return.
+    #
+    # Requires the following volume mounts:
+    #   /etc/ovn
+    #   /var/log/ovn
+    #   /run/ovn/
+    start-sbdb()
+    {
+      local log_level=$1
+
+      exec /usr/share/ovn/scripts/ovn-ctl \
+        --no-monitor \
+        --db-sb-sock=${sbdb_sock} \
+        --ovn-sb-log="-vconsole:${log_level} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
+        run_sb_ovsdb &
+      wait $!
+    }
+
+    # sbdb-post-start() tweaks sbdb database server settings
+    sbdb-post-start()
+    {
+      rm -f ${sbdb_pidfile}
+
+      # set inactivity probe
+      if ! retry 60 "inactivity-probe" "ovn-sbctl -t 5 --inactivity-probe={{.OVN_CONTROLLER_INACTIVITY_PROBE}} set-connection punix:${sbdb_sock}"; then
+        exit 1
+      fi
+      # set trim-on-compaction
+      if ! retry 60 "trim-on-compaction" "ovn-appctl -t ${sbdb_ctl} --timeout=5 ovsdb-server/memory-trim-on-compaction on"; then
         exit 1
       fi
     }

--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -24,6 +24,9 @@ data:
     controller_pidfile="/var/run/ovn/ovn-controller.pid"
     controller_logfile="/var/log/ovn/acl-audit-log.log"
     vswitch_dbsock="/var/run/openvswitch/db.sock"
+    nbdb_pidfile="/var/run/ovn/ovnnb_db.pid"
+    nbdb_sock="/var/run/ovn/ovnnb_db.sock"
+    nbdb_ctl="/var/run/ovn/ovnnb_db.ctl"
 
     # start-ovn-controller() starts ovn-controller and does not return until
     # ovn-controller exits
@@ -191,4 +194,126 @@ data:
         --upstream=http://127.0.0.1:${upstream_port}/ \
         --tls-private-key-file=${privkey} \
         --tls-cert-file=${clientcert}
+    }
+
+    # quit-nbdb() will cleanly shut down the northbound dbserver. It is intended
+    # to be run from a bash 'trap' like so:
+    #
+    #    trap quit-nbdb TERM INT
+    quit-nbdb()
+    {
+      echo "$(date -Iseconds) - stopping nbdb"
+      /usr/share/ovn/scripts/ovn-ctl stop_nb_ovsdb
+      echo "$(date -Iseconds) - nbdb stopped"
+      rm -f ${nbdb_pidfile}
+      exit 0
+    }
+
+    # start-nbdb() starts the OVN northbound database. This function does not
+    # return.
+    #
+    # Requires the following volume mounts:
+    #   /etc/ovn
+    #   /var/log/ovn
+    #   /run/ovn/
+    start-nbdb()
+    {
+      local log_level=$1
+
+      exec /usr/share/ovn/scripts/ovn-ctl \
+        --no-monitor \
+        --db-nb-sock=${nbdb_sock} \
+        --ovn-nb-log="-vconsole:${log_level} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
+        run_nb_ovsdb &
+      wait $!
+    }
+
+    # retry() an operation a number of times, sleeping 2 seconds between each try
+    retry() {
+      local tries=${1}
+      local desc=${2}
+      local cmd=${3}
+
+      local retries=0
+      while ! ${cmd}; do
+        (( retries += 1 ))
+        if [[ "${retries}" -gt ${tries} ]]; then
+          echo "$(date -Iseconds) - ERROR - nbdb ${desc} - too many failed attempts, giving up"
+          return 1
+        fi
+        echo "$(date -Iseconds) - WARN - nbdb ${desc} - failed try ${retries}, retrying..."
+        sleep 2
+      done
+      echo "$(date -Iseconds) - INFO - nbdb ${desc} - success"
+      return 0
+    }
+
+    # nbdb-post-start() tweaks nbdb database server settings and sets a number
+    # of options in NB_Globals to configure OVN global settings
+    nbdb-post-start()
+    {
+      local northd_probe_interval=${1:-10000}
+
+      rm -f ${nbdb_pidfile}
+
+      # set inactivity probe
+      if ! retry 60 "inactivity-probe" "ovn-nbctl -t 5 --inactivity-probe={{.OVN_NB_INACTIVITY_PROBE}} set-connection punix:${nbdb_sock}"; then
+        exit 1
+      fi
+      # set trim-on-compaction
+      if ! retry 60 "trim-on-compaction" "ovn-appctl -t ${nbdb_ctl} --timeout=5 ovsdb-server/memory-trim-on-compaction on"; then
+        exit 1
+      fi
+
+      # set IC zone
+      echo "Setting the IC zone to ${K8S_NODE}"
+      IC_OPTION="name=\"${K8S_NODE}\" options:name=\"${K8S_NODE}\""
+
+      # northd probe interval
+      echo "Setting northd probe interval to ${northd_probe_interval} ms"
+      NORTHD_PROBE_OPTION="options:northd_probe_interval=${northd_probe_interval}"
+
+      # let northd sleep so it takes less CPU
+      NORTHD_SLEEP_OPTION="options:northd-backoff-interval-ms={{.OVN_NORTHD_BACKOFF_MS}}"
+
+      local ipsec=false
+      local ipsec_encapsulation=false
+{{ if .OVNIPsecEnable }}
+      ipsec=true
+      # IBMCloud does not forward ESP (IP proto 50)
+      # Instead, force IBMCloud IPsec to always use NAT-T
+      if [ "{{.PlatformType}}" == "IBMCloud" ]; then
+        ipsec_encapsulation=true
+      fi
+{{ end }}
+      IPSEC_OPTION="ipsec=${ipsec} options:ipsec_encapsulation=${ipsec_encapsulation}"
+
+      # set all the NB_GLOBAL options
+      if ! retry 20 "nb-global options" "ovn-nbctl -t 5 set nb_global . ${IC_OPTION} ${NORTHD_PROBE_OPTION} ${NORTHD_SLEEP_OPTION} ${IPSEC_OPTION}"; then
+        exit 1
+      fi
+    }
+
+    # ovndb-readiness-probe() checks if the the database is in the active state
+    # and if not, exits with an error code.
+    ovndb-readiness-probe()
+    {
+      # dbname should be 'sb' or 'nb'
+      local dbname=$1
+
+      local ctlfile
+      if [[ "${dbname}" = "sb" ]]; then
+        ctlfile=${nbdb_ctl}
+      elif [[ "${dbname}" = "nb" ]]; then
+        ctlfile=${sbdb_ctl}
+      else
+        echo "unknown DB name ${dbname}"
+        exit 1
+      fi
+
+      status=$(/usr/bin/ovn-appctl -t ${ctlfile} --timeout=3 ovsdb-server/sync-status  2>/dev/null | { grep "state: active" || false; })
+      if [[ -z "${status}" ]]; then
+        echo "${dbname} DB is not running or active."
+        exit 1
+      fi
     }

--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -664,12 +664,6 @@ spec:
         configMap:
           name: env-overrides
           optional: true
-      - name: ovn-ca
-        configMap:
-          name: ovn-ca
-      - name: ovn-cert
-        secret:
-          secretName: ovn-cert
       - name: ovn-node-metrics-cert
         secret:
           secretName: ovn-node-metrics-cert

--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -599,12 +599,6 @@ spec:
                 if ! retry 60 "trim-on-compaction" "ovn-appctl -t /var/run/ovn/ovnsb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on"; then
                   exit 1
                 fi
-
-                # Kill some time while the cluster converges by checking IPsec status
-                OVN_SB_CTL="ovn-sbctl"
-                if ! retry 20 "ipsec" "${OVN_SB_CTL} get sb_global . ipsec"; then
-                  exit 1
-                fi
         readinessProbe:
           initialDelaySeconds: 10
           timeoutSeconds: 5

--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -399,8 +399,6 @@ spec:
               - |
                 set -x
                 rm -f /var/run/ovn/ovnnb_db.pid
-                #configure northd_probe_interval
-                OVN_NB_CTL="ovn-nbctl"
 
                 # retry an operation a number of times, sleeping 2 seconds between each try
                 retry() {
@@ -431,62 +429,33 @@ spec:
                   exit 1
                 fi
 
+                # set IC zone
                 echo "Setting the IC zone to ${K8S_NODE}"
-                retries=0
-                current_probe_interval=0
-                while [[ "${retries}" -lt 10 ]]; do
-                  current_probe_interval=$(${OVN_NB_CTL} set NB_Global . name="${K8S_NODE}" options:name="${K8S_NODE}")
-                  if [[ $? == 0 ]]; then
-                    current_probe_interval=$(echo ${current_probe_interval} | tr -d '\"')
-                    break
-                  else
-                    sleep 2
-                    (( retries += 1 ))
-                  fi
-                done
+                IC_OPTION="name=\"${K8S_NODE}\" options:name=\"${K8S_NODE}\""
 
+                # northd probe interval
                 northd_probe_interval=${OVN_NORTHD_PROBE_INTERVAL:-10000}
                 echo "Setting northd probe interval to ${northd_probe_interval} ms"
-                retries=0
-                current_probe_interval=0
-                while [[ "${retries}" -lt 10 ]]; do
-                  current_probe_interval=$(${OVN_NB_CTL} --if-exists get NB_GLOBAL . options:northd_probe_interval)
-                  if [[ $? == 0 ]]; then
-                    current_probe_interval=$(echo ${current_probe_interval} | tr -d '\"')
-                    break
-                  else
-                    sleep 2
-                    (( retries += 1 ))
-                  fi
-                done
+                NORTHD_PROBE_OPTION="options:northd_probe_interval=${northd_probe_interval}"
 
-                if [[ "${current_probe_interval}" != "${northd_probe_interval}" ]]; then
-                  retries=0
-                  while [[ "${retries}" -lt 10 ]]; do
-                    ${OVN_NB_CTL} set NB_GLOBAL . options:northd_probe_interval=${northd_probe_interval}
-                    if [[ $? != 0 ]]; then
-                      echo "Failed to set northd probe interval to ${northd_probe_interval}. retrying....."
-                      sleep 2
-                      (( retries += 1 ))
-                    else
-                      echo "Successfully set northd probe interval to ${northd_probe_interval} ms"
-                      break
-                    fi
-                  done
-                fi
+                # let northd sleep so it takes less CPU
+                NORTHD_SLEEP_OPTION="options:northd-backoff-interval-ms={{.OVN_NORTHD_BACKOFF_MS}}"
 
                 # Enable/disable IPsec
+                ipsec=false
+                ipsec_encapsulation=false
                 {{ if .OVNIPsecEnable }}
                 ipsec=true
-                {{ else }}
-                ipsec=false
-                {{ end }}
-                if ! retry 20 "ipsec" "${OVN_NB_CTL} set nb_global . ipsec=${ipsec}"; then
-                  exit 1
+                # IBMCloud does not forward ESP (IP proto 50)
+                # Instead, force IBMCloud IPsec to always use NAT-T
+                if [ "{{.PlatformType}}" == "IBMCloud" ]; then
+                    ipsec_encapsulation=true
                 fi
+                {{ end }}
+                IPSEC_OPTION="ipsec=${ipsec} options:ipsec_encapsulation=${ipsec_encapsulation}"
 
-                # Tell northd to sleep a bit so it takes less CPU
-                if ! retry 20 "northd-backoff" "${OVN_NB_CTL} set nb_global . options:northd-backoff-interval-ms={{.OVN_NORTHD_BACKOFF_MS}}"; then
+                # set all the NB_GLOBAL options
+                if ! retry 20 "nb-global options" "ovn-nbctl -t 5 set nb_global . ${IC_OPTION} ${NORTHD_PROBE_OPTION} ${NORTHD_SLEEP_OPTION} ${IPSEC_OPTION}"; then
                   exit 1
                 fi
         readinessProbe:

--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -486,7 +486,7 @@ spec:
                   exit 1
                 fi
         readinessProbe:
-          initialDelaySeconds: 90
+          initialDelaySeconds: 10
           timeoutSeconds: 5
           exec:
             command:
@@ -600,7 +600,7 @@ spec:
                   exit 1
                 fi
         readinessProbe:
-          initialDelaySeconds: 90
+          initialDelaySeconds: 10
           timeoutSeconds: 5
           exec:
             command:

--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -384,7 +384,7 @@ spec:
           # end of quit
           trap quit TERM INT
 
-          exec /usr/share/ovn/scripts/ovn-ctl --no-monitor \
+          exec /usr/share/ovn/scripts/ovn-ctl --no-monitor --db-nb-sock=/var/run/ovn/ovnnb_db.sock \
             --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
             run_nb_ovsdb &
 
@@ -422,8 +422,8 @@ spec:
                   return 0
                 }
 
-                # set the connection and inactivity probe
-                if ! retry 60 "inactivity-probe" "ovn-nbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_NB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_NB_INACTIVITY_PROBE}}"; then
+                # set inactivity probe
+                if ! retry 60 "inactivity-probe" "ovn-nbctl -t 5 --inactivity-probe={{.OVN_NB_INACTIVITY_PROBE}} set-connection punix:/var/run/ovn/ovnnb_db.sock"; then
                   exit 1
                 fi
                 # set trim-on-compaction
@@ -555,7 +555,7 @@ spec:
           # end of quit
           trap quit TERM INT
 
-          exec /usr/share/ovn/scripts/ovn-ctl --no-monitor \
+          exec /usr/share/ovn/scripts/ovn-ctl --no-monitor --db-sb-sock=/var/run/ovn/ovnsb_db.sock \
             --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
             run_sb_ovsdb &
 
@@ -591,8 +591,8 @@ spec:
                   return 0
                 }
 
-                # set the connection and inactivity probe
-                if ! retry 60 "inactivity-probe" "ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_CONTROLLER_INACTIVITY_PROBE}}"; then
+                # set inactivity probe
+                if ! retry 60 "inactivity-probe" "ovn-sbctl -t 5 --inactivity-probe={{.OVN_CONTROLLER_INACTIVITY_PROBE}} set-connection punix:/var/run/ovn/ovnsb_db.sock"; then
                   exit 1
                 fi
                 # set trim-on-compaction

--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -384,8 +384,7 @@ spec:
           # end of quit
           trap quit TERM INT
 
-          OVN_ARGS="--no-monitor"
-          exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
+          exec /usr/share/ovn/scripts/ovn-ctl --no-monitor \
             --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
             run_nb_ovsdb &
 
@@ -570,8 +569,7 @@ spec:
           # end of quit
           trap quit TERM INT
 
-          OVN_ARGS="--no-monitor"
-          exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
+          exec /usr/share/ovn/scripts/ovn-ctl --no-monitor \
             --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
             run_sb_ovsdb &
 

--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -426,6 +426,10 @@ spec:
                 if ! retry 60 "inactivity-probe" "ovn-nbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_NB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_NB_INACTIVITY_PROBE}}"; then
                   exit 1
                 fi
+                # set trim-on-compaction
+                if ! retry 60 "trim-on-compaction" "ovn-appctl -t /var/run/ovn/ovnnb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on"; then
+                  exit 1
+                fi
 
                 echo "Setting the IC zone to ${K8S_NODE}"
                 retries=0
@@ -499,8 +503,6 @@ spec:
                 echo "NB DB is not running or active."
                 exit 1
               fi
-              # set trim-on-compaction
-              /usr/bin/ovn-appctl -t /var/run/ovn/ovnnb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on 2>/dev/null
         env:
         - name: OVN_LOG_LEVEL
           value: info
@@ -593,6 +595,10 @@ spec:
                 if ! retry 60 "inactivity-probe" "ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_CONTROLLER_INACTIVITY_PROBE}}"; then
                   exit 1
                 fi
+                # set trim-on-compaction
+                if ! retry 60 "trim-on-compaction" "ovn-appctl -t /var/run/ovn/ovnsb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on"; then
+                  exit 1
+                fi
 
                 # Kill some time while the cluster converges by checking IPsec status
                 OVN_SB_CTL="ovn-sbctl"
@@ -613,8 +619,6 @@ spec:
                 echo "SB DB is not running or active."
                 exit 1
               fi
-              # set trim-on-compaction
-              /usr/bin/ovn-appctl -t /var/run/ovn/ovnsb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on 2>/dev/null
         env:
         - name: OVN_LOG_LEVEL
           value: info

--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -250,23 +250,10 @@ spec:
             source /env/_master
             set +o allexport
           fi
+          . /ovnkube-lib/ovnkube-lib.sh || exit 1
 
-          quit() {
-            echo "$(date -Iseconds) - stopping nbdb"
-            /usr/share/ovn/scripts/ovn-ctl stop_nb_ovsdb
-            echo "$(date -Iseconds) - nbdb stopped"
-            rm -f /var/run/ovn/ovnnb_db.pid
-            exit 0
-          }
-          # end of quit
-          trap quit TERM INT
-
-          exec /usr/share/ovn/scripts/ovn-ctl --no-monitor --db-nb-sock=/var/run/ovn/ovnnb_db.sock \
-            --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
-            run_nb_ovsdb &
-
-          wait $!
-
+          trap quit-nbdb TERM INT
+          start-nbdb ${OVN_LOG_LEVEL}
         lifecycle:
           postStart:
             exec:
@@ -275,66 +262,8 @@ spec:
               - -c
               - |
                 set -x
-                rm -f /var/run/ovn/ovnnb_db.pid
-
-                # retry an operation a number of times, sleeping 2 seconds between each try
-                retry() {
-                  local tries=${1}
-                  local desc=${2}
-                  local cmd=${3}
-
-                  local retries=0
-                  while ! ${cmd}; do
-                    (( retries += 1 ))
-                    if [[ "${retries}" -gt ${tries} ]]; then
-                      echo "$(date -Iseconds) - ERROR - nbdb ${desc} - too many failed attempts, giving up"
-                      return 1
-                    fi
-                    echo "$(date -Iseconds) - WARN - nbdb ${desc} - failed try ${retries}, retrying..."
-                    sleep 2
-                  done
-                  echo "$(date -Iseconds) - INFO - nbdb ${desc} - success"
-                  return 0
-                }
-
-                # set inactivity probe
-                if ! retry 60 "inactivity-probe" "ovn-nbctl -t 5 --inactivity-probe={{.OVN_NB_INACTIVITY_PROBE}} set-connection punix:/var/run/ovn/ovnnb_db.sock"; then
-                  exit 1
-                fi
-                # set trim-on-compaction
-                if ! retry 60 "trim-on-compaction" "ovn-appctl -t /var/run/ovn/ovnnb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on"; then
-                  exit 1
-                fi
-
-                # set IC zone
-                echo "Setting the IC zone to ${K8S_NODE}"
-                IC_OPTION="name=\"${K8S_NODE}\" options:name=\"${K8S_NODE}\""
-
-                # northd probe interval
-                northd_probe_interval=${OVN_NORTHD_PROBE_INTERVAL:-10000}
-                echo "Setting northd probe interval to ${northd_probe_interval} ms"
-                NORTHD_PROBE_OPTION="options:northd_probe_interval=${northd_probe_interval}"
-
-                # let northd sleep so it takes less CPU
-                NORTHD_SLEEP_OPTION="options:northd-backoff-interval-ms={{.OVN_NORTHD_BACKOFF_MS}}"
-
-                # Enable/disable IPsec
-                ipsec=false
-                ipsec_encapsulation=false
-                {{ if .OVNIPsecEnable }}
-                ipsec=true
-                # IBMCloud does not forward ESP (IP proto 50)
-                # Instead, force IBMCloud IPsec to always use NAT-T
-                if [ "{{.PlatformType}}" == "IBMCloud" ]; then
-                    ipsec_encapsulation=true
-                fi
-                {{ end }}
-                IPSEC_OPTION="ipsec=${ipsec} options:ipsec_encapsulation=${ipsec_encapsulation}"
-
-                # set all the NB_GLOBAL options
-                if ! retry 20 "nb-global options" "ovn-nbctl -t 5 set nb_global . ${IC_OPTION} ${NORTHD_PROBE_OPTION} ${NORTHD_SLEEP_OPTION} ${IPSEC_OPTION}"; then
-                  exit 1
-                fi
+                . /ovnkube-lib/ovnkube-lib.sh || exit 1
+                nbdb-post-start {{.OVN_NORTHD_PROBE_INTERVAL}}
         readinessProbe:
 {{ if not .IsSNO }}
           initialDelaySeconds: 10
@@ -346,22 +275,19 @@ spec:
             - -c
             - |
               set -xeo pipefail
-              status=$(/usr/bin/ovn-appctl -t /var/run/ovn/ovnnb_db.ctl --timeout=3 ovsdb-server/sync-status  2>/dev/null | { grep "state: active" || false; })
-              if [[  -z "${status}" ]]; then
-                echo "NB DB is not running or active."
-                exit 1
-              fi
+              . /ovnkube-lib/ovnkube-lib.sh || exit 1
+              ovndb-readiness-probe "nb"
         env:
         - name: OVN_LOG_LEVEL
           value: info
-        - name: OVN_NORTHD_PROBE_INTERVAL
-          value: "{{.OVN_NORTHD_PROBE_INTERVAL}}"
         - name: K8S_NODE
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
         volumeMounts:
-        - mountPath: /etc/ovn
+        - mountPath: /ovnkube-lib
+          name: ovnkube-script-lib
+        - mountPath: /etc/ovn/
           name: etc-openvswitch
         - mountPath: /var/log/ovn
           name: node-log
@@ -369,10 +295,6 @@ spec:
           name: run-ovn
         - mountPath: /env
           name: env-overrides
-        - mountPath: /ovn-cert
-          name: ovn-cert
-        - mountPath: /ovn-ca
-          name: ovn-ca
         resources:
           requests:
             cpu: 10m

--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -314,23 +314,10 @@ spec:
             source /env/_master
             set +o allexport
           fi
+          . /ovnkube-lib/ovnkube-lib.sh || exit 1
 
-          quit() {
-            echo "$(date -Iseconds) - stopping sbdb"
-            /usr/share/ovn/scripts/ovn-ctl stop_sb_ovsdb
-            echo "$(date -Iseconds) - sbdb stopped"
-            rm -f /var/run/ovn/ovnsb_db.pid
-            exit 0
-          }
-          # end of quit
-          trap quit TERM INT
-
-          exec /usr/share/ovn/scripts/ovn-ctl --no-monitor --db-sb-sock=/var/run/ovn/ovnsb_db.sock \
-            --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
-            run_sb_ovsdb &
-
-          wait $!
-
+          trap quit-sbdb TERM INT
+          start-sbdb ${OVN_LOG_LEVEL}
         lifecycle:
           postStart:
             exec:
@@ -339,36 +326,8 @@ spec:
               - -c
               - |
                 set -x
-                rm -f /var/run/ovn/ovnsb_db.pid
-
-                # retry an operation a number of times, sleeping 2 seconds between each try
-                retry() {
-                  local tries=${1}
-                  local desc=${2}
-                  local cmd=${3}
-
-                  local retries=0
-                  while ! ${cmd}; do
-                    (( retries += 1 ))
-                    if [[ "${retries}" -gt ${tries} ]]; then
-                      echo "$(date -Iseconds) - ERROR - sbdb ${desc} - too many failed attempts, giving up"
-                      return 1
-                    fi
-                    echo "$(date -Iseconds) - WARN - sbdb ${desc} - failed try ${retries}, retrying..."
-                    sleep 2
-                  done
-                  echo "$(date -Iseconds) - INFO - sbdb ${desc} - success"
-                  return 0
-                }
-
-                # set inactivity probe
-                if ! retry 60 "inactivity-probe" "ovn-sbctl -t 5 --inactivity-probe={{.OVN_CONTROLLER_INACTIVITY_PROBE}} set-connection punix:/var/run/ovn/ovnsb_db.sock"; then
-                  exit 1
-                fi
-                # set trim-on-compaction
-                if ! retry 60 "trim-on-compaction" "ovn-appctl -t /var/run/ovn/ovnsb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on"; then
-                  exit 1
-                fi
+                . /ovnkube-lib/ovnkube-lib.sh || exit 1
+                sbdb-post-start
         readinessProbe:
 {{ if not .IsSNO }}
           initialDelaySeconds: 10
@@ -380,27 +339,22 @@ spec:
             - -c
             - |
               set -xeo pipefail
-              status=$(/usr/bin/ovn-appctl -t /var/run/ovn/ovnsb_db.ctl --timeout=3 ovsdb-server/sync-status  2>/dev/null | { grep "state: active" || false; })
-              if [[  -z "${status}" ]]; then
-                echo "SB DB is not running or active."
-                exit 1
-              fi
+              . /ovnkube-lib/ovnkube-lib.sh || exit 1
+              ovndb-readiness-probe "sb"
         env:
         - name: OVN_LOG_LEVEL
           value: info
         volumeMounts:
+        - mountPath: /ovnkube-lib
+          name: ovnkube-script-lib
         - mountPath: /etc/ovn/
           name: etc-openvswitch
         - mountPath: /run/ovn/
           name: run-ovn
-        - mountPath: /env
-          name: env-overrides
-        - mountPath: /ovn-cert
-          name: ovn-cert
-        - mountPath: /ovn-ca
-          name: ovn-ca
         - mountPath: /var/log/ovn
           name: node-log
+        - mountPath: /env
+          name: env-overrides
         resources:
           requests:
             cpu: 10m

--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -137,51 +137,16 @@ spec:
         - -c
         - |
           set -euo pipefail
-
-          # Rotate audit log files when then get to max size (in bytes)
-          MAXFILESIZE=$(( "{{.OVNPolicyAuditMaxFileSize}}"*1000000 ))
-          MAXLOGFILES="{{.OVNPolicyAuditMaxLogFiles}}"
-          LOGDIR=/var/log/ovn
-          LOGFILE=${LOGDIR}/acl-audit-log.log
-          CONTROLLERPID=$(cat /run/ovn/ovn-controller.pid)
-
-          # Redirect err to null so no messages are shown upon rotation
-          tail -F ${LOGFILE} 2> /dev/null &
-
-          while true
-          do
-            # Make sure ovn-controller's logfile exists, and get current size in bytes
-            if [ -f "$LOGFILE" ]; then
-              file_size=`du -b ${LOGFILE} | tr -s '\t' ' ' | cut -d' ' -f1`
-            else
-              ovs-appctl -t /var/run/ovn/ovn-controller.${CONTROLLERPID}.ctl vlog/reopen
-              file_size=`du -b ${LOGFILE} | tr -s '\t' ' ' | cut -d' ' -f1`
-            fi
-
-            if [ $file_size -gt $MAXFILESIZE ];then
-              echo "Rotating OVN ACL Log File"
-              timestamp=`date '+%Y-%m-%dT%H-%M-%S'`
-              mv ${LOGFILE} /var/log/ovn/acl-audit-log.$timestamp.log
-              ovs-appctl -t /run/ovn/ovn-controller.${CONTROLLERPID}.ctl vlog/reopen
-              CONTROLLERPID=$(cat /run/ovn/ovn-controller.pid)
-            fi
-
-            # Ensure total number of log files does not exceed the maximum configured from OVNPolicyAuditMaxLogFiles
-            num_files=$(ls -1 ${LOGDIR}/acl-audit-log* 2>/dev/null | wc -l)
-            if [ "$num_files" -gt "$MAXLOGFILES" ]; then
-              num_to_delete=$(( num_files - ${MAXLOGFILES} ))
-              ls -1t ${LOGDIR}/acl-audit-log* 2>/dev/null | tail -$num_to_delete | xargs -I {} rm {}
-            fi
-
-            # sleep for 30 seconds to avoid wasting CPU
-            sleep 30
-          done
+          . /ovnkube-lib/ovnkube-lib.sh || exit 1
+          start-audit-log-rotation
         resources:
           requests:
             cpu: 10m
             memory: 20Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
+        - mountPath: /ovnkube-lib
+          name: ovnkube-script-lib
         - mountPath: /var/log/ovn/
           name: node-log
         - mountPath: /run/ovn/

--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -95,23 +95,8 @@ spec:
         - -c
         - |
           set -e
-          if [[ -f "/env/${K8S_NODE}" ]]; then
-            set -o allexport
-            source "/env/${K8S_NODE}"
-            set +o allexport
-          fi
-
-          echo "$(date -Iseconds) - starting ovn-controller"
-          exec ovn-controller unix:/var/run/openvswitch/db.sock -vfile:off \
-            --no-chdir --pidfile=/var/run/ovn/ovn-controller.pid \
-            --syslog-method="{{.OVNPolicyAuditDestination}}" \
-            --log-file=/var/log/ovn/acl-audit-log.log \
-            -vFACILITY:"{{.OVNPolicyAuditSyslogFacility}}" \
-            -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt \
-            -vconsole:"${OVN_LOG_LEVEL}" -vconsole:"acl_log:off" \
-            -vPATTERN:console:"{{.OVN_LOG_PATTERN_CONSOLE}}" \
-            -vsyslog:"acl_log:info" \
-            -vfile:"acl_log:info"
+          . /ovnkube-lib/ovnkube-lib.sh || exit 1
+          start-ovn-controller ${OVN_LOG_LEVEL}
         securityContext:
           privileged: true
         env:
@@ -122,6 +107,8 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         volumeMounts:
+        - mountPath: /ovnkube-lib
+          name: ovnkube-script-lib
         - mountPath: /run/openvswitch
           name: run-openvswitch
         - mountPath: /run/ovn/
@@ -134,10 +121,6 @@ spec:
           name: var-lib-openvswitch
         - mountPath: /env
           name: env-overrides
-        - mountPath: /ovn-cert
-          name: ovn-cert
-        - mountPath: /ovn-ca
-          name: ovn-ca
         - mountPath: /var/log/ovn/
           name: node-log
         - mountPath: /dev/log
@@ -1084,5 +1067,9 @@ spec:
         secret:
           secretName: ovn-node-metrics-cert
           optional: true
+      - name: ovnkube-script-lib
+        configMap:
+          name: ovnkube-script-lib
+          defaultMode: 0744
       tolerations:
       - operator: "Exists"

--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -384,8 +384,6 @@ spec:
           # end of quit
           trap quit TERM INT
 
-          bracketify() { case "$1" in *:*) echo "[$1]" ;; *) echo "$1" ;; esac }
-
           OVN_ARGS="--no-monitor"
           exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
             --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
@@ -571,8 +569,6 @@ spec:
           }
           # end of quit
           trap quit TERM INT
-
-          bracketify() { case "$1" in *:*) echo "[$1]" ;; *) echo "$1" ;; esac }
 
           OVN_ARGS="--no-monitor"
           exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \

--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -369,167 +369,8 @@ spec:
         - -c
         - |
           set -xe
-          if [[ -f "/env/${K8S_NODE}" ]]; then
-            set -o allexport
-            source "/env/${K8S_NODE}"
-            set +o allexport
-          fi
-
-          function log()
-          {
-              echo "$(date --iso-8601=seconds) [cnibincopy] ${1}"
-          }
-
-          # collect host os information
-          . /host/etc/os-release
-          rhelmajor=
-          # detect which version we're using in order to copy the proper binaries
-          case "${ID}" in
-            rhcos|scos)
-              RHEL_VERSION=$(echo "${CPE_NAME}" | cut -f 5 -d :)
-              rhelmajor=$(echo $RHEL_VERSION | sed -E 's/([0-9]+)\.{1}[0-9]+(\.[0-9]+)?/\1/')
-            ;;
-            rhel) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)
-            ;;
-            fedora)
-              if [ "${VARIANT_ID}" == "coreos" ]; then
-                rhelmajor=8
-              else
-                log "FATAL ERROR: Unsupported Fedora variant=${VARIANT_ID}"
-                exit 1
-              fi
-            ;;
-            *) log "FATAL ERROR: Unsupported OS ID=${ID}"; exit 1
-            ;;
-          esac
-
-          # Set which directory we'll copy from, detect if it exists
-          sourcedir=/usr/libexec/cni/
-          case "${rhelmajor}" in
-          8)
-            sourcedir=/usr/libexec/cni/rhel8
-          ;;
-          9)
-            sourcedir=/usr/libexec/cni/rhel9
-          ;;
-          *)
-            log "ERROR: RHEL Major Version Unsupported, rhelmajor=${rhelmajor}"
-          ;;
-          esac
-
-          cp -f "$sourcedir/ovn-k8s-cni-overlay" /cni-bin-dir/
-
-          ovn_config_namespace=openshift-ovn-kubernetes
-          echo "I$(date "+%m%d %H:%M:%S.%N") - disable conntrack on geneve port"
-          iptables -t raw -A PREROUTING -p udp --dport {{.GenevePort}} -j NOTRACK
-          iptables -t raw -A OUTPUT -p udp --dport {{.GenevePort}} -j NOTRACK
-          ip6tables -t raw -A PREROUTING -p udp --dport {{.GenevePort}} -j NOTRACK
-          ip6tables -t raw -A OUTPUT -p udp --dport {{.GenevePort}} -j NOTRACK
-          echo "I$(date "+%m%d %H:%M:%S.%N") - starting ovnkube-node"
-
-          if [ "{{.OVN_GATEWAY_MODE}}" == "shared" ]; then
-            gateway_mode_flags="--gateway-mode shared --gateway-interface br-ex"
-          elif [ "{{.OVN_GATEWAY_MODE}}" == "local" ]; then
-            gateway_mode_flags="--gateway-mode local --gateway-interface br-ex"
-          else
-            echo "Invalid OVN_GATEWAY_MODE: \"{{.OVN_GATEWAY_MODE}}\". Must be \"local\" or \"shared\"."
-            exit 1
-          fi
-
-          export_network_flows_flags=
-          if [[ -n "${NETFLOW_COLLECTORS}" ]] ; then
-            export_network_flows_flags="--netflow-targets ${NETFLOW_COLLECTORS}"
-          fi
-          if [[ -n "${SFLOW_COLLECTORS}" ]] ; then
-            export_network_flows_flags="$export_network_flows_flags --sflow-targets ${SFLOW_COLLECTORS}"
-          fi
-          if [[ -n "${IPFIX_COLLECTORS}" ]] ; then
-            export_network_flows_flags="$export_network_flows_flags --ipfix-targets ${IPFIX_COLLECTORS}"
-          fi
-          if [[ -n "${IPFIX_CACHE_MAX_FLOWS}" ]] ; then
-            export_network_flows_flags="$export_network_flows_flags --ipfix-cache-max-flows ${IPFIX_CACHE_MAX_FLOWS}"
-          fi
-          if [[ -n "${IPFIX_CACHE_ACTIVE_TIMEOUT}" ]] ; then
-            export_network_flows_flags="$export_network_flows_flags --ipfix-cache-active-timeout ${IPFIX_CACHE_ACTIVE_TIMEOUT}"
-          fi
-          if [[ -n "${IPFIX_SAMPLING}" ]] ; then
-            export_network_flows_flags="$export_network_flows_flags --ipfix-sampling ${IPFIX_SAMPLING}"
-          fi
-          gw_interface_flag=
-          # if br-ex1 is configured on the node, we want to use it for external gateway traffic
-          if [ -d /sys/class/net/br-ex1 ]; then
-            gw_interface_flag="--exgw-interface=br-ex1"
-          fi
-
-          node_mgmt_port_netdev_flags=
-          if [[ -n "${OVNKUBE_NODE_MGMT_PORT_NETDEV}" ]] ; then
-            node_mgmt_port_netdev_flags="--ovnkube-node-mgmt-port-netdev ${OVNKUBE_NODE_MGMT_PORT_NETDEV}"
-          fi
-          if [[ -n "${OVNKUBE_NODE_MGMT_PORT_DP_RESOURCE_NAME}" ]] ; then
-            node_mgmt_port_netdev_flags="$node_mgmt_port_netdev_flags --ovnkube-node-mgmt-port-dp-resource-name ${OVNKUBE_NODE_MGMT_PORT_DP_RESOURCE_NAME}"
-          fi
-
-          multi_network_enabled_flag=
-          if [[ "{{.OVN_MULTI_NETWORK_ENABLE}}" == "true" ]]; then
-            multi_network_enabled_flag="--enable-multi-network"
-          fi
-
-          multi_network_policy_enabled_flag=
-          if [[ "{{.OVN_MULTI_NETWORK_POLICY_ENABLE}}" == "true" ]]; then
-            multi_network_policy_enabled_flag="--enable-multi-networkpolicy"
-          fi
-
-          admin_network_policy_enabled_flag=
-          if [[ "{{.OVN_ADMIN_NETWORK_POLICY_ENABLE}}" == "true" ]]; then
-            admin_network_policy_enabled_flag="--enable-admin-network-policy"
-          fi
-
-          # If IP Forwarding mode is global set it in the host here.
-          ip_forwarding_flag=
-          if [ "{{.IP_FORWARDING_MODE}}" == "Global" ]; then
-            sysctl -w net.ipv4.ip_forward=1
-            sysctl -w net.ipv6.conf.all.forwarding=1
-          else
-            ip_forwarding_flag="--disable-forwarding"
-          fi
-
-          NETWORK_NODE_IDENTITY_ENABLE=
-          if [[ "{{.NETWORK_NODE_IDENTITY_ENABLE}}" == "true" ]]; then
-            NETWORK_NODE_IDENTITY_ENABLE="
-              --bootstrap-kubeconfig=/var/lib/kubelet/kubeconfig
-              --cert-dir=/etc/ovn/ovnkube-node-certs
-              --cert-duration={{.NodeIdentityCertDuration}}
-            "
-          fi
-
-          exec /usr/bin/ovnkube --init-ovnkube-controller "${K8S_NODE}" --init-node "${K8S_NODE}" \
-            --config-file=/run/ovnkube-config/ovnkube.conf \
-            --ovn-empty-lb-events \
-            --loglevel "${OVN_KUBE_LOG_LEVEL}" \
-            --inactivity-probe="${OVN_CONTROLLER_INACTIVITY_PROBE}" \
-            ${gateway_mode_flags} \
-            ${node_mgmt_port_netdev_flags} \
-            {{- if eq .OVN_NODE_MODE "dpu-host" }}
-            --ovnkube-node-mode dpu-host \
-            {{- end }}
-            --metrics-bind-address "127.0.0.1:29103" \
-            --ovn-metrics-bind-address "127.0.0.1:29105" \
-            --metrics-enable-pprof \
-            --metrics-enable-config-duration \
-            --export-ovs-metrics \
-            --disable-snat-multiple-gws \
-            ${export_network_flows_flags} \
-            ${multi_network_enabled_flag} \
-            ${multi_network_policy_enabled_flag} \
-            ${admin_network_policy_enabled_flag} \
-            --enable-multicast \
-            --zone ${K8S_NODE} \
-            --enable-interconnect \
-            --acl-logging-rate-limit "{{.OVNPolicyAuditRateLimit}}" \
-            ${gw_interface_flag} \
-            --enable-multi-external-gateway=true \
-            ${ip_forwarding_flag} \
-            ${NETWORK_NODE_IDENTITY_ENABLE}
+          . /ovnkube-lib/ovnkube-lib.sh || exit 1
+          start-ovnkube-node ${OVN_LOG_LEVEL} 29103 29105
         env:
         # for kubectl
         - name: KUBERNETES_SERVICE_PORT
@@ -584,6 +425,8 @@ spec:
           privileged: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
+        - mountPath: /ovnkube-lib
+          name: ovnkube-script-lib
 {{ if .NETWORK_NODE_IDENTITY_ENABLE }}
         - mountPath: /var/lib/kubelet
           name: host-kubelet
@@ -631,10 +474,6 @@ spec:
           name: ovnkube-config
         - mountPath: /env
           name: env-overrides
-        - mountPath: /ovn-cert
-          name: ovn-cert
-        - mountPath: /ovn-ca
-          name: ovn-ca
         resources:
           requests:
             cpu: 10m

--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -8,7 +8,6 @@ metadata:
   {{ else }}
   name: ovnkube-node
   {{ end }}
-  name: ovnkube-node
   namespace: openshift-ovn-kubernetes
   annotations:
     kubernetes.io/description: |
@@ -87,6 +86,7 @@ spec:
       # /run/openvswitch -> tmpfs - ovsdb sockets
       # /env -> configmap env-overrides - debug overrides
       containers:
+{{ if or (eq .OVN_NODE_MODE "full") (eq .OVN_NODE_MODE "smart-nic") }}
       # ovn-controller: programs the vswitch with flows from the sbdb
       - name: ovn-controller
         image: "{{.OvnImage}}"
@@ -203,6 +203,7 @@ spec:
           name: node-log
         - mountPath: /run/ovn/
           name: run-ovn
+{{ end }}
       - name: kube-rbac-proxy-node
         image: {{.KubeRBACProxyImage}}
         command:
@@ -211,6 +212,7 @@ spec:
         - |
           #!/bin/bash
           set -euo pipefail
+
           TLS_PK=/etc/pki/tls/metrics-cert/tls.key
           TLS_CERT=/etc/pki/tls/metrics-cert/tls.crt
           # As the secret mount is optional we must wait for the files to be present.
@@ -263,6 +265,7 @@ spec:
         - |
           #!/bin/bash
           set -euo pipefail
+
           TLS_PK=/etc/pki/tls/metrics-cert/tls.key
           TLS_CERT=/etc/pki/tls/metrics-cert/tls.crt
           # As the secret mount is optional we must wait for the files to be present.
@@ -336,7 +339,6 @@ spec:
             --no-chdir "-vconsole:${OVN_LOG_LEVEL}" -vfile:off "-vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
             --pidfile /var/run/ovn/ovn-northd.pid \
             --n-threads={{.NorthdThreads}} &
-
           wait $!
         env:
         - name: OVN_LOG_LEVEL
@@ -350,7 +352,7 @@ spec:
           name: run-ovn
         - mountPath: /env
           name: env-overrides
-        - mountPath: /ovn-cert  # not needed, but useful when exec'ing in to pod.
+        - mountPath: /ovn-cert # not needed, but useful when exec'ing in to pod.
           name: ovn-cert
         - mountPath: /ovn-ca
           name: ovn-ca
@@ -459,7 +461,9 @@ spec:
                   exit 1
                 fi
         readinessProbe:
+{{ if not .IsSNO }}
           initialDelaySeconds: 10
+{{ end }}
           timeoutSeconds: 5
           exec:
             command:
@@ -490,7 +494,7 @@ spec:
           name: run-ovn
         - mountPath: /env
           name: env-overrides
-        - mountPath: /ovn-cert  # not needed, but useful when exec'ing in to pod.
+        - mountPath: /ovn-cert
           name: ovn-cert
         - mountPath: /ovn-ca
           name: ovn-ca
@@ -569,7 +573,9 @@ spec:
                   exit 1
                 fi
         readinessProbe:
+{{ if not .IsSNO }}
           initialDelaySeconds: 10
+{{ end }}
           timeoutSeconds: 5
           exec:
             command:
@@ -592,13 +598,12 @@ spec:
           name: run-ovn
         - mountPath: /env
           name: env-overrides
-        - mountPath: /ovn-cert  # not needed, but useful when exec'ing in to pod.
+        - mountPath: /ovn-cert
           name: ovn-cert
         - mountPath: /ovn-ca
           name: ovn-ca
         - mountPath: /var/log/ovn
           name: node-log
-
         resources:
           requests:
             cpu: 10m
@@ -623,6 +628,7 @@ spec:
           {
               echo "$(date --iso-8601=seconds) [cnibincopy] ${1}"
           }
+
           # collect host os information
           . /host/etc/os-release
           rhelmajor=
@@ -721,7 +727,7 @@ spec:
           if [[ "{{.OVN_MULTI_NETWORK_POLICY_ENABLE}}" == "true" ]]; then
             multi_network_policy_enabled_flag="--enable-multi-networkpolicy"
           fi
-          
+
           admin_network_policy_enabled_flag=
           if [[ "{{.OVN_ADMIN_NETWORK_POLICY_ENABLE}}" == "true" ]]; then
             admin_network_policy_enabled_flag="--enable-admin-network-policy"
@@ -770,7 +776,7 @@ spec:
             --enable-interconnect \
             --acl-logging-rate-limit "{{.OVNPolicyAuditRateLimit}}" \
             ${gw_interface_flag} \
-            --enable-multi-external-gateway=true  \
+            --enable-multi-external-gateway=true \
             ${ip_forwarding_flag} \
             ${NETWORK_NODE_IDENTITY_ENABLE}
         env:
@@ -874,7 +880,7 @@ spec:
           name: ovnkube-config
         - mountPath: /env
           name: env-overrides
-        - mountPath: /ovn-cert  # not needed, but useful when exec'ing in to pod.
+        - mountPath: /ovn-cert
           name: ovn-cert
         - mountPath: /ovn-ca
           name: ovn-ca

--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -160,39 +160,8 @@ spec:
         - |
           #!/bin/bash
           set -euo pipefail
-
-          TLS_PK=/etc/pki/tls/metrics-cert/tls.key
-          TLS_CERT=/etc/pki/tls/metrics-cert/tls.crt
-          # As the secret mount is optional we must wait for the files to be present.
-          # The service is created in monitor.yaml and this is created in sdn.yaml.
-          # If it isn't created there is probably an issue so we want to crashloop.
-          retries=0
-          TS=$(date +%s)
-          WARN_TS=$(( ${TS} + $(( 20 * 60)) ))
-          HAS_LOGGED_INFO=0
-
-          log_missing_certs(){
-              CUR_TS=$(date +%s)
-              if [[ "${CUR_TS}" -gt "WARN_TS"  ]]; then
-                echo $(date -Iseconds) WARN: ovn-node-metrics-cert not mounted after 20 minutes.
-              elif [[ "${HAS_LOGGED_INFO}" -eq 0 ]] ; then
-                echo $(date -Iseconds) INFO: ovn-node-metrics-cert not mounted. Waiting one hour.
-                HAS_LOGGED_INFO=1
-              fi
-          }
-          while [[ ! -f "${TLS_PK}" ||  ! -f "${TLS_CERT}" ]] ; do
-            log_missing_certs
-            sleep 5
-          done
-
-          echo $(date -Iseconds) INFO: ovn-node-metrics-certs mounted, starting kube-rbac-proxy
-          exec /usr/bin/kube-rbac-proxy \
-            --logtostderr \
-            --secure-listen-address=:9103 \
-            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
-            --upstream=http://127.0.0.1:29103/ \
-            --tls-private-key-file=${TLS_PK} \
-            --tls-cert-file=${TLS_CERT}
+          . /ovnkube-lib/ovnkube-lib.sh || exit 1
+          start-rbac-proxy-node ovn-node-metrics 9103 29103 /etc/pki/tls/metrics-cert/tls.key /etc/pki/tls/metrics-cert/tls.crt
         ports:
         - containerPort: 9103
           name: https
@@ -202,6 +171,8 @@ spec:
             memory: 20Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
+        - mountPath: /ovnkube-lib
+          name: ovnkube-script-lib
         - name: ovn-node-metrics-cert
           mountPath: /etc/pki/tls/metrics-cert
           readOnly: True
@@ -213,39 +184,8 @@ spec:
         - |
           #!/bin/bash
           set -euo pipefail
-
-          TLS_PK=/etc/pki/tls/metrics-cert/tls.key
-          TLS_CERT=/etc/pki/tls/metrics-cert/tls.crt
-          # As the secret mount is optional we must wait for the files to be present.
-          # The service is created in monitor.yaml and this is created in sdn.yaml.
-          # If it isn't created there is probably an issue so we want to crashloop.
-          retries=0
-          TS=$(date +%s)
-          WARN_TS=$(( ${TS} + $(( 20 * 60)) ))
-          HAS_LOGGED_INFO=0
-
-          log_missing_certs(){
-              CUR_TS=$(date +%s)
-              if [[ "${CUR_TS}" -gt "WARN_TS"  ]]; then
-                echo $(date -Iseconds) WARN: ovn-node-metrics-cert not mounted after 20 minutes.
-              elif [[ "${HAS_LOGGED_INFO}" -eq 0 ]] ; then
-                echo $(date -Iseconds) INFO: ovn-node-metrics-cert not mounted. Waiting one hour.
-                HAS_LOGGED_INFO=1
-              fi
-          }
-          while [[ ! -f "${TLS_PK}" ||  ! -f "${TLS_CERT}" ]] ; do
-            log_missing_certs
-            sleep 5
-          done
-
-          echo $(date -Iseconds) INFO: ovn-node-metrics-certs mounted, starting kube-rbac-proxy
-          exec /usr/bin/kube-rbac-proxy \
-            --logtostderr \
-            --secure-listen-address=:9105 \
-            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
-            --upstream=http://127.0.0.1:29105/ \
-            --tls-private-key-file=${TLS_PK} \
-            --tls-cert-file=${TLS_CERT}
+          . /ovnkube-lib/ovnkube-lib.sh || exit 1
+          start-rbac-proxy-node ovn-metrics 9105 29105 /etc/pki/tls/metrics-cert/tls.key /etc/pki/tls/metrics-cert/tls.crt
         ports:
         - containerPort: 9105
           name: https
@@ -255,6 +195,8 @@ spec:
             memory: 20Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
+        - mountPath: /ovnkube-lib
+          name: ovnkube-script-lib
         - name: ovn-node-metrics-cert
           mountPath: /etc/pki/tls/metrics-cert
           readOnly: True

--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -306,27 +306,16 @@ spec:
             source /env/_master
             set +o allexport
           fi
+          . /ovnkube-lib/ovnkube-lib.sh || exit 1
 
-          quit() {
-            echo "$(date -Iseconds) - stopping ovn-northd"
-            OVN_MANAGE_OVSDB=no /usr/share/ovn/scripts/ovn-ctl stop_northd
-            echo "$(date -Iseconds) - ovn-northd stopped"
-            rm -f /var/run/ovn/ovn-northd.pid
-            exit 0
-          }
-          # end of quit
-          trap quit TERM INT
-
-          echo "$(date -Iseconds) - starting ovn-northd"
-          exec ovn-northd \
-            --no-chdir "-vconsole:${OVN_LOG_LEVEL}" -vfile:off "-vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
-            --pidfile /var/run/ovn/ovn-northd.pid \
-            --n-threads={{.NorthdThreads}} &
-          wait $!
+          trap quit-ovn-northd TERM INT
+          start-ovn-northd "${OVN_LOG_LEVEL}"
         env:
         - name: OVN_LOG_LEVEL
           value: info
         volumeMounts:
+        - mountPath: /ovnkube-lib
+          name: ovnkube-script-lib
         - mountPath: /etc/ovn
           name: etc-openvswitch
         - mountPath: /var/log/ovn
@@ -335,10 +324,6 @@ spec:
           name: run-ovn
         - mountPath: /env
           name: env-overrides
-        - mountPath: /ovn-cert # not needed, but useful when exec'ing in to pod.
-          name: ovn-cert
-        - mountPath: /ovn-ca
-          name: ovn-ca
         resources:
           requests:
             cpu: 10m

--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -427,22 +427,6 @@ spec:
                   exit 1
                 fi
 
-                # Upgrade the db if required.
-                DB_SCHEMA="/usr/share/ovn/ovn-nb.ovsschema"
-                DB_SERVER="unix:/var/run/ovn/ovnnb_db.sock"
-                schema_name=$(ovsdb-tool schema-name $DB_SCHEMA)
-                db_version=$(ovsdb-client -t 10 get-schema-version "$DB_SERVER" "$schema_name")
-                target_version=$(ovsdb-tool schema-version "$DB_SCHEMA")
-
-                if ovsdb-tool compare-versions "$db_version" == "$target_version"; then
-                  :
-                elif ovsdb-tool compare-versions "$db_version" ">" "$target_version"; then
-                    echo "Database $schema_name has newer schema version ($db_version) than our local schema ($target_version), possibly an upgrade is partially complete?"
-                else
-                    echo "Upgrading database $schema_name from schema version $db_version to $target_version"
-                    ovsdb-client -t 30 convert "$DB_SERVER" "$DB_SCHEMA"
-                fi
-
                 echo "Setting the IC zone to ${K8S_NODE}"
                 retries=0
                 current_probe_interval=0
@@ -608,22 +592,6 @@ spec:
                 # set the connection and inactivity probe
                 if ! retry 60 "inactivity-probe" "ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_CONTROLLER_INACTIVITY_PROBE}}"; then
                   exit 1
-                fi
-
-                # Upgrade the db if required.
-                DB_SCHEMA="/usr/share/ovn/ovn-sb.ovsschema"
-                DB_SERVER="unix:/var/run/ovn/ovnsb_db.sock"
-                schema_name=$(ovsdb-tool schema-name $DB_SCHEMA)
-                db_version=$(ovsdb-client -t 10 get-schema-version "$DB_SERVER" "$schema_name")
-                target_version=$(ovsdb-tool schema-version "$DB_SCHEMA")
-
-                if ovsdb-tool compare-versions "$db_version" == "$target_version"; then
-                  :
-                elif ovsdb-tool compare-versions "$db_version" ">" "$target_version"; then
-                    echo "Database $schema_name has newer schema version ($db_version) than our local schema ($target_version), possibly an upgrade is partially complete?"
-                else
-                    echo "Upgrading database $schema_name from schema version $db_version to $target_version"
-                    ovsdb-client -t 30 convert "$DB_SERVER" "$DB_SCHEMA"
                 fi
 
                 # Kill some time while the cluster converges by checking IPsec status

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -422,8 +422,7 @@ spec:
           # end of quit
           trap quit TERM INT
 
-          OVN_ARGS="--no-monitor"
-          exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
+          exec /usr/share/ovn/scripts/ovn-ctl --no-monitor \
             --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
             run_nb_ovsdb &
 
@@ -623,8 +622,7 @@ spec:
           # end of quit
           trap quit TERM INT
 
-          OVN_ARGS="--no-monitor"
-          exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
+          exec /usr/share/ovn/scripts/ovn-ctl --no-monitor \
             --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
             run_sb_ovsdb &
 

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -675,12 +675,6 @@ spec:
         configMap:
           name: env-overrides
           optional: true
-      - name: ovn-ca
-        configMap:
-          name: ovn-ca
-      - name: ovn-cert
-        secret:
-          secretName: ovn-cert
       - name: ovn-node-metrics-cert
         secret:
           secretName: ovn-node-metrics-cert

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -120,7 +120,7 @@ spec:
       # /run/openvswitch -> tmpfs - ovsdb sockets
       # /env -> configmap env-overrides - debug overrides
       containers:
-      {{ if or (eq .OVN_NODE_MODE "full") (eq .OVN_NODE_MODE "smart-nic") }}
+{{ if or (eq .OVN_NODE_MODE "full") (eq .OVN_NODE_MODE "smart-nic") }}
       # ovn-controller: programs the vswitch with flows from the sbdb
       - name: ovn-controller
         image: "{{.OvnImage}}"
@@ -237,7 +237,7 @@ spec:
           name: node-log
         - mountPath: /run/ovn/
           name: run-ovn
-      {{ end }}
+{{ end }}
       - name: kube-rbac-proxy-node
         image: {{.KubeRBACProxyImage}}
         command:

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -533,7 +533,7 @@ spec:
                 fi
         readinessProbe:
 {{ if not .IsSNO }}
-          initialDelaySeconds: 90
+          initialDelaySeconds: 10
 {{ end }}
           timeoutSeconds: 5
           exec:
@@ -654,7 +654,7 @@ spec:
                 fi
         readinessProbe:
 {{ if not .IsSNO }}
-          initialDelaySeconds: 90
+          initialDelaySeconds: 10
 {{ end }}
           timeoutSeconds: 5
           exec:

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -422,7 +422,7 @@ spec:
           # end of quit
           trap quit TERM INT
 
-          exec /usr/share/ovn/scripts/ovn-ctl --no-monitor \
+          exec /usr/share/ovn/scripts/ovn-ctl --no-monitor --db-nb-sock=/var/run/ovn/ovnnb_db.sock \
             --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
             run_nb_ovsdb &
 
@@ -460,8 +460,8 @@ spec:
                   return 0
                 }
 
-                # set the connection and inactivity probe
-                if ! retry 60 "inactivity-probe" "ovn-nbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_NB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_NB_INACTIVITY_PROBE}}"; then
+                # set inactivity probe
+                if ! retry 60 "inactivity-probe" "ovn-nbctl -t 5 --inactivity-probe={{.OVN_NB_INACTIVITY_PROBE}} set-connection punix:/var/run/ovn/ovnnb_db.sock"; then
                   exit 1
                 fi
                 # set trim-on-compaction
@@ -607,7 +607,7 @@ spec:
           # end of quit
           trap quit TERM INT
 
-          exec /usr/share/ovn/scripts/ovn-ctl --no-monitor \
+          exec /usr/share/ovn/scripts/ovn-ctl --no-monitor --db-sb-sock=/var/run/ovn/ovnsb_db.sock \
             --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
             run_sb_ovsdb &
 
@@ -643,8 +643,8 @@ spec:
                   return 0
                 }
 
-                # set the connection and inactivity probe
-                if ! retry 60 "inactivity-probe" "ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_CONTROLLER_INACTIVITY_PROBE}}"; then
+                # set inactivity probe
+                if ! retry 60 "inactivity-probe" "ovn-sbctl -t 5 --inactivity-probe={{.OVN_CONTROLLER_INACTIVITY_PROBE}} set-connection punix:/var/run/ovn/ovnsb_db.sock"; then
                   exit 1
                 fi
                 # set trim-on-compaction

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -348,23 +348,10 @@ spec:
             source /env/_master
             set +o allexport
           fi
+          . /ovnkube-lib/ovnkube-lib.sh || exit 1
 
-          quit() {
-            echo "$(date -Iseconds) - stopping sbdb"
-            /usr/share/ovn/scripts/ovn-ctl stop_sb_ovsdb
-            echo "$(date -Iseconds) - sbdb stopped"
-            rm -f /var/run/ovn/ovnsb_db.pid
-            exit 0
-          }
-          # end of quit
-          trap quit TERM INT
-
-          exec /usr/share/ovn/scripts/ovn-ctl --no-monitor --db-sb-sock=/var/run/ovn/ovnsb_db.sock \
-            --ovn-sb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
-            run_sb_ovsdb &
-
-          wait $!
-
+          trap quit-sbdb TERM INT
+          start-sbdb ${OVN_LOG_LEVEL}
         lifecycle:
           postStart:
             exec:
@@ -373,36 +360,8 @@ spec:
               - -c
               - |
                 set -x
-                rm -f /var/run/ovn/ovnsb_db.pid
-
-                # retry an operation a number of times, sleeping 2 seconds between each try
-                retry() {
-                  local tries=${1}
-                  local desc=${2}
-                  local cmd=${3}
-
-                  local retries=0
-                  while ! ${cmd}; do
-                    (( retries += 1 ))
-                    if [[ "${retries}" -gt ${tries} ]]; then
-                      echo "$(date -Iseconds) - ERROR - sbdb ${desc} - too many failed attempts, giving up"
-                      return 1
-                    fi
-                    echo "$(date -Iseconds) - WARN - sbdb ${desc} - failed try ${retries}, retrying..."
-                    sleep 2
-                  done
-                  echo "$(date -Iseconds) - INFO - sbdb ${desc} - success"
-                  return 0
-                }
-
-                # set inactivity probe
-                if ! retry 60 "inactivity-probe" "ovn-sbctl -t 5 --inactivity-probe={{.OVN_CONTROLLER_INACTIVITY_PROBE}} set-connection punix:/var/run/ovn/ovnsb_db.sock"; then
-                  exit 1
-                fi
-                # set trim-on-compaction
-                if ! retry 60 "trim-on-compaction" "ovn-appctl -t /var/run/ovn/ovnsb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on"; then
-                  exit 1
-                fi
+                . /ovnkube-lib/ovnkube-lib.sh || exit 1
+                sbdb-post-start
         readinessProbe:
 {{ if not .IsSNO }}
           initialDelaySeconds: 10
@@ -414,31 +373,22 @@ spec:
             - -c
             - |
               set -xeo pipefail
-              status=$(/usr/bin/ovn-appctl -t /var/run/ovn/ovnsb_db.ctl --timeout=3 ovsdb-server/sync-status  2>/dev/null | { grep "state: active" || false; })
-              if [[  -z "${status}" ]]; then
-                echo "SB DB is not running or active."
-                exit 1
-              fi
+              . /ovnkube-lib/ovnkube-lib.sh || exit 1
+              ovndb-readiness-probe "sb"
         env:
         - name: OVN_LOG_LEVEL
           value: info
         volumeMounts:
-        - mountPath: /etc/openvswitch/
-          name: etc-openvswitch
+        - mountPath: /ovnkube-lib
+          name: ovnkube-script-lib
         - mountPath: /etc/ovn/
           name: etc-openvswitch
-        - mountPath: /var/lib/openvswitch/
-          name: var-lib-openvswitch
-        - mountPath: /run/openvswitch/
-          name: run-openvswitch
         - mountPath: /run/ovn/
           name: run-ovn
+        - mountPath: /var/log/ovn
+          name: node-log
         - mountPath: /env
           name: env-overrides
-        - mountPath: /ovn-cert
-          name: ovn-cert
-        - mountPath: /ovn-ca
-          name: ovn-ca
         resources:
           requests:
             cpu: 10m

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -465,22 +465,6 @@ spec:
                   exit 1
                 fi
 
-                # Upgrade the db if required.
-                DB_SCHEMA="/usr/share/ovn/ovn-nb.ovsschema"
-                DB_SERVER="unix:/var/run/ovn/ovnnb_db.sock"
-                schema_name=$(ovsdb-tool schema-name $DB_SCHEMA)
-                db_version=$(ovsdb-client -t 10 get-schema-version "$DB_SERVER" "$schema_name")
-                target_version=$(ovsdb-tool schema-version "$DB_SCHEMA")
-
-                if ovsdb-tool compare-versions "$db_version" == "$target_version"; then
-                  :
-                elif ovsdb-tool compare-versions "$db_version" ">" "$target_version"; then
-                    echo "Database $schema_name has newer schema version ($db_version) than our local schema ($target_version), possibly an upgrade is partially complete?"
-                else
-                    echo "Upgrading database $schema_name from schema version $db_version to $target_version"
-                    ovsdb-client -t 30 convert "$DB_SERVER" "$DB_SCHEMA"
-                fi
-
                 echo "Setting the IC zone to ${K8S_NODE}"
                 retries=0
                 current_probe_interval=0
@@ -661,21 +645,6 @@ spec:
                 # set the connection and inactivity probe
                 if ! retry 60 "inactivity-probe" "ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_CONTROLLER_INACTIVITY_PROBE}}"; then
                   exit 1
-                fi
-
-                # Upgrade the db if required.
-                DB_SCHEMA="/usr/share/ovn/ovn-sb.ovsschema"
-                DB_SERVER="unix:/var/run/ovn/ovnsb_db.sock"
-                schema_name=$(ovsdb-tool schema-name $DB_SCHEMA)
-                db_version=$(ovsdb-client -t 10 get-schema-version "$DB_SERVER" "$schema_name")
-                target_version=$(ovsdb-tool schema-version "$DB_SCHEMA")
-                if ovsdb-tool compare-versions "$db_version" == "$target_version"; then
-                  :
-                elif ovsdb-tool compare-versions "$db_version" ">" "$target_version"; then
-                    echo "Database $schema_name has newer schema version ($db_version) than our local schema ($target_version), possibly an upgrade is partially complete?"
-                else
-                    echo "Upgrading database $schema_name from schema version $db_version to $target_version"
-                    ovsdb-client -t 30 convert "$DB_SERVER" "$DB_SCHEMA"
                 fi
 
                 # Kill some time while the cluster converges by checking IPsec status

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -464,6 +464,10 @@ spec:
                 if ! retry 60 "inactivity-probe" "ovn-nbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_NB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_NB_INACTIVITY_PROBE}}"; then
                   exit 1
                 fi
+                # set trim-on-compaction
+                if ! retry 60 "trim-on-compaction" "ovn-appctl -t /var/run/ovn/ovnnb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on"; then
+                  exit 1
+                fi
 
                 echo "Setting the IC zone to ${K8S_NODE}"
                 retries=0
@@ -547,9 +551,6 @@ spec:
                 echo "NB DB is not running or active."
                 exit 1
               fi
-
-              # set trim-on-compaction
-              /usr/bin/ovn-appctl -t /var/run/ovn/ovnnb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on 2>/dev/null
         env:
         - name: OVN_LOG_LEVEL
           value: info
@@ -646,6 +647,10 @@ spec:
                 if ! retry 60 "inactivity-probe" "ovn-sbctl --no-leader-only -t 5 set-connection pssl:{{.OVN_SB_PORT}}{{.LISTEN_DUAL_STACK}} -- set connection . inactivity_probe={{.OVN_CONTROLLER_INACTIVITY_PROBE}}"; then
                   exit 1
                 fi
+                # set trim-on-compaction
+                if ! retry 60 "trim-on-compaction" "ovn-appctl -t /var/run/ovn/ovnsb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on"; then
+                  exit 1
+                fi
 
                 # Kill some time while the cluster converges by checking IPsec status
                 OVN_SB_CTL="ovn-sbctl"
@@ -668,8 +673,6 @@ spec:
                 echo "SB DB is not running or active."
                 exit 1
               fi
-              # set trim-on-compaction
-              /usr/bin/ovn-appctl -t /var/run/ovn/ovnsb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on 2>/dev/null
         env:
         - name: OVN_LOG_LEVEL
           value: info

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -422,8 +422,6 @@ spec:
           # end of quit
           trap quit TERM INT
 
-          bracketify() { case "$1" in *:*) echo "[$1]" ;; *) echo "$1" ;; esac }
-
           OVN_ARGS="--no-monitor"
           exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \
             --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
@@ -624,8 +622,6 @@ spec:
           }
           # end of quit
           trap quit TERM INT
-
-          bracketify() { case "$1" in *:*) echo "[$1]" ;; *) echo "$1" ;; esac }
 
           OVN_ARGS="--no-monitor"
           exec /usr/share/ovn/scripts/ovn-ctl ${OVN_ARGS} \

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -437,8 +437,6 @@ spec:
               - |
                 set -x
                 rm -f /var/run/ovn/ovnnb_db.pid
-                #configure northd_probe_interval
-                OVN_NB_CTL="ovn-nbctl"
 
                 # retry an operation a number of times, sleeping 2 seconds between each try
                 retry() {
@@ -469,70 +467,33 @@ spec:
                   exit 1
                 fi
 
+                # set IC zone
                 echo "Setting the IC zone to ${K8S_NODE}"
-                retries=0
-                current_probe_interval=0
-                while [[ "${retries}" -lt 10 ]]; do
-                  current_probe_interval=$(${OVN_NB_CTL} set NB_Global . name="${K8S_NODE}" options:name="${K8S_NODE}")
-                  if [[ $? == 0 ]]; then
-                    current_probe_interval=$(echo ${current_probe_interval} | tr -d '\"')
-                    break
-                  else
-                    sleep 2
-                    (( retries += 1 ))
-                  fi
-                done
+                IC_OPTION="name=\"${K8S_NODE}\" options:name=\"${K8S_NODE}\""
 
+                # northd probe interval
                 northd_probe_interval=${OVN_NORTHD_PROBE_INTERVAL:-10000}
                 echo "Setting northd probe interval to ${northd_probe_interval} ms"
-                retries=0
-                current_probe_interval=0
-                while [[ "${retries}" -lt 10 ]]; do
-                  current_probe_interval=$(${OVN_NB_CTL} --if-exists get NB_GLOBAL . options:northd_probe_interval)
-                  if [[ $? == 0 ]]; then
-                    current_probe_interval=$(echo ${current_probe_interval} | tr -d '\"')
-                    break
-                  else
-                    sleep 2
-                    (( retries += 1 ))
-                  fi
-                done
+                NORTHD_PROBE_OPTION="options:northd_probe_interval=${northd_probe_interval}"
 
-                if [[ "${current_probe_interval}" != "${northd_probe_interval}" ]]; then
-                  retries=0
-                  while [[ "${retries}" -lt 10 ]]; do
-                    ${OVN_NB_CTL} set NB_GLOBAL . options:northd_probe_interval=${northd_probe_interval}
-                    if [[ $? != 0 ]]; then
-                      echo "Failed to set northd probe interval to ${northd_probe_interval}. retrying..."
-                      sleep 2
-                      (( retries += 1 ))
-                    else
-                      echo "Successfully set northd probe interval to ${northd_probe_interval} ms"
-                      break
-                    fi
-                  done
-                fi
+                # let northd sleep so it takes less CPU
+                NORTHD_SLEEP_OPTION="options:northd-backoff-interval-ms={{.OVN_NORTHD_BACKOFF_MS}}"
 
                 # Enable/disable IPsec
+                ipsec=false
+                ipsec_encapsulation=false
                 {{ if .OVNIPsecEnable }}
                 ipsec=true
-                {{ else }}
-                ipsec=false
+                # IBMCloud does not forward ESP (IP proto 50)
+                # Instead, force IBMCloud IPsec to always use NAT-T
+                if [ "{{.PlatformType}}" == "IBMCloud" ]; then
+                    ipsec_encapsulation=true
+                fi
                 {{ end }}
-                ipsec_encapsulation=false
-                if [ "${ipsec}" == "true" ]; then
-                    # IBMCloud does not forward ESP (IP proto 50)
-                    # Instead, force IBMCloud IPsec to always use NAT-T
-                    if [ "{{.PlatformType}}" == "IBMCloud" ]; then
-                        ipsec_encapsulation=true
-                    fi
-                fi
-                if ! retry 20 "ipsec" "${OVN_NB_CTL} set nb_global . ipsec=${ipsec} options:ipsec_encapsulation=${ipsec_encapsulation}"; then
-                  exit 1
-                fi
+                IPSEC_OPTION="ipsec=${ipsec} options:ipsec_encapsulation=${ipsec_encapsulation}"
 
-                # Tell northd to sleep a bit so it takes less CPU
-                if ! retry 20 "northd-backoff" "${OVN_NB_CTL} set nb_global . options:northd-backoff-interval-ms={{.OVN_NORTHD_BACKOFF_MS}}"; then
+                # set all the NB_GLOBAL options
+                if ! retry 20 "nb-global options" "ovn-nbctl -t 5 set nb_global . ${IC_OPTION} ${NORTHD_PROBE_OPTION} ${NORTHD_SLEEP_OPTION} ${IPSEC_OPTION}"; then
                   exit 1
                 fi
         readinessProbe:

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -651,12 +651,6 @@ spec:
                 if ! retry 60 "trim-on-compaction" "ovn-appctl -t /var/run/ovn/ovnsb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on"; then
                   exit 1
                 fi
-
-                # Kill some time while the cluster converges by checking IPsec status
-                OVN_SB_CTL="ovn-sbctl"
-                if ! retry 20 "ipsec" "${OVN_SB_CTL} get sb_global . ipsec"; then
-                  exit 1
-                fi
         readinessProbe:
 {{ if not .IsSNO }}
           initialDelaySeconds: 10

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -284,23 +284,10 @@ spec:
             source /env/_master
             set +o allexport
           fi
+          . /ovnkube-lib/ovnkube-lib.sh || exit 1
 
-          quit() {
-            echo "$(date -Iseconds) - stopping nbdb"
-            /usr/share/ovn/scripts/ovn-ctl stop_nb_ovsdb
-            echo "$(date -Iseconds) - nbdb stopped"
-            rm -f /var/run/ovn/ovnnb_db.pid
-            exit 0
-          }
-          # end of quit
-          trap quit TERM INT
-
-          exec /usr/share/ovn/scripts/ovn-ctl --no-monitor --db-nb-sock=/var/run/ovn/ovnnb_db.sock \
-            --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off -vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
-            run_nb_ovsdb &
-
-          wait $!
-
+          trap quit-nbdb TERM INT
+          start-nbdb ${OVN_LOG_LEVEL}
         lifecycle:
           postStart:
             exec:
@@ -309,66 +296,8 @@ spec:
               - -c
               - |
                 set -x
-                rm -f /var/run/ovn/ovnnb_db.pid
-
-                # retry an operation a number of times, sleeping 2 seconds between each try
-                retry() {
-                  local tries=${1}
-                  local desc=${2}
-                  local cmd=${3}
-
-                  local retries=0
-                  while ! ${cmd}; do
-                    (( retries += 1 ))
-                    if [[ "${retries}" -gt ${tries} ]]; then
-                      echo "$(date -Iseconds) - ERROR - nbdb ${desc} - too many failed attempts, giving up"
-                      return 1
-                    fi
-                    echo "$(date -Iseconds) - WARN - nbdb ${desc} - failed try ${retries}, retrying..."
-                    sleep 2
-                  done
-                  echo "$(date -Iseconds) - INFO - nbdb ${desc} - success"
-                  return 0
-                }
-
-                # set inactivity probe
-                if ! retry 60 "inactivity-probe" "ovn-nbctl -t 5 --inactivity-probe={{.OVN_NB_INACTIVITY_PROBE}} set-connection punix:/var/run/ovn/ovnnb_db.sock"; then
-                  exit 1
-                fi
-                # set trim-on-compaction
-                if ! retry 60 "trim-on-compaction" "ovn-appctl -t /var/run/ovn/ovnnb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on"; then
-                  exit 1
-                fi
-
-                # set IC zone
-                echo "Setting the IC zone to ${K8S_NODE}"
-                IC_OPTION="name=\"${K8S_NODE}\" options:name=\"${K8S_NODE}\""
-
-                # northd probe interval
-                northd_probe_interval=${OVN_NORTHD_PROBE_INTERVAL:-10000}
-                echo "Setting northd probe interval to ${northd_probe_interval} ms"
-                NORTHD_PROBE_OPTION="options:northd_probe_interval=${northd_probe_interval}"
-
-                # let northd sleep so it takes less CPU
-                NORTHD_SLEEP_OPTION="options:northd-backoff-interval-ms={{.OVN_NORTHD_BACKOFF_MS}}"
-
-                # Enable/disable IPsec
-                ipsec=false
-                ipsec_encapsulation=false
-                {{ if .OVNIPsecEnable }}
-                ipsec=true
-                # IBMCloud does not forward ESP (IP proto 50)
-                # Instead, force IBMCloud IPsec to always use NAT-T
-                if [ "{{.PlatformType}}" == "IBMCloud" ]; then
-                    ipsec_encapsulation=true
-                fi
-                {{ end }}
-                IPSEC_OPTION="ipsec=${ipsec} options:ipsec_encapsulation=${ipsec_encapsulation}"
-
-                # set all the NB_GLOBAL options
-                if ! retry 20 "nb-global options" "ovn-nbctl -t 5 set nb_global . ${IC_OPTION} ${NORTHD_PROBE_OPTION} ${NORTHD_SLEEP_OPTION} ${IPSEC_OPTION}"; then
-                  exit 1
-                fi
+                . /ovnkube-lib/ovnkube-lib.sh || exit 1
+                nbdb-post-start {{.OVN_NORTHD_PROBE_INTERVAL}}
         readinessProbe:
 {{ if not .IsSNO }}
           initialDelaySeconds: 10
@@ -380,37 +309,26 @@ spec:
             - -c
             - |
               set -xeo pipefail
-              status=$(/usr/bin/ovn-appctl -t /var/run/ovn/ovnnb_db.ctl --timeout=3 ovsdb-server/sync-status  2>/dev/null | { grep "state: active" || false; })
-              if [[  -z "${status}" ]]; then
-                echo "NB DB is not running or active."
-                exit 1
-              fi
+              . /ovnkube-lib/ovnkube-lib.sh || exit 1
+              ovndb-readiness-probe "nb"
         env:
         - name: OVN_LOG_LEVEL
           value: info
-        - name: OVN_NORTHD_PROBE_INTERVAL
-          value: "{{.OVN_NORTHD_PROBE_INTERVAL}}"
         - name: K8S_NODE
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
         volumeMounts:
-        - mountPath: /etc/openvswitch/
-          name: etc-openvswitch
+        - mountPath: /ovnkube-lib
+          name: ovnkube-script-lib
         - mountPath: /etc/ovn/
           name: etc-openvswitch
-        - mountPath: /var/lib/openvswitch/
-          name: var-lib-openvswitch
-        - mountPath: /run/openvswitch/
-          name: run-openvswitch
+        - mountPath: /var/log/ovn
+          name: node-log
         - mountPath: /run/ovn/
           name: run-ovn
         - mountPath: /env
           name: env-overrides
-        - mountPath: /ovn-cert
-          name: ovn-cert
-        - mountPath: /ovn-ca
-          name: ovn-ca
         resources:
           requests:
             cpu: 10m

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -129,23 +129,8 @@ spec:
         - -c
         - |
           set -e
-          if [[ -f "/env/${K8S_NODE}" ]]; then
-            set -o allexport
-            source "/env/${K8S_NODE}"
-            set +o allexport
-          fi
-
-          echo "$(date -Iseconds) - starting ovn-controller"
-          exec ovn-controller unix:/var/run/openvswitch/db.sock -vfile:off \
-            --no-chdir --pidfile=/var/run/ovn/ovn-controller.pid \
-            --syslog-method="{{.OVNPolicyAuditDestination}}" \
-            --log-file=/var/log/ovn/acl-audit-log.log \
-            -vFACILITY:"{{.OVNPolicyAuditSyslogFacility}}" \
-            -p /ovn-cert/tls.key -c /ovn-cert/tls.crt -C /ovn-ca/ca-bundle.crt \
-            -vconsole:"${OVN_LOG_LEVEL}" -vconsole:"acl_log:off" \
-            -vPATTERN:console:"{{.OVN_LOG_PATTERN_CONSOLE}}" \
-            -vsyslog:"acl_log:info" \
-            -vfile:"acl_log:info"
+          . /ovnkube-lib/ovnkube-lib.sh || exit 1
+          start-ovn-controller ${OVN_LOG_LEVEL}
         securityContext:
           privileged: true
         env:
@@ -156,6 +141,8 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         volumeMounts:
+        - mountPath: /ovnkube-lib
+          name: ovnkube-script-lib
         - mountPath: /run/openvswitch
           name: run-openvswitch
         - mountPath: /run/ovn/
@@ -168,10 +155,6 @@ spec:
           name: var-lib-openvswitch
         - mountPath: /env
           name: env-overrides
-        - mountPath: /ovn-cert
-          name: ovn-cert
-        - mountPath: /ovn-ca
-          name: ovn-ca
         - mountPath: /var/log/ovn/
           name: node-log
         - mountPath: /dev/log
@@ -1105,5 +1088,9 @@ spec:
         secret:
           secretName: ovn-node-metrics-cert
           optional: true
+      - name: ovnkube-script-lib
+        configMap:
+          name: ovnkube-script-lib
+          defaultMode: 0744
       tolerations:
       - operator: "Exists"

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -194,39 +194,8 @@ spec:
         - |
           #!/bin/bash
           set -euo pipefail
-
-          TLS_PK=/etc/pki/tls/metrics-cert/tls.key
-          TLS_CERT=/etc/pki/tls/metrics-cert/tls.crt
-          # As the secret mount is optional we must wait for the files to be present.
-          # The service is created in monitor.yaml and this is created in sdn.yaml.
-          # If it isn't created there is probably an issue so we want to crashloop.
-          retries=0
-          TS=$(date +%s)
-          WARN_TS=$(( ${TS} + $(( 20 * 60)) ))
-          HAS_LOGGED_INFO=0
-
-          log_missing_certs(){
-              CUR_TS=$(date +%s)
-              if [[ "${CUR_TS}" -gt "WARN_TS"  ]]; then
-                echo $(date -Iseconds) WARN: ovn-node-metrics-cert not mounted after 20 minutes.
-              elif [[ "${HAS_LOGGED_INFO}" -eq 0 ]] ; then
-                echo $(date -Iseconds) INFO: ovn-node-metrics-cert not mounted. Waiting one hour.
-                HAS_LOGGED_INFO=1
-              fi
-          }
-          while [[ ! -f "${TLS_PK}" ||  ! -f "${TLS_CERT}" ]] ; do
-            log_missing_certs
-            sleep 5
-          done
-
-          echo $(date -Iseconds) INFO: ovn-node-metrics-certs mounted, starting kube-rbac-proxy
-          exec /usr/bin/kube-rbac-proxy \
-            --logtostderr \
-            --secure-listen-address=:9103 \
-            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
-            --upstream=http://127.0.0.1:29103/ \
-            --tls-private-key-file=${TLS_PK} \
-            --tls-cert-file=${TLS_CERT}
+          . /ovnkube-lib/ovnkube-lib.sh || exit 1
+          start-rbac-proxy-node ovn-node-metrics 9103 29103 /etc/pki/tls/metrics-cert/tls.key /etc/pki/tls/metrics-cert/tls.crt
         ports:
         - containerPort: 9103
           name: https
@@ -236,6 +205,8 @@ spec:
             memory: 20Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
+        - mountPath: /ovnkube-lib
+          name: ovnkube-script-lib
         - name: ovn-node-metrics-cert
           mountPath: /etc/pki/tls/metrics-cert
           readOnly: True
@@ -247,39 +218,8 @@ spec:
         - |
           #!/bin/bash
           set -euo pipefail
-
-          TLS_PK=/etc/pki/tls/metrics-cert/tls.key
-          TLS_CERT=/etc/pki/tls/metrics-cert/tls.crt
-          # As the secret mount is optional we must wait for the files to be present.
-          # The service is created in monitor.yaml and this is created in sdn.yaml.
-          # If it isn't created there is probably an issue so we want to crashloop.
-          retries=0
-          TS=$(date +%s)
-          WARN_TS=$(( ${TS} + $(( 20 * 60)) ))
-          HAS_LOGGED_INFO=0
-
-          log_missing_certs(){
-              CUR_TS=$(date +%s)
-              if [[ "${CUR_TS}" -gt "WARN_TS"  ]]; then
-                echo $(date -Iseconds) WARN: ovn-node-metrics-cert not mounted after 20 minutes.
-              elif [[ "${HAS_LOGGED_INFO}" -eq 0 ]] ; then
-                echo $(date -Iseconds) INFO: ovn-node-metrics-cert not mounted. Waiting one hour.
-                HAS_LOGGED_INFO=1
-              fi
-          }
-          while [[ ! -f "${TLS_PK}" ||  ! -f "${TLS_CERT}" ]] ; do
-            log_missing_certs
-            sleep 5
-          done
-
-          echo $(date -Iseconds) INFO: ovn-node-metrics-certs mounted, starting kube-rbac-proxy
-          exec /usr/bin/kube-rbac-proxy \
-            --logtostderr \
-            --secure-listen-address=:9105 \
-            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
-            --upstream=http://127.0.0.1:29105/ \
-            --tls-private-key-file=${TLS_PK} \
-            --tls-cert-file=${TLS_CERT}
+          . /ovnkube-lib/ovnkube-lib.sh || exit 1
+          start-rbac-proxy-node ovn-metrics 9105 29105 /etc/pki/tls/metrics-cert/tls.key /etc/pki/tls/metrics-cert/tls.crt
         ports:
         - containerPort: 9105
           name: https
@@ -289,6 +229,8 @@ spec:
             memory: 20Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
+        - mountPath: /ovnkube-lib
+          name: ovnkube-script-lib
         - name: ovn-node-metrics-cert
           mountPath: /etc/pki/tls/metrics-cert
           readOnly: True

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -340,41 +340,24 @@ spec:
             source /env/_master
             set +o allexport
           fi
+          . /ovnkube-lib/ovnkube-lib.sh || exit 1
 
-          quit() {
-            echo "$(date -Iseconds) - stopping ovn-northd"
-            OVN_MANAGE_OVSDB=no /usr/share/ovn/scripts/ovn-ctl stop_northd
-            echo "$(date -Iseconds) - ovn-northd stopped"
-            rm -f /var/run/ovn/ovn-northd.pid
-            exit 0
-          }
-          # end of quit
-          trap quit TERM INT
-
-          echo "$(date -Iseconds) - starting ovn-northd"
-          exec ovn-northd \
-            --no-chdir "-vconsole:${OVN_LOG_LEVEL}" -vfile:off "-vPATTERN:console:{{.OVN_LOG_PATTERN_CONSOLE}}" \
-            --pidfile /var/run/ovn/ovn-northd.pid \
-            --n-threads={{.NorthdThreads}} &
-          wait $!
+          trap quit-ovn-northd TERM INT
+          start-ovn-northd "${OVN_LOG_LEVEL}"
         env:
         - name: OVN_LOG_LEVEL
           value: info
         volumeMounts:
-        - mountPath: /etc/openvswitch/
+        - mountPath: /ovnkube-lib
+          name: ovnkube-script-lib
+        - mountPath: /etc/ovn
           name: etc-openvswitch
-        - mountPath: /var/lib/openvswitch/
-          name: var-lib-openvswitch
-        - mountPath: /run/openvswitch/
-          name: run-openvswitch
+        - mountPath: /var/log/ovn
+          name: node-log
         - mountPath: /run/ovn/
           name: run-ovn
         - mountPath: /env
           name: env-overrides
-        - mountPath: /ovn-cert # not needed, but useful when exec'ing in to pod.
-          name: ovn-cert
-        - mountPath: /ovn-ca
-          name: ovn-ca
         resources:
           requests:
             cpu: 10m

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -171,51 +171,16 @@ spec:
         - -c
         - |
           set -euo pipefail
-
-          # Rotate audit log files when then get to max size (in bytes)
-          MAXFILESIZE=$(( "{{.OVNPolicyAuditMaxFileSize}}"*1000000 ))
-          MAXLOGFILES="{{.OVNPolicyAuditMaxLogFiles}}"
-          LOGDIR=/var/log/ovn
-          LOGFILE=${LOGDIR}/acl-audit-log.log
-          CONTROLLERPID=$(cat /run/ovn/ovn-controller.pid)
-
-          # Redirect err to null so no messages are shown upon rotation
-          tail -F ${LOGFILE} 2> /dev/null &
-
-          while true
-          do
-            # Make sure ovn-controller's logfile exists, and get current size in bytes
-            if [ -f "$LOGFILE" ]; then
-              file_size=`du -b ${LOGFILE} | tr -s '\t' ' ' | cut -d' ' -f1`
-            else
-              ovs-appctl -t /var/run/ovn/ovn-controller.${CONTROLLERPID}.ctl vlog/reopen
-              file_size=`du -b ${LOGFILE} | tr -s '\t' ' ' | cut -d' ' -f1`
-            fi
-
-            if [ $file_size -gt $MAXFILESIZE ];then
-              echo "Rotating OVN ACL Log File"
-              timestamp=`date '+%Y-%m-%dT%H-%M-%S'`
-              mv ${LOGFILE} /var/log/ovn/acl-audit-log.$timestamp.log
-              ovs-appctl -t /run/ovn/ovn-controller.${CONTROLLERPID}.ctl vlog/reopen
-              CONTROLLERPID=$(cat /run/ovn/ovn-controller.pid)
-            fi
-
-            # Ensure total number of log files does not exceed the maximum configured from OVNPolicyAuditMaxLogFiles
-            num_files=$(ls -1 ${LOGDIR}/acl-audit-log* 2>/dev/null | wc -l)
-            if [ "$num_files" -gt "$MAXLOGFILES" ]; then
-              num_to_delete=$(( num_files - ${MAXLOGFILES} ))
-              ls -1t ${LOGDIR}/acl-audit-log* 2>/dev/null | tail -$num_to_delete | xargs -I {} rm {}
-            fi
-
-            # sleep for 30 seconds to avoid wasting CPU
-            sleep 30
-          done
+          . /ovnkube-lib/ovnkube-lib.sh || exit 1
+          start-audit-log-rotation
         resources:
           requests:
             cpu: 10m
             memory: 20Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
+        - mountPath: /ovnkube-lib
+          name: ovnkube-script-lib
         - mountPath: /var/log/ovn/
           name: node-log
         - mountPath: /run/ovn/

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -403,167 +403,8 @@ spec:
         - -c
         - |
           set -xe
-          if [[ -f "/env/${K8S_NODE}" ]]; then
-            set -o allexport
-            source "/env/${K8S_NODE}"
-            set +o allexport
-          fi
-
-          function log()
-          {
-              echo "$(date --iso-8601=seconds) [cnibincopy] ${1}"
-          }
-
-          # collect host os information
-          . /host/etc/os-release
-          rhelmajor=
-          # detect which version we're using in order to copy the proper binaries
-          case "${ID}" in
-            rhcos|scos)
-              RHEL_VERSION=$(echo "${CPE_NAME}" | cut -f 5 -d :)
-              rhelmajor=$(echo $RHEL_VERSION | sed -E 's/([0-9]+)\.{1}[0-9]+(\.[0-9]+)?/\1/')
-            ;;
-            rhel) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)
-            ;;
-            fedora)
-              if [ "${VARIANT_ID}" == "coreos" ]; then
-                rhelmajor=8
-              else
-                log "FATAL ERROR: Unsupported Fedora variant=${VARIANT_ID}"
-                exit 1
-              fi
-            ;;
-            *) log "FATAL ERROR: Unsupported OS ID=${ID}"; exit 1
-            ;;
-          esac
-
-          # Set which directory we'll copy from, detect if it exists
-          sourcedir=/usr/libexec/cni/
-          case "${rhelmajor}" in
-          8)
-            sourcedir=/usr/libexec/cni/rhel8
-          ;;
-          9)
-            sourcedir=/usr/libexec/cni/rhel9
-          ;;
-          *)
-            log "ERROR: RHEL Major Version Unsupported, rhelmajor=${rhelmajor}"
-          ;;
-          esac
-
-          cp -f "$sourcedir/ovn-k8s-cni-overlay" /cni-bin-dir/
-
-          ovn_config_namespace=openshift-ovn-kubernetes
-          echo "I$(date "+%m%d %H:%M:%S.%N") - disable conntrack on geneve port"
-          iptables -t raw -A PREROUTING -p udp --dport {{.GenevePort}} -j NOTRACK
-          iptables -t raw -A OUTPUT -p udp --dport {{.GenevePort}} -j NOTRACK
-          ip6tables -t raw -A PREROUTING -p udp --dport {{.GenevePort}} -j NOTRACK
-          ip6tables -t raw -A OUTPUT -p udp --dport {{.GenevePort}} -j NOTRACK
-          echo "I$(date "+%m%d %H:%M:%S.%N") - starting ovnkube-node"
-
-          if [ "{{.OVN_GATEWAY_MODE}}" == "shared" ]; then
-            gateway_mode_flags="--gateway-mode shared --gateway-interface br-ex"
-          elif [ "{{.OVN_GATEWAY_MODE}}" == "local" ]; then
-            gateway_mode_flags="--gateway-mode local --gateway-interface br-ex"
-          else
-            echo "Invalid OVN_GATEWAY_MODE: \"{{.OVN_GATEWAY_MODE}}\". Must be \"local\" or \"shared\"."
-            exit 1
-          fi
-
-          export_network_flows_flags=
-          if [[ -n "${NETFLOW_COLLECTORS}" ]] ; then
-            export_network_flows_flags="--netflow-targets ${NETFLOW_COLLECTORS}"
-          fi
-          if [[ -n "${SFLOW_COLLECTORS}" ]] ; then
-            export_network_flows_flags="$export_network_flows_flags --sflow-targets ${SFLOW_COLLECTORS}"
-          fi
-          if [[ -n "${IPFIX_COLLECTORS}" ]] ; then
-            export_network_flows_flags="$export_network_flows_flags --ipfix-targets ${IPFIX_COLLECTORS}"
-          fi
-          if [[ -n "${IPFIX_CACHE_MAX_FLOWS}" ]] ; then
-            export_network_flows_flags="$export_network_flows_flags --ipfix-cache-max-flows ${IPFIX_CACHE_MAX_FLOWS}"
-          fi
-          if [[ -n "${IPFIX_CACHE_ACTIVE_TIMEOUT}" ]] ; then
-            export_network_flows_flags="$export_network_flows_flags --ipfix-cache-active-timeout ${IPFIX_CACHE_ACTIVE_TIMEOUT}"
-          fi
-          if [[ -n "${IPFIX_SAMPLING}" ]] ; then
-            export_network_flows_flags="$export_network_flows_flags --ipfix-sampling ${IPFIX_SAMPLING}"
-          fi
-          gw_interface_flag=
-          # if br-ex1 is configured on the node, we want to use it for external gateway traffic
-          if [ -d /sys/class/net/br-ex1 ]; then
-            gw_interface_flag="--exgw-interface=br-ex1"
-          fi
-
-          node_mgmt_port_netdev_flags=
-          if [[ -n "${OVNKUBE_NODE_MGMT_PORT_NETDEV}" ]] ; then
-            node_mgmt_port_netdev_flags="--ovnkube-node-mgmt-port-netdev ${OVNKUBE_NODE_MGMT_PORT_NETDEV}"
-          fi
-          if [[ -n "${OVNKUBE_NODE_MGMT_PORT_DP_RESOURCE_NAME}" ]] ; then
-            node_mgmt_port_netdev_flags="$node_mgmt_port_netdev_flags --ovnkube-node-mgmt-port-dp-resource-name ${OVNKUBE_NODE_MGMT_PORT_DP_RESOURCE_NAME}"
-          fi
-
-          multi_network_enabled_flag=
-          if [[ "{{.OVN_MULTI_NETWORK_ENABLE}}" == "true" ]]; then
-            multi_network_enabled_flag="--enable-multi-network"
-          fi
-
-          multi_network_policy_enabled_flag=
-          if [[ "{{.OVN_MULTI_NETWORK_POLICY_ENABLE}}" == "true" ]]; then
-            multi_network_policy_enabled_flag="--enable-multi-networkpolicy"
-          fi
-
-          admin_network_policy_enabled_flag=
-          if [[ "{{.OVN_ADMIN_NETWORK_POLICY_ENABLE}}" == "true" ]]; then
-            admin_network_policy_enabled_flag="--enable-admin-network-policy"
-          fi
-
-          # If IP Forwarding mode is global set it in the host here.
-          ip_forwarding_flag=
-          if [ "{{.IP_FORWARDING_MODE}}" == "Global" ]; then
-            sysctl -w net.ipv4.ip_forward=1
-            sysctl -w net.ipv6.conf.all.forwarding=1
-          else
-            ip_forwarding_flag="--disable-forwarding"
-          fi
-
-          NETWORK_NODE_IDENTITY_ENABLE=
-          if [[ "{{.NETWORK_NODE_IDENTITY_ENABLE}}" == "true" ]]; then
-            NETWORK_NODE_IDENTITY_ENABLE="
-              --bootstrap-kubeconfig=/var/lib/kubelet/kubeconfig
-              --cert-dir=/etc/ovn/ovnkube-node-certs
-              --cert-duration={{.NodeIdentityCertDuration}}
-            "
-          fi
-
-          exec /usr/bin/ovnkube --init-ovnkube-controller "${K8S_NODE}" --init-node "${K8S_NODE}" \
-            --config-file=/run/ovnkube-config/ovnkube.conf \
-            --ovn-empty-lb-events \
-            --loglevel "${OVN_KUBE_LOG_LEVEL}" \
-            --inactivity-probe="${OVN_CONTROLLER_INACTIVITY_PROBE}" \
-            ${gateway_mode_flags} \
-            ${node_mgmt_port_netdev_flags} \
-            {{- if eq .OVN_NODE_MODE "dpu-host" }}
-            --ovnkube-node-mode dpu-host \
-            {{- end }}
-            --metrics-bind-address "127.0.0.1:29103" \
-            --ovn-metrics-bind-address "127.0.0.1:29105" \
-            --metrics-enable-pprof \
-            --metrics-enable-config-duration \
-            --export-ovs-metrics \
-            --disable-snat-multiple-gws \
-            ${export_network_flows_flags} \
-            ${multi_network_enabled_flag} \
-            ${multi_network_policy_enabled_flag} \
-            ${admin_network_policy_enabled_flag} \
-            --enable-multicast \
-            --zone ${K8S_NODE} \
-            --enable-interconnect \
-            --acl-logging-rate-limit "{{.OVNPolicyAuditRateLimit}}" \
-            ${gw_interface_flag} \
-            --enable-multi-external-gateway=true \
-            ${ip_forwarding_flag} \
-            ${NETWORK_NODE_IDENTITY_ENABLE}
+          . /ovnkube-lib/ovnkube-lib.sh || exit 1
+          start-ovnkube-node ${OVN_LOG_LEVEL} 29103 29105
         env:
         # for kubectl
         - name: KUBERNETES_SERVICE_PORT
@@ -618,6 +459,8 @@ spec:
           privileged: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
+        - mountPath: /ovnkube-lib
+          name: ovnkube-script-lib
 {{ if .NETWORK_NODE_IDENTITY_ENABLE }}
         - mountPath: /var/lib/kubelet
           name: host-kubelet
@@ -665,10 +508,6 @@ spec:
           name: ovnkube-config
         - mountPath: /env
           name: env-overrides
-        - mountPath: /ovn-cert
-          name: ovn-cert
-        - mountPath: /ovn-ca
-          name: ovn-ca
         resources:
           requests:
             cpu: 10m

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -876,7 +876,7 @@ func checkOVNKubernetesPostStart(objects []*uns.Unstructured) error {
 		return fmt.Errorf("could not find nbdb postStart script in daemonset %s", ovnkubeNode.GetName())
 	}
 
-	expectedScriptSubStr := "Successfully set northd probe interval"
+	expectedScriptSubStr := "Setting the IC zone to"
 	if !strings.Contains(strings.Join(script, " "), expectedScriptSubStr) {
 		return fmt.Errorf("postStart script in daemonset %s does not contain %s: %s", ovnkubeNode.GetName(), expectedScriptSubStr, script)
 	}

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -876,7 +876,7 @@ func checkOVNKubernetesPostStart(objects []*uns.Unstructured) error {
 		return fmt.Errorf("could not find nbdb postStart script in daemonset %s", ovnkubeNode.GetName())
 	}
 
-	expectedScriptSubStr := "Setting the IC zone to"
+	expectedScriptSubStr := "nbdb-post-start"
 	if !strings.Contains(strings.Join(script, " "), expectedScriptSubStr) {
 		return fmt.Errorf("postStart script in daemonset %s does not contain %s: %s", ovnkubeNode.GetName(), expectedScriptSubStr, script)
 	}


### PR DESCRIPTION
Clean up a bunch of things that are done for us by other things, or just aren't necessary.

Then move all the common functionality to a bash script library shared between all the containers so we can use the same code from multiple daemonsets. Tip of the hat to Tomo for the ConfigMap trick.