### PR TITLE
[release-4.14] OCPBUGS-30021: Fully disable network-node-identity on ROKS

### DIFF
--- a/pkg/network/node_identity.go
+++ b/pkg/network/node_identity.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 
-	configv1 "github.com/openshift/api/config/v1"
 	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
@@ -53,15 +52,6 @@ func isBootstrapComplete(cli cnoclient.Client) (bool, error) {
 func renderNetworkNodeIdentity(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapResult, manifestDir string, client cnoclient.Client) ([]*uns.Unstructured, error) {
 	if !bootstrapResult.Infra.NetworkNodeIdentityEnabled {
 		klog.Infof("Network node identity is disabled")
-		return nil, nil
-	}
-	if bootstrapResult.Infra.ControlPlaneTopology == configv1.ExternalTopologyMode &&
-		bootstrapResult.Infra.PlatformType == configv1.IBMCloudPlatformType {
-		// In environments with external control plane topology, the API server is deployed out of cluster.
-		// This means that CNO cannot easily predict how to deploy and enforce the node identity webhook.
-		// IBMCloud uses an external control plane topology with Calico as the CNI for both HyperShift based ROKS
-		// deployments and IBM ROKS Toolkit based ROKS deployments.
-		klog.Infof("Network node identity is disabled on %s platorm", configv1.IBMCloudPlatformType)
 		return nil, nil
 	}
 	data := render.MakeRenderData()

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -25,7 +25,17 @@ var cloudProviderConfig = types.NamespacedName{
 // isNetworkNodeIdentityEnabled determines if network node identity should be enabled.
 // It checks the `enabled` key in the network-node-identity/openshift-network-operator configmap.
 // If the configmap doesn't exist, it returns true (the feature is enabled by default).
-func isNetworkNodeIdentityEnabled(client cnoclient.Client) (bool, error) {
+func isNetworkNodeIdentityEnabled(client cnoclient.Client, infra *bootstrap.InfraStatus) (bool, error) {
+	if infra.ControlPlaneTopology == configv1.ExternalTopologyMode &&
+		infra.PlatformType == configv1.IBMCloudPlatformType {
+		// In environments with external control plane topology, the API server is deployed out of cluster.
+		// This means that CNO cannot easily predict how to deploy and enforce the node identity webhook.
+		// IBMCloud uses an external control plane topology with Calico as the CNI for both HyperShift based ROKS
+		// deployments and IBM ROKS Toolkit based ROKS deployments.
+		klog.Infof("Network node identity is disabled on %s platorm", configv1.IBMCloudPlatformType)
+		return false, nil
+	}
+
 	nodeIdentity := &corev1.ConfigMap{}
 	nodeIdentityLookup := types.NamespacedName{Name: "network-node-identity", Namespace: names.APPLIED_NAMESPACE}
 	if err := client.ClientFor("").CRClient().Get(context.TODO(), nodeIdentityLookup, nodeIdentity); err != nil {
@@ -117,7 +127,7 @@ func InfraStatus(client cnoclient.Client) (*bootstrap.InfraStatus, error) {
 		res.HostedControlPlane = hcp
 	}
 
-	netIDEnabled, err := isNetworkNodeIdentityEnabled(client)
+	netIDEnabled, err := isNetworkNodeIdentityEnabled(client, res)
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine if network node identity should be enabled: %w", err)
 	}


### PR DESCRIPTION
Clean cherry-pick of https://github.com/openshift/cluster-network-operator/pull/2314.
/cc @dougbtv 