### PR TITLE
OCPBUGS-24436: Add probes to node-network-identity

### DIFF
--- a/bindata/network/node-identity/managed/node-identity.yaml
+++ b/bindata/network/node-identity/managed/node-identity.yaml
@@ -133,6 +133,22 @@ spec:
         env:
           - name: LOGLEVEL
             value: "2"
+        livenessProbe:
+          tcpSocket:
+            port: {{.NetworkNodeIdentityPort}}
+          failureThreshold: 5
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 5
+        readinessProbe:
+          tcpSocket:
+            port: {{.NetworkNodeIdentityPort}}
+          failureThreshold: 5
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
The node-network-identity deployment should contain liveness and readiness probes where applicable.