### PR TITLE
OCPBUGS-30021:  [release-4.14] Disable network-node-identity on ROKS

### DIFF
--- a/pkg/network/multus_admission_controller.go
+++ b/pkg/network/multus_admission_controller.go
@@ -50,7 +50,8 @@ func renderMultusAdmissonControllerConfig(manifestDir string, externalControlPla
 	objs := []*uns.Unstructured{}
 	var err error
 
-	replicas := getMultusAdmissionControllerReplicas(bootstrapResult)
+	hsc := platform.NewHyperShiftConfig()
+	replicas := getMultusAdmissionControllerReplicas(bootstrapResult, hsc.Enabled)
 	if ignoredNamespaces == "" {
 		ignoredNamespaces, err = getOpenshiftNamespaces(client)
 		if err != nil {
@@ -68,7 +69,6 @@ func renderMultusAdmissonControllerConfig(manifestDir string, externalControlPla
 	data.Data["ExternalControlPlane"] = externalControlPlane
 	data.Data["Replicas"] = replicas
 	// Hypershift
-	hsc := platform.NewHyperShiftConfig()
 	data.Data["HyperShiftEnabled"] = hsc.Enabled
 	data.Data["ManagementClusterName"] = names.ManagementClusterName
 	data.Data["AdmissionControllerNamespace"] = "openshift-multus"

--- a/pkg/network/node_identity.go
+++ b/pkg/network/node_identity.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	configv1 "github.com/openshift/api/config/v1"
 	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
@@ -52,6 +53,15 @@ func isBootstrapComplete(cli cnoclient.Client) (bool, error) {
 func renderNetworkNodeIdentity(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapResult, manifestDir string, client cnoclient.Client) ([]*uns.Unstructured, error) {
 	if !bootstrapResult.Infra.NetworkNodeIdentityEnabled {
 		klog.Infof("Network node identity is disabled")
+		return nil, nil
+	}
+	if bootstrapResult.Infra.ControlPlaneTopology == configv1.ExternalTopologyMode &&
+		bootstrapResult.Infra.PlatformType == configv1.IBMCloudPlatformType {
+		// In environments with external control plane topology, the API server is deployed out of cluster.
+		// This means that CNO cannot easily predict how to deploy and enforce the node identity webhook.
+		// IBMCloud uses an external control plane topology with Calico as the CNI for both HyperShift based ROKS
+		// deployments and IBM ROKS Toolkit based ROKS deployments.
+		klog.Infof("Network node identity is disabled on %s platorm", configv1.IBMCloudPlatformType)
 		return nil, nil
 	}
 	data := render.MakeRenderData()


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/cluster-network-operator/pull/2278.
There were conflicts in the second commit.