### PR TITLE
SDN-4227: Use specific permissions for CNCC in GCP

### DIFF
--- a/manifests/02-cncc-credentials.yaml
+++ b/manifests/02-cncc-credentials.yaml
@@ -21,8 +21,12 @@ spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: GCPProviderSpec
-    predefinedRoles:
-    - roles/compute.admin 
+    permissions:
+      - compute.instances.updateNetworkInterface
+      - compute.subnetworks.use
+      - compute.subnetworks.get
+      - compute.zoneOperations.get
+      - compute.instances.get
 ---
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest


### PR DESCRIPTION
Instead of using the roles/compute.admin role use specific permissions required by CNCC:
-    [Instances.UpdateNetworkInterface](https://github.com/openshift/cloud-network-config-controller/blob/90bf88ab7abfd2920c36a493103c4e610a9b110b/pkg/cloudprovider/gcp.go#L80) - compute.instances.updateNetworkInterface, compute.subnetworks.use ([GCP doc](https://cloud.google.com/compute/docs/reference/rest/beta/instances/updateNetworkInterface#iam-permissions))
-    [ZoneOperations.Wait](https://github.com/openshift/cloud-network-config-controller/blob/90bf88ab7abfd2920c36a493103c4e610a9b110b/pkg/cloudprovider/gcp.go#L173) - compute.zoneOperations.get ([GCP doc](https://cloud.google.com/compute/docs/reference/rest/v1/zoneOperations/wait#iam-permissions))
-    [Subnetworks.Get](https://github.com/openshift/cloud-network-config-controller/blob/90bf88ab7abfd2920c36a493103c4e610a9b110b/pkg/cloudprovider/gcp.go#L196) - compute.subnetworks.get ([GCP doc](https://cloud.google.com/compute/docs/reference/rest/v1/subnetworks/get#iam-permissions))
-    [Instances.Get](https://github.com/openshift/cloud-network-config-controller/blob/90bf88ab7abfd2920c36a493103c4e610a9b110b/pkg/cloudprovider/gcp.go#L240) - compute.instances.get ([GCP doc](https://cloud.google.com/compute/docs/reference/rest/v1/instances/get#iam-permissions))


/cc
