### PR TITLE
OCPBUGS-27925,OCPBUGS-30579:[release-4.14] tighten conditions for the state transitions in IC upgrade

### DIFF
--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -2121,7 +2121,7 @@ func daemonSetProgressing(ds *appsv1.DaemonSet, allowHung bool) bool {
 	}
 	klog.V(2).Infof("daemonset %s/%s rollout %s; %d/%d scheduled; %d unavailable; %d available; generation %d -> %d",
 		ds.Namespace, ds.Name, s, status.UpdatedNumberScheduled, status.DesiredNumberScheduled,
-		status.NumberUnavailable, status.NumberAvailable, ds.Generation, status.ObservedGeneration)
+		status.NumberUnavailable, status.NumberAvailable, status.ObservedGeneration, ds.Generation)
 
 	if !progressing {
 		klog.V(2).Infof("daemonset %s/%s rollout complete", ds.Namespace, ds.Name)
@@ -2180,7 +2180,7 @@ func deploymentProgressing(d *appsv1.Deployment) bool {
 	}
 	klog.V(2).Infof("deployment %s/%s rollout %s; %d/%d scheduled; %d available; generation %d -> %d",
 		d.Namespace, d.Name, s, status.ReadyReplicas, status.Replicas,
-		status.AvailableReplicas, d.Generation, status.ObservedGeneration)
+		status.AvailableReplicas, status.ObservedGeneration, d.Generation)
 
 	if !progressing {
 		klog.V(2).Infof("deployment %s/%s rollout complete", d.Namespace, d.Name)

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -528,7 +528,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	}
 
 	// Process phase 2 of the upgrade to IC (4.14 single zone  -> 4.14 multizone)
-	updateNode, updateMaster, updateControlPlane := shouldUpdateOVNKonInterConnectZoneModeChange(bootstrapResult.OVN, targetZoneMode.zoneMode)
+	updateNode, updateMaster, updateControlPlane := shouldUpdateOVNKonInterConnectZoneModeChange(bootstrapResult.OVN, targetZoneMode)
 
 	// Process any update in IP family if the cluster is not migrating from single zone to multizone;
 	// annotate ovnkube with IP family (single/dual stack) and cluster CIDR
