### PR TITLE
OCPBUGS-31669: [release-4.14] ensure local networking deployments within hypershift use the client side load balancer to be resilient to control plane node failures

### DIFF
--- a/pkg/network/kube_proxy.go
+++ b/pkg/network/kube_proxy.go
@@ -1,9 +1,12 @@
 package network
 
 import (
+	v1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-network-operator/pkg/platform"
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -210,8 +213,14 @@ func renderStandaloneKubeProxy(conf *operv1.NetworkSpec, bootstrapResult *bootst
 	data.Data["ReleaseVersion"] = os.Getenv("RELEASE_VERSION")
 	data.Data["KubeProxyImage"] = os.Getenv("KUBE_PROXY_IMAGE")
 	data.Data["KubeRBACProxyImage"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
-	data.Data["KUBERNETES_SERVICE_HOST"] = bootstrapResult.Infra.APIServers[bootstrap.APIServerDefault].Host
-	data.Data["KUBERNETES_SERVICE_PORT"] = bootstrapResult.Infra.APIServers[bootstrap.APIServerDefault].Port
+	hsc := platform.NewHyperShiftConfig()
+	if hsc.Enabled && bootstrapResult.Infra.PlatformType == v1.IBMCloudPlatformType {
+		data.Data["KUBERNETES_SERVICE_HOST"] = *bootstrapResult.Infra.HostedControlPlane.Spec.Networking.APIServer.AdvertiseAddress
+		data.Data["KUBERNETES_SERVICE_PORT"] = strconv.Itoa(int(*bootstrapResult.Infra.HostedControlPlane.Spec.Networking.APIServer.Port))
+	} else {
+		data.Data["KUBERNETES_SERVICE_HOST"] = bootstrapResult.Infra.APIServers[bootstrap.APIServerDefault].Host
+		data.Data["KUBERNETES_SERVICE_PORT"] = bootstrapResult.Infra.APIServers[bootstrap.APIServerDefault].Port
+	}
 	data.Data["KubeProxyConfig"] = kpc
 	data.Data["MetricsPort"] = metricsPort
 	data.Data["HealthzPort"] = healthzPort

--- a/pkg/network/multus.go
+++ b/pkg/network/multus.go
@@ -1,15 +1,16 @@
 package network
 
 import (
-	"os"
-	"path/filepath"
-
 	configv1 "github.com/openshift/api/config/v1"
 	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
+	"github.com/openshift/cluster-network-operator/pkg/platform"
 	"github.com/openshift/cluster-network-operator/pkg/render"
 	"github.com/pkg/errors"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"os"
+	"path/filepath"
+	"strconv"
 )
 
 const (
@@ -65,8 +66,14 @@ func renderMultusConfig(manifestDir, defaultNetworkType string, useDHCP bool, us
 	data.Data["WhereaboutsImage"] = os.Getenv("WHEREABOUTS_CNI_IMAGE")
 	data.Data["EgressRouterImage"] = os.Getenv("EGRESS_ROUTER_CNI_IMAGE")
 	data.Data["RouteOverrideImage"] = os.Getenv("ROUTE_OVERRRIDE_CNI_IMAGE")
-	data.Data["KUBERNETES_SERVICE_HOST"] = apihost
-	data.Data["KUBERNETES_SERVICE_PORT"] = apiport
+	hsc := platform.NewHyperShiftConfig()
+	if hsc.Enabled && bootstrapResult.Infra.PlatformType == configv1.IBMCloudPlatformType {
+		data.Data["KUBERNETES_SERVICE_HOST"] = *bootstrapResult.Infra.HostedControlPlane.Spec.Networking.APIServer.AdvertiseAddress
+		data.Data["KUBERNETES_SERVICE_PORT"] = strconv.Itoa(int(*bootstrapResult.Infra.HostedControlPlane.Spec.Networking.APIServer.Port))
+	} else {
+		data.Data["KUBERNETES_SERVICE_HOST"] = apihost
+		data.Data["KUBERNETES_SERVICE_PORT"] = apiport
+	}
 	data.Data["RenderDHCP"] = useDHCP
 	data.Data["RenderIpReconciler"] = useWhereabouts
 	data.Data["MultusCNIConfDir"] = MultusCNIConfDir

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -3,6 +3,7 @@ package platform
 import (
 	"context"
 	"fmt"
+	"k8s.io/utils/pointer"
 	"os"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -115,6 +116,18 @@ func InfraStatus(client cnoclient.Client) (*bootstrap.InfraStatus, error) {
 			return nil, fmt.Errorf("failed to retrieve HostedControlPlane %s: %v", types.NamespacedName{Namespace: hc.Namespace, Name: hc.Name}, err)
 		}
 		res.HostedControlPlane = hcp
+		if res.HostedControlPlane.Spec.Networking.APIServer == nil {
+			res.HostedControlPlane.Spec.Networking.APIServer = &hyperv1.APIServerNetworking{
+				AdvertiseAddress: pointer.String("172.20.0.1"),
+				Port:             pointer.Int32(6443),
+			}
+		}
+		if res.HostedControlPlane.Spec.Networking.APIServer.AdvertiseAddress == nil {
+			res.HostedControlPlane.Spec.Networking.APIServer.AdvertiseAddress = pointer.String("172.20.0.1")
+		}
+		if res.HostedControlPlane.Spec.Networking.APIServer.Port == nil {
+			res.HostedControlPlane.Spec.Networking.APIServer.Port = pointer.Int32(6443)
+		}
 	}
 
 	netIDEnabled, err := isNetworkNodeIdentityEnabled(client)


### PR DESCRIPTION
In environments with no cloud load balancer health checking and removing bad control plane endpoints: requests to the control plane from data plane components like kube-proxy and mutlus using the control plane dns name directly will see intermittent failures. In hypershift: a node local haproxy load balancer runs that health checks and removes failed control plane ingress points dynamically. When the components move to using this: control plane failures do not lead to further failures in the data plane starting new workload. fixes: https://issues.redhat.com/browse/OCPBUGS-30103, https://issues.redhat.com/browse/OCPBUGS-31514