### PR TITLE
OCPBUGS-31878: Propogate hypershift control plane priority class override to multus and preserve container resource requests

### DIFF
--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -218,11 +218,7 @@ spec:
       serviceAccountName: multus-ac
       priorityClassName: "system-cluster-critical"
 {{- else}}
-{{- if .PriorityClass}}
-      priorityClassName: {{.PriorityClass}}
-{{- else}}
-      priorityClassName: "hypershift-control-plane"
-{{- end }}
+      priorityClassName: {{ .PriorityClass | default "hypershift-control-plane" }}
 {{- end }}
       restartPolicy: Always
 {{- if not .ExternalControlPlane }}

--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -185,8 +185,8 @@ spec:
         imagePullPolicy: IfNotPresent
         resources:
           requests:
-            cpu: 10m
-            memory: 50Mi
+            cpu: {{ .ResourceRequestCPU | default "10" }}m
+            memory: {{ .ResourceRequestMemory | default "50" }}Mi
         ports:
         - name: metrics-port
           containerPort: 9091
@@ -218,7 +218,11 @@ spec:
       serviceAccountName: multus-ac
       priorityClassName: "system-cluster-critical"
 {{- else}}
+{{- if .PriorityClass}}
+      priorityClassName: {{.PriorityClass}}
+{{- else}}
       priorityClassName: "hypershift-control-plane"
+{{- end }}
 {{- end }}
       restartPolicy: Always
 {{- if not .ExternalControlPlane }}

--- a/pkg/hypershift/hypershift.go
+++ b/pkg/hypershift/hypershift.go
@@ -58,6 +58,7 @@ type HostedControlPlane struct {
 	NodeSelector                 map[string]string
 	AdvertiseAddress             string
 	AdvertisePort                int
+	PriorityClass                string
 }
 
 // AvailabilityPolicy specifies a high level availability policy for components.
@@ -141,6 +142,11 @@ func ParseHostedControlPlane(hcp *unstructured.Unstructured) (*HostedControlPlan
 		return nil, fmt.Errorf("failed to extract controllerAvailabilityPolicy: %v", err)
 	}
 
+	controlPlanePriorityClassAnnotation, _, err := unstructured.NestedString(hcp.UnstructuredContent(), "metadata", "annotations", "hypershift.openshift.io/control-plane-priority-class")
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract control plane priority class annotation: %v", err)
+	}
+
 	nodeSelector, _, err := unstructured.NestedStringMap(hcp.UnstructuredContent(), "spec", "nodeSelector")
 	if err != nil {
 		return nil, fmt.Errorf("failed extract nodeSelector: %v", err)
@@ -188,6 +194,7 @@ func ParseHostedControlPlane(hcp *unstructured.Unstructured) (*HostedControlPlan
 		NodeSelector:                 nodeSelector,
 		AdvertiseAddress:             advertiseAddress,
 		AdvertisePort:                int(advertisePort),
+		PriorityClass:                controlPlanePriorityClassAnnotation,
 	}, nil
 }
 

--- a/pkg/network/multus_admission_controller.go
+++ b/pkg/network/multus_admission_controller.go
@@ -11,7 +11,9 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 	"github.com/openshift/cluster-network-operator/pkg/hypershift"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/openshift/cluster-network-operator/pkg/names"
@@ -22,6 +24,8 @@ import (
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
 )
+
+const bytesInMiB = 1024 * 1024
 
 // ignoredNamespaces contains the comma separated namespace list that should be ignored
 // to watch by multus admission controller. This only initialized first invocation.
@@ -72,6 +76,8 @@ func renderMultusAdmissonControllerConfig(manifestDir string, externalControlPla
 	data.Data["ManagementClusterName"] = names.ManagementClusterName
 	data.Data["AdmissionControllerNamespace"] = "openshift-multus"
 	data.Data["RHOBSMonitoring"] = os.Getenv("RHOBS_MONITORING")
+	data.Data["ResourceRequestCPU"] = nil
+	data.Data["ResourceRequestMemory"] = nil
 	if hsc.Enabled {
 		data.Data["AdmissionControllerNamespace"] = hsc.Namespace
 		data.Data["KubernetesServiceHost"] = bootstrapResult.Infra.APIServers[bootstrap.APIServerDefaultLocal].Host
@@ -99,6 +105,25 @@ func renderMultusAdmissonControllerConfig(manifestDir string, externalControlPla
 		data.Data["ClusterIDLabel"] = hypershift.ClusterIDLabel
 		data.Data["ClusterID"] = bootstrapResult.Infra.HostedControlPlane.ClusterID
 		data.Data["HCPNodeSelector"] = bootstrapResult.Infra.HostedControlPlane.NodeSelector
+		data.Data["PriorityClass"] = bootstrapResult.Infra.HostedControlPlane.PriorityClass
+
+		// Preserve any existing multus container resource requests which may have been modified by an external source
+		multusDeploy := &appsv1.Deployment{}
+		err = client.ClientFor(clientName).CRClient().Get(
+			context.TODO(), types.NamespacedName{Namespace: hsc.Namespace, Name: "multus-admission-controller"}, multusDeploy)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get multus deployment: %v", err)
+		}
+		multusContainer, ok := findContainer(multusDeploy.Spec.Template.Spec.Containers, "multus-admission-controller")
+		if !ok {
+			return nil, errors.New("error finding multus container")
+		}
+		if !multusContainer.Resources.Requests.Cpu().IsZero() {
+			data.Data["ResourceRequestCPU"] = multusContainer.Resources.Requests.Cpu().MilliValue()
+		}
+		if !multusContainer.Resources.Requests.Memory().IsZero() {
+			data.Data["ResourceRequestMemory"] = multusContainer.Resources.Requests.Memory().Value() / bytesInMiB
+		}
 
 		data.Data["ReleaseImage"] = hsc.ReleaseImage
 	}
@@ -109,4 +134,13 @@ func renderMultusAdmissonControllerConfig(manifestDir string, externalControlPla
 	}
 	objs = append(objs, manifests...)
 	return objs, nil
+}
+
+func findContainer(conts []v1.Container, name string) (v1.Container, bool) {
+	for _, cont := range conts {
+		if cont.Name == name {
+			return cont, true
+		}
+	}
+	return v1.Container{}, false
 }

