### PR TITLE
[release-4.12] OCPBUGS-24571: Disable weak SSH cipher suites

### DIFF
--- a/bindata/kube-proxy/kube-proxy.yaml
+++ b/bindata/kube-proxy/kube-proxy.yaml
@@ -142,7 +142,7 @@ spec:
           exec /usr/bin/kube-rbac-proxy \
             --logtostderr \
             --secure-listen-address=:{{.MetricsPort}} \
-            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 \
+            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
             --upstream=http://127.0.0.1:29102/ \
             --tls-private-key-file=${TLS_PK} \
             --tls-cert-file=${TLS_CERT}

--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -175,7 +175,7 @@ spec:
         args:
         - --logtostderr
         - --secure-listen-address=:8443
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
         - --upstream=http://127.0.0.1:9091/
         - --tls-private-key-file=/etc/webhook/tls.key
         - --tls-cert-file=/etc/webhook/tls.crt

--- a/bindata/network/network-metrics/001-daemonset.yaml
+++ b/bindata/network/network-metrics/001-daemonset.yaml
@@ -62,7 +62,7 @@ spec:
           args:
             - --logtostderr
             - --secure-listen-address=:8443
-            - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+            - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
             - --upstream=http://127.0.0.1:9091/
             - --tls-private-key-file=/etc/metrics/tls.key
             - --tls-cert-file=/etc/metrics/tls.crt

--- a/bindata/network/openshift-sdn/controller.yaml
+++ b/bindata/network/openshift-sdn/controller.yaml
@@ -99,7 +99,7 @@ spec:
             exec /usr/bin/kube-rbac-proxy \
               --logtostderr \
               --secure-listen-address=:9106 \
-              --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 \
+              --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
               --upstream=http://127.0.0.1:29100/ \
               --tls-private-key-file=${TLS_PK} \
               --tls-cert-file=${TLS_CERT}

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -252,7 +252,7 @@ spec:
           exec /usr/bin/kube-rbac-proxy \
             --logtostderr \
             --secure-listen-address=:9101 \
-            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 \
+            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
             --upstream=http://127.0.0.1:29101/ \
             --tls-private-key-file=${TLS_PK} \
             --tls-cert-file=${TLS_CERT}

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -299,7 +299,7 @@ spec:
           exec /usr/bin/kube-rbac-proxy \
             --logtostderr \
             --secure-listen-address=:9103 \
-            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 \
+            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
             --upstream=http://127.0.0.1:29103/ \
             --tls-private-key-file=${TLS_PK} \
             --tls-cert-file=${TLS_CERT}
@@ -351,7 +351,7 @@ spec:
           exec /usr/bin/kube-rbac-proxy \
             --logtostderr \
             --secure-listen-address=:9105 \
-            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 \
+            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
             --upstream=http://127.0.0.1:29105/ \
             --tls-private-key-file=${TLS_PK} \
             --tls-cert-file=${TLS_CERT}

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-master.yaml
@@ -472,7 +472,7 @@ spec:
           exec /usr/bin/kube-rbac-proxy \
             --logtostderr \
             --secure-listen-address=:9102 \
-            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 \
+            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
             --upstream=http://127.0.0.1:29102/ \
             --tls-private-key-file=${TLS_PK} \
             --tls-cert-file=${TLS_CERT}

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -209,7 +209,7 @@ spec:
           exec /usr/bin/kube-rbac-proxy \
             --logtostderr \
             --secure-listen-address=:9103 \
-            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 \
+            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
             --upstream=http://127.0.0.1:29103/ \
             --tls-private-key-file=${TLS_PK} \
             --tls-cert-file=${TLS_CERT}
@@ -261,7 +261,7 @@ spec:
           exec /usr/bin/kube-rbac-proxy \
             --logtostderr \
             --secure-listen-address=:9105 \
-            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 \
+            --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 \
             --upstream=http://127.0.0.1:29105/ \
             --tls-private-key-file=${TLS_PK} \
             --tls-cert-file=${TLS_CERT}


### PR DESCRIPTION
During an internal audit conducted by one of our customers in OCP, it was discovered that the openshift-sdn component, specifically on port 9101, has exposed certain cipher suites that are considered weak. We have identified the following weak ciphers that are currently being accepted:

TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 - See [1]
TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 - See [2]

[1] https://ciphersuite.info/cs/TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256/
[2] https://ciphersuite.info/cs/TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256/
