### PR TITLE
OCPBUGS-27198: [release-4.15] Update ovn-k managed control-plane RBAC

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
@@ -104,7 +104,7 @@ spec:
         command: ["/usr/bin/control-plane-operator", "token-minter"]
         args:
         - --service-account-namespace=openshift-ovn-kubernetes
-        - --service-account-name=ovn-kubernetes-controller
+        - --service-account-name=ovn-kubernetes-control-plane
         - --token-audience={{.TokenAudience}}
         - --token-file=/var/run/secrets/hosted_cluster/token
         - --kubeconfig=/etc/kubernetes/kubeconfig

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -102,9 +102,9 @@ func TestRenderOVNKubernetes(t *testing.T) {
 	// It's important that the namespace is first
 	g.Expect(objs[0]).To(HaveKubernetesID("Namespace", "", "openshift-ovn-kubernetes"))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "openshift-ovn-kubernetes-node-limited")))
-	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "openshift-ovn-kubernetes-controller-limited")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "openshift-ovn-kubernetes-control-plane-limited")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ServiceAccount", "openshift-ovn-kubernetes", "ovn-kubernetes-node")))
-	g.Expect(objs).To(ContainElement(HaveKubernetesID("ServiceAccount", "openshift-ovn-kubernetes", "ovn-kubernetes-controller")))
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ServiceAccount", "openshift-ovn-kubernetes", "ovn-kubernetes-control-plane")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRoleBinding", "", "openshift-ovn-kubernetes-node-limited")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("Deployment", "openshift-ovn-kubernetes", "ovnkube-control-plane")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-ovn-kubernetes", "ovnkube-node")))


### PR DESCRIPTION
backport of https://github.com/openshift/cluster-network-operator/pull/2169 first commit
