### PR TITLE
OCPBUGS-23082: set automountServiceAccountToken to false for hypershift managed network-node-identity deploy

### DIFF
--- a/bindata/network/node-identity/managed/node-identity.yaml
+++ b/bindata/network/node-identity/managed/node-identity.yaml
@@ -89,6 +89,7 @@ spec:
           volumeMounts:
             - mountPath: /var/run/secrets/hosted_cluster
               name: hosted-cluster-api-access
+      automountServiceAccountToken: false
       containers:
       - name: webhook
         image: "{{.NetworkNodeIdentityImage}}"


### PR DESCRIPTION
Set `automountServiceAccountToken` to `false` for hypershift managed `network-node-identity` deployment

From our initial investigation, it seems like this component does not need management cluster access. We were looking at:
https://github.com/openshift/cluster-network-operator/blob/release-4.14/bindata/network/node-identity/managed/node-identity.yaml

For the webhook and approver container: https://github.com/openshift/ovn-kubernetes/blob/release-4.14/go-controller/cmd/ovnkube-identity/ovnkubeidentity.go

For the token minter container: https://github.com/openshift/hypershift/blob/release-4.14/token-minter/tokenminter.go

Addresses https://issues.redhat.com/browse/OCPBUGS-23082