### PR TITLE
OCPBUGS-22244: Remove IPsec daemonset after disabling IPsec in OVN

### DIFF
--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -35,15 +35,16 @@ type OVNConfigBoostrapResult struct {
 // OVNUpdateStatus contains the status of existing daemonset
 // or statefulset that are maily used by upgrade process
 type OVNUpdateStatus struct {
-	Kind                 string
-	Namespace            string
-	Name                 string
-	Version              string
-	IPFamilyMode         string
-	ClusterNetworkCIDRs  string
-	Progressing          bool
-	InterConnectEnabled  bool   // true if this ovnk component is running with --enable-interconnect
-	InterConnectZoneMode string // zone mode (singlezone, multizone) for this ovnk component
+	Kind                   string
+	Namespace              string
+	Name                   string
+	Version                string
+	IPFamilyMode           string
+	ClusterNetworkCIDRs    string
+	Progressing            bool
+	InterConnectEnabled    bool   // true if this ovnk component is running with --enable-interconnect
+	InterConnectZoneMode   string // zone mode (singlezone, multizone) for this ovnk component
+	IPsecMarkedForDeletion string // indicates IPsec daemonset can be removed when it's set with non-nil value.
 }
 
 type OVNBootstrapResult struct {

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -83,6 +83,10 @@ const NetworkHybridOverlayAnnotation = "networkoperator.openshift.io/hybrid-over
 // which node IP was the raft cluster initiator. The NB and SB DB will be initialized by the same member.
 const OVNRaftClusterInitiator = "networkoperator.openshift.io/ovn-cluster-initiator"
 
+// IPsecDeleteAnnotation is an annotation which indicates IPsec daemonset is going to be removed sooner
+// by network operator reconcile loop.
+const IPsecDeleteAnnotation = "networkoperator.openshift.io/ipsec-ready-for-deletion"
+
 // RolloutHungAnnotation is set to "" if it is detected that a rollout
 // (i.e. DaemonSet or Deployment) is not making progress, unset otherwise.
 const RolloutHungAnnotation = "networkoperator.openshift.io/rollout-hung"

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -548,7 +548,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 		kind := bootstrapResult.OVN.NodeUpdateStatus.Kind
 		namespace := bootstrapResult.OVN.NodeUpdateStatus.Namespace
 		name := bootstrapResult.OVN.NodeUpdateStatus.Name
-		if bootstrapResult.OVN.NodeUpdateStatus.IPsecMarkedForDeletion != "" {
+		if bootstrapResult.OVN.IPsecUpdateStatus.IPsecMarkedForDeletion != "" {
 			// When ovnkube-node daemonset is seen with 'networkoperator.openshift.io/ipsec-ready-for-deletion' annotation,
 			// then go ahead with skip rendering IPsec daemonset and also remove annotation from ovnkube-node daemonset.
 			objs = k8s.RemoveObjByGroupKindName(objs, "apps", "DaemonSet", util.OVN_NAMESPACE, "ovn-ipsec-host")


### PR DESCRIPTION
The ipsec daemonset pods are not removed currently because it keeps ovs monitor ipsec process running so that ovn disable ipsec option can be processed in ovs monitor script and then ipsec can be disabled in kernel.
Hence this PR makes operator to wait for ovn ipsec disable is rolled out into all nodes and then it goes out and remove ipsec daemonset.