### PR TITLE
OCPBUGS-23199: add env var in whereabouts-reconciler daemonset

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -726,11 +726,6 @@ spec:
           - >
             /usr/src/whereabouts/bin/entrypoint.sh -log-level debug
         image: {{.WhereaboutsImage}}
-        env:
-        - name: WHEREABOUTS_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         resources:
           requests:
             cpu: "50m"
@@ -747,6 +742,10 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
+        - name: WHEREABOUTS_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: KUBERNETES_SERVICE_PORT
           value: "{{.KUBERNETES_SERVICE_PORT}}"
         - name: KUBERNETES_SERVICE_HOST


### PR DESCRIPTION
WHEREABOUTS_NAMESPACE env var is used by whereabouts-reconciler to garbage collect the Pod IPs. When unset, it defaults to kube-system namespace, while ippool.whereabouts.cni.cncf.io custom resource only exist in openshift-multus namespace on openshift. Setting WHEREABOUTS_NAMESPACE env var will tell whereabouts-reconciler where to get the ippool customer resource