### PR TITLE
OCPBUGS-15817: Egress router: request at least 100 milliCPU

### DIFF
--- a/bindata/egress-router/001-deployment.yaml
+++ b/bindata/egress-router/001-deployment.yaml
@@ -32,3 +32,6 @@ spec:
           image: "{{.EgressRouterPodImage}}"
           command: ['/bin/sh', '-c', 'sleep infinity']
           terminationMessagePolicy: FallbackToLogsOnError
+          resources:
+            requests:
+              cpu: 100m


### PR DESCRIPTION
Before this change, Egress CNI Pod has a QOS
of BestEffort. This means it will utilise CPU
cores that arent Guaranteed to any other pods.
The kubelet prefers to evit pods with this QOS.
If no resource requests a specified, the kubelet
will allocate the default CPU share of 2.
For the worse case scenario, if a node had 1 core, this could end up being ~0.19% CPU time (2/1024*100).

Egress router will consume some CPU to route packets, therefore it seems sensible to give it minimum CPU share and give it QOS class of BURSTABLE.

Tested by replacing CNO and creating a `EgressRouter` CR:
```yaml
apiVersion: network.operator.openshift.io/v1
kind: EgressRouter
metadata:
  name: egress-router-test
spec:
  addresses: [
    {
      ip: "192.168.3.10/24",
      gateway: "192.168.3.1",
    },
  ]
  mode: Redirect
  redirect: {
    redirectRules: [
      {
        destinationIP: "10.100.3.0",
        port: 80,
        protocol: UDP,
      },
      {
        destinationIP: "203.0.113.26",
        port: 8080,
        protocol: TCP,
        targetPort: 80
      },
      {
        destinationIP: "203.0.113.27",
        port: 8443,
        protocol: TCP,
        targetPort: 443
      },
    ]
  }
```

Resulted in CNO creating deployment with CPU request set:
```
Name:             egress-router-cni-deployment-55b78c47d4-f75kr
Namespace:        default
Priority:         0
Service Account:  default
Node:             worker-1.ostest.test.metalkube.org/192.168.111.24
Start Time:       Fri, 20 Oct 2023 11:48:15 +0100
Labels:           app=egress-router-cni
                  pod-template-hash=55b78c47d4
Annotations:      k8s.ovn.org/pod-networks:
                    {"default":{"ip_addresses":["10.131.0.4/23","fd01:0:0:4::4/64"],"mac_address":"0a:58:0a:83:00:04","gateway_ips":["fd01:0:0:4::1"],"routes"...
                  k8s.v1.cni.cncf.io/network-status:
                    [{
                        "name": "ovn-kubernetes",
                        "interface": "eth0",
                        "ips": [
                            "10.131.0.4",
                            "fd01:0:0:4::4"
                        ],
                        "mac": "0a:58:0a:83:00:04",
                        "default": true,
                        "dns": {}
                    },{
                        "name": "default/egress-router-cni-nad",
                        "interface": "net1",
                        "ips": [
                            "192.168.3.10"
                        ],
                        "mac": "d2:3f:9c:5b:9f:07",
                        "dns": {}
                    }]
                  k8s.v1.cni.cncf.io/networks:
                    [
                      {
                        "name":"egress-router-cni-nad",
                        "default-route": ["192.168.3.1"]
                      }
                    ]
Status:           Running
IP:               10.131.0.4
IPs:
  IP:           10.131.0.4
  IP:           fd01:0:0:4::4
Controlled By:  ReplicaSet/egress-router-cni-deployment-55b78c47d4
Containers:
  egress-router-cni-pod:
    Container ID:  cri-o://bd9d4624eeb69fe93d0e2ff1616a5a418954fbe9413d4997698e6a7e0db5a9e7
    Image:         quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:fcf0a06f59fe23a7e3e914994f0bb8561cd8c1bc3961e7e597025504bfb0ea25
    Image ID:      quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:fcf0a06f59fe23a7e3e914994f0bb8561cd8c1bc3961e7e597025504bfb0ea25
    Port:          <none>
    Host Port:     <none>
    Command:
      /bin/sh
      -c
      sleep infinity
    State:          Running
      Started:      Fri, 20 Oct 2023 11:48:17 +0100
    Ready:          True
    Restart Count:  0
    Requests:
      cpu:        100m
    Environment:  <none>
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-8hzlw (ro)
Conditions:
  Type              Status
  Initialized       True 
  Ready             True 
  ContainersReady   True 
  PodScheduled      True 
Volumes:
  kube-api-access-8hzlw:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
    ConfigMapName:           openshift-service-ca.crt
    ConfigMapOptional:       <nil>
QoS Class:                   Burstable
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/memory-pressure:NoSchedule op=Exists
                             node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type    Reason          Age   From               Message
  ----    ------          ----  ----               -------
  Normal  Scheduled       119s  default-scheduler  Successfully assigned default/egress-router-cni-deployment-55b78c47d4-f75kr to worker-1.ostest.test.metalkube.org
  Normal  AddedInterface  117s  multus             Add eth0 [10.131.0.4/23 fd01:0:0:4::4/64] from ovn-kubernetes
  Normal  AddedInterface  117s  multus             Add net1 [192.168.3.10/24] from default/egress-router-cni-nad
  Normal  Pulled          117s  kubelet            Container image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:fcf0a06f59fe23a7e3e914994f0bb8561cd8c1bc3961e7e597025504bfb0ea25" already present on machine
  Normal  Created         117s  kubelet            Created container egress-router-cni-pod
  Normal  Started         117s  kubelet            Started container egress-router-cni-pod

```