### PR TITLE
OCPBUGS-11179: change CNO to use custom ServiceAccount

### DIFF
--- a/manifests/0000_70_cluster-network-operator_02_rbac.yaml
+++ b/manifests/0000_70_cluster-network-operator_02_rbac.yaml
@@ -1,16 +1,44 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-network-operator
+  namespace: openshift-network-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/single-node-developer: "true"
+---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: default-account-cluster-network-operator
+  name: cluster-network-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: cluster-network-operator
   namespace: openshift-network-operator
 roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: default-account-cluster-network-operator
+  annotations:
+    release.openshift.io/delete: "true"
+    include.release.openshift.io/self-managed-high-availability: "false"
+    include.release.openshift.io/ibm-cloud-managed: "false"
+    include.release.openshift.io/single-node-developer: "false"
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: openshift-network-operator
+roleRef: 
   kind: ClusterRole
   name: cluster-admin
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
@@ -122,6 +122,7 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
+      serviceAccountName: cluster-network-operator
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -121,6 +121,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: "system-cluster-critical"
+      serviceAccountName: cluster-network-operator
       volumes:
         - name: host-etc-kube
           hostPath:


### PR DESCRIPTION
To be compliant with CIS benchmark rule, network operator should run with separate service account instead of using default