### PR TITLE
OCPBUGS-19817: ipsec: add pluto restart

### DIFF
--- a/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
@@ -247,6 +247,9 @@ spec:
           ip x s flush
           ip x p flush
 
+          # since pluto is on the host, we need to restart it after the flush
+          chroot /proc/1/root ipsec restart
+
           # Workaround for https://github.com/libreswan/libreswan/issues/373
           ulimit -n 1024
 


### PR DESCRIPTION
we need to restart pluto after flushing xfrm state&policy
or else it loses all the previous state.

and we do want to flush, to get a "clean slate"

this fixes OCPBUGS-19817
