### PR TITLE
SDN-4308,OCPBUGS-24650: Set enable-multi-external-gateway flag in ovnkube.conf

### DIFF
--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -602,7 +602,6 @@ data:
         --enable-interconnect \
         --acl-logging-rate-limit "{{.OVNPolicyAuditRateLimit}}" \
         ${gw_interface_flag} \
-        --enable-multi-external-gateway=true \
         ${ip_forwarding_flag} \
         ${NETWORK_NODE_IDENTITY_ENABLE}
     }

--- a/bindata/network/ovn-kubernetes/managed/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/004-config.yaml
@@ -48,6 +48,7 @@ data:
 {{- if .OVN_ADMIN_NETWORK_POLICY_ENABLE }}
     enable-admin-network-policy=true
 {{- end }}
+    enable-multi-external-gateway=true
 
     [gateway]
     mode={{.OVN_GATEWAY_MODE}}
@@ -132,6 +133,7 @@ data:
 {{- if .OVN_MULTI_NETWORK_POLICY_ENABLE }}
     enable-multi-networkpolicy=true
 {{- end }}
+    enable-multi-external-gateway=true
 
     [gateway]
     mode={{.OVN_GATEWAY_MODE}}

--- a/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
@@ -51,6 +51,7 @@ data:
 {{- if .OVN_ADMIN_NETWORK_POLICY_ENABLE }}
     enable-admin-network-policy=true
 {{- end }}
+    enable-multi-external-gateway=true
 
     [gateway]
     mode={{.OVN_GATEWAY_MODE}}

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -213,6 +213,7 @@ enable-egress-qos=true
 enable-egress-service=true
 egressip-node-healthcheck-port=9107
 enable-multi-network=true
+enable-multi-external-gateway=true
 
 [gateway]
 mode=shared
@@ -253,6 +254,7 @@ enable-egress-qos=true
 enable-egress-service=true
 egressip-node-healthcheck-port=9107
 enable-multi-network=true
+enable-multi-external-gateway=true
 
 [gateway]
 mode=shared
@@ -296,6 +298,7 @@ enable-egress-qos=true
 enable-egress-service=true
 egressip-node-healthcheck-port=9107
 enable-multi-network=true
+enable-multi-external-gateway=true
 
 [gateway]
 mode=local
@@ -351,6 +354,7 @@ enable-egress-service=true
 egressip-reachability-total-timeout=3
 egressip-node-healthcheck-port=9107
 enable-multi-network=true
+enable-multi-external-gateway=true
 
 [gateway]
 mode=local
@@ -408,6 +412,7 @@ enable-egress-service=true
 egressip-reachability-total-timeout=0
 egressip-node-healthcheck-port=9107
 enable-multi-network=true
+enable-multi-external-gateway=true
 
 [gateway]
 mode=local
@@ -464,6 +469,7 @@ enable-egress-qos=true
 enable-egress-service=true
 egressip-node-healthcheck-port=9107
 enable-multi-network=true
+enable-multi-external-gateway=true
 
 [gateway]
 mode=local
@@ -520,6 +526,7 @@ enable-egress-qos=true
 enable-egress-service=true
 egressip-node-healthcheck-port=9107
 enable-multi-network=true
+enable-multi-external-gateway=true
 
 [gateway]
 mode=shared
@@ -565,6 +572,7 @@ enable-egress-qos=true
 enable-egress-service=true
 egressip-node-healthcheck-port=9107
 enable-multi-network=true
+enable-multi-external-gateway=true
 
 [gateway]
 mode=shared
@@ -613,6 +621,7 @@ enable-egress-qos=true
 enable-egress-service=true
 egressip-node-healthcheck-port=9107
 enable-multi-network=true
+enable-multi-external-gateway=true
 
 [gateway]
 mode=shared
@@ -653,6 +662,7 @@ enable-egress-firewall=true
 enable-egress-qos=true
 enable-egress-service=true
 egressip-node-healthcheck-port=9107
+enable-multi-external-gateway=true
 
 [gateway]
 mode=shared
@@ -697,6 +707,7 @@ egressip-node-healthcheck-port=9107
 enable-multi-network=true
 enable-multi-networkpolicy=true
 enable-admin-network-policy=true
+enable-multi-external-gateway=true
 
 [gateway]
 mode=shared
@@ -740,6 +751,7 @@ enable-egress-qos=true
 enable-egress-service=true
 egressip-node-healthcheck-port=9107
 enable-admin-network-policy=true
+enable-multi-external-gateway=true
 
 [gateway]
 mode=shared


### PR DESCRIPTION
 to pass to both ovnkube-node and control-plane pods. There is no feature gate, so it is set unconditionally.