### PR TITLE
SDN-4114: Add iptables-alerter daemonset

### DIFF
--- a/bindata/network/iptables-alerter/001-rbac.yaml
+++ b/bindata/network/iptables-alerter/001-rbac.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openshift-iptables-alerter
+rules:
+- apiGroups: ["", "events.k8s.io"]
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - create
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: iptables-alerter
+  namespace: openshift-network-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openshift-iptables-alerter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-iptables-alerter
+subjects:
+- kind: ServiceAccount
+  namespace: openshift-network-operator
+  name: iptables-alerter

--- a/bindata/network/iptables-alerter/002-script.yaml
+++ b/bindata/network/iptables-alerter/002-script.yaml
@@ -1,0 +1,105 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: iptables-alerter-script
+  namespace: openshift-network-operator
+  annotations:
+    kubernetes.io/description: |
+      This is a script used by the iptables-alerter DaemonSet
+    release.openshift.io/version: "{{.ReleaseVersion}}"
+data:
+  iptables-alerter.sh: |-
+    #!/bin/bash
+
+    set -euo pipefail
+
+    function crictl {
+        chroot /host /bin/crictl "$@"
+    }
+    function jq {
+        chroot /host /bin/jq "$@"
+    }
+    function ip {
+        chroot /host /sbin/ip "$@"
+    }
+
+    while :; do
+        date
+        # Iterate over local pods
+        for id in $(crictl pods -q); do
+            # Check that it's a pod-network pod
+            netns=$(crictl inspectp "${id}" | jq -r .status.linux.namespaces.options.network)
+            if [[ "${netns}" == "NODE" ]]; then
+                continue
+            fi
+
+            # Find the network namespace
+            netns_path=$(crictl inspectp "${id}" | jq -r '.info.runtimeSpec.linux.namespaces[] | select(.type == "network").path')
+            if [[ ! "${netns_path}" =~ ^/var/run/netns/ ]]; then
+                continue
+            fi
+            netns=$(basename "${netns_path}")
+
+            # Gather pod metadata
+            pod_namespace=$(crictl inspectp "${id}" | jq -r .status.metadata.namespace)
+            pod_name=$(crictl inspectp "${id}" | jq -r .status.metadata.name)
+            pod_uid=$(crictl inspectp "${id}" | jq -r .status.metadata.uid)
+
+            # Check if we already logged an event for it
+            events=$(kubectl get events -n "${pod_namespace}" -l pod-uid="${pod_uid}" 2>/dev/null)
+            if [[ -n "${events}" ]]; then
+                echo "Skipping pod ${pod_namespace}/${pod_name} which we already logged an event for."
+                continue
+            fi
+
+            # Set iptables_output to the first iptables rule in the pod's network
+            # namespace, if any. (We use `awk` here rather than `grep` intentionally
+            # to avoid awkwardness with grep's exit status on no match.)
+            iptables_output=$(
+                (ip netns exec "${netns}" iptables-save || true;
+                 ip netns exec "${netns}" ip6tables-save || true) 2>/dev/null | \
+                awk '/^-A/ {print; exit}'
+            )
+            if [[ -z "${iptables_output}" ]]; then
+                continue
+            fi
+
+            echo "Logging event for ${pod_namespace}/${pod_name} which has iptables rules"
+
+            # eg "2023-10-19T15:45:10.353846Z"
+            event_time=$(date -u +%FT%T.%6NZ)
+
+            kubectl create -f - <<EOF
+    apiVersion: events.k8s.io/v1
+    kind: Event
+    metadata:
+      namespace: ${pod_namespace}
+      generateName: iptables-alert-
+      labels:
+        pod-uid: ${pod_uid}
+    regarding:
+      apiVersion: v1
+      kind: Pod
+      namespace: ${pod_namespace}
+      name: ${pod_name}
+      uid: ${pod_uid}
+    reportingController: openshift.io/iptables-deprecation-alerter
+    reportingInstance: ${ALERTER_POD_NAME}
+    action: IPTablesUsageObserved
+    reason: IPTablesUsageObserved
+    type: Normal
+    note: |
+      This pod appears to have created one or more iptables rules. IPTables is
+      deprecated and will no longer be available in RHEL 10 and later. You should
+      consider migrating to another API such as nftables or eBPF. See also
+      https://access.redhat.com/solutions/6739041
+
+      Example iptables rule seen in this pod:
+      ${iptables_output}
+    eventTime: ${event_time}
+    EOF
+        done
+
+    echo ""
+    sleep 3600
+    done

