### PR TITLE
OCPBUGS-30950: Set mount propagation to HostToContainer for /var/lib/kubelet

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -282,6 +282,7 @@ spec:
         # kubelet socket
         - name: host-var-lib-kubelet
           mountPath: /var/lib/kubelet
+          mountPropagation: HostToContainer
         - name: hostroot
           mountPath: /hostroot
           mountPropagation: HostToContainer

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -438,6 +438,7 @@ spec:
         - mountPath: /var/lib/kubelet
           name: host-kubelet
           readOnly: true
+          mountPropagation: HostToContainer
 {{ end }}
         # for checking ovs-configuration service
         - mountPath: /etc/systemd/system

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -557,6 +557,7 @@ spec:
         - mountPath: /var/lib/kubelet
           name: host-kubelet
           readOnly: true
+          mountPropagation: HostToContainer
 {{ end }}
         # for checking ovs-configuration service
         - mountPath: /etc/systemd/system


### PR DESCRIPTION
This PR is to change mountPropagation for /var/lib/kubelet mount from None to HostToContainer. This is to allow clean unmount of CSI Volumes.

Jira: https://issues.redhat.com/browse/OCPBUGS-30950