### PR TITLE
OCPBUGS-19862: Multus per-node certificates should have 24h duration [backport 4.14]

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -125,7 +125,8 @@ data:
         "perNodeCertificate": {
           "enabled": true,
           "bootstrapKubeconfig": "/hostroot/var/lib/kubelet/kubeconfig",
-          "certDir": "/run/multus/certs"
+          "certDir": "/etc/cni/multus/certs",
+          "certDuration": "24h"
         },
 {{ end }}
         "cniConfigDir": "/host/etc/cni/net.d",
@@ -230,7 +231,7 @@ spec:
           mountPath: /etc/cni/net.d/multus.d
           readOnly: true
         - name: host-run-multus-certs
-          mountPath: /run/multus/certs
+          mountPath: /etc/cni/multus/certs
         env:
         - name: RHEL8_SOURCE_DIRECTORY
           value: "/usr/src/multus-cni/rhel8/bin/"
@@ -320,7 +321,7 @@ spec:
               path: daemon-config.json
         - name: host-run-multus-certs
           hostPath:
-            path: /run/multus_certs
+            path: /etc/cni/multus/certs
 ---
 kind: DaemonSet
 apiVersion: apps/v1


### PR DESCRIPTION
Also uses `/etc/cni/multus/certs` for certificate storage on host