### PR TITLE
OCPBUGS-24299: network-node-identity mounts secrets with mode 0640

### DIFF
--- a/bindata/network/node-identity/managed/node-identity.yaml
+++ b/bindata/network/node-identity/managed/node-identity.yaml
@@ -233,11 +233,13 @@ spec:
         - name: admin-kubeconfig
           secret:
             secretName: service-network-admin-kubeconfig
+            defaultMode: 0640
         - name: hosted-cluster-api-access
           emptyDir: {}
         - name: hosted-ca-cert
           secret:
             secretName: root-ca
+            defaultMode: 0640
             items:
               - key: ca.crt
                 path: ca.crt


### PR DESCRIPTION
CNO managed component (network-node-identity) to conform to hypershift control plane expectations that all secrets should be mounted to not have global read. change from 420(0644) to 416(0640)