### PR TITLE
[release-4.12] OCPBUGS-29302: Update ingressconfig_controller to use field Manager

### DIFF
--- a/pkg/controller/ingressconfig/ingressconfig_controller.go
+++ b/pkg/controller/ingressconfig/ingressconfig_controller.go
@@ -139,5 +139,7 @@ func (r *ReconcileIngressConfigs) updatePolicyGroupLabelOnNamespace(ctx context.
 
 	newNamespace.SetLabels(existingLabels)
 
-	return r.client.Patch(context.TODO(), newNamespace, crclient.MergeFrom(namespace))
+	return r.client.Patch(context.TODO(), newNamespace, crclient.MergeFrom(namespace), &crclient.PatchOptions{
+		FieldManager: "cluster-network-operator/ingress_controller",
+	})
 }


### PR DESCRIPTION
cherry-pick of https://github.com/openshift/cluster-network-operator/pull/2267