### PR TITLE
DNM/TEST: Remove OVN interconnect upgrade logic

### DIFF
--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -62,7 +62,6 @@ type OVNUpdateStatus struct {
 	IPFamilyMode         string
 	ClusterNetworkCIDRs  string
 	Progressing          bool
-	InterConnectEnabled  bool   // true if this ovnk component is running with --enable-interconnect
 	InterConnectZoneMode string // zone mode (singlezone, multizone) for this ovnk component
 }
 


### PR DESCRIPTION
Remove interconnect upgrade logic, since it is not necessary for 4.14->4.15 upgrades. Keep the possibility to switch to single zone (one global zone for all nodes) in 4.15 through a configmap. It will be removed in a following commit.