### PR TITLE
NP-974: Validation for live migration from OpenShiftSDN to OVNKubernetes 

### DIFF
--- a/pkg/client/list_pager.go
+++ b/pkg/client/list_pager.go
@@ -33,3 +33,17 @@ func ListAllNamespaces(ctx context.Context, client Client) ([]*v1.Namespace, err
 	})
 	return list, err
 }
+
+func ListAllPodsWithAnnotationKey(ctx context.Context, client Client, annotationKey string) ([]*v1.Pod, error) {
+	list := []*v1.Pod{}
+	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return client.Default().Kubernetes().CoreV1().Pods("").List(ctx, opts)
+	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+		pod := obj.(*v1.Pod)
+		if _, ok := pod.Annotations[annotationKey]; ok {
+			list = append(list, pod)
+		}
+		return nil
+	})
+	return list, err
+}

--- a/pkg/network/cluster_config.go
+++ b/pkg/network/cluster_config.go
@@ -1,16 +1,22 @@
 package network
 
 import (
+	"context"
+	"fmt"
 	"net"
 	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
+	v1 "github.com/openshift/api/network/v1"
 	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 	"github.com/openshift/cluster-network-operator/pkg/names"
 	"github.com/openshift/cluster-network-operator/pkg/platform"
 	iputil "github.com/openshift/cluster-network-operator/pkg/util/ip"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilnet "k8s.io/utils/net"
@@ -28,10 +34,10 @@ func ValidateClusterConfig(clusterConfig *configv1.Network, client cnoclient.Cli
 	if err != nil {
 		return err
 	}
-	return validateClusterConfig(clusterConfig, infraRes)
+	return validateClusterConfig(clusterConfig, infraRes, client)
 }
 
-func validateClusterConfig(clusterConfig *configv1.Network, infraRes *bootstrap.InfraStatus) error {
+func validateClusterConfig(clusterConfig *configv1.Network, infraRes *bootstrap.InfraStatus, client cnoclient.Client) error {
 
 	// Check all networks for overlaps
 	pool := iputil.IPPool{}
@@ -117,9 +123,129 @@ func validateClusterConfig(clusterConfig *configv1.Network, infraRes *bootstrap.
 	}
 
 	if _, ok := clusterConfig.Annotations[names.NetworkTypeMigrationAnnotation]; ok {
-		// HostedControlPlane is not nil if in a HyperShift env
-		if infraRes.HostedControlPlane != nil {
-			return errors.Errorf("network type live migration is not supported on HyperShift clusters")
+		return validateLiveMigration(clusterConfig, infraRes, client)
+	}
+
+	return nil
+}
+
+// validateCIDROverlap validates whether any of the ClusterNetwork and ServiceNetwork CIDRs overlap with
+// the internal CIDRs used by OVNKubernetes
+func validateOVNKubernetesCIDROverlap(clusterCofnig *configv1.Network, operConfig *operv1.Network) error {
+	// Verify whether the available subnets conflict between CNIs
+	type subnet struct {
+		name string
+		cidr string
+	}
+	var subnets []subnet
+	for _, cn := range clusterCofnig.Spec.ClusterNetwork {
+		subnets = append(subnets, subnet{
+			name: "clusterNetwork",
+			cidr: cn.CIDR,
+		})
+	}
+	for _, svcNet := range clusterCofnig.Spec.ServiceNetwork {
+		subnets = append(subnets, subnet{
+			name: "serviceNetwork",
+			cidr: svcNet,
+		})
+	}
+
+	v4InternalSubnet, v6InternalSubnet := GetInternalSubnets(operConfig.Spec.DefaultNetwork.OVNKubernetesConfig)
+	subnets = append(subnets, subnet{
+		name: "v4InternalSubnet",
+		cidr: v4InternalSubnet,
+	})
+	subnets = append(subnets, subnet{
+		name: "v6InternalSubnet",
+		cidr: v6InternalSubnet,
+	})
+
+	v4InternalTransitSwitchSubnet, v6InternalTransitSwitchSubnet := GetTransitSwitchSubnets(operConfig.Spec.DefaultNetwork.OVNKubernetesConfig)
+	subnets = append(subnets, subnet{
+		name: "v4InternalTransitSwitchSubnet",
+		cidr: v4InternalTransitSwitchSubnet,
+	})
+	subnets = append(subnets, subnet{
+		name: "v6InternalTransitSwitchSubnet",
+		cidr: v6InternalTransitSwitchSubnet,
+	})
+
+	v4InternalMasqueradeSubnet, v6InternalMasqueradeSubnet := GetMasqueradeSubnet(operConfig.Spec.DefaultNetwork.OVNKubernetesConfig)
+	subnets = append(subnets, subnet{
+		name: "v4InternalMasqueradeSubnet",
+		cidr: v4InternalMasqueradeSubnet,
+	})
+	subnets = append(subnets, subnet{
+		name: "v6InternalMasqueradeSubnet",
+		cidr: v6InternalMasqueradeSubnet,
+	})
+
+	for i, subnetA := range subnets {
+		for j, subnetB := range subnets {
+			// do not compare the same elements
+			if i == j {
+				continue
+			}
+
+			_, netA, err := net.ParseCIDR(subnetA.cidr)
+			if err != nil {
+				return errors.Wrapf(err, "could not parse %s:%s", subnetA.name, subnetA.cidr)
+			}
+			_, netB, err := net.ParseCIDR(subnetB.cidr)
+			if err != nil {
+				return errors.Wrapf(err, "could not parse %s:%s", subnetB.name, subnetB.cidr)
+			}
+			if netA.Contains(netB.IP) || netB.Contains(netA.IP) {
+				return fmt.Errorf("network %s(%s) overlaps with network %s(%s)",
+					subnetA.name, subnetA.cidr, subnetB.name, subnetB.cidr)
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateLiveMigration(clusterConfig *configv1.Network, infraRes *bootstrap.InfraStatus, client cnoclient.Client) error {
+	// If the migration is completed or is already progressing do not run the validation
+	if clusterConfig.Spec.NetworkType == clusterConfig.Status.NetworkType ||
+		meta.IsStatusConditionPresentAndEqual(clusterConfig.Status.Conditions, names.NetworkTypeMigrationInProgress, metav1.ConditionTrue) {
+		return nil
+	}
+	if clusterConfig.Spec.NetworkType != string(operv1.NetworkTypeOpenShiftSDN) &&
+		clusterConfig.Spec.NetworkType != string(operv1.NetworkTypeOVNKubernetes) {
+		return fmt.Errorf("network type live migration is only supported for OVNKubernetes and OpenShiftSDN CNI")
+	}
+
+	if infraRes.HostedControlPlane != nil {
+		return errors.Errorf("network type live migration is not supported on HyperShift clusters")
+	}
+
+	operNet := &operv1.Network{}
+	err := client.Default().CRClient().Get(context.TODO(), types.NamespacedName{Name: names.CLUSTER_CONFIG}, operNet)
+	if err != nil {
+		return errors.Errorf("error getting network configuration: %v", err)
+	}
+
+	// Status contains the CNI we are migrating from
+	if clusterConfig.Status.NetworkType == string(operv1.NetworkTypeOpenShiftSDN) {
+		if operNet.Spec.DefaultNetwork.OpenShiftSDNConfig != nil &&
+			operNet.Spec.DefaultNetwork.OpenShiftSDNConfig.Mode == operv1.SDNModeMultitenant {
+			return errors.Errorf("network type live migration is not supported on SDN Multitenant clusters")
+		}
+
+		if err := validateOVNKubernetesCIDROverlap(clusterConfig, operNet); err != nil {
+			return err
+		}
+
+		// Detect pods with pod.network.openshift.io/assign-macvlan (Used by egress router)
+		macVlanPods, err := cnoclient.ListAllPodsWithAnnotationKey(context.TODO(), client, v1.AssignMacvlanAnnotation)
+		if err != nil {
+			return errors.Wrapf(err, "error listing macvlan pods")
+		}
+		if len(macVlanPods) != 0 {
+			return fmt.Errorf("network type live migration is not supported for pods with %q annotation."+
+				" Please remove all egress router pods", v1.AssignMacvlanAnnotation)
 		}
 	}
 

--- a/pkg/network/cluster_config_test.go
+++ b/pkg/network/cluster_config_test.go
@@ -6,9 +6,12 @@ import (
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
+	v1 "github.com/openshift/api/network/v1"
 	operv1 "github.com/openshift/api/operator/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
 	"github.com/openshift/cluster-network-operator/pkg/client/fake"
@@ -106,52 +109,191 @@ func TestValidateClusterConfig(t *testing.T) {
 
 func TestValidClusterConfigLiveMigration(t *testing.T) {
 	g := NewGomegaWithT(t)
+	networkConfig := *ClusterConfig.DeepCopy()
+	networkConfig.NetworkType = "OVNKubernetes"
+
 	tests := []struct {
-		name              string
-		hypershiftCluster bool
-		annotation        bool
-		expectErr         bool
+		name             string
+		infraRes         *bootstrap.InfraStatus
+		config           *configv1.Network
+		objects          []crclient.Object
+		expectErr        bool
+		expectedErrorMsg string
 	}{
 		{
 			"no error when standalone cluster and migration label applied",
+			&bootstrap.InfraStatus{},
+			&configv1.Network{
+				Spec: networkConfig,
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{names.NetworkTypeMigrationAnnotation: ""},
+				}},
+			[]crclient.Object{&operv1.Network{ObjectMeta: metav1.ObjectMeta{Name: names.OPERATOR_CONFIG}}},
 			false,
-			true,
-			false,
+			"",
 		},
 		{
 
 			"no error when standalone cluster and migration label not applied",
+			&bootstrap.InfraStatus{},
+			&configv1.Network{Spec: networkConfig},
+			[]crclient.Object{&operv1.Network{ObjectMeta: metav1.ObjectMeta{Name: names.OPERATOR_CONFIG}}},
 			false,
-			false,
-			false,
+			"",
 		},
 		{
 			"error when HyperShift and migration label applied",
+			&bootstrap.InfraStatus{HostedControlPlane: &hypershift.HostedControlPlane{}},
+			&configv1.Network{
+				Spec: networkConfig,
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{names.NetworkTypeMigrationAnnotation: ""},
+				},
+				Status: configv1.NetworkStatus{NetworkType: string(operv1.NetworkTypeOpenShiftSDN)}},
+			[]crclient.Object{&operv1.Network{ObjectMeta: metav1.ObjectMeta{Name: names.OPERATOR_CONFIG}}},
 			true,
+			"network type live migration is not supported on HyperShift clusters",
+		},
+		{
+			"error when trying to migrate to an unsupported cni",
+			&bootstrap.InfraStatus{},
+			&configv1.Network{
+				Spec: *ClusterConfig.DeepCopy(),
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{names.NetworkTypeMigrationAnnotation: ""},
+				}},
+			[]crclient.Object{&operv1.Network{ObjectMeta: metav1.ObjectMeta{Name: names.OPERATOR_CONFIG}}},
 			true,
+			"network type live migration is only supported for OVNKubernetes and OpenShiftSDN CNI",
+		},
+		{
+			"error when trying to migrate from sdn in multinenat mode",
+			&bootstrap.InfraStatus{},
+			&configv1.Network{
+				Spec: networkConfig,
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{names.NetworkTypeMigrationAnnotation: ""},
+				},
+				Status: configv1.NetworkStatus{NetworkType: string(operv1.NetworkTypeOpenShiftSDN)}},
+			[]crclient.Object{&operv1.Network{
+				ObjectMeta: metav1.ObjectMeta{Name: names.OPERATOR_CONFIG},
+				Spec: operv1.NetworkSpec{
+					DefaultNetwork: operv1.DefaultNetworkDefinition{
+						Type:               operv1.NetworkTypeOpenShiftSDN,
+						OpenShiftSDNConfig: &operv1.OpenShiftSDNConfig{Mode: "Multitenant"}}}}},
 			true,
+			"network type live migration is not supported on SDN Multitenant clusters",
+		},
+		{
+			"error when cluster network overlaps with ovn-k internal subnet overlap",
+			&bootstrap.InfraStatus{},
+			&configv1.Network{
+				Spec: networkConfig,
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{names.NetworkTypeMigrationAnnotation: ""},
+				},
+				Status: configv1.NetworkStatus{NetworkType: string(operv1.NetworkTypeOpenShiftSDN)}},
+			[]crclient.Object{&operv1.Network{
+				ObjectMeta: metav1.ObjectMeta{Name: names.OPERATOR_CONFIG},
+				Spec: operv1.NetworkSpec{
+					DefaultNetwork: operv1.DefaultNetworkDefinition{
+						Type: operv1.NetworkTypeOpenShiftSDN,
+						OVNKubernetesConfig: &operv1.OVNKubernetesConfig{
+							// 10.2.0.0/22 is the second clusternetwork in networkConfig
+							V4InternalSubnet: "10.2.2.0/24",
+						}}}}},
+			true,
+			"network clusterNetwork(10.2.0.0/22) overlaps with network v4InternalSubnet(10.2.2.0/24)",
+		},
+		{
+			"error when service overlaps with ovn-k internal transit switch subnet overlap",
+			&bootstrap.InfraStatus{},
+			&configv1.Network{
+				Spec: networkConfig,
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{names.NetworkTypeMigrationAnnotation: ""},
+				},
+				Status: configv1.NetworkStatus{NetworkType: string(operv1.NetworkTypeOpenShiftSDN)}},
+			[]crclient.Object{&operv1.Network{
+				ObjectMeta: metav1.ObjectMeta{Name: names.OPERATOR_CONFIG},
+				Spec: operv1.NetworkSpec{
+					DefaultNetwork: operv1.DefaultNetworkDefinition{
+						Type: operv1.NetworkTypeOpenShiftSDN,
+						OVNKubernetesConfig: &operv1.OVNKubernetesConfig{
+							// "192.168.0.0/20" is the service network in networkConfig
+							IPv4: &operv1.IPv4OVNKubernetesConfig{
+								InternalTransitSwitchSubnet: "192.0.0.0/8",
+							},
+						}}}}},
+			true,
+
+			"network serviceNetwork(192.168.0.0/20) overlaps with network v4InternalTransitSwitchSubnet(192.0.0.0/8)",
+		},
+		{
+			"error when service network overlaps with ovn-k internal transit switch subnet overlap",
+			&bootstrap.InfraStatus{},
+			&configv1.Network{
+				Spec: func() configv1.NetworkSpec {
+					cfg := networkConfig
+					cfg.ClusterNetwork = []configv1.ClusterNetworkEntry{
+						{
+							CIDR:       "fd00:1234::/48",
+							HostPrefix: 64,
+						}}
+					//fd97::/64 is the default v6 transit switch subnet
+					cfg.ServiceNetwork = []string{"fd97::/48"}
+					return cfg
+				}(),
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{names.NetworkTypeMigrationAnnotation: ""},
+				},
+				Status: configv1.NetworkStatus{NetworkType: string(operv1.NetworkTypeOpenShiftSDN)}},
+			[]crclient.Object{&operv1.Network{
+				ObjectMeta: metav1.ObjectMeta{Name: names.OPERATOR_CONFIG},
+				Spec: operv1.NetworkSpec{
+					DefaultNetwork: operv1.DefaultNetworkDefinition{
+						Type: operv1.NetworkTypeOpenShiftSDN,
+					}}}},
+			true,
+			"network serviceNetwork(fd97::/48) overlaps with network v6InternalTransitSwitchSubnet(fd97::/64)",
+		},
+		{
+			"error when pods with 'pod.network.openshift.io/assign-macvlan' annotation are present in the cluster",
+			&bootstrap.InfraStatus{},
+			&configv1.Network{
+				Spec: networkConfig,
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{names.NetworkTypeMigrationAnnotation: ""},
+				},
+				Status: configv1.NetworkStatus{NetworkType: string(operv1.NetworkTypeOpenShiftSDN)}},
+			[]crclient.Object{
+				&operv1.Network{
+					ObjectMeta: metav1.ObjectMeta{Name: names.OPERATOR_CONFIG},
+					Spec: operv1.NetworkSpec{
+						DefaultNetwork: operv1.DefaultNetworkDefinition{
+							Type: operv1.NetworkTypeOpenShiftSDN,
+						},
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{v1.AssignMacvlanAnnotation: ""},
+					},
+				},
+			},
+			true,
+			"network type live migration is not supported for pods with \"pod.network.openshift.io/assign-macvlan\" annotation. Please remove all egress router pods",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cc := *ClusterConfig.DeepCopy()
-			net := &configv1.Network{Spec: cc}
-
-			infraRes := &bootstrap.InfraStatus{}
-
-			if tt.hypershiftCluster {
-				infraRes.HostedControlPlane = &hypershift.HostedControlPlane{}
-			}
-			if tt.annotation {
-				net.Annotations = map[string]string{names.NetworkTypeMigrationAnnotation: ""}
-			}
-			err := validateClusterConfig(net, infraRes)
+			client := fake.NewFakeClient(tt.objects...)
+			err := validateClusterConfig(tt.config, tt.infraRes, client)
 			if tt.expectErr {
 				g.Expect(err).To(HaveOccurred())
-				if tt.hypershiftCluster {
-					errMsg := "network type live migration is not supported on HyperShift clusters"
-					g.Expect(err).To(MatchError(Equal(errMsg)))
+				if tt.expectedErrorMsg != "" {
+					g.Expect(err).To(MatchError(Equal(tt.expectedErrorMsg)))
 				}
 			}
 			if !tt.expectErr {

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -65,8 +65,14 @@ const OVN_NODE_IDENTITY_CERT_DURATION = "24h"
 const OVN_EGRESSIP_HEALTHCHECK_PORT = "9107"
 
 const (
-	OVSFlowsConfigMapName   = "ovs-flows-config"
-	OVSFlowsConfigNamespace = names.APPLIED_NAMESPACE
+	OVSFlowsConfigMapName        = "ovs-flows-config"
+	OVSFlowsConfigNamespace      = names.APPLIED_NAMESPACE
+	defaultV4InternalSubnet      = "100.64.0.0/16"
+	defaultV6InternalSubnet      = "fd98::/64"
+	defaultV4TransitSwitchSubnet = "100.88.0.0/16"
+	defaultV6TransitSwitchSubnet = "fd97::/64"
+	defaultV4MasqueradeSubnet    = "169.254.169.0/29"
+	defaultV6MasqueradeSubnet    = "fd69::/125"
 )
 
 // renderOVNKubernetes returns the manifests for the ovn-kubernetes.
@@ -1883,4 +1889,81 @@ func validateOVNKubernetesSubnet(name, subnet string, otherSubnets *iputil.IPPoo
 		return fmt.Errorf("Whole or subset of %s CIDR %s is already in use: %s", name, subnet, err)
 	}
 	return nil
+}
+
+// GetInternalSubnets returns internal subnet values for both IP families
+// It returns default values if conf is nil or the subnets are not configured
+func GetInternalSubnets(conf *operv1.OVNKubernetesConfig) (v4Subnet, v6Subnet string) {
+	v4Subnet = defaultV4InternalSubnet
+	v6Subnet = defaultV6InternalSubnet
+
+	if conf == nil {
+		return
+	}
+
+	if conf.V4InternalSubnet != "" {
+		v4Subnet = conf.V4InternalSubnet
+	}
+	if conf.IPv4 != nil {
+		// conf.IPv4.InternalJoinSubnet takes precedence over conf.V4InternalSubnet
+		if conf.IPv4.InternalJoinSubnet != "" {
+			v4Subnet = conf.IPv4.InternalJoinSubnet
+		}
+	}
+
+	if conf.V6InternalSubnet != "" {
+		v6Subnet = conf.V6InternalSubnet
+	}
+	if conf.IPv6 != nil {
+		// conf.IPv6.InternalJoinSubnet takes precedence over conf.V6InternalSubnet
+		if conf.IPv6.InternalJoinSubnet != "" {
+			v6Subnet = conf.IPv6.InternalJoinSubnet
+		}
+	}
+	return
+}
+
+// GetTransitSwitchSubnets returns transit switch subnet values for both IP families
+// It returns default values if conf is nil or the subnets are not configured
+func GetTransitSwitchSubnets(conf *operv1.OVNKubernetesConfig) (v4Subnet, v6Subnet string) {
+	v4Subnet = defaultV4TransitSwitchSubnet
+	v6Subnet = defaultV6TransitSwitchSubnet
+
+	if conf == nil {
+		return
+	}
+
+	if conf.IPv4 != nil {
+		if conf.IPv4.InternalTransitSwitchSubnet != "" {
+			v4Subnet = conf.IPv4.InternalTransitSwitchSubnet
+		}
+	}
+
+	if conf.IPv6 != nil {
+		if conf.IPv6.InternalTransitSwitchSubnet != "" {
+			v6Subnet = conf.IPv6.InternalTransitSwitchSubnet
+		}
+	}
+	return
+}
+
+// GetMasqueradeSubnet returns masquerade subnet values for both IP families
+// It returns default values if conf is nil or the subnets are not configured
+func GetMasqueradeSubnet(conf *operv1.OVNKubernetesConfig) (v4Subnet, v6Subnet string) {
+	v4Subnet = defaultV4MasqueradeSubnet
+	v6Subnet = defaultV6MasqueradeSubnet
+
+	if conf == nil {
+		return
+	}
+
+	if conf.GatewayConfig != nil {
+		if conf.GatewayConfig.IPv4.InternalMasqueradeSubnet != "" {
+			v4Subnet = conf.GatewayConfig.IPv4.InternalMasqueradeSubnet
+		}
+		if conf.GatewayConfig.IPv6.InternalMasqueradeSubnet != "" {
+			v4Subnet = conf.GatewayConfig.IPv6.InternalMasqueradeSubnet
+		}
+	}
+	return
 }


### PR DESCRIPTION
Adds the following validations for OpenShiftSDN to OVNKubernetes live migration:
 - Do not allow migrating from OpenShiftSDN in multitenant mode.
 - Check whether any of the `ClusterNetwork` and `ServiceNetwork` CIDRs conflict with the internal OVNKubernetes subnets: `v[4|6]InternalSubnet`, `v[4|6]InternalTransitSwithSubnet` and `v[4|6]InternalMasquerateSubnet`.
 - Do not allow migrating from OpenShiftSDN if there are any pods
   with pod.network.openshift.io/assign-macvlan annotation present in the cluster.