### PR TITLE
Remove managed cluster checking for live migration

### DIFF
--- a/pkg/network/cluster_config.go
+++ b/pkg/network/cluster_config.go
@@ -116,9 +116,6 @@ func ValidateClusterConfig(clusterConfig *configv1.Network, client cnoclient.Cli
 		if infraRes.HostedControlPlane != nil {
 			return errors.Errorf("network type live migration is not supported on HyperShift clusters")
 		}
-		if !infraRes.StandaloneManagedCluster {
-			return errors.Errorf("network type live migration is not supported on self managed clusters")
-		}
 	}
 
 	return nil

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -675,10 +675,6 @@ func isMigrationChangeSafe(prev, next *operv1.NetworkSpec, infraStatus *bootstra
 	if next.Migration != nil && next.Migration.Mode == operv1.LiveNetworkMigrationMode && infraStatus.HostedControlPlane != nil {
 		return []error{errors.Errorf("live migration is unsupported in a HyperShift environment")}
 	}
-	if next.Migration != nil && next.Migration.Mode == operv1.LiveNetworkMigrationMode &&
-		!infraStatus.StandaloneManagedCluster {
-		return []error{errors.Errorf("live migration is unsupported on a self managed cluster")}
-	}
 	if prev.Migration != nil && next.Migration != nil && prev.Migration.NetworkType != next.Migration.NetworkType && next.Migration.Mode != operv1.LiveNetworkMigrationMode {
 		return []error{errors.Errorf("cannot change migration network type after migration has started")}
 	}


### PR DESCRIPTION
In 4.16, we want to support SDN live migration for unmanaged clusters.