### PR TITLE
OCPBUGS-24693: HyperShift, network-node-identity: Check the deployment in the management cluster

### DIFF
--- a/bindata/network/node-identity/managed/node-identity.yaml
+++ b/bindata/network/node-identity/managed/node-identity.yaml
@@ -132,7 +132,7 @@ spec:
                 --loglevel="${LOGLEVEL}"
         env:
           - name: LOGLEVEL
-            value: "5"
+            value: "2"
         resources:
           requests:
             cpu: 10m

--- a/pkg/network/node_identity.go
+++ b/pkg/network/node_identity.go
@@ -104,7 +104,7 @@ func renderNetworkNodeIdentity(conf *operv1.NetworkSpec, bootstrapResult *bootst
 			},
 		}
 		nsn := types.NamespacedName{Namespace: hcpCfg.Namespace, Name: "network-node-identity"}
-		if err := client.Default().CRClient().Get(context.TODO(), nsn, webhookDeployment); err != nil {
+		if err := client.ClientFor(names.ManagementClusterName).CRClient().Get(context.TODO(), nsn, webhookDeployment); err != nil {
 			if !apierrors.IsNotFound(err) {
 				return nil, fmt.Errorf("failed to retrieve existing network-node-identity deployment: %w", err)
 			} else {


### PR DESCRIPTION

In HyperShift the network-node-identity deployment is located in the management cluster. Use the appropriate client to retrieve it.