--- a/bindata/network/iptables-alerter/003-daemonset.yaml
+++ b/bindata/network/iptables-alerter/003-daemonset.yaml
@@ -1,0 +1,71 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: iptables-alerter
+  namespace: openshift-network-operator
+  annotations:
+    kubernetes.io/description: |
+      This daemon set runs the iptables-alerter on each node
+    release.openshift.io/version: "{{.ReleaseVersion}}"
+    networkoperator.openshift.io/non-critical: ""
+spec:
+  selector:
+    matchLabels:
+      app: iptables-alerter
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
+  template:
+    metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        app: iptables-alerter
+        component: network
+        type: infra
+        openshift.io/component: network
+    spec:
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: iptables-alerter
+      priorityClassName: "openshift-user-critical"
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      containers:
+      - name: iptables-alerter
+        image: {{.CLIImage}}
+        command: [ "/iptables-alerter/iptables-alerter.sh" ]
+        resources:
+          requests:
+            cpu: 10m
+            memory: 65Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /iptables-alerter
+          name: iptables-alerter-script
+        - mountPath: /host
+          name: host-slash
+          readOnly: true
+          mountPropagation: HostToContainer
+        env:
+        - name: CONTAINER_RUNTIME_ENDPOINT
+          value: unix:///run/crio/crio.sock
+        - name: ALERTER_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: iptables-alerter-script
+          configMap:
+            name: iptables-alerter-script
+            defaultMode: 0744
+        - name: host-slash
+          hostPath:
+            path: /

--- a/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
@@ -94,6 +94,8 @@ spec:
           value: quay.io/openshift/origin-cluster-network-operator:latest
         - name: CLOUD_NETWORK_CONFIG_CONTROLLER_IMAGE
           value: quay.io/openshift/origin-cloud-network-config-controller:latest
+        - name: CLI_IMAGE
+          value: quay.io/openshift/origin-cli:latest
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -106,6 +106,8 @@ spec:
           value: "quay.io/openshift/origin-cluster-network-operator:latest"
         - name: CLOUD_NETWORK_CONFIG_CONTROLLER_IMAGE
           value: "quay.io/openshift/origin-cloud-network-config-controller:latest"
+        - name: CLI_IMAGE
+          value: "quay.io/openshift/origin-cli:latest"
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -70,3 +70,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-cloud-network-config-controller:latest
+  - name: cli
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-cli:latest

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -65,9 +65,17 @@ type OVNBootstrapResult struct {
 	FlowsConfig           *FlowsConfig
 }
 
+// IPTablesAlerterBootstrapResult contains configuration for the iptables-alerter
+type IPTablesAlerterBootstrapResult struct {
+	// Enabled is true if the iptables-alerter should be enabled
+	Enabled bool
+}
+
 type BootstrapResult struct {
-	OVN   OVNBootstrapResult
 	Infra InfraStatus
+
+	OVN             OVNBootstrapResult
+	IPTablesAlerter IPTablesAlerterBootstrapResult
 }
 
 type InfraStatus struct {

--- a/pkg/network/bootstrap.go
+++ b/pkg/network/bootstrap.go
@@ -1,11 +1,19 @@
 package network
 
 import (
+	"context"
+
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 	"github.com/openshift/cluster-network-operator/pkg/platform"
 
 	operv1 "github.com/openshift/api/operator/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Bootstrap creates resources required by SDN on the cloud.
@@ -26,5 +34,33 @@ func Bootstrap(conf *operv1.Network, client cnoclient.Client) (*bootstrap.Bootst
 		out.OVN = *o
 	}
 
+	out.IPTablesAlerter = iptablesAlerterBootstrap(client.ClientFor("").CRClient())
+
 	return out, nil
+}
+
+func iptablesAlerterBootstrap(cl crclient.Reader) bootstrap.IPTablesAlerterBootstrapResult {
+	result := bootstrap.IPTablesAlerterBootstrapResult{
+		Enabled: true,
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := cl.Get(context.TODO(), types.NamespacedName{
+		Namespace: "openshift-network-operator",
+		Name:      "iptables-alerter-config",
+	}, cm); err != nil {
+		if !apierrors.IsNotFound(err) {
+			klog.Warningf("Error fetching iptables-alerter-config configmap: %v", err)
+		}
+		return result
+	}
+
+	enabled := cm.Data["enabled"]
+	if enabled == "false" {
+		result.Enabled = false
+	} else if enabled != "true" {
+		klog.Warningf("Ignoring unexpected iptables-alerter-config value enabled=%q", enabled)
+	}
+
+	return result
 }


### PR DESCRIPTION
This adds a daemonset that runs a script that periodically:
- lists all local non-`hostNetwork` pods
- checks if iptables rules have been created in that pod's network namespace (other than the rules created by ovn-kubernetes/openshift-sdn)
- logs an Event if so

There was an enhancement for this which never went anywhere, but you can see some discussion of ideas in https://github.com/openshift/enhancements/pull/1509/files.

I actually originally implemented this in MCO via a systemd timer that ran a locally-installed script. But this ran into problems because it had to use kubelet's serviceAccount, and kubelet doesn't have permission to list/create events in all namespaces. So I would have had to create a separate service account and get the credentials installed onto the node but I don't think we have any simple way to do that. So I went with the privileged-DaemonSet-while-loop approach instead.

The script is currently sort of a mess because I wasn't sure if there's a pre-built image that has the binaries I want (particularly `crictl`)...