### PR TITLE
OCPBUGS-28676: Precreate ipsec nss db directory

### DIFF
--- a/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
@@ -240,6 +240,9 @@ spec:
           # Workaround for https://github.com/libreswan/libreswan/issues/373
           ulimit -n 1024
 
+          # Create nss db directory which gets used by ipsec script.
+          mkdir -p /var/lib/ipsec/nss
+
           /usr/libexec/ipsec/addconn --config /etc/ipsec.conf --checkconfig
           # Check kernel modules
           /usr/libexec/ipsec/_stackmanager start


### PR DESCRIPTION
This commit precreates ipsec nss db directory for ipsec script, otherwise it throws up the following error in rhel node.

`ERROR: destination directory "/var/lib/ipsec/nss" is missing or permission denied`