### PR TITLE
Revert #2330 "SDN-4726: Block upgrade for openshift-sdn"

### DIFF
--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -369,26 +369,12 @@ func (status *StatusManager) set(reachedAvailableLevel bool, conditions ...operv
 			)
 		}
 
-		if oc.Spec.DefaultNetwork.Type == operv1.NetworkTypeOpenShiftSDN {
-			// OpenShiftSDN is removed in 4.17, so block the upgrade if we have OpenShiftSDN in the spec.
-			v1helpers.SetOperatorCondition(&oc.Status.Conditions,
-				operv1.OperatorCondition{
-					Type:   operv1.OperatorStatusTypeUpgradeable,
-					Status: operv1.ConditionFalse,
-					Reason: "OpenShiftSDNConfigured",
-					Message: "Cluster is configured with OpenShiftSDN, which is not supported in the next version. Please " +
-						"follow the documented steps to migrate from OpenShiftSDN to OVN-Kubernetes in order to be able to upgrade. " +
-						"https://docs.openshift.com/container-platform/4.16/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html",
-				},
-			)
-		} else {
-			v1helpers.SetOperatorCondition(&oc.Status.Conditions,
-				operv1.OperatorCondition{
-					Type:   operv1.OperatorStatusTypeUpgradeable,
-					Status: operv1.ConditionTrue,
-				},
-			)
-		}
+		v1helpers.SetOperatorCondition(&oc.Status.Conditions,
+			operv1.OperatorCondition{
+				Type:   operv1.OperatorStatusTypeUpgradeable,
+				Status: operv1.ConditionTrue,
+			},
+		)
 
 		operStatus = &oc.Status
 

--- a/pkg/controller/statusmanager/status_manager_test.go
+++ b/pkg/controller/statusmanager/status_manager_test.go
@@ -253,59 +253,6 @@ func TestStatusManager_set(t *testing.T) {
 	}
 }
 
-func TestStatusManager_set_OpenShiftSDN(t *testing.T) {
-	client := fake.NewFakeClient()
-	status := New(client, "testing", "")
-
-	// make the network.operator object
-	log.Print("Creating Network Operator Config")
-	no := &operv1.Network{
-		ObjectMeta: metav1.ObjectMeta{Name: names.OPERATOR_CONFIG},
-		Spec: operv1.NetworkSpec{
-			DefaultNetwork: operv1.DefaultNetworkDefinition{
-				Type: operv1.NetworkTypeOpenShiftSDN,
-			},
-		},
-	}
-
-	set(t, client, no)
-
-	condNoProgress := operv1.OperatorCondition{
-		Type:   operv1.OperatorStatusTypeProgressing,
-		Status: operv1.ConditionFalse,
-	}
-	condAvailable := operv1.OperatorCondition{
-		Type:   operv1.OperatorStatusTypeAvailable,
-		Status: operv1.ConditionTrue,
-	}
-
-	// Check if OpenShiftSDN will make operator non-upgradable
-	no.Spec = operv1.NetworkSpec{
-		DefaultNetwork: operv1.DefaultNetworkDefinition{
-			Type: operv1.NetworkTypeOpenShiftSDN,
-		},
-	}
-	set(t, client, no)
-
-	condUpdateBlocked := operv1.OperatorCondition{
-		Type:   operv1.OperatorStatusTypeUpgradeable,
-		Status: operv1.ConditionFalse,
-		Reason: "OpenShiftSDNConfigured",
-		Message: "Cluster is configured with OpenShiftSDN, which is not supported in the next version. Please " +
-			"follow the documented steps to migrate from OpenShiftSDN to OVN-Kubernetes in order to be able to upgrade. " +
-			"https://docs.openshift.com/container-platform/4.16/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html",
-	}
-	status.set(true, condNoProgress, condAvailable)
-
-	oc, err := getOC(client)
-	if err != nil {
-		t.Fatalf("error getting network.operator: %v", err)
-	}
-	if !conditionsEqual(oc.Status.Conditions, []operv1.OperatorCondition{condAvailable, condUpdateBlocked, condNoProgress}) {
-		t.Fatalf("unexpected Status.Conditions: %#v", oc.Status.Conditions)
-	}
-}
-
 func TestStatusManagerSetDegraded(t *testing.T) {
 	client := fake.NewFakeClient()
 	status := New(client, "testing", names.StandAloneClusterName)


### PR DESCRIPTION

Reverts #2330 ; tracked by https://issues.redhat.com/browse/TRT-1618

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

All SDN jobs failing due to upgradeable false

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload 4.16 nightly blocking
```

CC: @pperiyasamy

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
