### PR TITLE
NP-975: Align new node subnet allocation between OVN-K and SDN during live migration

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -67,26 +67,45 @@ spec:
           #!/bin/bash
           set -euo pipefail
 {{- if .IsNetworkTypeLiveMigration }}
-          # In case of rollback, openshift-sdn need to reuse the host subnet used by ovn-kube, so we need to create the hostsubnet CR for the local node if it doesn't exist.
+          set -x
+          NODE_CNI="OpenShiftSDN"
+          if ip link show br-ex; then
+            echo "br-ex exists"
+            NODE_CNI="OVNKubernetes"
+          else
+            echo "br-ex doesn't exist"
+          fi
+
           # retry loop
           RETRY_INTERVAL=3
-          MAX_RETRIES=10
+          MAX_RETRIES=100
           for ((retry_count=1; retry_count<=MAX_RETRIES; retry_count++)); do
-              # Get SDN subnet
-              SDN_SUBNET=$(oc get hostsubnet ${K8S_NODE_NAME} -o jsonpath="{.subnet}"||true)
+            # Get SDN subnet
+            SDN_SUBNET=$(oc get hostsubnet ${K8S_NODE_NAME} -o jsonpath="{.subnet}"||true)
 
-              # Get OVN subnet
-              OVN_SUBNET=$(oc get node ${K8S_NODE_NAME} -o jsonpath='{.metadata.annotations.k8s\.ovn\.org/node-subnets}' | grep -o -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,3}'||true)
+            # Get OVN subnet
+            OVN_SUBNET=$(oc get node ${K8S_NODE_NAME} -o jsonpath='{.metadata.annotations.k8s\.ovn\.org/node-subnets}' | grep -o -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,3}'||true)
 
