### PR TITLE
OCPBUGS-20076: Multus should determine kubeconfig path

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -125,7 +125,7 @@ data:
 {{ if .NETWORK_NODE_IDENTITY_ENABLE }}
         "perNodeCertificate": {
           "enabled": true,
-          "bootstrapKubeconfig": "/hostroot/var/lib/kubelet/kubeconfig",
+          "bootstrapKubeconfig": "{{ .KubeletKubeconfigPath }}",
           "certDir": "/etc/cni/multus/certs",
           "certDuration": "24h"
         },
@@ -233,6 +233,8 @@ spec:
           readOnly: true
         - name: host-run-multus-certs
           mountPath: /etc/cni/multus/certs
+        - name: etc-kubernetes
+          mountPath: /etc/kubernetes
         env:
         - name: RHEL8_SOURCE_DIRECTORY
           value: "/usr/src/multus-cni/rhel8/bin/"
@@ -323,6 +325,9 @@ spec:
         - name: host-run-multus-certs
           hostPath:
             path: /etc/cni/multus/certs
+        - name: etc-kubernetes
+          hostPath:
+            path: /etc/kubernetes
 ---
 kind: DaemonSet
 apiVersion: apps/v1

--- a/pkg/network/multus.go
+++ b/pkg/network/multus.go
@@ -84,6 +84,9 @@ func renderMultusConfig(manifestDir, defaultNetworkType string, useDHCP bool, us
 		data.Data["NO_PROXY"] = bootstrapResult.Infra.Proxy.NoProxy
 	}
 	data.Data["NETWORK_NODE_IDENTITY_ENABLE"] = bootstrapResult.Infra.NetworkNodeIdentityEnabled
+	if bootstrapResult.Infra.NetworkNodeIdentityEnabled {
+		data.Data["KubeletKubeconfigPath"] = determineKubeConfigPath()
+	}
 
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network/multus"), &data)
 	if err != nil {
@@ -120,4 +123,22 @@ func pluginCNIConfDir(conf *operv1.NetworkSpec) string {
 		return SystemCNIConfDir
 	}
 	return MultusCNIConfDir
+}
+
+// determineKubeConfigPath determines which kubeconfig path to use for certificate generation.
+// In some cases, specifically IBM Managed Openshift, the path differs.
+func determineKubeConfigPath() string {
+	var kubeletKubeconfigPaths = []string{
+		"/var/lib/kubelet/kubeconfig",        // Traditional OCP
+		"/etc/kubernetes/kubelet-kubeconfig", // IBM Managed OpenShift, see OCPBUGS-19795
+	}
+
+	for _, path := range kubeletKubeconfigPaths {
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+
+	// If none are found, we must assume the default traditional OCP path.
+	return kubeletKubeconfigPaths[0]
 }


### PR DESCRIPTION
Otherwise, we have a report of a file not found due to a symlink issue