@@ -2034,7 +2034,7 @@ func getProgressingState(ovn bootstrap.OVNBootstrapResult) string {
 //
 // To sum up:
 // - single zone -> multizone:   first roll out node,   then master+control plane; finally, remove master.
-func shouldUpdateOVNKonInterConnectZoneModeChange(ovn bootstrap.OVNBootstrapResult, targetZoneMode InterConnectZoneMode) (updateNode, updateMaster, addControlPlane bool) {
+func shouldUpdateOVNKonInterConnectZoneModeChange(ovn bootstrap.OVNBootstrapResult, targetZoneMode targetZoneModeType) (updateNode, updateMaster, addControlPlane bool) {
 
 	if ovn.NodeUpdateStatus == nil || ovn.MasterUpdateStatus == nil && ovn.ControlPlaneUpdateStatus == nil {
 		// Fresh cluster - full steam ahead!
@@ -2053,7 +2053,7 @@ func shouldUpdateOVNKonInterConnectZoneModeChange(ovn bootstrap.OVNBootstrapResu
 	// - ovnkube-control-plane can only be multizone, since it doesn't exist in single zone
 	// - ovnkube-master can only be single zone, since it doesn't exist in multizone
 
-	if targetZoneMode == zoneModeMultiZone {
+	if targetZoneMode.configMapFound && targetZoneMode.zoneMode == zoneModeMultiZone {
 
 		// First step, node is still in single zone: update it to multizone,
 		// leave master as is (no update anyway) and don't add control plane yet

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -71,6 +71,9 @@ const OVN_NODE_SELECTOR_DEFAULT_DPU_HOST = "network.operator.openshift.io/dpu-ho
 const OVN_NODE_SELECTOR_DEFAULT_DPU = "network.operator.openshift.io/dpu"
 const OVN_NODE_SELECTOR_DEFAULT_SMART_NIC = "network.operator.openshift.io/smart-nic"
 const OVN_NODE_IDENTITY_CERT_DURATION = "24h"
+const SINGLEZONE_FOLDER = "single-zone-interconnect"
+const MULTIZONE_FOLDER = "multi-zone-interconnect"
+const MULTIZONE_FOLDER_TMP = MULTIZONE_FOLDER + "-tmp"
 
 // gRPC healthcheck port. See: https://github.com/openshift/enhancements/pull/1209
 const OVN_EGRESSIP_HEALTHCHECK_PORT = "9107"
@@ -459,18 +462,18 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	ongoingMigrationFromSingleToMultiZone := (!targetZoneMode.fastForwardToMultiZone &&
 		isMigrationToMultiZoneAboutToStartOrOngoing(bootstrapResult.OVN, &targetZoneMode))
 	// choose the YAMLs based on the target zone mode (4.14 only)
-	manifestSubDir := filepath.Join(manifestSubDirBasePath, "multi-zone-interconnect") // default is multizone
+	manifestSubDir := filepath.Join(manifestSubDirBasePath, MULTIZONE_FOLDER) // default is multizone
 	if targetZoneMode.zoneMode == zoneModeSingleZone {
 		// non-default, internal use only; this is selected in the first phase of an upgrade from a
 		// non-interconnect version (< 4.14) to an interconnect version (>= 4.14)
-		manifestSubDir = filepath.Join(manifestSubDirBasePath, "single-zone-interconnect")
+		manifestSubDir = filepath.Join(manifestSubDirBasePath, SINGLEZONE_FOLDER)
 	} else if ongoingMigrationFromSingleToMultiZone {
 		// intermediate step when converting from single zone to multizone; this is selected
 		// in the second phase of an upgrade from a non-interconnect version (< 4.14)
 		// to an interconnect version (>= 4.14). Skipped when fastForwardToMultiZone is set.
-		manifestSubDir = filepath.Join(manifestSubDirBasePath, "multi-zone-interconnect-tmp")
+		manifestSubDir = filepath.Join(manifestSubDirBasePath, MULTIZONE_FOLDER_TMP)
 	}
-	ongoingUpgradeToInterconnect := manifestSubDir != filepath.Join(manifestSubDirBasePath, "multi-zone-interconnect")
+	ongoingUpgradeToInterconnect := manifestSubDir != filepath.Join(manifestSubDirBasePath, MULTIZONE_FOLDER)
 	klog.Infof("render YAMLs from %s folder", manifestSubDir)
 	manifestDirs = append(manifestDirs, manifestSubDir)
 

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -2340,9 +2340,9 @@ func isMigrationToMultiZoneOngoing(ovn bootstrap.OVNBootstrapResult, targetZoneM
 		ovn.NodeUpdateStatus.InterConnectZoneMode == string(zoneModeMultiZone) && // can be progressing or not
 
 		ovn.MasterUpdateStatus != nil &&
-		ovn.MasterUpdateStatus.InterConnectEnabled &&
-		(ovn.ControlPlaneUpdateStatus == nil ||
-			ovn.ControlPlaneUpdateStatus.Progressing && !ovn.NodeUpdateStatus.Progressing)
+		ovn.MasterUpdateStatus.InterConnectEnabled && // can be progressing or not
+
+		(ovn.ControlPlaneUpdateStatus == nil || ovn.ControlPlaneUpdateStatus.Progressing)
 }
 
 // migration from single zone to multizone is complete if:


### PR DESCRIPTION
A few misc fixes for the IC upgrade logic:

- When evaluating whether phase 2 is ongoing, don't rely on ovnkube-node being "progressing", since that might happen also due to transient node conditions _after_ a complete roll out of ovnkube-node (found in https://issues.redhat.com//browse/OCPBUGS-30579)
- Tighten the progression to phase 2 to the presence of the configmap: since CNO removes the configmap as soon as the upgrade is completed, checking for the configmap prevents us from mistakenly going back to the multi-zone-interconnect-tmp folder when some transient conditions on ovnkube-xyz pods could make us flag them as "progressing". (found in https://issues.redhat.com//browse/OCPBUGS-30579)
- Remove all code related to the migration from multizone to single zone, since we've decided not to support that.
- Tighten `shouldUpdateOVNKonInterConnectZoneModeChange` to the presence of the IC configmap, so that it only takes action when the upgrade to IC is happening and doesn't interfere with cluster CIDR expansion (https://issues.redhat.com//browse/OCPBUGS-27925)
