### PR TITLE
HOSTEDCP-1308:remove service account token mount in cloud-network-con…

### DIFF
--- a/bindata/cloud-network-config-controller/managed/controller.yaml
+++ b/bindata/cloud-network-config-controller/managed/controller.yaml
@@ -34,6 +34,7 @@ spec:
         type: infra
         openshift.io/component: network
     spec:
+      automountServiceAccountToken: false
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
adding "automountServiceAccountToken" false to cloud-network-config-controller deployment as the deployment doesn't need the service account mount

[HOSTEDCP-1308](https://issues.redhat.com/browse/HOSTEDCP-1308)