### PR TITLE
SDN-4607: Allow HyperShift ability to set ConfigMap through env var

### DIFF
--- a/bindata/network/multus-admission-controller/001-service.yaml
+++ b/bindata/network/multus-admission-controller/001-service.yaml
@@ -13,7 +13,10 @@ metadata:
 {{- if .HyperShiftEnabled}}
     network.operator.openshift.io/cluster-name: {{.ManagementClusterName}}
 {{- end }}
+# Any new HCP deployment will automatically reconcile this secret in the HCP without the service-ca operator
+{{- if or (not .HyperShiftEnabled) (eq .CAConfigMap "openshift-service-ca.crt")}}
     service.alpha.openshift.io/serving-cert-secret-name: multus-admission-controller-secret
+{{- end }}
 spec:
   ports:
   - name: webhook

--- a/bindata/network/multus-admission-controller/monitor.yaml
+++ b/bindata/network/multus-admission-controller/monitor.yaml
@@ -26,8 +26,8 @@ spec:
     tlsConfig:
       ca:
         configMap:
-          key: service-ca.crt
-          name: openshift-service-ca.crt
+          key: {{.CAConfigMapKey}}
+          name: {{.CAConfigMap}}
       cert:
         secret:
           key: tls.crt

--- a/bindata/network/node-identity/managed/node-identity-service.yaml
+++ b/bindata/network/node-identity/managed/node-identity-service.yaml
@@ -8,7 +8,11 @@ metadata:
     hypershift.openshift.io/allow-guest-webhooks: "true"
   annotations:
     network.operator.openshift.io/cluster-name: {{.ManagementClusterName}}
-    service.alpha.openshift.io/serving-cert-secret-name: network-node-identity-secret
+# If the default CAConfigMap 'openshift-service-ca.crt' was used then the HostedCluster isn't reconciling the secret, so
+# we need to add the annotation so service-ca creates the secret
+{{- if eq .CAConfigMap "openshift-service-ca.crt"}}
+    service.beta.openshift.io/serving-cert-secret-name: network-node-identity-secret
+{{- end}}
 spec:
   ports:
     - name: webhook

--- a/bindata/network/ovn-kubernetes/managed/monitor-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/monitor-control-plane.yaml
@@ -56,7 +56,11 @@ metadata:
   namespace: {{.HostedClusterNamespace}}
   annotations:
     network.operator.openshift.io/cluster-name:  {{.ManagementClusterName}}
+# If the default CAConfigMap 'openshift-service-ca.crt' was used then the HostedCluster isn't reconciling the secret, so
+# we need to add the annotation so service-ca creates the secret
+{{- if eq .CAConfigMap "openshift-service-ca.crt"}}
     service.beta.openshift.io/serving-cert-secret-name: ovn-control-plane-metrics-cert
+{{- end}}
   labels:
     app: ovnkube-control-plane
 spec:

--- a/bindata/network/ovn-kubernetes/managed/monitor-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/monitor-control-plane.yaml
@@ -23,8 +23,8 @@ spec:
     tlsConfig:
       ca:
         configMap:
-          key: service-ca.crt
-          name: openshift-service-ca.crt
+          key: {{.CAConfigMapKey}}
+          name: {{.CAConfigMap}}
       cert:
         secret:
           key: tls.crt

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -14,6 +14,8 @@ type OVNHyperShiftBootstrapResult struct {
 	ControlPlaneReplicas int
 	ReleaseImage         string
 	ControlPlaneImage    string
+	CAConfigMap          string
+	CAConfigMapKey       string
 }
 
 type OVNConfigBoostrapResult struct {

--- a/pkg/hypershift/hypershift.go
+++ b/pkg/hypershift/hypershift.go
@@ -29,6 +29,8 @@ var (
 	runAsUser         = os.Getenv("RUN_AS_USER")
 	releaseImage      = os.Getenv("OPENSHIFT_RELEASE_IMAGE")
 	controlPlaneImage = os.Getenv("OVN_CONTROL_PLANE_IMAGE")
+	caConfigMap       = os.Getenv("CA_CONFIG_MAP")
+	caConfigMapKey    = os.Getenv("CA_CONFIG_MAP_KEY")
 )
 
 const (
@@ -92,9 +94,19 @@ type HyperShiftConfig struct {
 	RelatedObjects    []RelatedObject
 	ReleaseImage      string
 	ControlPlaneImage string
+	CAConfigMap       string
+	CAConfigMapKey    string
 }
 
 func NewHyperShiftConfig() *HyperShiftConfig {
+	if caConfigMap == "" {
+		caConfigMap = "openshift-service-ca.crt"
+	}
+
+	if caConfigMapKey == "" {
+		caConfigMapKey = "service-ca.crt"
+	}
+
 	return &HyperShiftConfig{
 		Enabled:           hyperShiftEnabled(),
 		Name:              name,
@@ -102,6 +114,8 @@ func NewHyperShiftConfig() *HyperShiftConfig {
 		RunAsUser:         runAsUser,
 		ReleaseImage:      releaseImage,
 		ControlPlaneImage: controlPlaneImage,
+		CAConfigMap:       caConfigMap,
+		CAConfigMapKey:    caConfigMapKey,
 	}
 }
 

--- a/pkg/network/multus_admission_controller.go
+++ b/pkg/network/multus_admission_controller.go
@@ -46,11 +46,10 @@ func getOpenshiftNamespaces(client cnoclient.Client) (string, error) {
 }
 
 // renderMultusAdmissonControllerConfig returns the manifests of Multus Admisson Controller
-func renderMultusAdmissonControllerConfig(manifestDir string, externalControlPlane bool, bootstrapResult *bootstrap.BootstrapResult, client cnoclient.Client) ([]*uns.Unstructured, error) {
+func renderMultusAdmissonControllerConfig(manifestDir string, externalControlPlane bool, bootstrapResult *bootstrap.BootstrapResult, client cnoclient.Client, hsc *hypershift.HyperShiftConfig, clientName string) ([]*uns.Unstructured, error) {
 	objs := []*uns.Unstructured{}
 	var err error
 
-	hsc := hypershift.NewHyperShiftConfig()
 	replicas := getMultusAdmissionControllerReplicas(bootstrapResult, hsc.Enabled)
 	if ignoredNamespaces == "" {
 		ignoredNamespaces, err = getOpenshiftNamespaces(client)
@@ -85,7 +84,7 @@ func renderMultusAdmissonControllerConfig(manifestDir string, externalControlPla
 		data.Data["CAConfigMapKey"] = hsc.CAConfigMapKey
 
 		serviceCA := &corev1.ConfigMap{}
-		err := client.ClientFor(names.ManagementClusterName).CRClient().Get(
+		err := client.ClientFor(clientName).CRClient().Get(
 			context.TODO(), types.NamespacedName{Namespace: hsc.Namespace, Name: hsc.CAConfigMap}, serviceCA)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get managments clusters service CA: %v", err)

--- a/pkg/network/multus_admission_controller_test.go
+++ b/pkg/network/multus_admission_controller_test.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"github.com/openshift/cluster-network-operator/pkg/hypershift"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -82,6 +83,84 @@ func TestRenderMultusAdmissionController(t *testing.T) {
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRoleBinding", "", "multus-admission-controller-webhook")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ValidatingWebhookConfiguration", "", names.MULTUS_VALIDATING_WEBHOOK)))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("Deployment", "openshift-multus", "multus-admission-controller")))
+}
+
+// TestRenderMultusAdmissionController has some simple rendering tests
+func TestRenderMultusAdmissonControllerConfigForHyperShift(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	crd := MultusAdmissionControllerConfig.DeepCopy()
+	config := &crd.Spec
+	disabled := true
+	config.DisableMultiNetwork = &disabled
+	fillDefaults(config, nil)
+
+	fakeClient := cnofake.NewFakeClient(
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test1-ignored",
+				Labels: map[string]string{
+					"openshift.io/cluster-monitoring": "true",
+				},
+			},
+		},
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test2-not-ignored",
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "MyCM",
+				Namespace: "test1-ignored",
+			},
+			Data: map[string]string{
+				"MyCMKey": "key",
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "openshift-service-ca.crt",
+				Namespace: "test1-ignored",
+			},
+			Data: map[string]string{
+				"MyCMKey": "key",
+			},
+		},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name: "test3-ignored",
+			Labels: map[string]string{
+				"openshift.io/cluster-monitoring": "true",
+			},
+		},
+		})
+	bootstrap := fakeBootstrapResultWithHyperShift()
+
+	hsc := hypershift.NewHyperShiftConfig()
+	hsc.Enabled = true
+	hsc.CAConfigMap = "MyCM"
+	hsc.CAConfigMapKey = "MyCMKey"
+	hsc.Name = "MyCluster"
+	hsc.Namespace = "test1-ignored"
+	hsc.RunAsUser = "1001"
+	hsc.ReleaseImage = "MyImage"
+	hsc.ControlPlaneImage = "MyCPOImage"
+
+	objs, err := renderMultusAdmissonControllerConfig(manifestDir, false, bootstrap, fakeClient, hsc, "")
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Check rendered object
+	for _, obj := range objs {
+		if obj.GetKind() == "Service" && obj.GetName() == "multus-admission-controller" {
+			labels := obj.GetLabels()
+			g.Expect(len(labels)).To(Equal(2))
+			g.Expect(labels["hypershift.openshift.io/allow-guest-webhooks"]).To(Equal("true"))
+
+			annotations := obj.GetAnnotations()
+			g.Expect(len(annotations)).To(Equal(1))
+			g.Expect(annotations["network.operator.openshift.io/cluster-name"]).To(Equal("management"))
+		}
+	}
 }
 
 // TestRenderMultusAdmissionControllerGetNamespace tests getOpenshiftNamespaces()

