### PR TITLE
OCPBUGS-27823: Not update migration conditions when any MCP is updating

### DIFF
--- a/pkg/controller/clusterconfig/migration.go
+++ b/pkg/controller/clusterconfig/migration.go
@@ -67,6 +67,9 @@ func (r *ReconcileClusterConfig) prepareOperatorConfigForNetworkTypeMigration(ct
 	if mcpCondition == nil {
 		return fmt.Errorf("condition %q not found", names.NetworkTypeMigrationMTUReady)
 	}
+	if mcpCondition.Reason == names.MachineConfigPoolDegraded {
+		return fmt.Errorf("MCP is degraded, network type migration cannot proceed")
+	}
 	if mcpCondition.Reason == names.MachineConfigPoolsUpdating {
 		klog.Infof("MCP is updating, so we don't modify the operator config")
 		return nil

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -142,6 +142,10 @@ const NetworkTypeMigrationAnnotation = "network.openshift.io/network-type-migrat
 // conditions to indicate if MCP is updating
 const MachineConfigPoolsUpdating string = "MachineConfigPoolsUpdating"
 
+// MachineConfigPoolDegraded is the reason string NetworkTypeMigrationTargetCNIInUse and NetworkTypeMigrationMTUReady
+// conditions to indicate if MCP is degraded
+const MachineConfigPoolDegraded string = "MachineConfigPoolDegraded"
+
 // Status condition types of network.config for live migration
 const (
 	// NetworkTypeMigrationInProgress is the condition type for network type live migration to indicate if the migration


### PR DESCRIPTION
This issue always happens when doing live migration in a large (it was initially reported on a cluster with 26 workers) cluster. The CNO will enter an infinity loop of step3->step2->step3 during live migration.

The reason is that in a smaller cluster, the MCP master normally takes more time to finish updating. And the master pool is always the first item of `pools.Items`. So the reason for the condition `NetworkTypeMigrationMTUReady` will not be set to `MachineConfigNotApplied` before the master pool finishes updating and the condition `NetworkTypeMigrationTargetCNIInUse` becomes `True`. This patch will ensure the reason for the condition `NetworkTypeMigrationMTUReady` is always set to `MachineConfigPoolsUpdating`, if any of the pools is updating.