### PR TITLE
OCPBUGS-24635: network node identity: tolarate all taints

### DIFF
--- a/bindata/network/node-identity/self-hosted/node-identity.yaml
+++ b/bindata/network/node-identity/self-hosted/node-identity.yaml
@@ -132,11 +132,4 @@ spec:
               - key: additional-pod-admission-cond.json
                 path: additional-pod-admission-cond.json
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-      - key: "node.kubernetes.io/not-ready"
-        operator: "Exists"
-      - key: "node.kubernetes.io/unreachable"
-        operator: "Exists"
-      - key: "node.kubernetes.io/network-unavailable"
-        operator: "Exists"
+      - operator: "Exists"


### PR DESCRIPTION
The network node identity in self-hosted clusters should tolerate all taints, not only the common ones. 
This mimics the behavior of the API server pods: https://github.com/openshift/cluster-kube-apiserver-operator/blob/03c5a03d1bd0a952655aa180bd2708802e8cc1a4/bindata/assets/kube-apiserver/pod.yaml#L268-L269

