### PR TITLE
[release-4.15] NP-905,OCPBUGS-28902: Bump openshift API

### DIFF
--- a/bindata/cloud-network-config-controller/001-crd.yaml
+++ b/bindata/cloud-network-config-controller/001-crd.yaml
@@ -30,7 +30,7 @@ spec:
                 name:
                   anyOf:
                     - format: ipv4
-                    - format: ipv6
+                    - pattern: ^[0-9a-f]{4}(\.[0-9a-f]{4}){7}$
                   type: string
               type: object
             spec:

--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 )
 
 require (
-	github.com/openshift/api v0.0.0-20240116035456-11ed2fbcb805
+	github.com/openshift/api v0.0.0-20240203160143-dd853650077f
 	github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1
 	github.com/openshift/library-go v0.0.0-20231123173213-a037480d443b
 	github.com/openshift/machine-config-operator v0.0.1-0.20231002195040-a2469941c0dc

--- a/go.sum
+++ b/go.sum
@@ -315,8 +315,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.27.7 h1:fVih9JD6ogIiHUN6ePK7HJidyEDpWGVB5mzM7cWNXoU=
 github.com/onsi/gomega v1.27.7/go.mod h1:1p8OOlwo2iUUDsHnOrjE5UKYJ+e3W8eQ3qSlRahPmr4=
-github.com/openshift/api v0.0.0-20240116035456-11ed2fbcb805 h1:5NjcOG5i+WH0F4FI8dKSf0fNgX0YQkrJ8w3YcsHx6KM=
-github.com/openshift/api v0.0.0-20240116035456-11ed2fbcb805/go.mod h1:qNtV0315F+f8ld52TLtPvrfivZpdimOzTi3kn9IVbtU=
+github.com/openshift/api v0.0.0-20240203160143-dd853650077f h1:vEQNC/9AkZLl86PBhRBBmOJ1MRxIHL8IGxSCWtVd4Og=
+github.com/openshift/api v0.0.0-20240203160143-dd853650077f/go.mod h1:qNtV0315F+f8ld52TLtPvrfivZpdimOzTi3kn9IVbtU=
 github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d h1:RR4ah7FfaPR1WePizm0jlrsbmPu91xQZnAsVVreQV1k=
 github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1 h1:W1N/3nVciqmjPjn2xldHjb0AwwCQzlGxLvX5BCgE8H4=

--- a/manifests/0000_70_cluster-network-operator_01-Default.crd.yaml
+++ b/manifests/0000_70_cluster-network-operator_01-Default.crd.yaml
@@ -696,6 +696,23 @@ spec:
                           defaults to 'true' and multicast configure is migrated.
                         type: boolean
                     type: object
+                  mode:
+                    description: mode indicates the mode of network migration. The
+                      supported values are "Live", "Offline" and omitted. A "Live"
+                      migration operation will not cause service interruption by migrating
+                      the CNI of each node one by one. The cluster network will work
+                      as normal during the network migration. An "Offline" migration
+                      operation will cause service interruption. During an "Offline"
+                      migration, two rounds of node reboots are required. The cluster
+                      network will be malfunctioning during the network migration.
+                      When omitted, this means no opinion and the platform is left
+                      to choose a reasonable default which is subject to change over
+                      time. The current default value is "Offline".
+                    enum:
+                    - Live
+                    - Offline
+                    - ""
+                    type: string
                   mtu:
                     description: mtu contains the MTU migration configuration. Set
                       this to allow changing the MTU values for the default network.

--- a/vendor/github.com/openshift/api/cloudnetwork/v1/001-cloudprivateipconfig.crd.yaml
+++ b/vendor/github.com/openshift/api/cloudnetwork/v1/001-cloudprivateipconfig.crd.yaml
@@ -29,7 +29,7 @@ spec:
                 name:
                   anyOf:
                     - format: ipv4
-                    - format: ipv6
+                    - pattern: ^[0-9a-f]{4}(\.[0-9a-f]{4}){7}$
                   type: string
               type: object
             spec:

--- a/vendor/github.com/openshift/api/cloudnetwork/v1/001-cloudprivateipconfig.crd.yaml-patch
+++ b/vendor/github.com/openshift/api/cloudnetwork/v1/001-cloudprivateipconfig.crd.yaml-patch
@@ -7,4 +7,4 @@
         type: string
         anyOf:
         - format: ipv4
-        - format: ipv6
+        - pattern: '^[0-9a-f]{4}(\.[0-9a-f]{4}){7}$'

--- a/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_authentication.crd-CustomNoUpgrade.yaml
+++ b/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_authentication.crd-CustomNoUpgrade.yaml
@@ -216,6 +216,11 @@ spec:
                 type:
                   description: type identifies the cluster managed, user facing authentication mode in use. Specifically, it manages the component that responds to login attempts. The default is IntegratedOAuth.
                   type: string
+                  enum:
+                    - ""
+                    - None
+                    - IntegratedOAuth
+                    - OIDC
                 webhookTokenAuthenticator:
                   description: "webhookTokenAuthenticator configures a remote token reviewer. These remote authentication webhooks can be used to verify bearer tokens via the tokenreviews.authentication.k8s.io REST API. This is required to honor bearer tokens that are provisioned by an external authentication service. \n Can only be set if \"Type\" is set to \"None\"."
                   type: object

--- a/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_authentication.crd-Default-Hypershift.yaml
+++ b/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_authentication.crd-Default-Hypershift.yaml
@@ -3,11 +3,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
-    formatted: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: Default
   name: authentications.config.openshift.io
 spec:
   group: config.openshift.io

--- a/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_authentication.crd-Default-Hypershift.yaml-patch
+++ b/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_authentication.crd-Default-Hypershift.yaml-patch
@@ -1,0 +1,284 @@
+- op: add
+  path: /spec/versions/name=v1/schema/openAPIV3Schema/properties/spec/properties/oidcProviders
+  value:
+    description: "OIDCProviders are OIDC identity providers that can issue tokens for this cluster Can only be set if \"Type\" is set to \"OIDC\". \n At most one provider can be configured."
+    type: array
+    maxItems: 1
+    items:
+      type: object
+      required:
+        - issuer
+        - name
+      properties:
+        claimMappings:
+          description: ClaimMappings describes rules on how to transform information from an ID token into a cluster identity
+          type: object
+          properties:
+            groups:
+              description: Groups is a name of the claim that should be used to construct groups for the cluster identity. The referenced claim must use array of strings values.
+              type: object
+              required:
+                - claim
+              properties:
+                claim:
+                  description: Claim is a JWT token claim to be used in the mapping
+                  type: string
+                prefix:
+                  description: "Prefix is a string to prefix the value from the token in the result of the claim mapping. \n By default, no prefixing occurs. \n Example: if `prefix` is set to \"myoidc:\"\" and the `claim` in JWT contains an array of strings \"a\", \"b\" and  \"c\", the mapping will result in an array of string \"myoidc:a\", \"myoidc:b\" and \"myoidc:c\"."
+                  type: string
+            username:
+              description: "Username is a name of the claim that should be used to construct usernames for the cluster identity. \n Default value: \"sub\""
+              type: object
+              required:
+                - claim
+              properties:
+                claim:
+                  description: Claim is a JWT token claim to be used in the mapping
+                  type: string
+                prefix:
+                  type: object
+                  required:
+                    - prefixString
+                  properties:
+                    prefixString:
+                      type: string
+                      minLength: 1
+                prefixPolicy:
+                  description: "PrefixPolicy specifies how a prefix should apply. \n By default, claims other than `email` will be prefixed with the issuer URL to prevent naming clashes with other plugins. \n Set to \"NoPrefix\" to disable prefixing. \n Example: (1) `prefix` is set to \"myoidc:\" and `claim` is set to \"username\". If the JWT claim `username` contains value `userA`, the resulting mapped value will be \"myoidc:userA\". (2) `prefix` is set to \"myoidc:\" and `claim` is set to \"email\". If the JWT `email` claim contains value \"userA@myoidc.tld\", the resulting mapped value will be \"myoidc:userA@myoidc.tld\". (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`, the JWT claims include \"username\":\"userA\" and \"email\":\"userA@myoidc.tld\", and `claim` is set to: (a) \"username\": the mapped value will be \"https://myoidc.tld#userA\" (b) \"email\": the mapped value will be \"userA@myoidc.tld\""
+                  type: string
+                  enum:
+                    - ""
+                    - NoPrefix
+                    - Prefix
+              x-kubernetes-validations:
+                - rule: 'has(self.prefixPolicy) && self.prefixPolicy == ''Prefix'' ? (has(self.prefix) && size(self.prefix.prefixString) > 0) : !has(self.prefix)'
+                  message: prefix must be set if prefixPolicy is 'Prefix', but must remain unset otherwise
+        claimValidationRules:
+          description: ClaimValidationRules are rules that are applied to validate token claims to authenticate users.
+          type: array
+          items:
+            type: object
+            properties:
+              requiredClaim:
+                description: RequiredClaim allows configuring a required claim name and its expected value
+                type: object
+                required:
+                  - claim
+                  - requiredValue
+                properties:
+                  claim:
+                    description: Claim is a name of a required claim. Only claims with string values are supported.
+                    type: string
+                    minLength: 1
+                  requiredValue:
+                    description: RequiredValue is the required value for the claim.
+                    type: string
+                    minLength: 1
+              type:
+                description: Type sets the type of the validation rule
+                type: string
+                default: RequiredClaim
+                enum:
+                  - RequiredClaim
+          x-kubernetes-list-type: atomic
+        issuer:
+          description: Issuer describes atributes of the OIDC token issuer
+          type: object
+          required:
+            - audiences
+            - issuerURL
+          properties:
+            audiences:
+              description: Audiences is an array of audiences that the token was issued for. Valid tokens must include at least one of these values in their "aud" claim. Must be set to exactly one value.
+              type: array
+              maxItems: 1
+              items:
+                type: string
+                minLength: 1
+              x-kubernetes-list-type: set
+            issuerCertificateAuthority:
+              description: CertificateAuthority is a reference to a config map in the configuration namespace. The .data of the configMap must contain the "ca-bundle.crt" key. If unset, system trust is used instead.
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  description: name is the metadata.name of the referenced config map
+                  type: string
+            issuerURL:
+              description: URL is the serving URL of the token issuer. Must use the https:// scheme.
+              type: string
+              pattern: ^https:\/\/[^\s]
+        name:
+          description: Name of the OIDC provider
+          type: string
+          minLength: 1
+        oidcClients:
+          description: OIDCClients contains configuration for the platform's clients that need to request tokens from the issuer
+          type: array
+          maxItems: 20
+          items:
+            type: object
+            required:
+              - clientID
+              - componentName
+              - componentNamespace
+            properties:
+              clientID:
+                description: ClientID is the identifier of the OIDC client from the OIDC provider
+                type: string
+                minLength: 1
+              clientSecret:
+                description: ClientSecret refers to a secret in the `openshift-config` namespace that contains the client secret in the `clientSecret` key of the `.data` field
+                type: object
+                required:
+                  - name
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced secret
+                    type: string
+              componentName:
+                description: ComponentName is the name of the component that is supposed to consume this client configuration
+                type: string
+                maxLength: 256
+                minLength: 1
+              componentNamespace:
+                description: ComponentNamespace is the namespace of the component that is supposed to consume this client configuration
+                type: string
+                maxLength: 63
+                minLength: 1
+              extraScopes:
+                description: ExtraScopes is an optional set of scopes to request tokens with.
+                type: array
+                items:
+                  type: string
+                x-kubernetes-list-type: set
+          x-kubernetes-list-map-keys:
+            - componentNamespace
+            - componentName
+          x-kubernetes-list-type: map
+    x-kubernetes-list-map-keys:
+      - name
+    x-kubernetes-list-type: map
+- op: add
+  path: /spec/versions/name=v1/schema/openAPIV3Schema/properties/status/properties/oidcClients
+  value:
+    description: OIDCClients is where participating operators place the current OIDC client status for OIDC clients that can be customized by the cluster-admin.
+    items:
+      properties:
+        componentName:
+          description: ComponentName is the name of the component that will consume a client configuration.
+          maxLength: 256
+          minLength: 1
+          type: string
+        componentNamespace:
+          description: ComponentNamespace is the namespace of the component that will consume a client configuration.
+          maxLength: 63
+          minLength: 1
+          type: string
+        conditions:
+          description: "Conditions are used to communicate the state of the `oidcClients` entry. \n Supported conditions include Available, Degraded and Progressing. \n If Available is true, the component is successfully using the configured client. If Degraded is true, that means something has gone wrong trying to handle the client configuration. If Progressing is true, that means the component is taking some action related to the `oidcClients` entry."
+          items:
+            description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+            properties:
+              lastTransitionTime:
+                description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                format: date-time
+                type: string
+              message:
+                description: message is a human readable message indicating details about the transition. This may be an empty string.
+                maxLength: 32768
+                type: string
+              observedGeneration:
+                description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                format: int64
+                minimum: 0
+                type: integer
+              reason:
+                description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                maxLength: 1024
+                minLength: 1
+                pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                type: string
+              status:
+                description: status of the condition, one of True, False, Unknown.
+                enum:
+                  - "True"
+                  - "False"
+                  - Unknown
+                type: string
+              type:
+                description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                maxLength: 316
+                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                type: string
+            required:
+              - lastTransitionTime
+              - message
+              - reason
+              - status
+              - type
+            type: object
+          type: array
+          x-kubernetes-list-map-keys:
+            - type
+          x-kubernetes-list-type: map
+        consumingUsers:
+          description: ConsumingUsers is a slice of ServiceAccounts that need to have read permission on the `clientSecret` secret.
+          items:
+            description: ConsumingUser is an alias for string which we add validation to. Currently only service accounts are supported.
+            maxLength: 512
+            minLength: 1
+            pattern: ^system:serviceaccount:[a-z0-9]([-a-z0-9]*[a-z0-9])?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+            type: string
+          maxItems: 5
+          type: array
+          x-kubernetes-list-type: set
+        currentOIDCClients:
+          description: CurrentOIDCClients is a list of clients that the component is currently using.
+          items:
+            properties:
+              clientID:
+                description: ClientID is the identifier of the OIDC client from the OIDC provider
+                minLength: 1
+                type: string
+              issuerURL:
+                description: URL is the serving URL of the token issuer. Must use the https:// scheme.
+                pattern: ^https:\/\/[^\s]
+                type: string
+              oidcProviderName:
+                description: OIDCName refers to the `name` of the provider from `oidcProviders`
+                minLength: 1
+                type: string
+            required:
+              - clientID
+              - issuerURL
+              - oidcProviderName
+            type: object
+          type: array
+          x-kubernetes-list-map-keys:
+            - issuerURL
+            - clientID
+          x-kubernetes-list-type: map
+      required:
+        - componentName
+        - componentNamespace
+      type: object
+    maxItems: 20
+    type: array
+    x-kubernetes-list-map-keys:
+      - componentNamespace
+      - componentName
+    x-kubernetes-list-type: map
+- op: add
+  path: /spec/versions/name=v1/schema/openAPIV3Schema/x-kubernetes-validations
+  value:
+    - message: all oidcClients in the oidcProviders must match their componentName and componentNamespace to either a previously configured oidcClient or they must exist in the status.oidcClients
+      rule: '!has(self.spec.oidcProviders) || self.spec.oidcProviders.all(p, !has(p.oidcClients) || p.oidcClients.all(specC, self.status.oidcClients.exists(statusC, statusC.componentNamespace == specC.componentNamespace && statusC.componentName == specC.componentName) || (has(oldSelf.spec.oidcProviders) && oldSelf.spec.oidcProviders.exists(oldP, oldP.name == p.name && has(oldP.oidcClients) && oldP.oidcClients.exists(oldC, oldC.componentNamespace == specC.componentNamespace && oldC.componentName == specC.componentName)))))'
+- op: add
+  path: /spec/versions/name=v1/schema/openAPIV3Schema/properties/spec/properties/type/enum
+  value:
+    - ""
+    - None
+    - IntegratedOAuth
+    - OIDC

--- a/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_authentication.crd-Default.yaml
+++ b/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_authentication.crd-Default.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/feature-set: Default
@@ -52,6 +51,10 @@ spec:
                 type:
                   description: type identifies the cluster managed, user facing authentication mode in use. Specifically, it manages the component that responds to login attempts. The default is IntegratedOAuth.
                   type: string
+                  enum:
+                    - ""
+                    - None
+                    - IntegratedOAuth
                 webhookTokenAuthenticator:
                   description: "webhookTokenAuthenticator configures a remote token reviewer. These remote authentication webhooks can be used to verify bearer tokens via the tokenreviews.authentication.k8s.io REST API. This is required to honor bearer tokens that are provisioned by an external authentication service. \n Can only be set if \"Type\" is set to \"None\"."
                   type: object

--- a/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_authentication.crd-TechPreviewNoUpgrade.yaml-patch
+++ b/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_authentication.crd-TechPreviewNoUpgrade.yaml-patch
@@ -1,0 +1,4 @@
+- op: add
+  path: /metadata/annotations/formatted
+  value:
+     "true"

--- a/vendor/github.com/openshift/api/config/v1/custom.authentication.testsuite.yaml
+++ b/vendor/github.com/openshift/api/config/v1/custom.authentication.testsuite.yaml
@@ -12,6 +12,17 @@ tests:
       apiVersion: config.openshift.io/v1
       kind: Authentication
       spec: {}
+  - name: Should be able to use the OIDC type
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: Authentication
+      spec:
+        type: OIDC
+    expected: |
+      apiVersion: config.openshift.io/v1
+      kind: Authentication
+      spec:
+        type: OIDC
   - name: Cannot set username claim prefix with policy NoPrefix
     initial: |
       apiVersion: config.openshift.io/v1

--- a/vendor/github.com/openshift/api/config/v1/stable.authentication.testsuite.yaml
+++ b/vendor/github.com/openshift/api/config/v1/stable.authentication.testsuite.yaml
@@ -1,6 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "[Stable] Authentication"
-crd: 0000_10_config-operator_01_authentication.crd.yaml
+crd: 0000_10_config-operator_01_authentication.crd-Default.yaml
 tests:
   onCreate:
   - name: Should be able to create a minimal Authentication
@@ -12,3 +12,10 @@ tests:
       apiVersion: config.openshift.io/v1
       kind: Authentication
       spec: {}
+  - name: Shouldn't be able to use the OIDC type in a stable version of the resource
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: Authentication
+      spec:
+        type: OIDC
+    expectedError: "spec.type: Unsupported value: \"OIDC\": supported values: \"\", \"None\", \"IntegratedOAuth\""

--- a/vendor/github.com/openshift/api/config/v1/stable.hypershift.authentication.testsuite.yaml
+++ b/vendor/github.com/openshift/api/config/v1/stable.hypershift.authentication.testsuite.yaml
@@ -1,0 +1,298 @@
+apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
+name: "[Stable][Hypershift] Authentication"
+crd: 0000_10_config-operator_01_authentication.crd-Default-Hypershift.yaml
+tests:
+  onCreate:
+    - name: Should be able to create a minimal Authentication
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Authentication
+        spec: {} # No spec is required for a Authentication
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Authentication
+        spec: {}
+    - name: Should be able to use the OIDC type
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Authentication
+        spec:
+          type: OIDC
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Authentication
+        spec:
+          type: OIDC
+    - name: Cannot set username claim prefix with policy NoPrefix
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Authentication
+        spec:
+          type: OIDC
+          oidcProviders:
+          - name: myoidc
+            issuer:
+              issuerURL: https://meh.tld
+              audiences: ['openshift-aud']
+            claimMappings:
+              username:
+                claim: "preferred_username"
+                prefixPolicy: NoPrefix
+                prefix:
+                  prefixString: "myoidc:"
+      expectedError: "prefix must be set if prefixPolicy is 'Prefix', but must remain unset otherwise"
+    - name: Can set username claim prefix with policy Prefix
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Authentication
+        spec:
+          type: OIDC
+          oidcProviders:
+          - name: myoidc
+            issuer:
+              issuerURL: https://meh.tld
+              audiences: ['openshift-aud']
+            claimMappings:
+              username:
+                claim: "preferred_username"
+                prefixPolicy: Prefix
+                prefix:
+                  prefixString: "myoidc:"
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Authentication
+        spec:
+          type: OIDC
+          oidcProviders:
+          - name: myoidc
+            issuer:
+              issuerURL: https://meh.tld
+              audiences: ['openshift-aud']
+            claimMappings:
+              username:
+                claim: "preferred_username"
+                prefixPolicy: Prefix
+                prefix:
+                  prefixString: "myoidc:"
+    - name: Cannot leave username claim prefix blank with policy Prefix
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Authentication
+        spec:
+          type: OIDC
+          oidcProviders:
+          - name: myoidc
+            issuer:
+              issuerURL: https://meh.tld
+              audiences: ['openshift-aud']
+            claimMappings:
+              username:
+                claim: "preferred_username"
+                prefixPolicy: Prefix
+      expectedError: "prefix must be set if prefixPolicy is 'Prefix', but must remain unset otherwise"
+    - name: Can set OIDC providers with no username prefixing
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Authentication
+        spec:
+          type: OIDC
+          oidcProviders:
+          - name: myoidc
+            issuer:
+              issuerURL: https://meh.tld
+              audiences: ['openshift-aud']
+            claimMappings:
+              username:
+                claim: "preferred_username"
+                prefixPolicy: NoPrefix
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Authentication
+        spec:
+          type: OIDC
+          oidcProviders:
+          - name: myoidc
+            issuer:
+              issuerURL: https://meh.tld
+              audiences: ['openshift-aud']
+            claimMappings:
+              username:
+                claim: "preferred_username"
+                prefixPolicy: NoPrefix
+  onUpdate:
+    - name: Updating OIDC provider with a client that's not in the status
+      initial: &initConfig |
+        apiVersion: config.openshift.io/v1
+        kind: Authentication
+        spec:
+          type: OIDC
+          oidcProviders:
+          - name: myoidc
+            issuer:
+              issuerURL: https://meh.tld
+              audiences: ['openshift-aud']
+            oidcClients:
+              - componentNamespace: namespace
+                componentName: preexisting
+                clientID: someclient
+              - componentNamespace: namespace
+                componentName: name
+                clientID: legitclient
+        status:
+          oidcClients:
+          - componentNamespace: namespace
+            componentName: name
+          - componentNamespace: namespace2
+            componentName: name2
+          - componentNamespace: namespace2
+            componentName: name3
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Authentication
+        spec:
+          type: OIDC
+          oidcProviders:
+          - name: myoidc
+            issuer:
+              issuerURL: https://meh.tld
+              audiences: ['openshift-aud']
+            oidcClients:
+            - componentNamespace: namespace
+              componentName: preexisting
+              clientID: someclient
+            - componentNamespace: namespace
+              componentName: name
+              clientID: legitclient
+            - componentNamespace: dif-namespace # new client here
+              componentName: tehName
+              clientID: cool-client
+        status:
+          oidcClients:
+          - componentNamespace: namespace
+            componentName: name
+          - componentNamespace: namespace2
+            componentName: name2
+          - componentNamespace: namespace2
+            componentName: name3
+      expectedError: "all oidcClients in the oidcProviders must match their componentName and componentNamespace to either a previously configured oidcClient or they must exist in the status.oidcClients"
+    - name: Updating OIDC provider with a client that's different from the previous one
+      initial: *initConfig
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Authentication
+        spec:
+          type: OIDC
+          oidcProviders:
+          - name: myoidc
+            issuer:
+              issuerURL: https://meh.tld
+              audiences: ['openshift-aud']
+            oidcClients:
+            - componentNamespace: dif-namespace
+              componentName: tehName
+              clientID: cool-client
+        status:
+          oidcClients:
+          - componentNamespace: namespace
+            componentName: name
+          - componentNamespace: namespace2
+            componentName: name2
+          - componentNamespace: namespace2
+            componentName: name3
+      expectedError: "all oidcClients in the oidcProviders must match their componentName and componentNamespace to either a previously configured oidcClient or they must exist in the status.oidcClients"
+    - name: Updating previously existing client
+      initial: *initConfig
+      updated: &prevExistingUpdated |
+        apiVersion: config.openshift.io/v1
+        kind: Authentication
+        spec:
+          type: OIDC
+          oidcProviders:
+          - name: myoidc
+            issuer:
+              issuerURL: https://meh.tld
+              audiences: ['openshift-aud']
+            oidcClients:
+              - componentNamespace: namespace
+                componentName: preexisting
+                clientID: different-client
+        status:
+          oidcClients:
+          - componentNamespace: namespace
+            componentName: name
+          - componentNamespace: namespace2
+            componentName: name2
+          - componentNamespace: namespace2
+            componentName: name3
+      expected: *prevExistingUpdated
+    - name: Removing a configured client from the status (== component unregister)
+      initial: *initConfig
+      updated: &removeFromStatus |
+        apiVersion: config.openshift.io/v1
+        kind: Authentication
+        spec:
+          type: OIDC
+          oidcProviders:
+          - name: myoidc
+            issuer:
+              issuerURL: https://meh.tld
+              audiences: ['openshift-aud']
+            oidcClients:
+              - componentNamespace: namespace
+                componentName: preexisting
+                clientID: different-client
+              - componentNamespace: namespace
+                componentName: name
+                clientID: legitclient
+        status:
+          oidcClients:
+          - componentNamespace: namespace2
+            componentName: name2
+          - componentNamespace: namespace2
+            componentName: name3
+      expected: *removeFromStatus
+    - name: Simply add a valid client
+      initial: *initConfig
+      updated: &addClient |
+        apiVersion: config.openshift.io/v1
+        kind: Authentication
+        spec:
+          type: OIDC
+          oidcProviders:
+          - name: myoidc
+            issuer:
+              issuerURL: https://meh.tld
+              audiences: ['openshift-aud']
+            oidcClients:
+              - componentNamespace: namespace
+                componentName: preexisting
+                clientID: different-client
+              - componentNamespace: namespace
+                componentName: name
+                clientID: legitclient
+              - componentNamespace: namespace2
+                componentName: name3
+                clientID: justavalidclient
+        status:
+          oidcClients:
+          - componentNamespace: namespace
+            componentName: name
+          - componentNamespace: namespace2
+            componentName: name2
+          - componentNamespace: namespace2
+            componentName: name3
+      expected: *addClient
+    - name: Remove all oidcProviders
+      initial: *initConfig
+      updated: &removeFromStatus |
+        apiVersion: config.openshift.io/v1
+        kind: Authentication
+        spec:
+          type: OIDC
+        status:
+          oidcClients:
+          - componentNamespace: namespace2
+            componentName: name2
+          - componentNamespace: namespace2
+            componentName: name3
+      expected: *removeFromStatus

--- a/vendor/github.com/openshift/api/config/v1/techpreview.authentication.testsuite.yaml
+++ b/vendor/github.com/openshift/api/config/v1/techpreview.authentication.testsuite.yaml
@@ -12,6 +12,17 @@ tests:
       apiVersion: config.openshift.io/v1
       kind: Authentication
       spec: {}
+  - name: Should be able to use the OIDC type
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: Authentication
+      spec:
+        type: OIDC
+    expected: |
+      apiVersion: config.openshift.io/v1
+      kind: Authentication
+      spec:
+        type: OIDC
   - name: Cannot set username claim prefix with policy NoPrefix
     initial: |
       apiVersion: config.openshift.io/v1

--- a/vendor/github.com/openshift/api/config/v1/types_authentication.go
+++ b/vendor/github.com/openshift/api/config/v1/types_authentication.go
@@ -130,6 +130,8 @@ type AuthenticationList struct {
 	Items []Authentication `json:"items"`
 }
 
+// +openshift:validation:FeatureSetAwareEnum:featureSet=Default,enum="";None;IntegratedOAuth
+// +openshift:validation:FeatureSetAwareEnum:featureSet=CustomNoUpgrade;TechPreviewNoUpgrade,enum="";None;IntegratedOAuth;OIDC
 type AuthenticationType string
 
 const (

--- a/vendor/github.com/openshift/api/config/v1/types_feature.go
+++ b/vendor/github.com/openshift/api/config/v1/types_feature.go
@@ -188,7 +188,6 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with(metricsServer).
 		with(installAlternateInfrastructureAWS).
 		without(clusterAPIInstall).
-		with(sdnLiveMigration).
 		with(mixedCPUsAllocation).
 		with(managedBootImages).
 		without(disableKubeletCloudCredentialProviders).
@@ -211,6 +210,7 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 		externalCloudProviderExternal,
 		privateHostedZoneAWS,
 		buildCSIVolumes,
+		sdnLiveMigration,
 	},
 	Disabled: []FeatureGateDescription{
 		disableKubeletCloudCredentialProviders, // We do not currently ship the correct config to use the external credentials provider.

--- a/vendor/github.com/openshift/api/operator/v1/0000_70_cluster-network-operator_01-Default.crd.yaml
+++ b/vendor/github.com/openshift/api/operator/v1/0000_70_cluster-network-operator_01-Default.crd.yaml
@@ -428,6 +428,13 @@ spec:
                           description: multicast specifies whether or not the multicast configuration is migrated automatically when changing the cluster default network provider. If unset, this property defaults to 'true' and multicast configure is migrated.
                           type: boolean
                           default: true
+                    mode:
+                      description: mode indicates the mode of network migration. The supported values are "Live", "Offline" and omitted. A "Live" migration operation will not cause service interruption by migrating the CNI of each node one by one. The cluster network will work as normal during the network migration. An "Offline" migration operation will cause service interruption. During an "Offline" migration, two rounds of node reboots are required. The cluster network will be malfunctioning during the network migration. When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time. The current default value is "Offline".
+                      type: string
+                      enum:
+                        - Live
+                        - Offline
+                        - ""
                     mtu:
                       description: mtu contains the MTU migration configuration. Set this to allow changing the MTU values for the default network. If unset, the operation of changing the MTU for the default network will be rejected.
                       type: object

--- a/vendor/github.com/openshift/api/operator/v1/stable.network.testsuite.yaml
+++ b/vendor/github.com/openshift/api/operator/v1/stable.network.testsuite.yaml
@@ -255,11 +255,11 @@ tests:
               ipv6:
                 internalMasqueradeSubnet: "abcd:eff01:2345:6789::2345:6789/20"
     expectedError: "Invalid value: \"string\": each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 2"
-  - name: Should not be able to create migration mode
+  - name: Should be able to create migration mode
     initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
-      spec: 
+      spec:
         migration:
           mode: Live
     expected: |
@@ -269,7 +269,8 @@ tests:
         disableNetworkDiagnostics: false
         logLevel: Normal
         operatorLogLevel: Normal
-        migration: {}
+        migration:
+          mode: Live
   - name: "IPsec - Empty ipsecConfig is allowed in initial state"
     initial: |
       apiVersion: operator.openshift.io/v1

--- a/vendor/github.com/openshift/api/operator/v1/types_network.go
+++ b/vendor/github.com/openshift/api/operator/v1/types_network.go
@@ -157,7 +157,6 @@ type NetworkMigration struct {
 	// An "Offline" migration operation will cause service interruption. During an "Offline" migration, two rounds of node reboots are required. The cluster network will be malfunctioning during the network migration.
 	// When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time.
 	// The current default value is "Offline".
-	// +openshift:enable:FeatureSets=CustomNoUpgrade;TechPreviewNoUpgrade
 	// +optional
 	Mode NetworkMigrationMode `json:"mode"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -282,7 +282,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/openshift/api v0.0.0-20240116035456-11ed2fbcb805
+# github.com/openshift/api v0.0.0-20240203160143-dd853650077f
 ## explicit; go 1.20
 github.com/openshift/api
 github.com/openshift/api/apiserver


### PR DESCRIPTION
Includes moving the live migration to default.
Additionally it pulls the CNCC change, cc: @dulek, @martinkennelly 

Commands ran:
```
go get github.com/openshift/api@release-4.15
go mod tidy && go mod vendor
./hack/update-codegen.sh
```