### PR TITLE
OPNET-358, OPNET-360: Allow VIP mutation in Infra CR

### DIFF
--- a/pkg/controller/infrastructureconfig/sync_specstatus.go
+++ b/pkg/controller/infrastructureconfig/sync_specstatus.go
@@ -1,0 +1,200 @@
+package infrastructureconfig
+
+import (
+	"fmt"
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-network-operator/pkg/util/ip"
+	"log"
+)
+
+type specStatusSynchronizer interface {
+	SpecStatusSynchronize(*configv1.Infrastructure) (*configv1.Infrastructure, error)
+}
+
+type specStatusSunchronizer struct{}
+
+func (*specStatusSunchronizer) SpecStatusSynchronize(infraConfig *configv1.Infrastructure) (*configv1.Infrastructure, error) {
+	updatedInfraConfig := infraConfig.DeepCopy()
+
+	var (
+		statusApiVips, statusIngressVips           *[]string
+		specApiVips, specIngressVips               *[]configv1.IP
+		statusMachineNetworks, specMachineNetworks *[]configv1.CIDR
+		elb                                        bool
+	)
+
+	if updatedInfraConfig.Status.PlatformStatus == nil {
+		// This should not happen because of guards at openshift/installer but if by any chance we
+		// arrive at this situation, just exit to avoid errors or panics
+		return updatedInfraConfig, nil
+	}
+
+	switch {
+	case updatedInfraConfig.Status.PlatformStatus.Type == configv1.BareMetalPlatformType:
+		if updatedInfraConfig.Spec.PlatformSpec.BareMetal == nil {
+			// This is migration path from pre-4.16 version in which PlatformSpec was not defined.
+			// We first upgrade the struct to a new one (introduced in 4.16) and populate afterward.
+			log.Print("Detected nil platform spec for baremetal, initializing")
+			updatedInfraConfig.Spec.PlatformSpec.BareMetal = &configv1.BareMetalPlatformSpec{}
+		}
+		if updatedInfraConfig.Status.PlatformStatus.BareMetal == nil {
+			// This is a safeguard against strange platform combinations that do not fill the
+			// PlatformStatus (e.g. UPI under some circumstances).
+			log.Print("Detected nil platform status for baremetal, aborting")
+			return updatedInfraConfig, nil
+		}
+		statusApiVips = &updatedInfraConfig.Status.PlatformStatus.BareMetal.APIServerInternalIPs
+		specApiVips = &updatedInfraConfig.Spec.PlatformSpec.BareMetal.APIServerInternalIPs
+
+		statusIngressVips = &updatedInfraConfig.Status.PlatformStatus.BareMetal.IngressIPs
+		specIngressVips = &updatedInfraConfig.Spec.PlatformSpec.BareMetal.IngressIPs
+
+		statusMachineNetworks = &updatedInfraConfig.Status.PlatformStatus.BareMetal.MachineNetworks
+		specMachineNetworks = &updatedInfraConfig.Spec.PlatformSpec.BareMetal.MachineNetworks
+
+		if updatedInfraConfig.Status.PlatformStatus.BareMetal.LoadBalancer != nil &&
+			updatedInfraConfig.Status.PlatformStatus.BareMetal.LoadBalancer.Type == configv1.LoadBalancerTypeUserManaged {
+			elb = true
+		}
+
+	case updatedInfraConfig.Status.PlatformStatus.Type == configv1.VSpherePlatformType:
+		if updatedInfraConfig.Spec.PlatformSpec.VSphere == nil {
+			log.Print("Detected nil platform spec for vSphere, initializing")
+			updatedInfraConfig.Spec.PlatformSpec.VSphere = &configv1.VSpherePlatformSpec{}
+		}
+		if updatedInfraConfig.Status.PlatformStatus.VSphere == nil {
+			log.Print("Detected nil platform status for vSphere, aborting")
+			return updatedInfraConfig, nil
+		}
+		statusApiVips = &updatedInfraConfig.Status.PlatformStatus.VSphere.APIServerInternalIPs
+		specApiVips = &updatedInfraConfig.Spec.PlatformSpec.VSphere.APIServerInternalIPs
+
+		statusIngressVips = &updatedInfraConfig.Status.PlatformStatus.VSphere.IngressIPs
+		specIngressVips = &updatedInfraConfig.Spec.PlatformSpec.VSphere.IngressIPs
+
+		statusMachineNetworks = &updatedInfraConfig.Status.PlatformStatus.VSphere.MachineNetworks
+		specMachineNetworks = &updatedInfraConfig.Spec.PlatformSpec.VSphere.MachineNetworks
+
+		if updatedInfraConfig.Status.PlatformStatus.VSphere.LoadBalancer != nil &&
+			updatedInfraConfig.Status.PlatformStatus.VSphere.LoadBalancer.Type == configv1.LoadBalancerTypeUserManaged {
+			elb = true
+		}
+
+	case updatedInfraConfig.Status.PlatformStatus.Type == configv1.OpenStackPlatformType:
+		if updatedInfraConfig.Spec.PlatformSpec.OpenStack == nil {
+			log.Print("Detected nil platform spec for openstack, initializing")
+			updatedInfraConfig.Spec.PlatformSpec.OpenStack = &configv1.OpenStackPlatformSpec{}
+		}
+		if updatedInfraConfig.Status.PlatformStatus.OpenStack == nil {
+			log.Print("Detected nil platformstatus for OpenStack, aborting")
+			return updatedInfraConfig, nil
+		}
+		statusApiVips = &updatedInfraConfig.Status.PlatformStatus.OpenStack.APIServerInternalIPs
+		specApiVips = &updatedInfraConfig.Spec.PlatformSpec.OpenStack.APIServerInternalIPs
+
+		statusIngressVips = &updatedInfraConfig.Status.PlatformStatus.OpenStack.IngressIPs
+		specIngressVips = &updatedInfraConfig.Spec.PlatformSpec.OpenStack.IngressIPs
+
+		statusMachineNetworks = &updatedInfraConfig.Status.PlatformStatus.OpenStack.MachineNetworks
+		specMachineNetworks = &updatedInfraConfig.Spec.PlatformSpec.OpenStack.MachineNetworks
+
+		if updatedInfraConfig.Status.PlatformStatus.OpenStack.LoadBalancer != nil &&
+			updatedInfraConfig.Status.PlatformStatus.OpenStack.LoadBalancer.Type == configv1.LoadBalancerTypeUserManaged {
+			elb = true
+		}
+
+	default:
+		// nothing to do for this platform type
+		return updatedInfraConfig, nil
+	}
+
+	if err := syncMachineNetworks(specMachineNetworks, statusMachineNetworks); err != nil {
+		return nil, fmt.Errorf("Error on syncing machine networks: %v", err)
+	}
+	if err := validateVipsWithVips(*specApiVips, *specIngressVips, elb); err != nil {
+		return nil, fmt.Errorf("Error on validating VIPs: %v", err)
+	}
+	if err := validateVipsWithMachineNetworks(*specApiVips, *specMachineNetworks); err != nil {
+		return nil, fmt.Errorf("Error on validating API VIPs and Machine Networks: %v", err)
+	}
+	if err := validateVipsWithMachineNetworks(*specIngressVips, *specMachineNetworks); err != nil {
+		return nil, fmt.Errorf("Error on validating Ingress VIPs and Machine Networks: %v", err)
+	}
+
+	if err := syncVips(specApiVips, statusApiVips); err != nil {
+		return nil, fmt.Errorf("Error on syncing API VIPs: %v", err)
+	}
+	if err := syncVips(specIngressVips, statusIngressVips); err != nil {
+		return nil, fmt.Errorf("Error on syncing Ingress VIPs: %v", err)
+	}
+
+	return updatedInfraConfig, nil
+}
+
+// syncMachineNetworks propagates machine networks from Spec to Status assuming they pass required validations.
+// In order to be valid, machine networks need to fulfil the following spec:
+//
+//   - the first machine network can never be modified
+//     -- the only exception is when Spec is empty, then adding is allowed
+//   - the number of machine networks is not limited to 2 as opposed to e.g. service networks
+//   - removal of machine networks is allowed as long as first entry is not modified
+//
+// It is possible that Status and/or Spec are empty if this is the very first time we modify this field
+// after upgrading from the version of the API that did not contain the field.
+func syncMachineNetworks(spec, status *[]configv1.CIDR) error {
+	if spec == nil || status == nil {
+		return fmt.Errorf("passed nil value as spec or status machine network")
+	}
+	if len(*spec) == 0 {
+		// This is a subtlety of JSON marshalling. What happens is that
+		// `var myslice []int` gets marshalled to null, but
+		// `myslice := []int{}` gets marshalled to []
+		// Because of this we want to be explicit that machine networks is an empty list and not null
+		*spec = []configv1.CIDR{}
+	}
+
+	if len(*status) != 0 {
+		if len(*spec) == 0 {
+			return fmt.Errorf("removing machine networks is forbidden")
+		}
+		if (*spec)[0] != (*status)[0] {
+			return fmt.Errorf("first machine network cannot be modified, have '%s' and requested '%s'", (*status)[0], (*spec)[0])
+		}
+	}
+
+	// `spec` is updated, need to propagate to `status`
+	*status = *spec
+
+	return nil
+}
+
+// syncVips propagates set of VIPs (ingress or API) from Spec to Status assuming they pass required validations.
+// It uses machine networks as additional source of knowledge about the environment so that validations can be
+// stricter. In order to be valid, VIPs need to fulfil the following spec:
+//
+//   - the first VIP can never be modified
+//   - modification or removal of the second VIP is allowed
+//
+// It is possible that Spec is empty and Status is not if this is a cluster that has been upgraded from an older
+// version where this CRD did not have Spec defined.
+//
+// It is not possible to have Status field empty. This would happen only when something went wrong during
+// the installation, and we would catch it way before running this code.
+func syncVips(spec *[]configv1.IP, status *[]string) error {
+	if spec == nil || status == nil {
+		return fmt.Errorf("passed nil value as spec or status vip")
+	}
+	// `spec` is empty, `status` with value: copy status to spec
+	if len(*spec) == 0 {
+		*spec = ip.StringsToIPs(*status)
+	} else {
+		if string((*spec)[0]) != (*status)[0] {
+			return fmt.Errorf("first VIP cannot be modified, have '%s' and requested '%s'", (*status)[0], (*spec)[0])
+		}
+
+		// `spec` is updated, need to propagate to `status`
+		*status = ip.IPsToStrings(*spec)
+	}
+
+	return nil
+}

