### PR TITLE
use $CPE_NAME to find the OS major version

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -39,6 +39,7 @@ data:
     # detect which version we're using in order to copy the proper binaries
     case "${ID}" in
       rhcos|scos)
+        RHEL_VERSION=$(echo "${CPE_NAME}" | cut -f 5 -d :)
         rhelmajor=$(echo $RHEL_VERSION | sed -E 's/([0-9]+)\.{1}[0-9]+(\.[0-9]+)?/\1/')
       ;;
       rhel) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -113,6 +113,7 @@ spec:
           # detect which version we're using in order to copy the proper binaries
           case "${ID}" in
             rhcos|scos)
+              RHEL_VERSION=$(echo "${CPE_NAME}" | cut -f 5 -d :)
               rhelmajor=$(echo $RHEL_VERSION | sed -E 's/([0-9]+)\.{1}[0-9]+(\.[0-9]+)?/\1/')
             ;;
             rhel) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -392,6 +392,7 @@ spec:
           # detect which version we're using in order to copy the proper binaries
           case "${ID}" in
             rhcos|scos)
+              RHEL_VERSION=$(echo "${CPE_NAME}" | cut -f 5 -d :)
               rhelmajor=$(echo $RHEL_VERSION | sed -E 's/([0-9]+)\.{1}[0-9]+(\.[0-9]+)?/\1/')
             ;;
             rhel) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -302,6 +302,7 @@ spec:
           # detect which version we're using in order to copy the proper binaries
           case "${ID}" in
             rhcos|scos)
+              RHEL_VERSION=$(echo "${CPE_NAME}" | cut -f 5 -d :)
               rhelmajor=$(echo $RHEL_VERSION | sed -E 's/([0-9]+)\.{1}[0-9]+(\.[0-9]+)?/\1/')
             ;;
             rhel) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)


### PR DESCRIPTION
RHEL_VERSION isn't present in scos, but $CPE_NAME
is present in /etc/os-release on both distros.

As I could tell it has been fixed above 4.13, so I'd like to fix in this branch too. 