### PR TITLE
OCPBUGS-24379: Remove egressip write permissions from ovn-kubernetes-node

### DIFF
--- a/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
+++ b/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
@@ -140,7 +140,6 @@ rules:
   - adminpolicybasedexternalroutes/status
   - egressfirewalls
   - egressfirewalls/status
-  - egressips
   - egressqoses
   - egressservices
   - egressservices/status
@@ -150,6 +149,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups: ["k8s.ovn.org"]
+  resources:
+    - egressips
+  verbs:
+    - get
+    - list
+    - watch
 {{- if .OVN_ADMIN_NETWORK_POLICY_ENABLE }}
 - apiGroups: ["policy.networking.k8s.io"]
   resources:
@@ -166,17 +172,6 @@ rules:
   verbs:
   - update
 {{- end }}
-- apiGroups: ["cloud.network.openshift.io"]
-  resources:
-  - cloudprivateipconfigs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - k8s.cni.cncf.io
   resources:


### PR DESCRIPTION
ovn-kubernetes-node does not write anything to egressip and doesn't interact with cloudprivateipconfigs at all. This commit removes the unnecessary permissions.
This PR specifically handles the egressip resource, other features will be handled separately. 