### PR TITLE
NO-JIRA: Fix jira component info

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -18,6 +18,5 @@ approvers:
   - knobunc
   - trozet
 
-# Bugzilla info; "openshift-sdn" is wrong but there is no "generic networking" subcomponent
 component: Networking
-subcomponent: openshift-sdn
+subcomponent: cluster-network-operator


### PR DESCRIPTION
At some point someone added a `cluster-network-operator` subcomponent in jira, but never updated the OWNERS file here to reference it