--- a/pkg/network/node_identity.go
+++ b/pkg/network/node_identity.go
@@ -79,8 +79,12 @@ func renderNetworkNodeIdentity(conf *operv1.NetworkSpec, bootstrapResult *bootst
 	// HyperShift specific
 	if hcpCfg := hypershift.NewHyperShiftConfig(); hcpCfg.Enabled {
 		webhookCAClient = client.ClientFor(names.ManagementClusterName)
-		webhookCALookup = types.NamespacedName{Name: "openshift-service-ca.crt", Namespace: hcpCfg.Namespace}
-		caKey = "service-ca.crt"
+
+		data.Data["CAConfigMap"] = hcpCfg.CAConfigMap
+		data.Data["CAConfigMapKey"] = hcpCfg.CAConfigMapKey
+
+		webhookCALookup = types.NamespacedName{Name: hcpCfg.CAConfigMap, Namespace: hcpCfg.Namespace}
+		caKey = hcpCfg.CAConfigMapKey
 
 		data.Data["HostedClusterNamespace"] = hcpCfg.Namespace
 		data.Data["ManagementClusterName"] = names.ManagementClusterName

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -361,6 +361,8 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	productFlavor := "self-hosted"
 	if bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.Enabled {
 		productFlavor = "managed"
+		data.Data["CAConfigMap"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.CAConfigMap
+		data.Data["CAConfigMapKey"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.CAConfigMapKey
 	}
 	manifestSubDir := filepath.Join(manifestDir, "network/ovn-kubernetes", productFlavor)
 	manifestDirs = append(manifestDirs, manifestSubDir)
@@ -642,6 +644,8 @@ func bootstrapOVNHyperShiftConfig(hc *hypershift.HyperShiftConfig, kubeClient cn
 		Namespace:         hc.Namespace,
 		ReleaseImage:      hc.ReleaseImage,
 		ControlPlaneImage: hc.ControlPlaneImage,
+		CAConfigMap:       hc.CAConfigMap,
+		CAConfigMapKey:    hc.CAConfigMapKey,
 	}
 
 	if !hc.Enabled {

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"github.com/openshift/cluster-network-operator/pkg/names"
 	"log"
 	"net"
 	"os"
@@ -770,8 +771,9 @@ func renderMultusAdmissionController(conf *operv1.NetworkSpec, manifestDir strin
 	var err error
 	out := []*uns.Unstructured{}
 
+	hsc := hypershift.NewHyperShiftConfig()
 	objs, err := renderMultusAdmissonControllerConfig(manifestDir, externalControlPlane,
-		bootstrapResult, client)
+		bootstrapResult, client, hsc, names.ManagementClusterName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/testutil_test.go
+++ b/pkg/network/testutil_test.go
@@ -8,6 +8,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
 	"github.com/openshift/cluster-network-operator/pkg/client"
+	"github.com/openshift/cluster-network-operator/pkg/hypershift"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -72,6 +73,27 @@ func fakeBootstrapResult() *bootstrap.BootstrapResult {
 					Host: "testing.test",
 					Port: "8443",
 				},
+			},
+		},
+	}
+}
+
+func fakeBootstrapResultWithHyperShift() *bootstrap.BootstrapResult {
+	return &bootstrap.BootstrapResult{
+		Infra: bootstrap.InfraStatus{
+			PlatformType:           "GCP",
+			PlatformRegion:         "moon-2",
+			ControlPlaneTopology:   configv1.HighlyAvailableTopologyMode,
+			InfrastructureTopology: configv1.HighlyAvailableTopologyMode,
+			APIServers: map[string]bootstrap.APIServer{
+				bootstrap.APIServerDefault: {
+					Host: "testing.test",
+					Port: "8443",
+				},
+			},
+			HostedControlPlane: &hypershift.HostedControlPlane{
+				ClusterID:    "test",
+				NodeSelector: map[string]string{},
 			},
 		},
 	}


### PR DESCRIPTION
This PR allows HyperShift the ability to set the CA ConfigMap and key through an environment variable. The PR also removes the service-sa annotation from services used by HyperShift since we will pass through a CA ConfigMap for the services we are using.

Fixes [SDN-4607](https://issues.redhat.com//browse/SDN-4607)