### PR TITLE
NP-903: Only allows live migration on standalone managed clusters

### DIFF
--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -75,6 +75,8 @@ type InfraStatus struct {
 	ControlPlaneTopology   configv1.TopologyMode
 	InfrastructureTopology configv1.TopologyMode
 	InfraName              string
+	// StandaloneManagedCluster is set to true when the cluster is a standalone managed cluster (excl HyperShift)
+	StandaloneManagedCluster bool
 
 	// KubeCloudConfig is the contents of the openshift-config-managed/kube-cloud-config ConfigMap
 	KubeCloudConfig map[string]string

--- a/pkg/controller/operconfig/cluster.go
+++ b/pkg/controller/operconfig/cluster.go
@@ -38,7 +38,7 @@ func (r *ReconcileOperConfig) MergeClusterConfig(ctx context.Context, operConfig
 	}
 	// Validate cluster config
 	// If invalid just warn and proceed.
-	if err := network.ValidateClusterConfig(clusterConfig.Spec, r.client); err != nil {
+	if err := network.ValidateClusterConfig(clusterConfig, r.client); err != nil {
 		log.Printf("WARNING: ignoring Network.config.openshift.io/v1/cluster - failed validation: %v", err)
 		return nil
 	}

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -278,7 +278,7 @@ func IsChangeSafe(prev, next *operv1.NetworkSpec, infraStatus *bootstrap.InfraSt
 	}
 
 	// Check the network migration
-	errs = append(errs, isMigrationChangeSafe(prev, next)...)
+	errs = append(errs, isMigrationChangeSafe(prev, next, infraStatus)...)
 
 	// Check the default network
 	errs = append(errs, isDefaultNetworkChangeSafe(prev, next)...)
@@ -670,7 +670,15 @@ func isDefaultNetworkChangeSafe(prev, next *operv1.NetworkSpec) []error {
 	return nil
 }
 
-func isMigrationChangeSafe(prev, next *operv1.NetworkSpec) []error {
+func isMigrationChangeSafe(prev, next *operv1.NetworkSpec, infraStatus *bootstrap.InfraStatus) []error {
+	// infra.HostedControlPlane is not nil only when HyperShift is enabled
+	if next.Migration != nil && next.Migration.Mode == operv1.LiveNetworkMigrationMode && infraStatus.HostedControlPlane != nil {
+		return []error{errors.Errorf("live migration is unsupported in a HyperShift environment")}
+	}
+	if next.Migration != nil && next.Migration.Mode == operv1.LiveNetworkMigrationMode &&
+		!infraStatus.StandaloneManagedCluster {
+		return []error{errors.Errorf("live migration is unsupported on a self managed cluster")}
+	}
 	if prev.Migration != nil && next.Migration != nil && prev.Migration.NetworkType != next.Migration.NetworkType && next.Migration.Mode != operv1.LiveNetworkMigrationMode {
 		return []error{errors.Errorf("cannot change migration network type after migration has started")}
 	}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -10,6 +10,7 @@ import (
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 	"github.com/openshift/cluster-network-operator/pkg/hypershift"
 	"github.com/openshift/cluster-network-operator/pkg/names"
+	"github.com/openshift/cluster-network-operator/pkg/util"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -131,6 +132,13 @@ func InfraStatus(client cnoclient.Client) (*bootstrap.InfraStatus, error) {
 		return nil, fmt.Errorf("failed to determine if network node identity should be enabled: %w", err)
 	}
 	res.NetworkNodeIdentityEnabled = netIDEnabled
+
+	// standalone managed clusters is a set managed clusters (excl HyperShift clusters).
+	isStandaloneManagedCluster, err := util.IsStandaloneManagedCluster(context.TODO(), client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect if standalone managed cluster: %v", err)
+	}
+	res.StandaloneManagedCluster = isStandaloneManagedCluster
 
 	// Skip retrieving IPsec MachineConfig and MachineConfigPool if it's a hypershift cluster because
 	// those object kinds are not supported there.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -23,6 +24,7 @@ const SDN_NAMESPACE = "openshift-sdn"
 const MTU_CM_NAMESPACE = "openshift-network-operator"
 const MTU_CM_NAME = "mtu"
 const OVN_NBDB = "nbdb"
+const STANDALONE_MANAGED_CLUSTER_NAMESPACE = "dedicated-admin" // namespace required for standalone managed clusters (excluding hypershift)
 
 func GetInterConnectConfigMap(kubeClient kubernetes.Interface) (*corev1.ConfigMap, error) {
 	return kubeClient.CoreV1().ConfigMaps(OVN_NAMESPACE).Get(context.TODO(), OVN_INTERCONNECT_CONFIGMAP_NAME, metav1.GetOptions{})
@@ -42,4 +44,19 @@ func ReadMTUConfigMap(ctx context.Context, client cnoclient.Client) (int, error)
 
 	klog.V(2).Infof("Found mtu %d", mtu)
 	return mtu, nil
+}
+
+// IsStandaloneManagedCluster returns true if the operator is running in a managed cluster that isn't managed by HyperShift.
+// It checks for the existence of the dedicated-admin namespace.
+func IsStandaloneManagedCluster(ctx context.Context, client cnoclient.Client) (bool, error) {
+	// TODO(martinkennelly): replace detection of a standalone managed cluster with a metric instead of a namespace when that metric
+	// becomes available.
+	err := client.Default().CRClient().Get(ctx, types.NamespacedName{Name: STANDALONE_MANAGED_CLUSTER_NAMESPACE}, &corev1.Namespace{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }


### PR DESCRIPTION
In all the managed clusters excl hypershift aka standalone managed clusters, the namespace "dedicated-admin" shall exist. We use this to figure out if CNO is running in a managed cluster.