-              if [ -n "${SDN_SUBNET}" ] && [ -z "${OVN_SUBNET}" ]; then
-                  echo "SDN_SUBNET is ${SDN_SUBNET}"
-                  break
-              elif [ -z "${SDN_SUBNET}" ] && [ -n "${OVN_SUBNET}" ]; then
+            if [ "${NODE_CNI}" == "OpenShiftSDN" ]; then
+              if [ -z "${SDN_SUBNET}" ]; then
+                echo "SDN node subnet is not found, retry..."
+                sleep $RETRY_INTERVAL
+              else
+                break
+              fi
+            else
+              if [ -z "${OVN_SUBNET}" ]; then
+                echo "OVN node subnet is not found, retry..."
+                sleep $RETRY_INTERVAL
+              else
+                # When rolling back, SDN controll plane will not start until the hostsubnet has been created here.
+                echo "Use OVN-K subnet ${OVN_SUBNET}, when the node CNI is OVN-K"
+                if [ -z "${SDN_SUBNET}" ]; then
                   echo "SDN_SUBNET is empty, create the hostsubnet CR with OVN_SUBNET ${OVN_SUBNET}"
                   SUBNET=${OVN_SUBNET}
                   NODE_UID=$(oc get node ${K8S_NODE_NAME} -o jsonpath='{.metadata.uid}')
                   NODE_IP=$(oc get node ${K8S_NODE_NAME} -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
-          cat <<EOF | oc apply -f -
+                  cat <<EOF | oc apply -f -
           apiVersion: network.openshift.io/v1
           kind: HostSubnet
           metadata:
@@ -97,27 +116,21 @@ spec:
           hostIP: ${NODE_IP}
           subnet: ${SUBNET}
           EOF
-              elif [ -n "${SDN_SUBNET}" ] && [ -n "${OVN_SUBNET}" ] && [ "${SDN_SUBNET}" == "${OVN_SUBNET}" ]; then
-                  echo "Subnets matched! SDN_SUBNET: ${SDN_SUBNET}, OVN_SUBNET: ${OVN_SUBNET}"
-                  break
-              elif [ -n "${SDN_SUBNET}" ] && [ -n "${OVN_SUBNET}" ] && ! [ "${SDN_SUBNET}" == "${OVN_SUBNET}" ]; then
-                  echo "Subnets don't match! SDN_SUBNET: ${SDN_SUBNET}, OVN_SUBNET: ${OVN_SUBNET}"
-                  exit 1
-              else
-                  echo "Round ${retry_count}/${MAX_RETRIES} - Retrying... SDN_SUBNET: ${SDN_SUBNET}, OVN_SUBNET: ${OVN_SUBNET}"
-                  sleep $RETRY_INTERVAL
+                fi
+                break
               fi
+            fi
           done
           if [ ${retry_count} -gt ${MAX_RETRIES} ]; then
-              echo "All retries failed. Exiting."
-              exit 1
+            echo "All retries failed. Exiting."
+            exit 1
           fi
-          if ovs-vsctl br-exists br-ex; then
-            echo "br-ex exists, sleep..."
+          if [ "${NODE_CNI}" == "OVNKubernetes" ]; then
+            echo "sleep..."
             trap : TERM INT; sleep infinity & wait
             exit
           else
-            echo "br-ex doesn't exist"
+            echo "run openshift-sdn-node"
           fi
           ovs-vsctl --if-exists del-br br-int
           ovs-vsctl --if-exists del-br br-ext
@@ -315,7 +328,7 @@ spec:
               #!/bin/bash
               set -euo pipefail
 {{- if .IsNetworkTypeLiveMigration }}
-              if ovs-vsctl br-exists br-ex; then
+              if ip link show br-ex; then
                 exit 0
               fi
 {{- end}}

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -435,49 +435,39 @@ spec:
         - |
           set -xe
 {{- if .IsNetworkTypeLiveMigration }}
-          # In case of rollback, ovnkube need to reuse the host subnet used by openshift-sdn, so we need to create the node subnets annotations for the local node if it doesn't exist.
-          # retry loop
+          NODE_CNI="OVNKubernetes"
+          if ip link show br-ex; then
+            echo "br-ex exists"
+            kubectl label node --overwrite ${K8S_NODE} migration.network.openshift.io/plugin-
+          else
+            echo "br-ex doesn't exist"
+            NODE_CNI="OpenShiftSDN"
+            kubectl label node --overwrite ${K8S_NODE} migration.network.openshift.io/plugin=
+          fi
+
           RETRY_INTERVAL=3
-          MAX_RETRIES=10
+          MAX_RETRIES=100
           for ((retry_count=1; retry_count<=MAX_RETRIES; retry_count++)); do
-              # Get SDN subnet
-              SDN_SUBNET=$(kubectl get hostsubnet ${K8S_NODE} -o jsonpath="{.subnet}"||true)
-
-              # Get OVN subnet
-              OVN_SUBNET=$(kubectl get node ${K8S_NODE} -o jsonpath='{.metadata.annotations.k8s\.ovn\.org/node-subnets}' | grep -o -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,3}'||true)
-
-              if [ -n "${SDN_SUBNET}" ] && [ -z "${OVN_SUBNET}" ]; then
-                  echo "OVN_SUBNET is empty, create the node-subnets annotation with the SDN_SUBNET ${SDN_SUBNET}"
-                  SUBNET=${SDN_SUBNET}
-                  break
-              elif [ -z "${SDN_SUBNET}" ] && [ -n "${OVN_SUBNET}" ]; then
-                  echo "OVN_SUBNET is ${OVN_SUBNET}"
-                  break
-              elif [ -n "${SDN_SUBNET}" ] && [ -n "${OVN_SUBNET}" ] && [ "${SDN_SUBNET}" == "${OVN_SUBNET}" ]; then
-                  echo "Subnets matched! SDN_SUBNET: ${SDN_SUBNET}, OVN_SUBNET: ${OVN_SUBNET}"
-                  SUBNET=${SDN_SUBNET}
-                  break
-              elif [ -n "${SDN_SUBNET}" ] && [ -n "${OVN_SUBNET}" ] && ! [ "${SDN_SUBNET}" == "${OVN_SUBNET}" ]; then
-                  echo "Subnets don't match! SDN_SUBNET: ${SDN_SUBNET}, OVN_SUBNET: ${OVN_SUBNET}"
-                  exit 1
-              else
-                  echo "Round ${retry_count}/${MAX_RETRIES} - Retrying... SDN_SUBNET: ${SDN_SUBNET}, OVN_SUBNET: ${OVN_SUBNET}"
-                  sleep $RETRY_INTERVAL
-              fi
+            # Align the node subnet with SDN
+            SDN_SUBNET=$(kubectl get hostsubnet ${K8S_NODE} -o jsonpath="{.subnet}"||true)
+            if [ -z "${SDN_SUBNET}" ]; then
+              echo "SDN node subnet is not found, retry..."
+              sleep $RETRY_INTERVAL
+            else
+              echo "use SDN node subnet ${SDN_SUBNET}"
+              SUBNET=${SDN_SUBNET}
+              break
+            fi
           done
           if [ ${retry_count} -gt ${MAX_RETRIES} ]; then
-              echo "All retries failed. Exiting."
-              exit 1
+            echo "All retries failed. Exiting."
+            exit 1
           fi
 
           kubectl annotate node ${K8S_NODE} --overwrite k8s.ovn.org/node-subnets={\"default\":[\"${SUBNET}\"]}
           kubectl annotate node ${K8S_NODE} --overwrite k8s.ovn.org/hybrid-overlay-node-subnet=${SUBNET}
-          if ip link show br-ex; then
-            echo "br-ex exists, run ovnkube"
-            kubectl label node --overwrite ${K8S_NODE} migration.network.openshift.io/plugin-
-          else
-            echo "br-ex doesn't exist"
-            kubectl label node --overwrite ${K8S_NODE} migration.network.openshift.io/plugin=
+
+          if [ "${NODE_CNI}" == "OpenShiftSDN" ]; then
             echo "run hybrid-overlay-node"
             NETWORK_NODE_IDENTITY_ENABLE=
             if [[ "{{.NETWORK_NODE_IDENTITY_ENABLE}}" == "true" ]]; then


### PR DESCRIPTION
During live migration, we run ovn-k and sdn in parallel. When new nodes are added to the cluster, ovn-k and sdn may assign different subnets to the nodes. This patch lets ovn-k subject to sdn for the node subnet allocation when both CNIs are deployed.