### PR TITLE
Fix log message about generation and observed generation of daemonsets and deployments

### DIFF
--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -1606,7 +1606,7 @@ func daemonSetProgressing(ds *appsv1.DaemonSet, allowHung bool) bool {
 	}
 	klog.V(2).Infof("daemonset %s/%s rollout %s; %d/%d scheduled; %d unavailable; %d available; generation %d -> %d",
 		ds.Namespace, ds.Name, s, status.UpdatedNumberScheduled, status.DesiredNumberScheduled,
-		status.NumberUnavailable, status.NumberAvailable, ds.Generation, status.ObservedGeneration)
+		status.NumberUnavailable, status.NumberAvailable, status.ObservedGeneration, ds.Generation)
 
 	if !progressing {
 		klog.V(2).Infof("daemonset %s/%s rollout complete", ds.Namespace, ds.Name)
@@ -1641,7 +1641,7 @@ func deploymentProgressing(d *appsv1.Deployment) bool {
 	}
 	klog.V(2).Infof("deployment %s/%s rollout %s; %d/%d scheduled; %d available; generation %d -> %d",
 		d.Namespace, d.Name, s, status.ReadyReplicas, status.Replicas,
-		status.AvailableReplicas, d.Generation, status.ObservedGeneration)
+		status.AvailableReplicas, status.ObservedGeneration, d.Generation)
 
 	if !progressing {
 		klog.V(2).Infof("deployment %s/%s rollout complete", d.Namespace, d.Name)


### PR DESCRIPTION
generation and observed generation were swapped, leading to:

`2024-01-09T13:30:59.894794643+01:00 I0109 12:30:59.894647       1 ovn_kubernetes.go:2084] daemonset openshift-ovn-kubernetes/ovnkube-master rollout progressing; 3/3 scheduled; 0 unavailable; 3 available; generation 9 -> 8`

(`9 -> 8` instead of `8 -> 9`)

Let's fix that.