### PR TITLE
OCPBUGS-19370: Added HCP label to CNO pods

### DIFF
--- a/bindata/cloud-network-config-controller/managed/controller.yaml
+++ b/bindata/cloud-network-config-controller/managed/controller.yaml
@@ -12,6 +12,7 @@ metadata:
   labels:
     # used by PodAffinity to prefer co-locating pods that belong to the same hosted cluster.
     hypershift.openshift.io/hosted-control-plane: {{.HostedClusterNamespace}}
+    hypershift.openshift.io/control-plane: "true"
 spec:
   selector:
     matchLabels:
@@ -27,6 +28,8 @@ spec:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: cloud-network-config-controller
+        hypershift.openshift.io/hosted-control-plane: {{.HostedClusterNamespace}}
+        hypershift.openshift.io/control-plane: "true"
         component: network
         type: infra
         openshift.io/component: network

--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -9,6 +9,7 @@ metadata:
 {{- if .HyperShiftEnabled}}
     # used by PodAffinity to prefer co-locating pods that belong to the same hosted cluster.
     hypershift.openshift.io/hosted-control-plane: {{.AdmissionControllerNamespace}}
+    hypershift.openshift.io/control-plane: "true"
 {{- end }}
   annotations:
     kubernetes.io/description: |
@@ -42,6 +43,10 @@ spec:
       labels:
         app: multus-admission-controller
         namespace: {{.AdmissionControllerNamespace}}
+{{- if .HyperShiftEnabled}}
+        hypershift.openshift.io/hosted-control-plane: {{.AdmissionControllerNamespace}}
+        hypershift.openshift.io/control-plane: "true"
+{{- end }}
         component: network
         type: infra
         openshift.io/component: network

--- a/bindata/network/node-identity/managed/node-identity.yaml
+++ b/bindata/network/node-identity/managed/node-identity.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     # used by PodAffinity to prefer co-locating pods that belong to the same hosted cluster.
     hypershift.openshift.io/hosted-control-plane: {{.HostedClusterNamespace}}
+    hypershift.openshift.io/control-plane: "true"
 spec:
   replicas: {{.NetworkNodeIdentityReplicas}}
 {{ if (gt .NetworkNodeIdentityReplicas 1)}}
@@ -34,6 +35,8 @@ spec:
         type: infra
         openshift.io/component: network
         hypershift.openshift.io/control-plane-component: network-node-identity
+        hypershift.openshift.io/hosted-control-plane: {{.HostedClusterNamespace}}
+        hypershift.openshift.io/control-plane: "true"
         kubernetes.io/os: "linux"
     spec:
       affinity:
@@ -99,7 +102,7 @@ spec:
               source "/env/_master"
               set +o allexport
             fi
-            
+
             retries=0
             while [ ! -f /var/run/secrets/hosted_cluster/token ]; do
               (( retries += 1 ))
@@ -162,7 +165,7 @@ spec:
               source "/env/_master"
               set +o allexport
             fi
-            
+
             retries=0
             while [ ! -f /var/run/secrets/hosted_cluster/token ]; do
               (( retries += 1 ))

--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-control-plane.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     # used by PodAffinity to prefer co-locating pods that belong to the same hosted cluster.
     hypershift.openshift.io/hosted-control-plane: {{.HostedClusterNamespace}}
+    hypershift.openshift.io/control-plane: "true"
 spec:
   selector:
     matchLabels:
@@ -38,6 +39,8 @@ spec:
         type: infra
         openshift.io/component: network
         hypershift.openshift.io/control-plane-component: ovnkube-control-plane
+        hypershift.openshift.io/control-plane: "true"
+        hypershift.openshift.io/hosted-control-plane: {{.HostedClusterNamespace}}
         kubernetes.io/os: "linux"
     spec:
       affinity:

--- a/bindata/network/ovn-kubernetes/managed/single-zone-interconnect/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/single-zone-interconnect/ovnkube-master.yaml
@@ -29,6 +29,7 @@ metadata:
   labels:
     # used by PodAffinity to prefer co-locating pods that belong to the same hosted cluster.
     hypershift.openshift.io/hosted-control-plane: {{.HostedClusterNamespace}}
+    hypershift.openshift.io/control-plane: "true"
 spec:
   podManagementPolicy: Parallel
   selector:
@@ -61,6 +62,8 @@ spec:
         type: infra
         openshift.io/component: network
         hypershift.openshift.io/control-plane-component: ovnkube-master
+        hypershift.openshift.io/hosted-control-plane: {{.HostedClusterNamespace}}
+        hypershift.openshift.io/control-plane: "true"
         kubernetes.io/os: "linux"
     spec:
       affinity:


### PR DESCRIPTION
Added 2 missing labels in the CNO pods on Hypershift context:
    
- hypershift.openshift.io/hosted-control-plane
- hypershift.openshift.io/control-plane
    
The `hypershift.openshift.io/hosted-control-plane` label needs to be present to signal the Management Cluster router to fulfil the route.

The `hypershift.openshift.io/control-plane` is needed to mark those pods as part of the ControlPlane avoiding to fall into the serving-component-nodes.

Signed-off-by: Juan Manuel Parrilla Madrid <jparrill@redhat.com>