### PR TITLE
OCPBUGS-28676: Remove libreswan rpm existence checks

### DIFF
--- a/bindata/network/ovn-kubernetes/common/ipsec-containerized.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-containerized.yaml
@@ -90,11 +90,6 @@ spec:
           export KUBECONFIG=/var/run/ovnkube-kubeconfig
 {{ end }}
 
-          if rpm --dbpath=/usr/share/rpm -q libreswan; then
-            echo "host has libreswan and therefore ipsec will be configured by ipsec daemonset, this ovn ipsec container doesnt need to init anything"
-            exit 0
-          fi
-
           # Every time we restart this container, we will create a new key pair if
           # we are close to key expiration or if we do not already have a signed key pair.
           #
@@ -192,9 +187,6 @@ spec:
           name: signer-ca
         - mountPath: /etc/openvswitch
           name: etc-openvswitch
-        - mountPath: /usr/share/rpm
-          name: host-usr-share-rpm
-          readOnly: true
         resources:
           requests:
             cpu: 10m
@@ -225,11 +217,6 @@ spec:
             exit 0
           }
           trap cleanup SIGTERM
-
-          if rpm --dbpath=/usr/share/rpm -q libreswan; then
-            echo "host has libreswan and therefore ipsec will be configured by ipsec daemonset, this ovn ipsec container will sleep to infinity"
-            sleep infinity
-          fi
 
           # Don't start IPsec until ovnkube-node has finished setting up the node
           counter=0
@@ -287,9 +274,6 @@ spec:
           name: host-var-log-ovs
         - mountPath: /etc/openvswitch
           name: etc-openvswitch
-        - mountPath: /usr/share/rpm
-          name: host-usr-share-rpm
-          readOnly: true
         resources:
           requests:
             cpu: 10m
@@ -302,11 +286,6 @@ spec:
             - -c
             - |
               #!/bin/bash
-              if rpm --dbpath=/usr/share/rpm -q libreswan; then
-                echo "host has libreswan and therefore ipsec will be configured by ipsec daemonset, this ovn ipsec container is always \"alive\""
-                exit 0
-              fi
-
               if [[ $(ipsec whack --trafficstatus | wc -l) -eq 0 ]]; then
                 echo "no ipsec traffic configured"
                 exit 10
@@ -340,10 +319,6 @@ spec:
       - name: host-cni-netd
         hostPath:
           path: "{{.CNIConfDir}}"
-      - name: host-usr-share-rpm
-        hostPath:
-          path: /usr/share/rpm
-          type: Directory
       tolerations:
       - operator: "Exists"
 {{end}}

--- a/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
@@ -91,11 +91,6 @@ spec:
           export KUBECONFIG=/var/run/ovnkube-kubeconfig
 {{ end }}
 
-          if ! rpm --dbpath=/usr/share/rpm -q libreswan; then
-            echo "host doesnt have libreswan, therefore ipsec will be configured by ipsec-pre414 daemonset, this ovn ipsec container has nothing to init"
-            exit 0
-          fi
-
           # Every time we restart this container, we will create a new key pair if
           # we are close to key expiration or if we do not already have a signed key pair.
           #
@@ -197,9 +192,6 @@ spec:
           name: etc-openvswitch
         - mountPath: /etc
           name: host-etc
-        - mountPath: /usr/share/rpm
-          name: host-usr-share-rpm
-          readOnly: true
         resources:
           requests:
             cpu: 10m
@@ -216,11 +208,6 @@ spec:
           #!/bin/bash
           set -exuo pipefail
 
-
-          if ! rpm --dbpath=/usr/share/rpm -q libreswan; then
-            echo "host doesnt have libreswan, therefore ipsec will be configured by ipsec-pre414 daemonset, this ovn ipsec container will sleep to infinity"
-            sleep infinity
-          fi
 
           # Don't start IPsec until ovnkube-node has finished setting up the node
           counter=0
@@ -279,11 +266,6 @@ spec:
                    # In order to maintain traffic flows during container restart, we
                    # need to ensure that xfrm state and policies are not flushed.
 
-                   if ! rpm --dbpath=/usr/share/rpm -q libreswan; then
-                     echo "host doesnt have libreswan, therefore ipsec will be configured by ipsec-pre414 daemonset, preStop wont do anything"
-                     exit 0
-                   fi
-
                    # Don't allow ovs monitor to cleanup persistent state
                    kill $(cat /var/run/openvswitch/ovs-monitor-ipsec.pid 2>/dev/null) 2>/dev/null || true
         env:
@@ -307,9 +289,6 @@ spec:
           name: host-var-lib
         - mountPath: /etc
           name: host-etc
-        - mountPath: /usr/share/rpm
-          name: host-usr-share-rpm
-          readOnly: true
         resources:
           requests:
             cpu: 10m
@@ -322,11 +301,6 @@ spec:
             - -c
             - |
               #!/bin/bash
-              if ! rpm --dbpath=/usr/share/rpm -q libreswan; then
-                echo "host doesnt have libreswan, therefore ipsec will be configured by ipsec-pre414 daemonset, this ovn ipsec container is always \"alive\""
-                exit 0
-              fi
-
               if [[ $(ipsec whack --trafficstatus | wc -l) -eq 0 ]]; then
                 echo "no ipsec traffic configured"
                 exit 10
@@ -370,10 +344,6 @@ spec:
           path: /etc
           type: Directory
         name: host-etc
-      - name: host-usr-share-rpm
-        hostPath:
-          path: /usr/share/rpm
-          type: DirectoryOrCreate
       tolerations:
       - operator: "Exists"
 {{end}}


### PR DESCRIPTION
There is no need for libreswan rpm existence checks anymore in ipsec daemonset pod because libreswan is always expected to be present, otherwise it should be an error. Hence this commit is removing those checks. This also inherently fixes rpm db directory mount issue because rhel and rhcos use different directories for it.