### PR TITLE
OCPBUGS-25337: Avoid removal of ipsec-host daemonset when node is NotReady

### DIFF
--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -1432,13 +1432,10 @@ func shouldUpdateOVNKonPrepull(ovn bootstrap.OVNBootstrapResult, releaseVersion 
 }
 
 // isUserIPsecMachineConfigPresent returns true if user owned MachineConfigs for IPsec plugin
-// are already present in master and worker nodes, otherwise returns false.
+// are already present either in master or worker nodes, otherwise returns false.
 func isUserIPsecMachineConfigPresent(infra bootstrap.InfraStatus) bool {
-	if infra.MasterIPsecMachineConfig == nil && infra.WorkerIPsecMachineConfig == nil {
-		return false
-	}
-	return !containsNetworkOwnerRef(infra.MasterIPsecMachineConfig.OwnerReferences) ||
-		!containsNetworkOwnerRef(infra.WorkerIPsecMachineConfig.OwnerReferences)
+	return (infra.MasterIPsecMachineConfig != nil && !containsNetworkOwnerRef(infra.MasterIPsecMachineConfig.OwnerReferences)) ||
+		(infra.WorkerIPsecMachineConfig != nil && !containsNetworkOwnerRef(infra.WorkerIPsecMachineConfig.OwnerReferences))
 }
 
 func containsNetworkOwnerRef(ownerRefs []metav1.OwnerReference) bool {
@@ -1460,9 +1457,7 @@ func isIPsecMachineConfigActive(infra bootstrap.InfraStatus) bool {
 	}
 	ipSecPluginOnMasterNodes := hasSourceInMachineConfigStatus(infra.MasterMCPStatus, infra.MasterIPsecMachineConfig.Name)
 	ipSecPluginOnWorkerNodes := hasSourceInMachineConfigStatus(infra.WorkerMCPStatus, infra.WorkerIPsecMachineConfig.Name)
-	return infra.MasterMCPStatus.MachineCount == infra.MasterMCPStatus.ReadyMachineCount &&
-		infra.WorkerMCPStatus.MachineCount == infra.WorkerMCPStatus.ReadyMachineCount &&
-		ipSecPluginOnMasterNodes && ipSecPluginOnWorkerNodes
+	return ipSecPluginOnMasterNodes && ipSecPluginOnWorkerNodes
 }
 
 func hasSourceInMachineConfigStatus(machineConfigStatus mcfgv1.MachineConfigPoolStatus, sourceName string) bool {

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -2206,9 +2206,9 @@ func TestRenderOVNKubernetesEnableIPsec(t *testing.T) {
 
 	// At the 2nd pass, test render logic while MC extension rollout is in progress.
 	bootstrapResult.Infra.MasterMCPStatus = mcfgv1.MachineConfigPoolStatus{MachineCount: 1, ReadyMachineCount: 0,
-		Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{Source: []v1.ObjectReference{{Name: masterMachineConfigIPsecExtName}}}}
+		Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{}}
 	bootstrapResult.Infra.WorkerMCPStatus = mcfgv1.MachineConfigPoolStatus{MachineCount: 1, ReadyMachineCount: 1,
-		Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{Source: []v1.ObjectReference{{Name: workerMachineConfigIPsecExtName}}}}
+		Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{}}
 	objs, _, err = renderOVNKubernetes(config, bootstrapResult, manifestDirOvn, fakeClient, featureGatesCNO)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)


### PR DESCRIPTION
It's not reliable to check on ready machine count as it won't work in case of node reboot. Moreover it's enough to check for ipsec machine config extension in machine config pool status to confirm whether ipsec extension is completely rolled out or not. Hence this commit removes additional checks on ready machine count.