### PR TITLE
Narrow down CNO RBAC

### DIFF
--- a/manifests/0000_70_cluster-network-operator_02_rbac.yaml
+++ b/manifests/0000_70_cluster-network-operator_02_rbac.yaml
@@ -8,10 +8,169 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-network-operator-using
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/single-node-developer: "true"
+rules:
+- apiGroups:
+  - config.openshift.io
+  - machineconfiguration.openshift.io
+  - network.operator.openshift.io
+  - operator.openshift.io
+  resources:
+  - clusteroperators
+  - clusterversions
+  - egressrouters
+  - featuregates
+  - infrastructures
+  - ingresscontrollers
+  - openshiftapiservers
+  - networks
+  - proxies
+  - machineconfigs
+  - machineconfigpools
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusteroperators
+  verbs:
+  - create
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusteroperators
+  - clusteroperators/status
+  resourceNames:
+  - network
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - networks
+  - networks/status
+  resourceNames:
+  - cluster
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - networks
+  - networks/status
+  - networks/finalizers
+  resourceNames:
+  - cluster
+  verbs:
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - machineconfiguration.openshift.io
+  resources:
+  - machineconfigs
+  resourceNames:
+  - 80-ipsec-master-extensions
+  - 80-ipsec-worker-extensions
+  verbs:
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  - admissionregistration.k8s.io
+  - apiextensions.k8s.io
+  - apps
+  - batch
+  - flowcontrol.apiserver.k8s.io
+  - k8s.cni.cncf.io
+  - monitoring.coreos.com
+  - network.openshift.io
+  - network.operator.openshift.io
+  - operator.openshift.io
+  - rbac.authorization.k8s.io
+  resources:
+  - clusternetworks
+  - clusterroles
+  - clusterrolebindings
+  - configmaps
+  - customresourcedefinitions
+  - daemonsets
+  - deployments
+  - flowschemas
+  - jobs
+  - namespaces
+  - netnamespaces
+  - network-attachment-definitions
+  - operatorpkis
+  - prometheusrules
+  - resourcequotas
+  - roles
+  - rolebindings
+  - secrets
+  - serviceaccounts
+  - servicemonitors
+  - services
+  - statefulsets
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - k8s.ovn.org
+  - network.openshift.io
+  resources:
+  - egressfirewalls
+  - egressnetworkpolicies
+  - egressips
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  - network.openshift.io
+  resources:
+  - nodes
+  - hostsubnets
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - cloud.network.openshift.io
+  resources:
+  - cloudprivateipconfigs
+  verbs:
+  - delete
+---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: cluster-network-operator
+  name: cluster-network-operator-using
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
@@ -22,8 +181,242 @@ subjects:
   namespace: openshift-network-operator
 roleRef:
   kind: ClusterRole
-  name: cluster-admin
+  name: cluster-network-operator-using
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-network-operator-granting
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/single-node-developer: "true"
+rules:
+- apiGroups:
+  - ""
+  - apiextensions.k8s.io
+  - apps
+  - config.openshift.io
+  - discovery.k8s.io
+  - events.k8s.io
+  - networking.k8s.io
+  - policy.networking.k8s.io
+  resources:
+  - adminnetworkpolicies
+  - baselineadminnetworkpolicies
+  - clusterversions
+  - customresourcedefinitions
+  - customresourcedefinitions/status
+  - configmaps
+  - endpointslices
+  - events
+  - featuregates
+  - infrastructures
+  - namespaces
+  - networkpolicies
+  - nodes
+  - pods
+  - replicasets
+  - secrets
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - patch
+- apiGroups:
+  - k8s.cni.cncf.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - cloud.network.openshift.io
+  - network.openshift.io
+  - whereabouts.cni.cncf.io
+  resources:
+  - egressnetworkpolicies
+  - cloudprivateipconfigs
+  - cloudprivateipconfigs/status
+  - clusternetworks
+  - hostsubnets
+  - ippools
+  - netnamespaces
+  - overlappingrangeipreservations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - "*"
+- apiGroups:
+  - authentication.k8s.io
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  - cloud.network.openshift.io
+  - controlplane.operator.openshift.io
+  - k8s.ovn.org
+  - policy.networking.k8s.io
+  resources:
+  - adminnetworkpolicies/status
+  - adminpolicybasedexternalroutes
+  - adminpolicybasedexternalroutes/status
+  - baselineadminnetworkpolicies/status
+  - egressfirewalls
+  - egressfirewalls/status
+  - egressips
+  - egressqoses
+  - egressservices
+  - egressservices/status
+  - namespaces/status
+  - nodes
+  - nodes/status
+  - podnetworkconnectivitychecks
+  - podnetworkconnectivitychecks/status
+  - pods/status
+  - services
+  - services/status 
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups: 
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups: 
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests/approval
+  verbs:
+  - update
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - signers
+  resourceNames:
+  - kubernetes.io/kube-apiserver-client
+  verbs:
+  - approve
+- apiGroups: 
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  resourceNames:
+  - privileged
+  - hostnetwork-v2
+  verbs:
+  - use
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cluster-network-operator-granting
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/single-node-developer: "true"
+subjects:
+- kind: ServiceAccount
+  name: cluster-network-operator
+  namespace: openshift-network-operator
+roleRef:
+  kind: ClusterRole
+  name: cluster-network-operator-granting
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: openshift-network-operator
+  name: cluster-network-operator
+rules:
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs:
+  - create
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: openshift-network-operator
+  name: cluster-network-operator
+subjects:
+- kind: ServiceAccount
+  name: cluster-network-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-network-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    release.openshift.io/delete: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: cluster-network-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: cluster-network-operator
+  namespace: openshift-network-operator
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Recently, a CNO service account was introduced bound to the cluster admin role. Those permissions are more than we need, so try to narrow them down with specific roles.