--- a/pkg/controller/infrastructureconfig/sync_specstatus.go
+++ b/pkg/controller/infrastructureconfig/sync_specstatus.go
@@ -7,13 +7,7 @@ import (
 	"log"
 )
 
-type specStatusSynchronizer interface {
-	SpecStatusSynchronize(*configv1.Infrastructure) (*configv1.Infrastructure, error)
-}
-
-type specStatusSunchronizer struct{}
-
-func (*specStatusSunchronizer) SpecStatusSynchronize(infraConfig *configv1.Infrastructure) (*configv1.Infrastructure, error) {
+func (*synchronizer) SpecStatusSynchronize(infraConfig *configv1.Infrastructure) (*configv1.Infrastructure, error) {
 	updatedInfraConfig := infraConfig.DeepCopy()
 
 	var (

--- a/pkg/controller/infrastructureconfig/sync_specstatus_test.go
+++ b/pkg/controller/infrastructureconfig/sync_specstatus_test.go
@@ -1,0 +1,863 @@
+package infrastructureconfig
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_SpecStatusSynchronizer(t *testing.T) {
+	tests := []struct {
+		name        string
+		givenInfra  configv1.Infrastructure
+		wantedInfra configv1.Infrastructure
+		wantedErr   string
+	}{
+		{
+			name: "succeed: spec is empty, status with value: should propagate spec from status",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "BareMetal",
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1"},
+							IngressIPs:           []string{"224.0.0.2"},
+						},
+					},
+				},
+			},
+			wantedInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.0.1"},
+							IngressIPs:           []configv1.IP{"224.0.0.2"},
+							MachineNetworks:      []configv1.CIDR{},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "BareMetal",
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1"},
+							IngressIPs:           []string{"224.0.0.2"},
+							MachineNetworks:      []configv1.CIDR{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "succeed: no changes, spec equals status",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.0.1"},
+							IngressIPs:           []configv1.IP{"224.0.0.2"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "BareMetal",
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1"},
+							IngressIPs:           []string{"224.0.0.2"},
+						},
+					},
+				},
+			},
+			wantedInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.0.1"},
+							IngressIPs:           []configv1.IP{"224.0.0.2"},
+							MachineNetworks:      []configv1.CIDR{},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "BareMetal",
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1"},
+							IngressIPs:           []string{"224.0.0.2"},
+							MachineNetworks:      []configv1.CIDR{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "succeed: add additional pair of vips; empty machine networks",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.0.1", "2001:0DB8::1"},
+							IngressIPs:           []configv1.IP{"224.0.0.2", "2001:0DB8::2"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "BareMetal",
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1"},
+							IngressIPs:           []string{"224.0.0.2"},
+						},
+					},
+				},
+			},
+			wantedInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.0.1", "2001:0DB8::1"},
+							IngressIPs:           []configv1.IP{"224.0.0.2", "2001:0DB8::2"},
+							MachineNetworks:      []configv1.CIDR{},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "BareMetal",
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1", "2001:0DB8::1"},
+							IngressIPs:           []string{"224.0.0.2", "2001:0DB8::2"},
+							MachineNetworks:      []configv1.CIDR{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "fail: modifying first pair of vips forbidden",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"2001:0DB8::1"},
+							IngressIPs:           []configv1.IP{"2001:0DB8::2"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "BareMetal",
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1"},
+							IngressIPs:           []string{"224.0.0.2"},
+						},
+					},
+				},
+			},
+			wantedErr: "first VIP cannot be modified",
+		},
+		{
+			name: "fail: removing machine networks from spec is forbidden",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"2001:0DB8::1"},
+							IngressIPs:           []configv1.IP{"2001:0DB8::2"},
+							MachineNetworks:      []configv1.CIDR{},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "BareMetal",
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{"2001:0DB8::1"},
+							IngressIPs:           []string{"2001:0DB8::2"},
+							MachineNetworks:      []configv1.CIDR{"2001:0DB8::0/64"},
+						},
+					},
+				},
+			},
+			wantedErr: "removing machine networks is forbidden",
+		},
+		{
+			name: "fail: multiple vips of the same IP stack forbidden",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"2001:0DB8::1", "2001:0DB8::10"},
+							IngressIPs:           []configv1.IP{"2001:0DB8::2", "2001:0DB8::20"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "BareMetal",
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1"},
+							IngressIPs:           []string{"224.0.0.2"},
+						},
+					},
+				},
+			},
+			wantedErr: "at least one from each IP family is required",
+		},
+		{
+			name: "fail: vip from outside of machine network",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.1.1"},
+							IngressIPs:           []configv1.IP{"224.0.1.2"},
+							MachineNetworks:      []configv1.CIDR{"224.0.0.1/24", "224.1.0.1/24"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "BareMetal",
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1"},
+							IngressIPs:           []string{"224.0.0.2"},
+							MachineNetworks:      []configv1.CIDR{"224.0.0.1/24", "224.1.0.1/24"},
+						},
+					},
+				},
+			},
+			wantedErr: "cannot be found in any machine network",
+		},
+		{
+			name: "fail: duplicate vips without ELB",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.1.1"},
+							IngressIPs:           []configv1.IP{"224.0.1.1"},
+							MachineNetworks:      []configv1.CIDR{"224.0.0.1/24", "224.0.1.1/24"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "BareMetal",
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1"},
+							IngressIPs:           []string{"224.0.0.2"},
+							MachineNetworks:      []configv1.CIDR{"224.0.0.1/24"},
+						},
+					},
+				},
+			},
+			wantedErr: "VIPs cannot be equal",
+		},
+		{
+			name: "succeed: duplicate vips with ELB",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.0.1"},
+							IngressIPs:           []configv1.IP{"224.0.0.1"},
+							MachineNetworks:      []configv1.CIDR{"224.0.0.1/24", "224.0.1.1/24"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "BareMetal",
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1"},
+							IngressIPs:           []string{"224.0.0.1"},
+							MachineNetworks:      []configv1.CIDR{"224.0.0.1/24"},
+							LoadBalancer:         &configv1.BareMetalPlatformLoadBalancer{Type: configv1.LoadBalancerTypeUserManaged},
+						},
+					},
+				},
+			},
+			wantedInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.0.1"},
+							IngressIPs:           []configv1.IP{"224.0.0.1"},
+							MachineNetworks:      []configv1.CIDR{"224.0.0.1/24", "224.0.1.1/24"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "BareMetal",
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1"},
+							IngressIPs:           []string{"224.0.0.1"},
+							MachineNetworks:      []configv1.CIDR{"224.0.0.1/24", "224.0.1.1/24"},
+							LoadBalancer:         &configv1.BareMetalPlatformLoadBalancer{Type: configv1.LoadBalancerTypeUserManaged},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "fail: non-equal number of vips",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.1.1", "2001:0DB8::1"},
+							IngressIPs:           []configv1.IP{"224.0.1.2"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "BareMetal",
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1"},
+							IngressIPs:           []string{"224.0.0.2"},
+						},
+					},
+				},
+			},
+			wantedErr: "does not match number",
+		},
+		{
+			name: "fail: too many vips",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.1.1", "2001:0DB8::1", "2001:0DB8::10"},
+							IngressIPs:           []configv1.IP{"224.0.1.2", "2001:0DB8::2", "2001:0DB8::20"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "BareMetal",
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1"},
+							IngressIPs:           []string{"224.0.0.2"},
+						},
+					},
+				},
+			},
+			wantedErr: "number of API VIPs needs to be less or equal to 2",
+		},
+		{
+			name: "succeed: add pair of IPv6 vips; non-empty machine networks",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"10.0.0.1", "fe80:1:2:3::1"},
+							IngressIPs:           []configv1.IP{"10.0.0.2", "fe80:1:2:3::2"},
+							MachineNetworks:      []configv1.CIDR{"10.0.0.0/24", "fe80:1:2:3::/64"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "BareMetal",
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{"10.0.0.1"},
+							IngressIPs:           []string{"10.0.0.2"},
+							MachineNetworks:      []configv1.CIDR{"10.0.0.0/24"},
+						},
+					},
+				},
+			},
+			wantedInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"10.0.0.1", "fe80:1:2:3::1"},
+							IngressIPs:           []configv1.IP{"10.0.0.2", "fe80:1:2:3::2"},
+							MachineNetworks:      []configv1.CIDR{"10.0.0.0/24", "fe80:1:2:3::/64"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "BareMetal",
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{"10.0.0.1", "fe80:1:2:3::1"},
+							IngressIPs:           []string{"10.0.0.2", "fe80:1:2:3::2"},
+							MachineNetworks:      []configv1.CIDR{"10.0.0.0/24", "fe80:1:2:3::/64"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "succeed: delete 2nd pair of vips",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.0.1"},
+							IngressIPs:           []configv1.IP{"224.0.0.2"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "BareMetal",
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1", "2001:0DB8::1"},
+							IngressIPs:           []string{"224.0.0.2", "2001:0DB8::2"},
+						},
+					},
+				},
+			},
+			wantedInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.0.1"},
+							IngressIPs:           []configv1.IP{"224.0.0.2"},
+							MachineNetworks:      []configv1.CIDR{},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "BareMetal",
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1"},
+							IngressIPs:           []string{"224.0.0.2"},
+							MachineNetworks:      []configv1.CIDR{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "should handle OpenStack platform: add additional pair of vips",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						OpenStack: &configv1.OpenStackPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.0.1", "2001:0DB8::1"},
+							IngressIPs:           []configv1.IP{"224.0.0.2", "2001:0DB8::2"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.OpenStackPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "OpenStack",
+						OpenStack: &configv1.OpenStackPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1"},
+							IngressIPs:           []string{"224.0.0.2"},
+						},
+					},
+				},
+			},
+			wantedInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						OpenStack: &configv1.OpenStackPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.0.1", "2001:0DB8::1"},
+							IngressIPs:           []configv1.IP{"224.0.0.2", "2001:0DB8::2"},
+							MachineNetworks:      []configv1.CIDR{},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.OpenStackPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "OpenStack",
+						OpenStack: &configv1.OpenStackPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1", "2001:0DB8::1"},
+							IngressIPs:           []string{"224.0.0.2", "2001:0DB8::2"},
+							MachineNetworks:      []configv1.CIDR{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "should handle vSphere platform: add additional pair of vips",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						VSphere: &configv1.VSpherePlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.0.1", "2001:0DB8::1"},
+							IngressIPs:           []configv1.IP{"224.0.0.2", "2001:0DB8::2"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.VSpherePlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "VSphere",
+						VSphere: &configv1.VSpherePlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1"},
+							IngressIPs:           []string{"224.0.0.2"},
+						},
+					},
+				},
+			},
+			wantedInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						VSphere: &configv1.VSpherePlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.0.1", "2001:0DB8::1"},
+							IngressIPs:           []configv1.IP{"224.0.0.2", "2001:0DB8::2"},
+							MachineNetworks:      []configv1.CIDR{},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.VSpherePlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "VSphere",
+						VSphere: &configv1.VSpherePlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1", "2001:0DB8::1"},
+							IngressIPs:           []string{"224.0.0.2", "2001:0DB8::2"},
+							MachineNetworks:      []configv1.CIDR{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "should handle missing baremetal platform spec: create and propagate from status",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: nil,
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "BareMetal",
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1"},
+							IngressIPs:           []string{"224.0.0.2"},
+						},
+					},
+				},
+			},
+			wantedInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.0.1"},
+							IngressIPs:           []configv1.IP{"224.0.0.2"},
+							MachineNetworks:      []configv1.CIDR{},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "BareMetal",
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1"},
+							IngressIPs:           []string{"224.0.0.2"},
+							MachineNetworks:      []configv1.CIDR{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "should handle missing vsphere platform spec: create and propagate from status",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						VSphere: nil,
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.VSpherePlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "VSphere",
+						VSphere: &configv1.VSpherePlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1"},
+							IngressIPs:           []string{"224.0.0.2"},
+						},
+					},
+				},
+			},
+			wantedInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						VSphere: &configv1.VSpherePlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.0.1"},
+							IngressIPs:           []configv1.IP{"224.0.0.2"},
+							MachineNetworks:      []configv1.CIDR{},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.VSpherePlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "VSphere",
+						VSphere: &configv1.VSpherePlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1"},
+							IngressIPs:           []string{"224.0.0.2"},
+							MachineNetworks:      []configv1.CIDR{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "should handle missing openstack platform spec: create and propagate from status",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						OpenStack: nil,
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.OpenStackPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "OpenStack",
+						OpenStack: &configv1.OpenStackPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1"},
+							IngressIPs:           []string{"224.0.0.2"},
+						},
+					},
+				},
+			},
+			wantedInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						OpenStack: &configv1.OpenStackPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.0.1"},
+							IngressIPs:           []configv1.IP{"224.0.0.2"},
+							MachineNetworks:      []configv1.CIDR{},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.OpenStackPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "OpenStack",
+						OpenStack: &configv1.OpenStackPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.0.1"},
+							IngressIPs:           []string{"224.0.0.2"},
+							MachineNetworks:      []configv1.CIDR{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "should handle missing platform status: unreachable path but should not crash",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{},
+				},
+				Status: configv1.InfrastructureStatus{
+					PlatformStatus: nil,
+				},
+			},
+			wantedInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{},
+				},
+				Status: configv1.InfrastructureStatus{
+					PlatformStatus: nil,
+				},
+			},
+		},
+		{
+			name: "should handle missing baremetal platform status: unreachable path but should not crash",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.0.1"},
+							IngressIPs:           []configv1.IP{"224.0.0.2"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type:      "BareMetal",
+						BareMetal: nil,
+					},
+				},
+			},
+			wantedInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.0.1"},
+							IngressIPs:           []configv1.IP{"224.0.0.2"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type:      "BareMetal",
+						BareMetal: nil,
+					},
+				},
+			},
+		},
+		{
+			name: "should handle missing openstack platform status: unreachable path but should not crash",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						OpenStack: &configv1.OpenStackPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.0.1"},
+							IngressIPs:           []configv1.IP{"224.0.0.2"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.OpenStackPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type:      "OpenStack",
+						OpenStack: nil,
+					},
+				},
+			},
+			wantedInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						OpenStack: &configv1.OpenStackPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.0.1"},
+							IngressIPs:           []configv1.IP{"224.0.0.2"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.OpenStackPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type:      "OpenStack",
+						OpenStack: nil,
+					},
+				},
+			},
+		},
+		{
+			name: "should handle missing vsphere platform status: VSphere UPI doesn't populate VSphere field",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						VSphere: &configv1.VSpherePlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.0.1"},
+							IngressIPs:           []configv1.IP{"224.0.0.2"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.VSpherePlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type:    "VSphere",
+						VSphere: nil,
+					},
+				},
+			},
+			wantedInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						VSphere: &configv1.VSpherePlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.0.1"},
+							IngressIPs:           []configv1.IP{"224.0.0.2"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.VSpherePlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type:    "VSphere",
+						VSphere: nil,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &specStatusSunchronizer{}
+			gotInfra, err := a.SpecStatusSynchronize(&tt.givenInfra)
+
+			if tt.wantedErr == "" {
+				assert.Equal(t, err, nil)
+				assert.EqualValues(t, &tt.wantedInfra, gotInfra, "should update infra correctly")
+			} else {
+				assert.Contains(t, err.Error(), tt.wantedErr)
+			}
+		})
+	}
+}

