### PR TITLE
Render IPsec MachineConfig once MCO upgraded to latest version

### DIFF
--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -10,6 +10,7 @@ import (
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 	"github.com/openshift/cluster-network-operator/pkg/hypershift"
 	"github.com/openshift/cluster-network-operator/pkg/names"
+	"github.com/openshift/cluster-network-operator/pkg/version"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -222,5 +223,11 @@ func isMachineConfigClusterOperatorReady(client cnoclient.Client) (bool, error) 
 		}
 	}
 	machineConfigClusterOperatorReady := available && !degraded && !progressing
-	return machineConfigClusterOperatorReady, nil
+	for _, mcoVersion := range machineConfigClusterOperator.Status.Versions {
+		if mcoVersion.Name == "operator" {
+			return version.IsVersionGreaterThanOrEqualTo(mcoVersion.Version, 4, 15) &&
+				machineConfigClusterOperatorReady, nil
+		}
+	}
+	return false, nil
 }

--- a/pkg/version/semver.go
+++ b/pkg/version/semver.go
@@ -1,4 +1,4 @@
-package network
+package version
 
 import (
 	"github.com/Masterminds/semver"
@@ -8,21 +8,21 @@ import (
 type versionChange int
 
 const (
-	versionUpgrade   versionChange = -1
-	versionSame      versionChange = 0
-	versionDowngrade versionChange = 1
-	versionUnknown   versionChange = 2
+	VersionUpgrade   versionChange = -1
+	VersionSame      versionChange = 0
+	VersionDowngrade versionChange = 1
+	VersionUnknown   versionChange = 2
 )
 
 func (v versionChange) String() string {
 	switch v {
-	case versionUpgrade:
+	case VersionUpgrade:
 		return "upgrade"
-	case versionSame:
+	case VersionSame:
 		return "same"
-	case versionDowngrade:
+	case VersionDowngrade:
 		return "downgrade"
-	case versionUnknown:
+	case VersionUnknown:
 		return "unknown"
 	}
 	klog.Warningf("unhandled versionChange value %d", v)
@@ -32,25 +32,25 @@ func (v versionChange) String() string {
 // compareVersions compares two semver versions
 // if fromVersion is older than toVersion, returns versionOlder
 // likewise, if fromVersion is newer, returns versionNewer
-func compareVersions(fromVersion, toVersion string) versionChange {
+func CompareVersions(fromVersion, toVersion string) versionChange {
 	if fromVersion == toVersion {
-		return versionSame
+		return VersionSame
 	}
 
 	v1, err := semver.NewVersion(fromVersion)
 	if err != nil {
-		return versionUnknown
+		return VersionUnknown
 	}
 
 	v2, err := semver.NewVersion(toVersion)
 	if err != nil {
-		return versionUnknown
+		return VersionUnknown
 	}
 
 	return versionChange(v1.Compare(v2))
 }
 
-func isVersionGreaterThanOrEqualTo(version string, major int, minor int) bool {
+func IsVersionGreaterThanOrEqualTo(version string, major int, minor int) bool {
 	v, err := semver.NewVersion(version)
 	if err != nil {
 		klog.Errorf("failed to parse version %s: %v", version, err)

--- a/pkg/version/semver_test.go
+++ b/pkg/version/semver_test.go
@@ -1,4 +1,4 @@
-package network
+package version
 
 import (
 	"strconv"
@@ -16,47 +16,47 @@ func TestDirection(t *testing.T) {
 		{
 			"1.2.3",
 			"1.2.4",
-			versionUpgrade,
+			VersionUpgrade,
 		},
 		{
 			"1.2.4",
 			"1.2.3",
-			versionDowngrade,
+			VersionDowngrade,
 		},
 		{
 			"asdf",
 			"fdsa",
-			versionUnknown,
+			VersionUnknown,
 		},
 		{
 			"1.1.1",
 			"1.1.1",
-			versionSame,
+			VersionSame,
 		},
 		{
 			"4.7.0-0.ci-2021-01-16-102811",
 			"4.7.0-0.ci-2021-01-18-121038",
-			versionUpgrade,
+			VersionUpgrade,
 		},
 		{
 			"4.7.0-0.ci-2021-01-18-121038",
 			"4.7.0-0.ci-2021-01-16-102811",
-			versionDowngrade,
+			VersionDowngrade,
 		},
 		{
 			"4.6.0-0.ci-2021-01-18-121038",
 			"4.7.0-0.ci-2021-01-16-102811",
-			versionUpgrade,
+			VersionUpgrade,
 		},
 		{
 			"4.6.5",
 			"4.7.0-0.ci-2021-01-16-102811",
-			versionUpgrade,
+			VersionUpgrade,
 		},
 	} {
 		t.Run(strconv.Itoa(idx), func(t *testing.T) {
 			g := NewGomegaWithT(t)
-			g.Expect(compareVersions(tc.from, tc.to)).To(Equal(tc.result))
+			g.Expect(CompareVersions(tc.from, tc.to)).To(Equal(tc.result))
 		})
 	}
 }
@@ -102,7 +102,7 @@ func TestVersionComparison(t *testing.T) {
 		t.Run(strconv.Itoa(idx), func(t *testing.T) {
 			g := NewGomegaWithT(t)
 
-			g.Expect(isVersionGreaterThanOrEqualTo(tc.version, tc.otherVersionMajor, tc.otherVersionMinor)).To(Equal(tc.resultGreaterThanOrEqualTo))
+			g.Expect(IsVersionGreaterThanOrEqualTo(tc.version, tc.otherVersionMajor, tc.otherVersionMinor)).To(Equal(tc.resultGreaterThanOrEqualTo))
 		})
 	}
 }


### PR DESCRIPTION
This commit makes CNO to wait for MCO to be upgraded into 4.15 before rendering IPsec machine config onto the cluster.