### PR TITLE
CONSOLE-3952: Add networking-console-plugin image to release payload

### DIFF
--- a/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
@@ -96,6 +96,8 @@ spec:
           value: quay.io/openshift/origin-cli:latest
         - name: FRR_K8S_IMAGE
           value: quay.io/openshift/origin-metallb-frr:latest
+        - name: NETWORKING_CONSOLE_PLUGIN_IMAGE
+          value: quay.io/openshift/origin-networking-console-plugin:latest
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -108,6 +108,8 @@ spec:
           value: "quay.io/openshift/origin-cli:latest"
         - name: FRR_K8S_IMAGE
           value: "quay.io/openshift/origin-metallb-frr:latest"
+        - name: NETWORKING_CONSOLE_PLUGIN_IMAGE
+          value: "quay.io/openshift/origin-networking-console-plugin:latest"
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -82,3 +82,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-metallb-frr:latest
+  - name: networking-console-plugin
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-networking-console-plugin:latest


### PR DESCRIPTION
This is required so hypershift's control-plane-operator will be able to deploy CNO with this image, extracted from the release payload.

This PR is a prerequisite for #2322