### PR TITLE
OCPBUGS-24633: ipsec add pluto restart

### DIFF
--- a/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
@@ -247,6 +247,9 @@ spec:
           ip x s flush
           ip x p flush
 
+          # since pluto is on the host, we need to restart it after the flush
+          chroot /proc/1/root ipsec restart
+
           # Workaround for https://github.com/libreswan/libreswan/issues/373
           ulimit -n 1024
 


### PR DESCRIPTION
we need to restart pluto after flushing xfrm state&policy or else it loses all the previous state.

and we do want to flush, to get a "clean slate"

(cherry picked from commit 2f5879349699b8477a2fcef9bc6d725e741c59c8)