### PR TITLE
OCPBUGS-25207: Render IPsec MachineConfig after cluster settles with MachineConfigs

### DIFF
--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -102,6 +102,9 @@ type InfraStatus struct {
 
 	// WorkerMCPStatus contains machine config pool status of worker nodes.
 	WorkerMCPStatus mcfgv1.MachineConfigPoolStatus
+
+	// MachineConfigClusterOperatorReady set to true when Machine Config cluster operator is in ready state.
+	MachineConfigClusterOperatorReady bool
 }
 
 // APIServer is the hostname & port of a given APIServer. (This is the


### PR DESCRIPTION
The Machine Config Operator doesn't understand how to process IPsec MachineConfig as it's rolled out by network operator and that wasn't present in install manifest. This makes cluster operator "machine-config" to degraded state. Hence this commit waits for both master and worker machine config pool to be in ready state and then renders IPsec MachineConfig.