### PR TITLE
OCPBUGS-28230: add FallbackToLogsOnError for easier debugging

### DIFF
--- a/bindata/allowlist/daemonset/daemonset.yaml
+++ b/bindata/allowlist/daemonset/daemonset.yaml
@@ -25,6 +25,7 @@ spec:
             exec:
               command: ["/bin/bash", "-c", "test -f /ready/ready"]
             initialDelaySeconds: 1
+          terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - mountPath: /entrypoint
               name: cni-sysctl-allowlist

--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -101,6 +101,7 @@ spec:
               kubectl --kubeconfig $kc config set contexts.default.user admin
               kubectl --kubeconfig $kc config set contexts.default.namespace openshift-multus
               kubectl --kubeconfig $kc config use-context default
+          terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - mountPath: /var/run/secrets/hosted_cluster
               name: hosted-cluster-api-access
@@ -128,6 +129,7 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
           - mountPath: /etc/kubernetes
             name: admin-kubeconfig
@@ -165,6 +167,7 @@ spec:
 {{- end }}
             -alsologtostderr=true \
             -ignore-namespaces=openshift-etcd,openshift-console,openshift-ingress-canary,{{.IgnoredNamespace}}
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: webhook-certs
           mountPath: /etc/webhook

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -431,6 +431,7 @@ spec:
       - name: egress-router-binary-copy
         image: {{.EgressRouterImage}}
         command: ["/entrypoint/cnibincopy.sh"]
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /entrypoint
           name: cni-binary-copy
@@ -449,6 +450,7 @@ spec:
       - name: cni-plugins
         image: {{.CNIPluginsImage}}
         command: ["/bin/bash", "-c", "/entrypoint/cnibincopy.sh && cp -n /sysctls/allowlist.conf /host/etc/cni/tuning/"]
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /entrypoint
           name: cni-binary-copy
@@ -472,6 +474,7 @@ spec:
       - name: bond-cni-plugin
         image: {{.BondCNIPluginImage}}
         command: ["/entrypoint/cnibincopy.sh"]
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /entrypoint
           name: cni-binary-copy
@@ -490,6 +493,7 @@ spec:
       - name: routeoverride-cni
         image: {{.RouteOverrideImage}}
         command: ["/entrypoint/cnibincopy.sh"]
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /entrypoint
           name: cni-binary-copy
@@ -512,6 +516,7 @@ spec:
           requests:
             cpu: 10m
             memory: 10Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /entrypoint
           name: cni-binary-copy
@@ -632,6 +637,7 @@ spec:
           requests:
             cpu: 10m
             memory: 10Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /host/opt/cni/bin
           name: cnibin
@@ -663,6 +669,7 @@ spec:
             memory: 10Mi
         securityContext:
           privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
       terminationGracePeriodSeconds: 10
       volumes:
         - name: system-cni-dir
@@ -735,6 +742,7 @@ spec:
           requests:
             cpu: "50m"
             memory: "50Mi"
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
           - name: cni-net-dir
             mountPath: /host/etc/cni/net.d

--- a/bindata/network/network-metrics/001-daemonset.yaml
+++ b/bindata/network/network-metrics/001-daemonset.yaml
@@ -52,6 +52,7 @@ spec:
               cpu: 10m
               memory: 100Mi
           imagePullPolicy: IfNotPresent
+          terminationMessagePolicy: FallbackToLogsOnError
           env:
             - name: NODE_NAME
               valueFrom:

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -113,6 +113,7 @@ spec:
                     client-certificate: /etc/ovn/ovnkube-node-certs/ovnkube-client-current.pem
                     client-key: /etc/ovn/ovnkube-node-certs/ovnkube-client-current.pem
               EOF
+          terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - mountPath: /etc/ovn/
               name: etc-openvswitch


### PR DESCRIPTION
All openshift operators must include FallbackToLogsOnError to ease debugging.