### PR TITLE
OCPBUGS-28777: fix whereabouts conformance test failures

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -537,14 +537,21 @@ spec:
       name: whereabouts-reconciler
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: whereabouts-reconciler
         name: whereabouts-reconciler
     spec:
       hostNetwork: true      
+      nodeSelector:
+        kubernetes.io/os: linux
       serviceAccountName: multus
+      priorityClassName: "system-node-critical"
       tolerations:
       - operator: Exists
         effect: NoSchedule
@@ -565,9 +572,6 @@ spec:
           requests:
             cpu: "50m"
             memory: "50Mi"
-          limits:
-            cpu: "50m"
-            memory: "100Mi"
         volumeMounts:
           - name: cni-net-dir
             mountPath: /host/etc/cni/net.d


### PR DESCRIPTION
Signed-off-by: Zenghui Shi <zshi@redhat.com>
(cherry picked from commit 5045f12323487d76b40c49ba4e7b873552e40535)

fixed the following merge conflict by keeping the serviceAccountName to be multus since the security hardening work hasn't been backported to 4.13:
```
++<<<<<<< HEAD
 +      serviceAccountName: multus
++=======
+       nodeSelector:
+         kubernetes.io/os: linux
+       serviceAccountName: multus-ancillary-tools
+       priorityClassName: "system-node-critical"
++>>>>>>> 5045f1232 (OCPBUGS-19830: fix whereabouts conformance test failures)
```