### PR TITLE
OCPBUGS-32991: Add conditions for ignored-namespaces

### DIFF
--- a/pkg/network/multus_admission_controller.go
+++ b/pkg/network/multus_admission_controller.go
@@ -40,7 +40,10 @@ func getOpenshiftNamespaces(client cnoclient.Client) (string, error) {
 	}
 
 	for _, ns := range nsList.Items {
-		namespaces = append(namespaces, ns.Name)
+		// add OpenShift components to ignored namespace
+		if metav1.HasAnnotation(ns.ObjectMeta, "workload.openshift.io/allowed") && ns.Annotations["workload.openshift.io/allowed"] == "management" {
+			namespaces = append(namespaces, ns.Name)
+		}
 	}
 	return strings.Join(namespaces, ","), nil
 }

--- a/pkg/network/multus_admission_controller_test.go
+++ b/pkg/network/multus_admission_controller_test.go
@@ -174,6 +174,9 @@ func TestRenderMultusAdmissionControllerGetNamespace(t *testing.T) {
 				Labels: map[string]string{
 					"openshift.io/cluster-monitoring": "true",
 				},
+				Annotations: map[string]string{
+					"workload.openshift.io/allowed": "management",
+				},
 			},
 		},
 		&corev1.Namespace{
@@ -185,6 +188,9 @@ func TestRenderMultusAdmissionControllerGetNamespace(t *testing.T) {
 			Name: "test3-ignored",
 			Labels: map[string]string{
 				"openshift.io/cluster-monitoring": "true",
+			},
+			Annotations: map[string]string{
+				"workload.openshift.io/allowed": "management",
 			},
 		},
 		})


### PR DESCRIPTION
This code changes to introduce additional condition check for ignored-namespaces, whether the ns is openshift component or not