### PR TITLE
OCPBUGS-26408: automountServiceAccountToken:false hosted CP pods

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
@@ -96,6 +96,7 @@ spec:
             This allows for pod-pod connectivity in postStart hooks the first time they run.
             EOF
         image: "{{.OvnControlPlaneImage}}"
+      automountServiceAccountToken: false
       containers:
       # token-minter creates a token with the default service account path
       # The token is read by ovn-k containers to authenticate against the hosted cluster api server


### PR DESCRIPTION
without this, configuring 'automountServiceAccountToken: false' cause ovnkube-control-plane pods to CrashLoop with:

"unable to create kubernetes rest config, err: TLS-secured apiservers require token/cert and CA certificate."