### PR TITLE
OCPBUGS-25079: Prevent NoRunningOvnControlPlane alert getting fired continuously

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/alert-rules-control-plane.yaml
@@ -42,7 +42,7 @@ spec:
           Networking control plane is degraded. Networking configuration updates applied to the cluster will not be
           implemented while there are no OVN Kubernetes pods.
       expr: |
-        absent(up{job="ovnkube-control-plane", namespace="openshift-ovn-kubernetes"} == 1)
+        absent(up{job="ovnkube-control-plane", namespace="{{.HostedClusterNamespace}}"} == 1)
       for: 5m
       labels:
         namespace: {{.HostedClusterNamespace}}

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
@@ -152,7 +152,7 @@ spec:
             --config-file=/run/ovnkube-config/ovnkube.conf \
             --k8s-token-file=/var/run/secrets/hosted_cluster/token \
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
-            --metrics-bind-address "127.0.0.1:9108" \
+            --metrics-bind-address "0.0.0.0:9108" \
             --metrics-enable-pprof \
             --metrics-enable-config-duration \
             --node-server-privkey ${TLS_PK} \


### PR DESCRIPTION
Prevent NoRunningOvnControlPlane alert getting fired continuously for managed cluster

In managed cluster kube-rbac-proxy is not there to scrape metrics from ovnkube-cluster-manager. Instead metrics endpoint of ovnkube-cluster-manager gets exposed directly. This PR takes care of following aspects:

- Makes 9108 port listen on all IPv4 interfaces instead of localhost only.
- Change expression used with NoRunningOvnControlPlane alert to correct namespace to HostedClusterNamespace.