### PR TITLE
Network metrics daemon: change priority class to openshift-user-critical

### DIFF
--- a/bindata/network/network-metrics/001-daemonset.yaml
+++ b/bindata/network/network-metrics/001-daemonset.yaml
@@ -38,7 +38,7 @@ spec:
                 operator: DoesNotExist
               - key: network.operator.openshift.io/dpu
                 operator: DoesNotExist
-      priorityClassName: "system-node-critical"
+      priorityClassName: "openshift-user-critical"
       tolerations:
         - operator: Exists
       containers:


### PR DESCRIPTION
I noticed during CI tests that sometimes this component will attempt to start at the same time the CNI is attemting to start.

This can cause multus to return an error during CNI ADD and cause test failures.

Metrics are user facing.
See openshift docs on priority class definitions: https://docs.openshift.com/container-platform/4.13/nodes/pods/nodes-pods-priority.html
