### PR TITLE
OCPBUGS-24383: Limit write permissions for egressservices

### DIFF
--- a/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
+++ b/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
@@ -140,7 +140,6 @@ rules:
   - adminpolicybasedexternalroutes/status
   - egressfirewalls
   - egressfirewalls/status
-  - egressips
   - egressqoses
   - egressservices
   - egressservices/status
@@ -150,6 +149,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups: ["k8s.ovn.org"]
+  resources:
+    - egressips
+  verbs:
+    - get
+    - list
+    - watch
 {{- if .OVN_ADMIN_NETWORK_POLICY_ENABLE }}
 - apiGroups: ["policy.networking.k8s.io"]
   resources:
@@ -166,17 +172,6 @@ rules:
   verbs:
   - update
 {{- end }}
-- apiGroups: ["cloud.network.openshift.io"]
-  resources:
-  - cloudprivateipconfigs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - k8s.cni.cncf.io
   resources:

--- a/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
+++ b/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
@@ -141,8 +141,6 @@ rules:
   - egressfirewalls
   - egressfirewalls/status
   - egressqoses
-  - egressservices
-  - egressservices/status
   verbs:
   - get
   - list
@@ -152,6 +150,7 @@ rules:
 - apiGroups: ["k8s.ovn.org"]
   resources:
     - egressips
+    - egressservices
   verbs:
     - get
     - list

--- a/bindata/network/ovn-kubernetes/common/004-rbac-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/common/004-rbac-control-plane.yaml
@@ -59,8 +59,6 @@ rules:
 - apiGroups: ["k8s.ovn.org"]
   resources:
   - egressips
-  - egressservices
-  - egressservices/status
   - adminpolicybasedexternalroutes
   - adminpolicybasedexternalroutes/status
   - egressfirewalls
@@ -71,6 +69,18 @@ rules:
   - patch
   - update
   - watch
+- apiGroups: ["k8s.ovn.org"]
+  resources:
+    - egressservices
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups: ["k8s.ovn.org"]
+  resources:
+    - egressservices/status
+  verbs:
+    - update
 - apiGroups: ["cloud.network.openshift.io"]
   resources:
   - cloudprivateipconfigs


### PR DESCRIPTION
Based on https://github.com/openshift/cluster-network-operator/pull/2170

ovn-kubernetes-node should only be allowed to read the egressservices resources. Additionally ovn-kubernetes-control-plane should only be allowed to update egressservices/status.
This PR specifically handles the egressservices resource, other features will be handled separately.

The only place we modify the egresservices resource is a status update here: https://github.com/ovn-org/ovn-kubernetes/blob/7447607048cf6fca57b0a51dd3361e694fea851d/go-controller/pkg/kube/kube.go#L456
Other than that both the ovn-kubernetes-node and ovn-kubernetes-control-plane read the egresservices from the API.