### PR TITLE
OCPBUGS-29341: Run dhcp-daemon pods as system-node-critical priority

### DIFF
--- a/bindata/network/multus/003-dhcp-daemon.yaml
+++ b/bindata/network/multus/003-dhcp-daemon.yaml
@@ -31,6 +31,7 @@ spec:
         kubernetes.io/os: linux
       tolerations:
       - operator: Exists
+      priorityClassName: "system-node-critical"
       initContainers:
       - name: dhcp-daemon-initialization
         image: {{.CNIPluginsImage}}


### PR DESCRIPTION
With system-node-critical priority, dhcp-daemon pods will not get evicted before workloads.