### PR TITLE
[release-4.13] OCPBUGS-24570: Disable weak SSH cipher suitesRm weak ciphers 4.13

### DIFF
--- a/bindata/kube-proxy/kube-proxy.yaml
+++ b/bindata/kube-proxy/kube-proxy.yaml
@@ -142,7 +142,7 @@ spec:
           exec /usr/bin/kube-rbac-proxy \
             --logtostderr \
             --secure-listen-address=:{{.MetricsPort}} \
-            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 \
+            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
             --upstream=http://127.0.0.1:29102/ \
             --tls-private-key-file=${TLS_PK} \
             --tls-cert-file=${TLS_CERT}

--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -178,7 +178,7 @@ spec:
         args:
         - --logtostderr
         - --secure-listen-address=:8443
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
         - --upstream=http://127.0.0.1:9091/
         - --tls-private-key-file=/etc/webhook/tls.key
         - --tls-cert-file=/etc/webhook/tls.crt

--- a/bindata/network/network-metrics/001-daemonset.yaml
+++ b/bindata/network/network-metrics/001-daemonset.yaml
@@ -62,7 +62,7 @@ spec:
           args:
             - --logtostderr
             - --secure-listen-address=:8443
-            - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+            - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
             - --upstream=http://127.0.0.1:9091/
             - --tls-private-key-file=/etc/metrics/tls.key
             - --tls-cert-file=/etc/metrics/tls.crt

--- a/bindata/network/openshift-sdn/controller.yaml
+++ b/bindata/network/openshift-sdn/controller.yaml
@@ -99,7 +99,7 @@ spec:
             exec /usr/bin/kube-rbac-proxy \
               --logtostderr \
               --secure-listen-address=:9106 \
-              --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 \
+              --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
               --upstream=http://127.0.0.1:29100/ \
               --tls-private-key-file=${TLS_PK} \
               --tls-cert-file=${TLS_CERT}

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -292,7 +292,7 @@ spec:
           exec /usr/bin/kube-rbac-proxy \
             --logtostderr \
             --secure-listen-address=:9101 \
-            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 \
+            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
             --upstream=http://127.0.0.1:29101/ \
             --tls-private-key-file=${TLS_PK} \
             --tls-cert-file=${TLS_CERT}

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -308,7 +308,7 @@ spec:
           exec /usr/bin/kube-rbac-proxy \
             --logtostderr \
             --secure-listen-address=:9103 \
-            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 \
+            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
             --upstream=http://127.0.0.1:29103/ \
             --tls-private-key-file=${TLS_PK} \
             --tls-cert-file=${TLS_CERT}
@@ -360,7 +360,7 @@ spec:
           exec /usr/bin/kube-rbac-proxy \
             --logtostderr \
             --secure-listen-address=:9105 \
-            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 \
+            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
             --upstream=http://127.0.0.1:29105/ \
             --tls-private-key-file=${TLS_PK} \
             --tls-cert-file=${TLS_CERT}

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
@@ -480,7 +480,7 @@ spec:
           exec /usr/bin/kube-rbac-proxy \
             --logtostderr \
             --secure-listen-address=:9102 \
-            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 \
+            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
             --upstream=http://127.0.0.1:29102/ \
             --tls-private-key-file=${TLS_PK} \
             --tls-cert-file=${TLS_CERT}

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -218,7 +218,7 @@ spec:
           exec /usr/bin/kube-rbac-proxy \
             --logtostderr \
             --secure-listen-address=:9103 \
-            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 \
+            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
             --upstream=http://127.0.0.1:29103/ \
             --tls-private-key-file=${TLS_PK} \
             --tls-cert-file=${TLS_CERT}
@@ -270,7 +270,7 @@ spec:
           exec /usr/bin/kube-rbac-proxy \
             --logtostderr \
             --secure-listen-address=:9105 \
-            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 \
+            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
             --upstream=http://127.0.0.1:29105/ \
             --tls-private-key-file=${TLS_PK} \
             --tls-cert-file=${TLS_CERT}


### PR DESCRIPTION
cherry pick from https://github.com/openshift/cluster-network-operator/pull/2090/commits/f91a102386fd2bec25cf941839793cfcff7d2c75

During an internal audit conducted by one of our customers in OCP, it was discovered that the openshift-sdn component, specifically on port 9101, has exposed certain cipher suites that are considered weak. We have identified the following weak ciphers that are currently being accepted:

[TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256](https://ciphersuite.info/cs/TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256/)
[TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256](https://ciphersuite.info/cs/TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256/)

