### PR TITLE
OCPBUGS-22995: Tighten the permissions on whereabouts.conf

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -609,6 +609,7 @@ spec:
               "log_level": "debug"
             }
             EOF
+            chmod 600 $WHEREABOUTS_GLOBALCONFIG
 
             else
               warn "Doesn't look like we're running in a kubernetes environment (no serviceaccount token)"


### PR DESCRIPTION
According to CIS benchmark guidance, all files according to networking configuration should only be read/writeable to the owner (600).

This commit updates the installation script that lays down the whereabouts.conf file to use permissions 600 instead of 644.