### PR TITLE
[release-4.13]SDN-4184: Limit OVN-Kubernetes RBAC permissions

### DIFF
--- a/bindata/network/ovn-kubernetes/common/002-rbac.yaml
+++ b/bindata/network/ovn-kubernetes/common/002-rbac.yaml
@@ -126,7 +126,6 @@ rules:
   verbs:
     - create
     - get
-    - update
     - list
 
 ---

--- a/bindata/network/ovn-kubernetes/common/002-rbac.yaml
+++ b/bindata/network/ovn-kubernetes/common/002-rbac.yaml
@@ -126,7 +126,6 @@ rules:
   verbs:
     - create
     - get
-    - delete
     - update
     - list
 

--- a/bindata/network/ovn-kubernetes/common/002-rbac.yaml
+++ b/bindata/network/ovn-kubernetes/common/002-rbac.yaml
@@ -52,6 +52,12 @@ rules:
   - update
 - apiGroups: [""]
   resources:
+  - pods/status
+  verbs:
+  - patch
+  - update
+- apiGroups: [""]
+  resources:
   - namespaces
   - endpoints
   - services
@@ -87,6 +93,12 @@ rules:
   - get
   - list
   - watch
+  - patch
+  - update
+- apiGroups: [""]
+  resources:
+  - nodes/status
+  verbs:
   - patch
   - update
 - apiGroups: ["k8s.ovn.org"]

--- a/bindata/network/ovn-kubernetes/common/003-rbac-controller.yaml
+++ b/bindata/network/ovn-kubernetes/common/003-rbac-controller.yaml
@@ -24,13 +24,12 @@ rules:
   - update
 - apiGroups: [""]
   resources:
-  - pods
+  - namespaces/status
+  - nodes/status
+  - pods/status
   verbs:
-  - get
-  - list
   - patch
-  - watch
-  - delete
+  - update
 - apiGroups: [""]
   resources:
   - configmaps
@@ -77,8 +76,9 @@ rules:
   - privileged
 - apiGroups: [""]
   resources:
-  - "nodes/status"
+  - nodes/status
   - services
+  - services/status
   verbs:
   - patch
   - update

--- a/bindata/network/ovn-kubernetes/common/ipsec.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec.yaml
@@ -79,31 +79,28 @@ spec:
 
             csr_64=$(cat /etc/openvswitch/keys/ipsec-req.pem | base64 | tr -d "\n")
 
-            # The signer controller does not allow re-signing a key. We will
-            # delete the old key to be sure it is not there
-            kubectl delete --ignore-not-found=true csr/$(hostname)
-
             # Request that our generated certificate signing request is
             # signed by the "network.openshift.io/signer" signer that is
             # implemented by the CNO signer controller. This will sign the
             # certificate signing request using the signer-ca which has been
             # set up by the OperatorPKI. In this way, we have a signed certificate
             # and our private key has remained private on this host.
-            cat <<EOF | kubectl apply -f -
+            cat <<EOF | kubectl create -f -
             apiVersion: certificates.k8s.io/v1
             kind: CertificateSigningRequest
             metadata:
-              name: $(hostname)
+              generateName: ipsec-csr-$(hostname)-
+              labels:
+                k8s.ovn.org/ipsec-csr: $(hostname)
             spec:
               request: ${csr_64}
               signerName: network.openshift.io/signer
               usages:
               - ipsec tunnel
           EOF
-
             # Wait until the certificate signing request has been signed.
             counter=0
-            until [ ! -z $(kubectl get csr/$(hostname) -o jsonpath='{.status.certificate}' 2>/dev/null) ]
+            until [ ! -z $(kubectl get csr -lk8s.ovn.org/ipsec-csr=$(hostname) --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1:].status.certificate}' 2>/dev/null) ]
             do
               counter=$((counter+1))
               sleep 1
@@ -115,7 +112,7 @@ spec:
             done
 
             # Decode the signed certificate.
