### PR TITLE
Remove extra env section in whereabouts-reconciler daemonset [ocp 4.12]

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -557,11 +557,6 @@ spec:
           - >
             /usr/src/whereabouts/bin/ip-control-loop -log-level debug
         image: {{.WhereaboutsImage}}
-        env:
-        - name: WHEREABOUTS_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         resources:
           requests:
             cpu: "50m"
@@ -580,6 +575,10 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
+        - name: WHEREABOUTS_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: KUBERNETES_SERVICE_PORT
           value: "{{.KUBERNETES_SERVICE_PORT}}"
         - name: KUBERNETES_SERVICE_HOST


### PR DESCRIPTION
WHEREABOUTS_NAMESPACE env var was mistakenly added in a separate env section which doesn't take effect.

WHEREABOUTS_NAMESPACE env var is used by whereabouts-reconciler to garbage collect the Pod IPs. When unset, it defaults to kube-system namespace, while ippool.whereabouts.cni.cncf.io custom resource only exist in openshift-multus namespace on openshift.