### PR TITLE
OPNET-360: Propagate VIPs in Infra CR during upgrade

### DIFF
--- a/pkg/controller/infrastructureconfig/sync_specstatus.go
+++ b/pkg/controller/infrastructureconfig/sync_specstatus.go
@@ -1,0 +1,80 @@
+package infrastructureconfig
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+	"log"
+)
+
+type specStatusSynchronizer interface {
+	SpecStatusSynchronize(*configv1.Infrastructure) *configv1.Infrastructure
+}
+
+type specStatusSunchronizer struct{}
+
+func (*specStatusSunchronizer) SpecStatusSynchronize(infraConfig *configv1.Infrastructure) *configv1.Infrastructure {
+	updatedInfraConfig := infraConfig.DeepCopy()
+
+	var (
+		statusApiVips, specApiVips                 *[]string
+		statusIngressVips, specIngressVips         *[]string
+		statusMachineNetworks, specMachineNetworks *[]string
+	)
+
+	switch {
+	case updatedInfraConfig.Status.Platform == configv1.BareMetalPlatformType:
+		statusApiVips = &updatedInfraConfig.Status.PlatformStatus.BareMetal.APIServerInternalIPs
+		specApiVips = &updatedInfraConfig.Spec.PlatformSpec.BareMetal.APIServerInternalIPs
+
+		statusIngressVips = &updatedInfraConfig.Status.PlatformStatus.BareMetal.IngressIPs
+		specIngressVips = &updatedInfraConfig.Spec.PlatformSpec.BareMetal.IngressIPs
+
+		statusMachineNetworks = &updatedInfraConfig.Status.PlatformStatus.BareMetal.MachineNetworks
+		specMachineNetworks = &updatedInfraConfig.Spec.PlatformSpec.BareMetal.MachineNetworks
+
+	// TODO(chocobomb) Add case statements for vSphere and OpenStack
+	default:
+		// nothing to do for this platform type
+		return updatedInfraConfig
+	}
+
+	// TODO(chocobomb) Decide on the failure strategy if validation fails. Should we set InfraConfig as degraded or only print warning in the log?
+	if err := syncMachineNetworks(specMachineNetworks, statusMachineNetworks); err != nil {
+		log.Printf("Warning on syncing machine networks: %v", err) // this is only a warning -> continue
+	}
+
+	if err := syncVips(specApiVips, statusApiVips, *statusMachineNetworks); err != nil {
+		log.Printf("Warning on syncing API VIPs: %v", err) // this is only a warning -> continue
+	}
+
+	if err := syncVips(specIngressVips, statusIngressVips, *statusMachineNetworks); err != nil {
+		log.Printf("Warning on syncing Ingress VIPs: %v", err) // this is only a warning -> continue
+	}
+
+	return updatedInfraConfig
+}
+
+func syncMachineNetworks(spec, status *[]string) error {
+	// `spec` is empty, `status` with value: copy status to spec
+	if len(*spec) == 0 {
+		*spec = *status
+	} else {
+		// TODO(chocobomb) Add some validations here
+		// `spec` is updated, need to propagate to `status`
+		*status = *spec
+	}
+
+	return nil
+}
+
+func syncVips(spec, status *[]string, machineNetworks []string) error {
+	// `spec` is empty, `status` with value: copy status to spec
+	if len(*spec) == 0 {
+		*spec = *status
+	} else {
+		// TODO(chocobomb) Add some validations here. Remember to validate if VIP inside MachineNetwork
+		// `spec` is updated, need to propagate to `status`
+		*status = *spec
+	}
+
+	return nil
+}


### PR DESCRIPTION
Recently we have introduced VIPs to the PlatformSpec in the Infrastructure CR. Previously they only existed in PlatformStatus and now we will have them in both Spec and Status.

In order to properly handle clusters created before the change was introduced, during the upgrade of such a cluster we will detect case when PlatformSpec is empty and PlatformStatus is filled with VIPs. For those, we will copy content from Status to Spec.

Note this commit is explicitly not handling validations because the assumption is that PlatformStatus has been validated earlier by the Installer. A subsequent commit will add validations to cover scenario when user is modifying PlatformSpec.

Closes: [OPNET-360](https://issues.redhat.com//browse/OPNET-360)
Contributes-to: [OPNET-340](https://issues.redhat.com//browse/OPNET-340) (Mutable Infrastructure)
Contributes-to: [OPNET-80](https://issues.redhat.com//browse/OPNET-80) (Dual-stack VIPs)