### PR TITLE
OCPBUGS-22869: hypershift, hosted clusters: enable multi-homing and multi-net features

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/common/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/common/004-config.yaml
@@ -126,6 +126,12 @@ data:
 {{- if .ReachabilityNodePort }}
     egressip-node-healthcheck-port={{.ReachabilityNodePort}}
 {{- end }}
+{{- if .OVN_MULTI_NETWORK_ENABLE }}
+    enable-multi-network=true
+{{- end }}
+{{- if .OVN_MULTI_NETWORK_POLICY_ENABLE }}
+    enable-multi-networkpolicy=true
+{{- end }}
 
     [gateway]
     mode={{.OVN_GATEWAY_MODE}}


### PR DESCRIPTION
On HyperShift hosted cluster we were not enabling the multi-net (or multi-net policy) features; as such, the network attachment definition informers were not started, which caused multi-homed pods from being started in the hosted cluster.

Also enabled the multi-net policy feature depending on the operator configuration, since it was also missing from the configuration.
