### PR TITLE
OCPBUGS-24036: remove all managed fields used by old manager

### DIFF
--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -125,29 +125,37 @@ func ApplyObject(ctx context.Context, client cnoclient.Client, obj Object, subco
 		log.Printf("could not encode %s for apply", objDesc)
 		return fmt.Errorf("could not encode for patching: %w", err)
 	}
-	us, err := clusterClient.Dynamic().Resource(rm.Resource).Namespace(namespace).Patch(ctx, name, types.ApplyPatchType, data, patchOptions, subresources...)
+	// consider removing in OCP 4.18 when we know field manager 'cluster-network-operator' no longer possibly
+	// exists in any object from all upgrade paths
+	// Retrieve the current state of the resource
+	if isDepFieldManagerCleanupNeeded(subcontroller) {
+		us, err := clusterClient.Dynamic().Resource(rm.Resource).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get current state of %s: %w", objDesc, err)
+		}
+		if us != nil {
+			us.SetGroupVersionKind(gvk)
+
+			if doesManagerOpExist(us.GetManagedFields(), depreciatedFieldManager, metav1.ManagedFieldsOperationUpdate,
+				metav1.ManagedFieldsOperationApply) {
+
+				us.SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
+				if err = mergeManager(ctx, clusterClient, us, depreciatedFieldManager, fieldManager, rm.Resource); err != nil {
+					klog.Errorf("Failed to merge field managers %q for object %q %s %s: %v", depreciatedFieldManager,
+						gvk.String(), obj.GetNamespace(), obj.GetName(), err)
+				} else {
+					klog.Infof("Depreciated field manager %s for object %q %s %s", depreciatedFieldManager,
+						gvk.String(), obj.GetNamespace(), obj.GetName())
+				}
+			}
+		}
+	}
+
+	_, err = clusterClient.Dynamic().Resource(rm.Resource).Namespace(namespace).Patch(ctx, name, types.ApplyPatchType, data, patchOptions, subresources...)
 	if err != nil {
 		return fmt.Errorf("failed to apply / update %s: %w", objDesc, err)
 	}
 
-	// consider removing in OCP 4.18 when we know field manager 'cluster-network-operator' no longer possibly
-	// exists in any object from all upgrade paths
-	if isDepFieldManagerCleanupNeeded(subcontroller) {
-		us.SetGroupVersionKind(gvk)
-
-		if doesManagerOpExist(us.GetManagedFields(), depreciatedFieldManager, metav1.ManagedFieldsOperationUpdate,
-			metav1.ManagedFieldsOperationApply) {
-
-			us.SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
-			if err = mergeManager(ctx, clusterClient, us, depreciatedFieldManager, fieldManager, rm.Resource); err != nil {
-				klog.Errorf("Failed to merge field managers %q for object %q %s %s: %v", depreciatedFieldManager,
-					gvk.String(), obj.GetNamespace(), obj.GetName(), err)
-			} else {
-				klog.Infof("Depreciated field manager %s for object %q %s %s", depreciatedFieldManager,
-					gvk.String(), obj.GetNamespace(), obj.GetName())
-			}
-		}
-	}
 	log.Printf("Apply / Create of %s was successful", objDesc)
 	return nil
 }


### PR DESCRIPTION
the old manager "cluster-network-operator" was changed to "cluster-network-operator/operconfig" in 4.11 when server-side-apply was migrated to from client-side-apply. However, the old operator still had it's own managed fields and some interaction between those and the change to remove preStop hooks in ovnkube-master's daemonset containers was causing upgrades to stick in the network operator.

this will just remove the old manager (and it's managed fields) entirely. it's done before the update to apply the object instead of after.

JIRA: https://issues.redhat.com/browse/OCPBUGS-22293



deal w/ deprecated field manager before apply