### PR TITLE
OCPBUGS-27264: Only reconcile on Node updates with Label changes

### DIFF
--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -183,8 +183,13 @@ func add(mgr manager.Manager, r *ReconcileOperConfig) error {
 		CreateFunc: func(_ event.CreateEvent) bool {
 			return true
 		},
-		UpdateFunc: func(_ event.UpdateEvent) bool {
-			return true
+		UpdateFunc: func(ev event.UpdateEvent) bool {
+			// Node conditions change *a lot* and we don't care. We only care
+			// about updates when the labels change.
+			return !reflect.DeepEqual(
+				ev.ObjectOld.GetLabels(),
+				ev.ObjectNew.GetLabels(),
+			)
 		},
 		DeleteFunc: func(_ event.DeleteEvent) bool {
 			return true


### PR DESCRIPTION
`e2e-aws-ovn-shared-to-local-gateway-mode-migration` and its opposite flake about 50% of the time with

```
+ oc patch Network.operator.openshift.io cluster --type=merge --patch '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"gatewayConfig":{"routingViaHost":false}}}}}'
network.operator.openshift.io/cluster patched
+ oc wait co network --for=condition=PROGRESSING=True --timeout=60s
error: timed out waiting for the condition on clusteroperators/network 
```

This is because #1721 changed CNO to re-reconcile any time any Node object changes, but Nodes change *a lot* (specifically, their Conditions), so now we do a ton of unnecessary reconciling, causing CNO to be super busy and lag behind in processing events. This PR fixes it to only reconcile when node labels change.

(I don't know whether CNO lagginess causes any other problems currently?)