-            kubectl get csr/$(hostname) -o jsonpath='{.status.certificate}' | base64 -d | openssl x509 -outform pem -text -out /etc/openvswitch/keys/ipsec-cert.pem
+            kubectl get csr -lk8s.ovn.org/ipsec-csr=$(hostname) --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1:].status.certificate}' | base64 -d | openssl x509 -outform pem -text -out /etc/openvswitch/keys/ipsec-cert.pem
 
             kubectl delete csr/$(hostname)
 

--- a/bindata/network/ovn-kubernetes/common/ipsec.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec.yaml
@@ -58,10 +58,11 @@ spec:
           # authentic.
           echo "Configuring IPsec keys"
 
+          cert_pem=/etc/openvswitch/keys/ipsec-cert.pem
+
           # If the certificate does not exist or it will expire in the next 6 months
           # (15770000 seconds), we will generate a new one.
-          if [ ! -e /etc/openvswitch/keys/ipsec-cert.pem ] || [ ! openssl x509 -noout -dates -checkend 15770000 ];
-          then
+          if ! openssl x509 -noout -dates -checkedn 15770000 -in $cert_pem; then
             # We use the system-id as the CN for our certificate signing request. This
             # is a requirement by OVN.
             cn=$(ovs-vsctl --retry -t 60 get Open_vSwitch . external-ids:system-id | tr -d "\"")
@@ -112,7 +113,7 @@ spec:
             done
 
             # Decode the signed certificate.
-            kubectl get csr -lk8s.ovn.org/ipsec-csr=$(hostname) --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1:].status.certificate}' | base64 -d | openssl x509 -outform pem -text -out /etc/openvswitch/keys/ipsec-cert.pem
+            kubectl get csr -lk8s.ovn.org/ipsec-csr=$(hostname) --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1:].status.certificate}' | base64 -d | openssl x509 -outform pem -text -out $cert_pem
 
             # Get the CA certificate so we can authenticate peer nodes.
             cat /signer-ca/ca-bundle.crt | openssl x509 -outform pem -text > /etc/openvswitch/keys/ipsec-cacert.pem
@@ -123,7 +124,7 @@ spec:
           # Updating the certificates does not need to be an atomic operation as
           # the will get read and loaded into NSS by the ovs-monitor-ipsec process
           # which has not started yet.
-          ovs-vsctl --retry -t 60 set Open_vSwitch . other_config:certificate=/etc/openvswitch/keys/ipsec-cert.pem \
+          ovs-vsctl --retry -t 60 set Open_vSwitch . other_config:certificate=$cert_pem/g \
                                                      other_config:private_key=/etc/openvswitch/keys/ipsec-privkey.pem \
                                                      other_config:ca_cert=/etc/openvswitch/keys/ipsec-cacert.pem
         env:

--- a/bindata/network/ovn-kubernetes/common/ipsec.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec.yaml
@@ -114,8 +114,6 @@ spec:
             # Decode the signed certificate.
             kubectl get csr -lk8s.ovn.org/ipsec-csr=$(hostname) --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1:].status.certificate}' | base64 -d | openssl x509 -outform pem -text -out /etc/openvswitch/keys/ipsec-cert.pem
 
-            kubectl delete csr/$(hostname)
-
             # Get the CA certificate so we can authenticate peer nodes.
             cat /signer-ca/ca-bundle.crt | openssl x509 -outform pem -text > /etc/openvswitch/keys/ipsec-cacert.pem
           fi


### PR DESCRIPTION
this is the CNO portion of https://github.com/openshift/ovn-kubernetes/pull/1950 and limit the RBAC permissions of ovn-kubernetes

the changes are from 
https://github.com/openshift/cluster-network-operator/pull/1896 
https://github.com/openshift/cluster-network-operator/pull/1928 
https://github.com/openshift/cluster-network-operator/pull/1934

the first two commits applied cleanly leaving the third to have a small conflict because master branch had additional security constraints added  

was able to cleanly bring in https://github.com/openshift/cluster-network-operator/commit/8b5cd5fa892e737287b6bf78ad1091618899668e and https://github.com/openshift/cluster-network-operator/commit/2e3fc8e7a01fc47cb213e77a033564d7babedc8b to address https://github.com/openshift/cluster-network-operator/issues/1960