### PR TITLE
CONSOLE-3952: Deploy networking-console-plugin by CNO

### DIFF
--- a/bindata/networking-console-plugin/000-namespace.yaml
+++ b/bindata/networking-console-plugin/000-namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-network-console
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  annotations:
+    openshift.io/description: "Namespace for running the networking-console-plugin pods that enables the Networking console section"
+    workload.openshift.io/allowed: "management"

--- a/bindata/networking-console-plugin/001-config-map.yaml
+++ b/bindata/networking-console-plugin/001-config-map.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+data:
+  nginx.conf: |
+    error_log /dev/stdout info;
+    events {}
+    http {
+      include            /etc/nginx/mime.types;
+      default_type       application/octet-stream;
+      keepalive_timeout  65;
+      server {
+        listen              9443 ssl;
+        ssl_certificate     /var/cert/tls.crt;
+        ssl_certificate_key /var/cert/tls.key;
+        root                /opt/app-root/src;
+
+        # Prevent caching for plugin-manifest.json
+        location = /plugin-manifest.json {
+          add_header Cache-Control 'no-cache, no-store, must-revalidate, proxy-revalidate, max-age=0';
+          add_header Pragma 'no-cache';
+          add_header Expires '0';
+        }
+
+        # Prevent caching for plugin-entry.js
+        location = /plugin-entry.js {
+          add_header Cache-Control 'no-cache, no-store, must-revalidate, proxy-revalidate, max-age=0';
+          add_header Pragma 'no-cache';
+          add_header Expires '0';
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: networking-console-plugin
+    app.kubernetes.io/managed-by: cluster-network-operator
+    app.kubernetes.io/name: networking-console-plugin
+    app.kubernetes.io/part-of: cluster-network-operator
+  name: networking-console-plugin
+  namespace: openshift-network-console

--- a/bindata/networking-console-plugin/002-deployment.yaml
+++ b/bindata/networking-console-plugin/002-deployment.yaml
@@ -1,0 +1,116 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: networking-console-plugin
+  namespace: openshift-network-console
+  annotations:
+    kubernetes.io/description: |
+      This deployment deploys the Networking console plugin pod which serves
+      the contents of the Networking section in OpenShift Console
+    release.openshift.io/version: "{{.ReleaseVersion}}"
+    networkoperator.openshift.io/non-critical: ""
+  labels:
+    app.kubernetes.io/component: networking-console-plugin
+    app.kubernetes.io/managed-by: cluster-network-operator
+    app.kubernetes.io/name: networking-console-plugin
+    app.kubernetes.io/part-of: cluster-network-operator
+spec:
+  replicas: {{.Replicas}}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: networking-console-plugin
+      app.kubernetes.io/managed-by: cluster-network-operator
+      app.kubernetes.io/name: networking-console-plugin
+      app.kubernetes.io/part-of: cluster-network-operator
+{{- if gt .Replicas 1 }}
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+{{- end }}
+  template:
+    metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        app.kubernetes.io/component: networking-console-plugin
+        app.kubernetes.io/managed-by: cluster-network-operator
+        app.kubernetes.io/name: networking-console-plugin
+        app.kubernetes.io/part-of: cluster-network-operator
+    spec:
+{{- if gt .Replicas 1 }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: networking-console-plugin
+                  app.kubernetes.io/managed-by: cluster-network-operator
+                  app.kubernetes.io/name: networking-console-plugin
+                  app.kubernetes.io/part-of: cluster-network-operator
+              namespaces:
+              - openshift-network-console
+              topologyKey: kubernetes.io/hostname
+            weight: 90
+{{- end }}
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - /bin/sh
+        - -c
+        - |
+          if echo "$POD_IP" | grep -qE '^([0-9]{1,3}\.){3}[0-9]{1,3}$'; then
+            LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME="9443"
+          else
+            LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME="[::]:9443"
+          fi
+          sed "s/LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME/$LISTEN_ADDRESS_PORT_REPLACED_AT_RUNTIME/g" /etc/nginx/nginx.conf > /tmp/nginx.conf
+          exec nginx -c /tmp/nginx.conf -g 'daemon off;'
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: "{{.NetworkingConsolePluginImage}}"
+        imagePullPolicy: IfNotPresent
+        name: networking-console-plugin
+        ports:
+        - containerPort: 9443
+          name: https
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/cert
+          name: networking-console-plugin-cert
+          readOnly: true
+        - mountPath: /etc/nginx/nginx.conf
+          name: nginx-conf
+          readOnly: true
+          subPath: nginx.conf
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: networking-console-plugin
+        name: nginx-conf
+      - name: networking-console-plugin-cert
+        secret:
+          defaultMode: 420
+          secretName: networking-console-plugin-cert

--- a/bindata/networking-console-plugin/003-service.yaml
+++ b/bindata/networking-console-plugin/003-service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    openshift.io/description: Expose the networking console plugin service on port 9443. This port is for internal use, and no other usage is guaranteed.
+    service.beta.openshift.io/serving-cert-secret-name: networking-console-plugin-cert
+  labels:
+    app.kubernetes.io/component: networking-console-plugin
+    app.kubernetes.io/managed-by: cluster-network-operator
+    app.kubernetes.io/name: networking-console-plugin
+    app.kubernetes.io/part-of: cluster-network-operator
+  name: networking-console-plugin
+  namespace: openshift-network-console
+spec:
+  ports:
+  - name: https
+    port: 9443
+    targetPort: https
+  selector:
+    app.kubernetes.io/component: networking-console-plugin
+    app.kubernetes.io/managed-by: cluster-network-operator
+    app.kubernetes.io/name: networking-console-plugin
+    app.kubernetes.io/part-of: cluster-network-operator
+  sessionAffinity: None

--- a/bindata/networking-console-plugin/004-console-plugin.yaml
+++ b/bindata/networking-console-plugin/004-console-plugin.yaml
@@ -1,0 +1,18 @@
+apiVersion: console.openshift.io/v1
+kind: ConsolePlugin
+metadata:
+  labels:
+    app.kubernetes.io/component: networking-console-plugin
+    app.kubernetes.io/managed-by: cluster-network-operator
+    app.kubernetes.io/name:  networking-console-plugin
+    app.kubernetes.io/part-of: cluster-network-operator
+  name:  networking-console-plugin
+spec:
+  backend:
+    service:
+      basePath: /
+      name:  networking-console-plugin
+      namespace: openshift-network-console
+      port: 9443
+    type: Service
+  displayName: Networking Console Plugin

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -119,6 +119,9 @@ type InfraStatus struct {
 
 	// MachineConfigClusterOperatorReady set to true when Machine Config cluster operator is in ready state.
 	MachineConfigClusterOperatorReady bool
+
+	// ConsolePluginCRDExists set to true when the consoleplugins.console.openshift.io has been deployed.
+	ConsolePluginCRDExists bool
 }
 
 // APIServer is the hostname & port of a given APIServer. (This is the

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -31,6 +31,7 @@ import (
 	operv1 "github.com/openshift/api/operator/v1"
 	netopv1 "github.com/openshift/cluster-network-operator/pkg/apis/network/v1"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -46,6 +47,7 @@ func init() {
 	utilruntime.Must(machineapi.AddToScheme(scheme.Scheme))
 	utilruntime.Must(op_netopv1.Install(scheme.Scheme))
 	utilruntime.Must(mcfgv1.Install(scheme.Scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme.Scheme))
 }
 
 // OperatorClusterClient is a bag of holding for object clients & informers.

--- a/pkg/client/fake/fake_client.go
+++ b/pkg/client/fake/fake_client.go
@@ -80,7 +80,7 @@ func isOpenShiftObject(obj crclient.Object) bool {
 	return false
 }
 
-// NewFakeClient creates a fake client with a backing store that contains the given objexts.
+// NewFakeClient creates a fake client with a backing store that contains the given objects.
 //
 // Note that, due to limitations in the test infrastructure, each client has an independent store.
 // This means that changes made in, say, the crclient, won't show up in the Dynamic client or the typed

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -3,6 +3,7 @@ package platform
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -11,7 +12,9 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/hypershift"
 	"github.com/openshift/cluster-network-operator/pkg/names"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -148,6 +151,11 @@ func InfraStatus(client cnoclient.Client) (*bootstrap.InfraStatus, error) {
 	}
 	res.NetworkNodeIdentityEnabled = netIDEnabled
 
+	res.ConsolePluginCRDExists, err = consolePluginCRDExists(client)
+	if err != nil {
+		return nil, err
+	}
+
 	// Skip retrieving IPsec MachineConfig and MachineConfigPool if it's a hypershift cluster because
 	// those object kinds are not supported there.
 	if res.HostedControlPlane != nil {
@@ -251,4 +259,19 @@ func getMachineConfigPoolStatuses(ctx context.Context, client cnoclient.Client, 
 		}
 	}
 	return mcpStatuses, nil
+}
+
+func consolePluginCRDExists(cl cnoclient.Client) (bool, error) {
+	consolePluginCrdKey := crclient.ObjectKey{Name: "consoleplugins.console.openshift.io"}
+	consolePluginCrdObj := &apiextensionsv1.CustomResourceDefinition{}
+	err := cl.Default().CRClient().Get(context.TODO(), consolePluginCrdKey, consolePluginCrdObj)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Printf("consoleplugins.console.openshift.io CRD was not found: %v", err)
+			return false, nil
+		} else {
+			return false, errors.Wrap(err, "failed to get consoleplugins.console.openshift.io CRD")
+		}
+	}
+	return true, nil
 }


### PR DESCRIPTION
Use the CNO operator config controller to deploy and reconcile the resources required to enable the new Networking console plugin:
* Deployment (hosts the plugin pages contents via an nginx web server)
* Service (exposes the webserver to the console)
* ConfigMap (for nginx config)
* ConsolePlugin (binds the console with the dynamic plugin)

Also, enables the console plugin by adding it to the cluster Console plugins list.

Jira ticket: https://issues.redhat.com/browse/CONSOLE-3952