--- a/pkg/network/multus_admission_controller.go
+++ b/pkg/network/multus_admission_controller.go
@@ -14,6 +14,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/openshift/cluster-network-operator/pkg/names"
@@ -78,6 +79,7 @@ func renderMultusAdmissonControllerConfig(manifestDir string, externalControlPla
 	data.Data["RHOBSMonitoring"] = os.Getenv("RHOBS_MONITORING")
 	data.Data["ResourceRequestCPU"] = nil
 	data.Data["ResourceRequestMemory"] = nil
+	data.Data["PriorityClass"] = nil
 	if hsc.Enabled {
 		data.Data["AdmissionControllerNamespace"] = hsc.Namespace
 		data.Data["KubernetesServiceHost"] = bootstrapResult.Infra.APIServers[bootstrap.APIServerDefaultLocal].Host
@@ -111,18 +113,23 @@ func renderMultusAdmissonControllerConfig(manifestDir string, externalControlPla
 		multusDeploy := &appsv1.Deployment{}
 		err = client.ClientFor(clientName).CRClient().Get(
 			context.TODO(), types.NamespacedName{Namespace: hsc.Namespace, Name: "multus-admission-controller"}, multusDeploy)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get multus deployment: %v", err)
-		}
-		multusContainer, ok := findContainer(multusDeploy.Spec.Template.Spec.Containers, "multus-admission-controller")
-		if !ok {
-			return nil, errors.New("error finding multus container")
-		}
-		if !multusContainer.Resources.Requests.Cpu().IsZero() {
-			data.Data["ResourceRequestCPU"] = multusContainer.Resources.Requests.Cpu().MilliValue()
-		}
-		if !multusContainer.Resources.Requests.Memory().IsZero() {
-			data.Data["ResourceRequestMemory"] = multusContainer.Resources.Requests.Memory().Value() / bytesInMiB
+		if err == nil {
+			multusContainer, ok := findContainer(multusDeploy.Spec.Template.Spec.Containers, "multus-admission-controller")
+			if !ok {
+				return nil, errors.New("error finding multus container")
+			}
+			if !multusContainer.Resources.Requests.Cpu().IsZero() {
+				data.Data["ResourceRequestCPU"] = multusContainer.Resources.Requests.Cpu().MilliValue()
+			}
+			if !multusContainer.Resources.Requests.Memory().IsZero() {
+				data.Data["ResourceRequestMemory"] = multusContainer.Resources.Requests.Memory().Value() / bytesInMiB
+			}
+		} else {
+			if apierrors.IsNotFound(err) {
+				klog.Warningf("failed to get multus deployment: %v", err)
+			} else {
+				return nil, fmt.Errorf("failed to get multus deployment: %v", err)
+			}
 		}
 
 		data.Data["ReleaseImage"] = hsc.ReleaseImage

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -3612,15 +3612,6 @@ func (f *fakeClientReader) List(_ context.Context, _ crclient.ObjectList, _ ...c
 	return errors.New("unexpected invocation to List")
 }
 
-func findContainer(conts []v1.Container, name string) (v1.Container, bool) {
-	for _, cont := range conts {
-		if cont.Name == name {
-			return cont, true
-		}
-	}
-	return v1.Container{}, false
-}
-
 func convert(src *uns.Unstructured, dst metav1.Object) error {
 	j, err := src.MarshalJSON()
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
The multus-admission-controller component currently does not honor the hypershift custom priority class overrides specified on the hostedcluster.  The custom priority class override feature was first introduced to all other hypershift hosted control plane components in https://github.com/openshift/hypershift/pull/2661.  Multus was left out at the time due to it not being directly managed by the CPO.  These changes extend the hypershift custom priority class override feature to the multus-admission-controller to ensure that this component honors the custom class if it is set.  These changes also extend the hypershift control plane component resource preservation support to the multus container as well, where the expected behavior is that any modifications to the container's resource requests are not overwritten on subsequent reconciliations.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/OCPBUGS-31878