### PR TITLE
[release-4.14] OCPBUGS-18281: only 2 master nodes are required for ovn-kubernetes

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/ovnkube-control-plane.yaml
@@ -20,8 +20,8 @@ spec:
   selector:
     matchLabels:
       app: ovnkube-control-plane
-  replicas: {{.OvnkubeMasterReplicas}}
-{{ if (gt .OvnkubeMasterReplicas 1)}}
+  replicas: {{.ClusterManagerReplicas}}
+{{ if (gt .ClusterManagerReplicas 1)}}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/ovnkube-control-plane.yaml
@@ -9,7 +9,7 @@ metadata:
       This deployment launches the ovn-kubernetes controller (control-plane) networking components.
     release.openshift.io/version: "{{.ReleaseVersion}}"
 spec:
-  replicas: {{.OvnkubeMasterReplicas}}
+  replicas: {{.ClusterManagerReplicas}}
   selector:
     matchLabels:
       app: ovnkube-control-plane

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -409,8 +409,14 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 		data.Data["OVN_MULTI_NETWORK_POLICY_ENABLE"] = true
 	}
 
-	commonManifestDir := filepath.Join(manifestDir, "network/ovn-kubernetes/common")
+	//there only needs to be two cluster managers
+	clusterManagerReplicas := 2
+	if len(bootstrapResult.OVN.MasterAddresses) < 2 {
+		clusterManagerReplicas = len(bootstrapResult.OVN.MasterAddresses)
+	}
+	data.Data["ClusterManagerReplicas"] = clusterManagerReplicas
 
+	commonManifestDir := filepath.Join(manifestDir, "network/ovn-kubernetes/common")
 	cmPaths := []string{
 		filepath.Join(commonManifestDir, "008-script-lib.yaml"),
 	}


### PR DESCRIPTION
in 4.14 we switched to OVN-IC and no longer require 3 nodes for RAFT consensus

backport of: https://github.com/openshift/cluster-network-operator/pull/2052
This needs to be a manual backport because the filenames of the yamls changed 
