### PR TITLE
OCPBUGS-19635: OVN-K in SNO deployment mode: fix Lease override for CM

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/004-config.yaml
@@ -72,7 +72,7 @@ data:
 {{- end  }}
 {{- if .IsSNO }}
 
-    [masterha]
+    [clustermgrha]
     {{- /* 
     Even in case of SNO there will be only one ovn-master, we set dedicated values for leader election 
     durations in SNO, as disabling it can cause issues on scaling out SNO again. 
@@ -163,7 +163,7 @@ data:
 {{- end  }}
 {{- if .IsSNO }}
 
-    [masterha]
+    [clustermgrha]
     {{- /*
     Even in case of SNO there will be only one ovn-master, we set dedicated values for leader election
     durations in SNO, as disabling it can cause issues on scaling out SNO again.

--- a/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
@@ -84,7 +84,7 @@ data:
 {{- end  }}
 {{- if .IsSNO }}
 
-    [masterha]
+    [clustermgrha]
     {{- /* 
     Even in case of SNO there will be only one ovn-master, we set dedicated values for leader election 
     durations in SNO, as disabling it can cause issues on scaling out SNO again. 

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -591,7 +591,7 @@ logfile-maxsize=100
 logfile-maxbackups=5
 logfile-maxage=0
 
-[masterha]
+[clustermgrha]
 election-lease-duration=137
 election-renew-deadline=107
 election-retry-period=26`,


### PR DESCRIPTION
OVNKube-controller, formerly known as OVNKube-master, no longer uses HA if the the deployment mode is SNO. OVNKube-cluster-manger however does use HA via a lease even though there is only expected to be one instance in this HA set.

For now, fix the lease config override mechanism via config file.

Depends on ovn-kubernetes#3967