### PR TITLE
reduce nbdb & sbdb initialDelaySeconds: 90s -> 10s

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-node.yaml
@@ -505,7 +505,7 @@ spec:
                   exit 1
                 fi
         readinessProbe:
-          initialDelaySeconds: 90
+          initialDelaySeconds: 10
           timeoutSeconds: 5
           exec:
             command:
@@ -638,7 +638,7 @@ spec:
                   exit 1
                 fi
         readinessProbe:
-          initialDelaySeconds: 90
+          initialDelaySeconds: 10
           timeoutSeconds: 5
           exec:
             command:

--- a/bindata/network/ovn-kubernetes/managed/single-zone-interconnect/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/single-zone-interconnect/ovnkube-master.yaml
@@ -461,7 +461,7 @@ spec:
                   exit 1
                 fi
         readinessProbe:
-          initialDelaySeconds: 90
+          initialDelaySeconds: 10
           timeoutSeconds: 5
           exec:
             command:
@@ -747,7 +747,7 @@ spec:
                   exit 1
                 fi
         readinessProbe:
-          initialDelaySeconds: 90
+          initialDelaySeconds: 10
           timeoutSeconds: 5
           exec:
             command:

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-node.yaml
@@ -552,7 +552,7 @@ spec:
                 fi
         readinessProbe:
 {{ if not .IsSNO }}
-          initialDelaySeconds: 90
+          initialDelaySeconds: 10
 {{ end }}
           timeoutSeconds: 5
           exec:
@@ -691,7 +691,7 @@ spec:
                 fi
         readinessProbe:
 {{ if not .IsSNO }}
-          initialDelaySeconds: 90
+          initialDelaySeconds: 10
 {{ end }}
           timeoutSeconds: 5
           exec:

--- a/bindata/network/ovn-kubernetes/self-hosted/single-zone-interconnect/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/single-zone-interconnect/ovnkube-master.yaml
@@ -408,7 +408,7 @@ spec:
                 fi
         readinessProbe:
 {{ if not .IsSNO }}
-          initialDelaySeconds: 90
+          initialDelaySeconds: 10
 {{ end }}
           timeoutSeconds: 5
           exec:
@@ -750,7 +750,7 @@ spec:
                 fi
         readinessProbe:
 {{ if not .IsSNO }}
-          initialDelaySeconds: 90
+          initialDelaySeconds: 10
 {{ end }}
           timeoutSeconds: 5
           exec:


### PR DESCRIPTION
the initial need for this delay was to allow RAFT clusters to settle. Without it now, we don't need to wait as long.

JIRA: https://issues.redhat.com/browse/OCPBUGS-18349