### PR TITLE
OCPBUGS-30299: Fix managed cluster detection on ARO

### DIFF
--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -134,7 +134,7 @@ func InfraStatus(client cnoclient.Client) (*bootstrap.InfraStatus, error) {
 	res.NetworkNodeIdentityEnabled = netIDEnabled
 
 	// standalone managed clusters is a set managed clusters (excl HyperShift clusters).
-	isStandaloneManagedCluster, err := util.IsStandaloneManagedCluster(context.TODO(), client)
+	isStandaloneManagedCluster, err := util.IsStandaloneManagedCluster(context.TODO(), client, res.PlatformType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to detect if standalone managed cluster: %v", err)
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
+	v1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,7 +25,8 @@ const SDN_NAMESPACE = "openshift-sdn"
 const MTU_CM_NAMESPACE = "openshift-network-operator"
 const MTU_CM_NAME = "mtu"
 const OVN_NBDB = "nbdb"
-const STANDALONE_MANAGED_CLUSTER_NAMESPACE = "dedicated-admin" // namespace required for standalone managed clusters (excluding hypershift)
+const STANDALONE_MANAGED_CLUSTER_NAMESPACE = "dedicated-admin"      // namespace required for standalone managed clusters (excluding hypershift and ARO)
+const STANDALONE_ARO_CLUSTER_NAMESPACE = "openshift-azure-operator" // namespace required for standalone ARO clusters
 
 func GetInterConnectConfigMap(kubeClient kubernetes.Interface) (*corev1.ConfigMap, error) {
 	return kubeClient.CoreV1().ConfigMaps(OVN_NAMESPACE).Get(context.TODO(), OVN_INTERCONNECT_CONFIGMAP_NAME, metav1.GetOptions{})
@@ -47,11 +49,15 @@ func ReadMTUConfigMap(ctx context.Context, client cnoclient.Client) (int, error)
 }
 
 // IsStandaloneManagedCluster returns true if the operator is running in a managed cluster that isn't managed by HyperShift.
-// It checks for the existence of the dedicated-admin namespace.
-func IsStandaloneManagedCluster(ctx context.Context, client cnoclient.Client) (bool, error) {
+// It checks for the existence of the openshift-azure-operator namespace on azure and dedicated-admin namespace otherwise.
+func IsStandaloneManagedCluster(ctx context.Context, client cnoclient.Client, platform v1.PlatformType) (bool, error) {
 	// TODO(martinkennelly): replace detection of a standalone managed cluster with a metric instead of a namespace when that metric
 	// becomes available.
-	err := client.Default().CRClient().Get(ctx, types.NamespacedName{Name: STANDALONE_MANAGED_CLUSTER_NAMESPACE}, &corev1.Namespace{})
+	namespace := STANDALONE_MANAGED_CLUSTER_NAMESPACE
+	if platform == v1.AzurePlatformType {
+		namespace = STANDALONE_ARO_CLUSTER_NAMESPACE
+	}
+	err := client.Default().CRClient().Get(ctx, types.NamespacedName{Name: namespace}, &corev1.Namespace{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return false, nil


### PR DESCRIPTION
In ARO the dedicated-admin namespace does not exit. Detect `openshift-azure-operator` instead.
/cc @martinkennelly @pliurh 