### PR TITLE
OCPBUGS-28920: Update ingressconfig_controller to use field Manager

### DIFF
--- a/pkg/controller/ingressconfig/ingressconfig_controller.go
+++ b/pkg/controller/ingressconfig/ingressconfig_controller.go
@@ -142,5 +142,7 @@ func (r *ReconcileIngressConfigs) updatePolicyGroupLabelOnNamespace(ctx context.
 
 	newNamespace.SetLabels(existingLabels)
 
-	return r.client.Patch(context.TODO(), newNamespace, crclient.MergeFrom(namespace))
+	return r.client.Patch(context.TODO(), newNamespace, crclient.MergeFrom(namespace), &crclient.PatchOptions{
+		FieldManager: "cluster-network-operator/ingress_controller",
+	})
 }


### PR DESCRIPTION
Update ingressconfig_controller to use subcontroller "ingress_controller"
for field management on Patch calls. It used to apply changes with
deprecated cluster-network-operator field manager, that was overridden
and removed by ApplyObject. Thus, labels applied to
openshift-host-network namespace were periodically removed.


On upgrade, ingress-owned labels will be merged with "cluster-network-operator/operconfig" Apply call here https://github.com/openshift/cluster-network-operator/blob/master/pkg/apply/apply.go#L139-L150 and removed as the new owner didn't specify them. On the next reconcile loop, ingress controller will re-apply the labels with the new fieldManager and everything should work fine ever after.

For some reason, ingress controller was last this that doesn't use apply logic, but Patches instead.

Should end up with something like this
```
  managedFields:
  - apiVersion: v1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          f:openshift.io/description: {}
          f:workload.openshift.io/allowed: {}
        f:labels:
          f:policy-group.network.openshift.io/host-network: {}
        f:ownerReferences:
          k:{"uid":"eae5d3b2-cf31-4bfa-940a-fa631adce87d"}: {}
    manager: cluster-network-operator/operconfig
    operation: Apply
    time: "2024-02-07T11:38:45Z"
  - apiVersion: v1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:labels:
          f:network.openshift.io/policy-group: {}
          f:policy-group.network.openshift.io/ingress: {}
      f:spec: {}
    manager: cluster-network-operator/ingress_controller
    operation: Apply
    time: "2024-02-07T11:41:11Z"
  - apiVersion: v1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          f:openshift.io/sa.scc.mcs: {}
          f:openshift.io/sa.scc.supplemental-groups: {}
          f:openshift.io/sa.scc.uid-range: {}
    manager: cluster-policy-controller
    operation: Update
    time: "2024-02-07T08:49:53Z"

```