### PR TITLE
OCPBUGS-27748: [release-4.15] Add ConfigMap mount to the whereabouts-reconciler

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -741,6 +741,8 @@ spec:
         volumeMounts:
           - name: cni-net-dir
             mountPath: /host/etc/cni/net.d
+          - name: cron-scheduler-configmap
+            mountPath: /cron-schedule
         env:
         - name: NODENAME
           valueFrom:
@@ -755,4 +757,12 @@ spec:
         - name: cni-net-dir
           hostPath:
             path: {{ .SystemCNIConfDir }}
+        - name: cron-scheduler-configmap
+          configMap:
+            name: whereabouts-config
+            optional: true
+            defaultMode: 0744
+            items:
+            - key: reconciler_cron_expression
+              path: config
 {{- end}}


### PR DESCRIPTION
Cherry-pick of #2209 
Related to: https://github.com/openshift/whereabouts-cni/pull/239

Modify the whereabouts-reconciler DaemonSet to mount the whereabouts-config ConfigMap into /cron-schedule/config. This will be consumed by Whereabouts, which monitors this path to update its cron schedule for cleaning up unused IPs.

Please note that we set the ConfigMap volume as optional to reduce complexity and avoid requiring the cluster-network-operator to deploy the whereabouts ConfigMap.

Users will be able to create the whereabouts ConfigMap later, and it will update automatically in the whereabouts container. For example: oc create configmap whereabouts-config -n openshift-multus \ --from-literal=reconciler_cron_expression="*/15 * * * *"

To update the value use:
oc patch configmap whereabouts-config -n openshift-multus --type merge \ -p '{"data":{"reconciler_cron_expression":"*/3 * * * *"}}'