### PR TITLE
[release-4.14] OCPBUGS-31360: Remove egressip write permissions from ovn-kubernetes-node

### DIFF
--- a/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
+++ b/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
@@ -139,7 +139,6 @@ rules:
   - adminpolicybasedexternalroutes
   - adminpolicybasedexternalroutes/status
   - egressfirewalls
-  - egressips
   - egressqoses
   - egressservices
   - egressservices/status
@@ -149,6 +148,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups: ["k8s.ovn.org"]
+  resources:
+    - egressips
+  verbs:
+    - get
+    - list
+    - watch
 {{- if .OVN_ADMIN_NETWORK_POLICY_ENABLE }}
 - apiGroups: ["policy.networking.k8s.io"]
   resources:
@@ -165,17 +171,6 @@ rules:
   verbs:
   - update
 {{- end }}
-- apiGroups: ["cloud.network.openshift.io"]
-  resources:
-  - cloudprivateipconfigs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - k8s.cni.cncf.io
   resources:


### PR DESCRIPTION
Backport of https://github.com/openshift/cluster-network-operator/pull/2203

CONFLICT (content): Merge conflict in bindata/network/ovn-kubernetes/common/002-rbac-node.yaml

Signed-off-by: Patryk Diak <pdiak@redhat.com>
(cherry picked from commit 4019afea4c61c3349fa8be5543ceec9e80a9b0d8)