### PR TITLE
SDN-4163: Improved prometheus rule for ipsec metric

### DIFF
--- a/bindata/cluster-network-operator/prometheus.yaml
+++ b/bindata/cluster-network-operator/prometheus.yaml
@@ -12,7 +12,7 @@ spec:
     - name: openshift-network.rules
       rules:
       - expr: |-
-          sum by (mode,is_legacy_api) (
+          group by (mode,is_legacy_api) (
             openshift_network_operator_ipsec_state{namespace=~"openshift-network-operator"}
           )
-        record: openshift:openshift_network_operator_ipsec_state:sum
+        record: openshift:openshift_network_operator_ipsec_state:info


### PR DESCRIPTION
A minor change to the Prometheus rule query and name as requested by the monitoring team