### PR TITLE
OCPBUGS-20519: hosted cluster upgrade failure from 4.13 stable to 4.14

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/single-zone-interconnect/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/managed/single-zone-interconnect/ovnkube-master.yaml
@@ -889,6 +889,10 @@ spec:
         volumeMounts:
         - mountPath: /etc/ovn
           name: datadir
+        # gives write access to libovsdb logs until moving to multi-zone
+        # https://issues.redhat.com//browse/OCPBUGS-20472
+        - mountPath: /var/log/ovnkube/
+          name: datadir
         - mountPath: /var/run/ovn
           name: datadir
         - mountPath: /run/ovnkube-config/

--- a/bindata/network/ovn-kubernetes/managed/single-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/single-zone-interconnect/ovnkube-node.yaml
@@ -658,6 +658,10 @@ spec:
           name: host-var-lib-cni-networks-ovn-kubernetes
         - mountPath: /run/openvswitch
           name: run-openvswitch
+        # gives write access to libovsdb logs until moving to multi-zone
+        # https://issues.redhat.com//browse/OCPBUGS-20472
+        - mountPath: /var/log/ovnkube/
+          name: etc-openvswitch
         - mountPath: /run/ovn/
           name: run-ovn
         - mountPath: /etc/openvswitch

--- a/bindata/network/ovn-kubernetes/self-hosted/single-zone-interconnect/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/single-zone-interconnect/ovnkube-master.yaml
@@ -881,6 +881,10 @@ spec:
           name: var-lib-openvswitch
         - mountPath: /run/openvswitch/
           name: run-openvswitch
+        # gives write access to libovsdb logs until moving to multi-zone
+        # https://issues.redhat.com//browse/OCPBUGS-20472
+        - mountPath: /var/log/ovnkube/
+          name: etc-openvswitch
         - mountPath: /run/ovn/
           name: run-ovn
         - mountPath: /run/ovnkube-config/

--- a/bindata/network/ovn-kubernetes/self-hosted/single-zone-interconnect/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/single-zone-interconnect/ovnkube-node.yaml
@@ -553,6 +553,10 @@ spec:
           name: host-var-lib-cni-networks-ovn-kubernetes
         - mountPath: /run/openvswitch
           name: run-openvswitch
+        # gives write access to libovsdb logs until moving to multi-zone
+        # https://issues.redhat.com//browse/OCPBUGS-20472
+        - mountPath: /var/log/ovnkube/
+          name: etc-openvswitch
         - mountPath: /run/ovn/
           name: run-ovn
         - mountPath: /etc/openvswitch


### PR DESCRIPTION
Add missing volume mount to ovnkube-node pods while in the single zone phase
