### PR TITLE
WIP: Dockerfile.rhel7: Move networks.operator.openshift.io CRD to runlevel 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY --from=builder  /go/src/github.com/openshift/cluster-network-operator/clust
 COPY --from=builder  /go/src/github.com/openshift/cluster-network-operator/cluster-network-check-target /usr/bin/
 
 COPY manifests /manifests
+RUN mv /manifests/0000_70_cluster-network-operator_01_crd.yaml /manifests/0000_50_cluster-network-operator_01_crd.yaml
 COPY bindata /bindata
 ENV OPERATOR_NAME=cluster-network-operator
 CMD ["/usr/bin/cluster-network-operator"]

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -8,6 +8,7 @@ COPY --from=builder  /go/src/github.com/openshift/cluster-network-operator/clust
 COPY --from=builder  /go/src/github.com/openshift/cluster-network-operator/cluster-network-check-endpoints /usr/bin/
 COPY --from=builder  /go/src/github.com/openshift/cluster-network-operator/cluster-network-check-target /usr/bin/
 COPY manifests /manifests
+RUN mv /manifests/0000_70_cluster-network-operator_01_crd.yaml /manifests/0000_50_cluster-network-operator_01_crd.yaml
 COPY bindata /bindata
 ENV OPERATOR_NAME=cluster-network-operator
 CMD ["/usr/bin/cluster-network-operator"]


### PR DESCRIPTION
Hack to see if this dodges a race on HyperShift, where the HostedControlPlane controller updates to the 4.14 network operator before the independent cluster-version operator updates to the 4.14 CRD.  Because [the incoming 4.14 network operator doesn't like the outgoing 4.13 CRD][1]:

```console
$ oc get -o json clusteroperator network | jq '.status.conditions[] | select(.type == "Degraded")'
{
  "lastTransitionTime": "2023-10-19T09:02:50Z",
  "message": "Internal error while updating operator configuration: could not apply (operator.openshift.io/v1, Kind=Network) /cluster, err: failed to apply / update (operator.openshift.io/v1, Kind=Network) /cluster: failed to create typed patch object (/cluster; operator.openshift.io/v1, Kind=Network): .spec.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding: field not declared in schema",
  "reason": "UpdateOperatorConfig",
  "status": "True",
  "type": "Degraded"
}
```

And some in-cluster Deployments that the CVO manages at run level 50 don't like networking being down, blocking the CVO at level 50:

```console
$ oc -n openshift-cluster-version logs -l k8s-app=cluster-version-operator --tail -1 | grep -o 'Result of work.*' log | uniq -c
...
     86 Result of work: [Cluster operator image-registry is degraded Cluster operator ingress is degraded deployment openshift-monitoring/cluster-monitoring-operator is Progressing=False: ProgressDeadlineExceeded: ReplicaSet "cluster-monitoring-operator-86596d8db" has timed out progressing. deployment openshift-insights/insights-operator is not available MinimumReplicasUnavailable (Deployment does not have minimum availability.) or progressing ProgressDeadlineExceeded (ReplicaSet "insights-operator-5dfd74b8dc" has timed out progressing.)]
```

Moving the CRD to level 10 breaks the current deadlock cycle:

* the ProgressDeadlineExceeded is because networking is having trouble
* networking is having trouble because the old CRD
* the new CRD is not rolling out because the ProgressDeadlineExceeded block the CVO from getting that far in

And while the HostedControlPlane controller and cluster-version operator will still race with their respective pushes, at least now the CRD will get pushed without blocking behind Deployments, and allow the race-y failure to gradually heal.  Level 10 was chosen to be in parallel with the earliest Deployments that might rely on networking being alive to position them:

```console
$ oc adm release extract --to manifests quay.io/openshift-release-dev/ocp-release:4.14.0-rc.6-x86_64
$ grep -r '^kind: Deployment$' manifests | sort | head -n1
manifests/0000_10_config-operator_07_deployment.yaml:kind: Deployment
```

That will push the CRD very early, but the outgoing network operator already ran for a bit against the incoming CRD, so some extra time vs. the incoming CRD should not be a problem.

[1]: https://issues.redhat.com/browse/OCPBUGS-22108