### PR TITLE
[release-4.15] OCPBUGS-29299: Update ingressconfig_controller to use field Manager

### DIFF
--- a/pkg/controller/ingressconfig/ingressconfig_controller.go
+++ b/pkg/controller/ingressconfig/ingressconfig_controller.go
@@ -142,5 +142,7 @@ func (r *ReconcileIngressConfigs) updatePolicyGroupLabelOnNamespace(ctx context.
 
 	newNamespace.SetLabels(existingLabels)
 
-	return r.client.Patch(context.TODO(), newNamespace, crclient.MergeFrom(namespace))
+	return r.client.Patch(context.TODO(), newNamespace, crclient.MergeFrom(namespace), &crclient.PatchOptions{
+		FieldManager: "cluster-network-operator/ingress_controller",
+	})
 }


### PR DESCRIPTION
clean backport of https://github.com/openshift/cluster-network-operator/pull/2259