### PR TITLE
OCPBUGS-26492: Not set CNO to degraded if API server returns conflict error

### DIFF
--- a/pkg/controller/operconfig/cluster.go
+++ b/pkg/controller/operconfig/cluster.go
@@ -70,7 +70,7 @@ func (r *ReconcileOperConfig) UpdateOperConfig(ctx context.Context, operConfig *
 		return fmt.Errorf("failed to transmute operator config, err: %v", err)
 	}
 	if err = apply.ApplyObject(ctx, r.client, us, "operconfig"); err != nil {
-		return fmt.Errorf("could not apply (%s) %s/%s, err: %v", operConfig.GroupVersionKind(), operConfig.GetNamespace(), operConfig.GetName(), err)
+		return fmt.Errorf("could not apply (%s) %s/%s, err: %w", operConfig.GroupVersionKind(), operConfig.GetNamespace(), operConfig.GetName(), err)
 	}
 	return nil
 }

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -256,8 +256,11 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 	// This will also commit the change back to the apiserver.
 	if err := r.MergeClusterConfig(ctx, operConfig); err != nil {
 		log.Printf("Failed to merge the cluster configuration: %v", err)
-		r.status.SetDegraded(statusmanager.OperatorConfig, "MergeClusterConfig",
-			fmt.Sprintf("Internal error while merging cluster configuration and operator configuration: %v", err))
+		// not set degraded if the err is a version conflict, but return a reconcile err for retry.
+		if !apierrors.IsConflict(err) {
+			r.status.SetDegraded(statusmanager.OperatorConfig, "MergeClusterConfig",
+				fmt.Sprintf("Internal error while merging cluster configuration and operator configuration: %v", err))
+		}
 		return reconcile.Result{}, err
 	}
 
@@ -337,8 +340,11 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 	if !reflect.DeepEqual(operConfig, newOperConfig) {
 		if err := r.UpdateOperConfig(ctx, newOperConfig); err != nil {
 			log.Printf("Failed to update the operator configuration: %v", err)
-			r.status.SetDegraded(statusmanager.OperatorConfig, "UpdateOperatorConfig",
-				fmt.Sprintf("Internal error while updating operator configuration: %v", err))
+			// not set degraded if the err is a version conflict, but return a reconcile err for retry.
+			if !apierrors.IsConflict(err) {
+				r.status.SetDegraded(statusmanager.OperatorConfig, "UpdateOperatorConfig",
+					fmt.Sprintf("Internal error while updating operator configuration: %v", err))
+			}
 			return reconcile.Result{}, err
 		}
 	}


### PR DESCRIPTION
In CNO, the network.operator CR can be updated by both operconfig and clusterconfig controllers. There is a chance that these two controllers may encounter a racing condition, resulting in conflict error.

Normally, this type of error can be automatically recovered by retrying the operation. Therefore, we don't set CNO to degrade when encountering this error.