### PR TITLE
[OCPBUGS-22729] Add IP validation in schema for static hop IP

### DIFF
--- a/bindata/network/ovn-kubernetes/common/001-crd.yaml
+++ b/bindata/network/ovn-kubernetes/common/001-crd.yaml
@@ -689,6 +689,7 @@ spec:
                         ip:
                           description: IP defines the static IP to be used for egress
                             traffic. The IP can be either IPv4 or IPv6.
+                          format: ip
                           type: string
                       required:
                       - ip


### PR DESCRIPTION
Adds IP validation in the static hop IP field for the Admin Policy Based External Route CR to ensure the field is matches an IPv4 or IPv6 format.

```

@tshefi FYI