### PR TITLE
OCPBUGS-24380,OCPBUGS-24381,OCPBUGS-24382: Update APBExternalRoute, EgressFirewall, EgressQoS permissions for ovnkube pods

### DIFF
--- a/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
+++ b/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
@@ -136,8 +136,6 @@ rules:
   - privileged
 - apiGroups: ["k8s.ovn.org"]
   resources:
-  - egressfirewalls
-  - egressfirewalls/status
   - egressqoses
   verbs:
   - get
@@ -148,6 +146,7 @@ rules:
 - apiGroups: ["k8s.ovn.org"]
   resources:
     - adminpolicybasedexternalroutes
+    - egressfirewalls
     - egressips
     - egressservices
   verbs:
@@ -157,6 +156,7 @@ rules:
 - apiGroups: ["k8s.ovn.org"]
   resources:
   - adminpolicybasedexternalroutes/status
+  - egressfirewalls/status
   verbs:
   - patch
 {{- if .OVN_ADMIN_NETWORK_POLICY_ENABLE }}

--- a/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
+++ b/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
@@ -136,8 +136,6 @@ rules:
   - privileged
 - apiGroups: ["k8s.ovn.org"]
   resources:
-  - adminpolicybasedexternalroutes
-  - adminpolicybasedexternalroutes/status
   - egressfirewalls
   - egressfirewalls/status
   - egressqoses
@@ -149,12 +147,18 @@ rules:
   - watch
 - apiGroups: ["k8s.ovn.org"]
   resources:
+    - adminpolicybasedexternalroutes
     - egressips
     - egressservices
   verbs:
     - get
     - list
     - watch
+- apiGroups: ["k8s.ovn.org"]
+  resources:
+  - adminpolicybasedexternalroutes/status
+  verbs:
+  - patch
 {{- if .OVN_ADMIN_NETWORK_POLICY_ENABLE }}
 - apiGroups: ["policy.networking.k8s.io"]
   resources:

--- a/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
+++ b/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
@@ -136,18 +136,10 @@ rules:
   - privileged
 - apiGroups: ["k8s.ovn.org"]
   resources:
-  - egressqoses
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups: ["k8s.ovn.org"]
-  resources:
     - adminpolicybasedexternalroutes
     - egressfirewalls
     - egressips
+    - egressqoses
     - egressservices
   verbs:
     - get

--- a/bindata/network/ovn-kubernetes/common/004-rbac-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/common/004-rbac-control-plane.yaml
@@ -59,8 +59,6 @@ rules:
 - apiGroups: ["k8s.ovn.org"]
   resources:
   - egressips
-  - egressfirewalls
-  - egressfirewalls/status
   verbs:
   - get
   - list
@@ -70,6 +68,7 @@ rules:
 - apiGroups: ["k8s.ovn.org"]
   resources:
     - adminpolicybasedexternalroutes
+    - egressfirewalls
     - egressservices
   verbs:
     - get
@@ -78,6 +77,7 @@ rules:
 - apiGroups: ["k8s.ovn.org"]
   resources:
   - adminpolicybasedexternalroutes/status
+  - egressfirewalls/status
   verbs:
   - patch
 - apiGroups: ["k8s.ovn.org"]

--- a/bindata/network/ovn-kubernetes/common/004-rbac-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/common/004-rbac-control-plane.yaml
@@ -59,8 +59,6 @@ rules:
 - apiGroups: ["k8s.ovn.org"]
   resources:
   - egressips
-  - adminpolicybasedexternalroutes
-  - adminpolicybasedexternalroutes/status
   - egressfirewalls
   - egressfirewalls/status
   verbs:
@@ -71,11 +69,17 @@ rules:
   - watch
 - apiGroups: ["k8s.ovn.org"]
   resources:
+    - adminpolicybasedexternalroutes
     - egressservices
   verbs:
     - get
     - list
     - watch
+- apiGroups: ["k8s.ovn.org"]
+  resources:
+  - adminpolicybasedexternalroutes/status
+  verbs:
+  - patch
 - apiGroups: ["k8s.ovn.org"]
   resources:
     - egressservices/status


### PR DESCRIPTION
The ovnkube-node pod only listens to CRUD events of APBExternalRoutes and updates its status, So this PR adjusts its cluster role accordingly.