### PR TITLE
OCPBUGS-29099: Add hostNetwork:true to cni-sysctl-allowlist ds

### DIFF
--- a/bindata/allowlist/daemonset/daemonset.yaml
+++ b/bindata/allowlist/daemonset/daemonset.yaml
@@ -15,6 +15,7 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
+      hostNetwork: true
       containers:
         - name: kube-multus-additional-cni-plugins
           image:  {{.MultusImage}}


### PR DESCRIPTION
This code changes cni-sysctl-allowlist ds without container network interface because this ds does not require any network.