### PR TITLE
OCPBUGS-24176: Ignore invalid PEM blocks

### DIFF
--- a/pkg/controller/proxyconfig/validation.go
+++ b/pkg/controller/proxyconfig/validation.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/hypershift"
 	"github.com/openshift/cluster-network-operator/pkg/names"
 	"github.com/openshift/cluster-network-operator/pkg/util/validation"
+	"github.com/openshift/library-go/pkg/crypto"
 	netproxy "golang.org/x/net/proxy"
 
 	corev1 "k8s.io/api/core/v1"
@@ -179,7 +180,7 @@ func (r *ReconcileProxyConfig) validateSystemTrustBundle(trustBundle string) ([]
 	if err != nil {
 		return nil, err
 	}
-	if _, _, err := validation.CertificateData(bundleData); err != nil {
+	if _, err := crypto.CertsFromPEM(bundleData); err != nil {
 		return nil, err
 	}
 

--- a/pkg/util/validation/trustbundle.go
+++ b/pkg/util/validation/trustbundle.go
@@ -2,17 +2,12 @@ package validation
 
 import (
 	"crypto/x509"
-	"encoding/pem"
 	"fmt"
 
 	"github.com/openshift/cluster-network-operator/pkg/names"
+	"github.com/openshift/library-go/pkg/crypto"
 
 	corev1 "k8s.io/api/core/v1"
-)
-
-const (
-	// certPEMBlock is the type taken from the preamble of a PEM-encoded structure.
-	certPEMBlock = "CERTIFICATE"
 )
 
 // TrustBundleConfigMap validates that ConfigMap contains a
@@ -27,7 +22,7 @@ func TrustBundleConfigMap(cfgMap *corev1.ConfigMap, caDataKey string) ([]*x509.C
 	if len(trustBundleData) == 0 {
 		return nil, nil, fmt.Errorf("data key %q is empty from ConfigMap %q", names.TRUSTED_CA_BUNDLE_CONFIGMAP_KEY, cfgMap.Name)
 	}
-	certBundle, _, err := CertificateData(trustBundleData)
+	certBundle, err := crypto.CertsFromPEM(trustBundleData)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed parsing certificate data from ConfigMap %q: %v", cfgMap.Name, err)
 	}
@@ -35,45 +30,19 @@ func TrustBundleConfigMap(cfgMap *corev1.ConfigMap, caDataKey string) ([]*x509.C
 	return certBundle, trustBundleData, nil
 }
 
-// CertificateData decodes certData, ensuring each PEM block is type
-// "CERTIFICATE" and the block can be parsed as an x509 certificate,
-// returning slices of parsed certificates and parsed certificate data.
-func CertificateData(certData []byte) ([]*x509.Certificate, []byte, error) {
-	var block *pem.Block
-	certBundle := []*x509.Certificate{}
-	for len(certData) != 0 {
-		block, certData = pem.Decode(certData)
-		if block == nil {
-			return nil, nil, fmt.Errorf("failed to parse certificate PEM")
-		}
-		if block.Type != certPEMBlock {
-			return nil, nil, fmt.Errorf("invalid certificate PEM, must be of type %q", certPEMBlock)
-
-		}
-
-		cert, err := x509.ParseCertificate(block.Bytes)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to parse certificate: %v", err)
-		}
-		certBundle = append(certBundle, cert)
-	}
-
-	return certBundle, certData, nil
-}
-
 // MergeCertificateData merges certificates, if any, from adlData and systemData,
 // returning the merged certificates as a slice of *x509.Certificate.
 func MergeCertificateData(addlData, systemData []byte) ([]*x509.Certificate, error) {
 	var mergedCerts []*x509.Certificate
 	if len(addlData) > 0 {
-		addlCerts, _, err := CertificateData(addlData)
+		addlCerts, err := crypto.CertsFromPEM(addlData)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse certificate data: %v", err)
 		}
 		mergedCerts = append(mergedCerts, addlCerts...)
 	}
 	if len(systemData) > 0 {
-		systemCerts, _, err := CertificateData(systemData)
+		systemCerts, err := crypto.CertsFromPEM(systemData)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse certificate data: %v", err)
 		}


### PR DESCRIPTION
Copy of https://github.com/openshift/cluster-network-operator/pull/2141 as I was unable to make the the tide happy...
@trozet please approve again.


Previously, the CertificateData function would error out when unable to decode the next PEM block, causing issues with files containing empty lines at the end.

This causes problems for HyperShift clusters with a management cluster that uses the legacyVulnerableCABundle:
https://github.com/openshift/service-ca-operator/blob/fe887613d031435fb0c76eb397764ba68fe09014/pkg/controller/cabundleinjector/starter.go#L30C5-L35
https://github.com/openshift/service-ca-operator/blob/fe887613d031435fb0c76eb397764ba68fe09014/pkg/controller/cabundleinjector/starter.go#L72

This change addresses the problem by using crypto.CertsFromPEM from library-go, which returns early when it cannot decode the next PEM block without throwing an error.
