### PR TITLE
OCPBUGS-28230: enforce termination message policy on all platform pods

### DIFF
--- a/bindata/network-diagnostics/network-check-target.yaml
+++ b/bindata/network-diagnostics/network-check-target.yaml
@@ -54,6 +54,7 @@ spec:
             path: /
           initialDelaySeconds: 30
           timeoutSeconds: 10
+        terminationMessagePolicy: FallbackToLogsOnError
         env:
         - name: K8S_NODE_NAME
           valueFrom:


### PR DESCRIPTION
missed one last time.  this adds the debugging info to the API on container crash.