### PR TITLE
[release-4.14] OCPBUGS-29300: Update ingressconfig_controller to use field Manager

### DIFF
--- a/pkg/controller/ingressconfig/ingressconfig_controller.go
+++ b/pkg/controller/ingressconfig/ingressconfig_controller.go
@@ -142,5 +142,7 @@ func (r *ReconcileIngressConfigs) updatePolicyGroupLabelOnNamespace(ctx context.
 
 	newNamespace.SetLabels(existingLabels)
 
-	return r.client.Patch(context.TODO(), newNamespace, crclient.MergeFrom(namespace))
+	return r.client.Patch(context.TODO(), newNamespace, crclient.MergeFrom(namespace), &crclient.PatchOptions{
+		FieldManager: "cluster-network-operator/ingress_controller",
+	})
 }


### PR DESCRIPTION
cherry-pick of https://github.com/openshift/cluster-network-operator/pull/2265