### PR TITLE
SDN-4163: Add ipsec state to telemetry

### DIFF
--- a/bindata/cluster-network-operator/prometheus.yaml
+++ b/bindata/cluster-network-operator/prometheus.yaml
@@ -1,0 +1,18 @@
+##
+# This file is not applied correctly during cluster installation when located in
+# the manifests directory, this is the reason why it is located in the bindata directory.
+##
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+    name: openshift-network-operator-ipsec-rules
+    namespace: openshift-network-operator
+spec:
+    groups:
+    - name: openshift-network.rules
+      rules:
+      - expr: |-
+          sum by (mode,is_legacy_api) (
+            openshift_network_operator_ipsec_state{namespace=~"openshift-network-operator"}
+          )
+        record: openshift:openshift_network_operator_ipsec_state:sum

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -124,6 +124,12 @@ func Render(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapResult
 	}
 	objs = append(objs, o...)
 
+	o, err = renderCNO(manifestDir)
+	if err != nil {
+		return nil, progressing, err
+	}
+	objs = append(objs, o...)
+
 	log.Printf("Render phase done, rendered %d objects", len(objs))
 	return objs, progressing, nil
 }
@@ -822,6 +828,17 @@ func renderNetworkPublic(manifestDir string) ([]*uns.Unstructured, error) {
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network", "public"), &data)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to render network/public manifests")
+	}
+	return manifests, nil
+}
+
+// renderCNO renders the common objects in the cluster-network-operator directory
+func renderCNO(manifestDir string) ([]*uns.Unstructured, error) {
+	data := render.MakeRenderData()
+
+	manifests, err := render.RenderDir(filepath.Join(manifestDir, "cluster-network-operator"), &data)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to render cluster-network-operator manifests")
 	}
 	return manifests, nil
 }

--- a/pkg/util/ipsec/metrics.go
+++ b/pkg/util/ipsec/metrics.go
@@ -1,0 +1,44 @@
+package ipsec
+
+import (
+	"strconv"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/klog/v2"
+)
+
+const (
+	cnoNamespace  = "openshift_network_operator"
+	ipsecStateNA  = "N/A - ipsec not supported (non-OVN network)"
+	ipsecDisabled = "Disabled"
+)
+
+var (
+	ipsecStateGauge *metrics.GaugeVec
+)
+
+func init() {
+	ipsecStateGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
+		Namespace: cnoNamespace,
+		Name:      "ipsec_state",
+		Help: "A metric with a constant '1' value labeled by the latest ipsecMode of the cluster, " +
+			"and the API that invoked it, legacy (pre OCP 4.14) or new. " +
+			"In case the network doesn't support ipsec (non-OVN network), " +
+			"the 'is_legacy_api' value is set to '" + ipsecStateNA + "'.",
+	}, []string{"mode", "is_legacy_api"})
+	legacyregistry.MustRegister(ipsecStateGauge)
+}
+
+func UpdateIPsecMetric(state string, isLegacyAPI bool) {
+	klog.V(5).Infof("IPsec mode: %s, isLegacyAPI: %v",
+		state, isLegacyAPI)
+	ipsecStateGauge.Reset()
+	ipsecStateGauge.WithLabelValues(state, strconv.FormatBool(isLegacyAPI)).Set(1)
+}
+
+func UpdateIPsecMetricNA() {
+	klog.V(5).Infof("IPsec is not supported by non-OVN network (disabled)")
+	ipsecStateGauge.Reset()
+	ipsecStateGauge.WithLabelValues(ipsecDisabled, ipsecStateNA).Set(1)
+}


### PR DESCRIPTION
This PR adds a metric for the ipsec mode. The metric created is a Gauge named `cluster_network_ipsec_state` with a constant value of 1 and 2 labels:
1. "mode" which lists the ipsec mode, one of `Disabled` `External` or `Full`
2. "is_legacy_api" which states the flavor of the API used - either `true`
   for legacy API (up to OCP V4.14) or `false` for the new API (OCP 4.15+)
    -- If the cluster uses non ovn-k network (a network that does not
        support ipsec) the value of this label is "N/A - ipsec not supported (non-OVN network)"

Then a Prometheus rule  is created to remove other labels and this rule `openshift:cluster_network_ipsec_state:sum` will be collected in the telemetry

Jira ticket https://issues.redhat.com/browse/MON-3707