### PR TITLE
NO ISSUE: add ownership of the proxy-ca

### DIFF
--- a/pkg/controller/proxyconfig/controller.go
+++ b/pkg/controller/proxyconfig/controller.go
@@ -384,6 +384,9 @@ func (r *ReconcileProxyConfig) mergeTrustBundlesToConfigMap(additionalData, syst
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      names.TRUSTED_CA_BUNDLE_CONFIGMAP,
 			Namespace: names.TRUSTED_CA_BUNDLE_CONFIGMAP_NS,
+			Annotations: map[string]string{
+				names.OpenShiftComponent: names.ClusterNetworkOperatorJiraComponent,
+			},
 		},
 		Data: map[string]string{
 			names.TRUSTED_CA_BUNDLE_CONFIGMAP_KEY: string(combinedTrustData),
@@ -427,6 +430,9 @@ func (r *ReconcileProxyConfig) syncTrustedCABundle(trustedCABundle *corev1.Confi
 // configMapsEqual compares the data key values between
 // a and b ConfigMaps, returning true if they are equal.
 func configMapsEqual(key string, a, b *corev1.ConfigMap) bool {
+	if a.Annotations[names.OpenShiftComponent] != b.Annotations[names.OpenShiftComponent] {
+		return false
+	}
 	return a.Data[key] == b.Data[key]
 }
 
@@ -445,6 +451,9 @@ func (r *ReconcileProxyConfig) generateSystemTrustBundle() (*corev1.ConfigMap, e
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      names.TRUSTED_CA_BUNDLE_CONFIGMAP,
 			Namespace: names.TRUSTED_CA_BUNDLE_CONFIGMAP_NS,
+			Annotations: map[string]string{
+				names.OpenShiftComponent: names.ClusterNetworkOperatorJiraComponent,
+			},
 		},
 		Data: map[string]string{
 			names.TRUSTED_CA_BUNDLE_CONFIGMAP_KEY: string(bundleData),

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -127,6 +127,13 @@ const TRUSTED_CA_BUNDLE_CONFIGMAP_LABEL = "config.openshift.io/inject-trusted-ca
 // the system trust bundle.
 const SYSTEM_TRUST_BUNDLE = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
 
+// OpenShiftComponent mirrors https://github.com/openshift/api/blob/master/annotations/annotations.go#L33 but a zero-diff
+// tidy and vendor result in a non-building project, so working from a copy here until the next dep update.
+const OpenShiftComponent = "openshift.io/owning-component"
+
+// ClusterNetworkOperatorJiraComponent is the jira component name for the cluster-network-operator
+const ClusterNetworkOperatorJiraComponent = "Networking / cluster-network-operator"
+
 // Proxy returns the namespaced name "cluster" in the
 // default namespace.
 func Proxy() types.NamespacedName {


### PR DESCRIPTION
Mark ownership of the proxy-ca configmaps managed and injected by this operator.  This is later harvested by generated documentation.

/cc @vrutkovs 