--- a/pkg/controller/infrastructureconfig/sync_specstatus_test.go
+++ b/pkg/controller/infrastructureconfig/sync_specstatus_test.go
@@ -849,7 +849,7 @@ func Test_SpecStatusSynchronizer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a := &specStatusSunchronizer{}
+			a := &synchronizer{}
 			gotInfra, err := a.SpecStatusSynchronize(&tt.givenInfra)
 
 			if tt.wantedErr == "" {

--- a/pkg/controller/infrastructureconfig/sync_vips.go
+++ b/pkg/controller/infrastructureconfig/sync_vips.go
@@ -9,17 +9,18 @@ import (
 	utilslice "k8s.io/utils/strings/slices"
 )
 
-type vipsSynchronizer interface {
+type fieldSynchronizer interface {
 	VipsSynchronize(*configv1.Infrastructure) *configv1.Infrastructure
+	SpecStatusSynchronize(*configv1.Infrastructure) (*configv1.Infrastructure, error)
 }
 
-type apiAndIngressVipsSynchronizer struct{}
+type synchronizer struct{}
 
 // VipsSynchronize synchronizes new API & Ingress VIPs with old fields.
 // It returns if the status was updated and the updated infrastructure object.
 //
 //nolint:staticcheck
-func (*apiAndIngressVipsSynchronizer) VipsSynchronize(infraConfig *configv1.Infrastructure) *configv1.Infrastructure {
+func (*synchronizer) VipsSynchronize(infraConfig *configv1.Infrastructure) *configv1.Infrastructure {
 	var apiVIPs, ingressVIPs *[]string // new fields
 	var apiVIP, ingressVIP *string     // old/deprecated fields
 

--- a/pkg/controller/infrastructureconfig/sync_vips_test.go
+++ b/pkg/controller/infrastructureconfig/sync_vips_test.go
@@ -289,7 +289,7 @@ func Test_apiAndIngressVipsSynchronizer_VipsSynchronize(t *testing.T) {
 				Status:     tt.givenStatus,
 			}
 
-			a := &apiAndIngressVipsSynchronizer{}
+			a := &synchronizer{}
 			gotInfra := a.VipsSynchronize(givenInfra)
 
 			assert.EqualValues(t, tt.wantStatus, gotInfra.Status, "should update status correctly")

--- a/pkg/controller/infrastructureconfig/validations.go
+++ b/pkg/controller/infrastructureconfig/validations.go
@@ -1,0 +1,92 @@
+package infrastructureconfig
+
+import (
+	"fmt"
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-network-operator/pkg/util/ip"
+	utilnet "k8s.io/utils/net"
+	"net/netip"
+)
+
+// validateVipsWithVips compares API and Ingress VIPs to detect whether those can coexist. It is supposed to catch
+// scenarios when configuring particular set of addresses is valid in the given environment (by machine networks)
+// but invalid between set of VIPs. In order to be valid, VIPs need to fulfil the following spec:
+//
+//   - 0 VIPs is allowed as a migration from pre-4.16 (where Spec is empty)
+//   - the number of VIPs is either 1 or 2
+//   - number of VIPs needs to be the same for API and ingress
+//   - no any pair of VIPs can be equal, unless External Load Balancer is used
+//   - IP stack of the second VIP needs to be different from IP stack of the first VIP
+func validateVipsWithVips(api, ingress []configv1.IP, elb bool) error {
+	if len(api) > 2 {
+		return fmt.Errorf("number of API VIPs needs to be less or equal to 2, got %d", len(api))
+	}
+	if len(ingress) > 2 {
+		return fmt.Errorf("number of Ingress VIPs needs to be less or equal to 2, got %d", len(api))
+	}
+	if len(api) != len(ingress) {
+		return fmt.Errorf("number of API VIPs (%d) does not match number of Ingress VIPs (%d)", len(api), len(ingress))
+	}
+
+	// For external load balancer we allow VIPs to be equal.
+	if !elb {
+		for i := 0; i < len(api); i++ {
+			if api[i] == ingress[i] {
+				return fmt.Errorf("VIPs cannot be equal, got '%s' for API and '%s' for Ingress", api[i], ingress[i])
+			}
+		}
+	}
+
+	if len(api) > 1 {
+		ok, err := utilnet.IsDualStackIPStrings(ip.IPsToStrings(api))
+		if !ok || err != nil {
+			return fmt.Errorf("with more than 1 API VIP at least one from each IP family is required, err: %v", err)
+		}
+
+		ok, err = utilnet.IsDualStackIPStrings(ip.IPsToStrings(ingress))
+		if !ok || err != nil {
+			return fmt.Errorf("with more than 1 Ingress VIP at least one from each IP family is required, err: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// validateVipsWithMachineNetworks compares VIPs and machine networks to detect whether those can coexist. It is
+// supposed to catch scenarios when configuring particular set of VIPs would be illegal given the provided Machine
+// Networks. In order to be valid, VIPs need to fulfil the following spec:
+//
+//   - IP stack of the first VIP needs to be IP stack of the first machine network (we do not actually check it in
+//     this function because o/api and o/installer make sure this is the case; unless we allow changing 1st VIP no
+//     need to check it also here)
+//   - every VIP needs to belong to the machine network (one of them, no matter which one)
+func validateVipsWithMachineNetworks(vips []configv1.IP, machineNetworks []configv1.CIDR) error {
+	if len(machineNetworks) == 0 {
+		return nil
+	}
+
+	for _, vip := range vips {
+		found := false
+		ip, err := netip.ParseAddr(string(vip))
+		if err != nil {
+			return err
+		}
+
+		for _, machine := range machineNetworks {
+			network, err := netip.ParsePrefix(string(machine))
+			if err != nil {
+				return err
+			}
+			if network.Contains(ip) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("VIP '%s' cannot be found in any machine network", vip)
+		}
+	}
+
+	return nil
+}

--- a/pkg/util/ip/addr.go
+++ b/pkg/util/ip/addr.go
@@ -1,6 +1,7 @@
 package ip
 
 import (
+	configv1 "github.com/openshift/api/config/v1"
 	"net"
 
 	"github.com/pkg/errors"
@@ -42,4 +43,22 @@ func lastIP(subnet net.IPNet) net.IP {
 		end = append(end, subnet.IP[i]|^subnet.Mask[i])
 	}
 	return end
+}
+
+// IPsToStrings converts IP addresses from configv1.IP type to a simple String
+func IPsToStrings(ips []configv1.IP) []string {
+	res := make([]string, len(ips))
+	for i, ip := range ips {
+		res[i] = string(ip)
+	}
+	return res
+}
+
+// StringsToIPs converts IP addresses from a String type to configv1.IP
+func StringsToIPs(ips []string) []configv1.IP {
+	res := make([]configv1.IP, len(ips))
+	for i, ip := range ips {
+		res[i] = configv1.IP(ip)
+	}
+	return res
 }

--- a/pkg/util/ip/addr_test.go
+++ b/pkg/util/ip/addr_test.go
@@ -1,6 +1,7 @@
 package ip
 
 import (
+	configv1 "github.com/openshift/api/config/v1"
 	"net"
 	"testing"
 
@@ -119,5 +120,59 @@ func TestLastIP(t *testing.T) {
 		_, cidr, err := net.ParseCIDR(tc.cidr)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(lastIP(*cidr).String()).To(Equal(tc.expected))
+	}
+}
+
+func TestIPsToStrings(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	testcases := []struct {
+		ips      []configv1.IP
+		expected []string
+	}{
+		{
+			[]configv1.IP{"10.0.0.1", "10.0.0.2"},
+			[]string{"10.0.0.1", "10.0.0.2"},
+		},
+		{
+			[]configv1.IP{},
+			[]string{},
+		},
+		{
+			[]configv1.IP{"fe80:1:2:3::"},
+			[]string{"fe80:1:2:3::"},
+		},
+	}
+
+	for _, tc := range testcases {
+		res := IPsToStrings(tc.ips)
+		g.Expect(res).To(Equal(tc.expected))
+	}
+}
+
+func TestStringsToIPs(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	testcases := []struct {
+		ips      []string
+		expected []configv1.IP
+	}{
+		{
+			[]string{"10.0.0.1", "10.0.0.2"},
+			[]configv1.IP{"10.0.0.1", "10.0.0.2"},
+		},
+		{
+			[]string{},
+			[]configv1.IP{},
+		},
+		{
+			[]string{"fe80:1:2:3::"},
+			[]configv1.IP{"fe80:1:2:3::"},
+		},
+	}
+
+	for _, tc := range testcases {
+		res := StringsToIPs(tc.ips)
+		g.Expect(res).To(Equal(tc.expected))
 	}
 }


### PR DESCRIPTION
Recently we have introduced VIPs to the PlatformSpec in the
Infrastructure CR. Previously they only existed in PlatformStatus and
now we will have them in both Spec and Status.

In order to properly handle clusters created before the change was
introduced, during the upgrade of such a cluster we will detect case
when PlatformSpec is empty and PlatformStatus is filled with VIPs. For
those, we will copy content from Status to Spec.

We are adding validation logic to the Infrastructure Controller that is
responsible for checking if requested changes to the VIPs or Machine
Networks are valid. Those validations are in principle the same as
validations performed by the o/installer but those here happen when
Infrastructure CR is updated by the end user (as opposed to the
o/installer ones which happen at install-time only).

Updating VIPs and Networks in the Infra CR is a new feature and for this
reason there is no any validation that exists currently. This commit is
an enabler for this brand new and shiny feature.

Closes: [OPNET-358](https://issues.redhat.com//browse/OPNET-358)
Closes: [OPNET-360](https://issues.redhat.com//browse/OPNET-360)
Contributes-to: [OPNET-340](https://issues.redhat.com//browse/OPNET-340) (Mutable Infrastructure)
Contributes-to: [OPNET-80](https://issues.redhat.com//browse/OPNET-80) (Dual-stack VIPs)