### PR TITLE
NP-975: Stop OpenShift SDN control plane during live migration

### DIFF
--- a/bindata/network/openshift-sdn/controller.yaml
+++ b/bindata/network/openshift-sdn/controller.yaml
@@ -28,9 +28,8 @@ spec:
         - -c
         - |
 {{- if .IsNetworkTypeLiveMigration }}
-          echo "wait for hostsubnets to be created by sdn pods"
-          # The hostsubnets needs be created according to the ovnkube node-subnets by the sdn pods before running the sdn controller.
-          while ! oc get nodes -o custom-columns=NAME:.metadata.name --no-headers| xargs -i oc get hostsubnet {}; do sleep 3; done
+          echo "stop sdn controller in live migration"
+          sleep infinity
 {{- end }}
           if [[ -f /env/_master ]]; then
             set -o allexport

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -452,6 +452,7 @@ spec:
                   break
               elif [ -z "${SDN_SUBNET}" ] && [ -n "${OVN_SUBNET}" ]; then
                   echo "OVN_SUBNET is ${OVN_SUBNET}"
+                  SUBNET=${OVN_SUBNET}
                   break
               elif [ -n "${SDN_SUBNET}" ] && [ -n "${OVN_SUBNET}" ] && [ "${SDN_SUBNET}" == "${OVN_SUBNET}" ]; then
                   echo "Subnets matched! SDN_SUBNET: ${SDN_SUBNET}, OVN_SUBNET: ${OVN_SUBNET}"


### PR DESCRIPTION
During SDN live migration, both OpenShift and OVNKubernetes run in parallel within a cluster. If a new node is added to the cluster, the control planes of both CNIs attempt to allocate a node subnet for it, resulting in a conflict. To address this, the OpenShift SDN control plane is halted during live migration, and the migration script within the ovnkube-node pod takes responsibility for creating the hostsubnet for the new node, and make the allocated node subnet aligned in both CNIs.