### PR TITLE
OCPBUGS-24601: Add minReadySeconds to network-node-identity

### DIFF
--- a/bindata/network/node-identity/managed/node-identity.yaml
+++ b/bindata/network/node-identity/managed/node-identity.yaml
@@ -13,6 +13,7 @@ metadata:
     hypershift.openshift.io/hosted-control-plane: {{.HostedClusterNamespace}}
     hypershift.openshift.io/control-plane: "true"
 spec:
+  minReadySeconds: 15
   replicas: {{.NetworkNodeIdentityReplicas}}
 {{ if (gt .NetworkNodeIdentityReplicas 1)}}
   strategy:


### PR DESCRIPTION
The node-network-identity deployment should be set to assist in a controlled rollout of the microservice pods.