### PR TITLE
OCPBUGS-23000: Adds cluster-autoscaler annotation to prevent eviction

### DIFF
--- a/bindata/allowlist/daemonset/daemonset.yaml
+++ b/bindata/allowlist/daemonset/daemonset.yaml
@@ -14,6 +14,8 @@ spec:
         app: cni-sysctl-allowlist-ds
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        # prevent blocks when node critical pods get evicted prior to workloads
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
     spec:
       hostNetwork: true
       containers:

--- a/bindata/kube-proxy/kube-proxy.yaml
+++ b/bindata/kube-proxy/kube-proxy.yaml
@@ -29,6 +29,8 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        # prevent blocks when node critical pods get evicted prior to workloads
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
       labels:
         app: kube-proxy
         component: network

--- a/bindata/network/iptables-alerter/003-daemonset.yaml
+++ b/bindata/network/iptables-alerter/003-daemonset.yaml
@@ -20,6 +20,8 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        # prevent blocks when node critical pods get evicted prior to workloads
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
       labels:
         app: iptables-alerter
         component: network

--- a/bindata/network/multus-networkpolicy/multus-networkpolicy.yaml
+++ b/bindata/network/multus-networkpolicy/multus-networkpolicy.yaml
@@ -20,6 +20,8 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        # prevent blocks when node critical pods get evicted prior to workloads
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
       labels:
         app: multus-networkpolicy
         component: network

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -215,6 +215,8 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        # prevent blocks when node critical pods get evicted prior to workloads
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
       labels:
         app: multus
         component: network
@@ -415,6 +417,8 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        # prevent blocks when node critical pods get evicted prior to workloads
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
       labels:
         app: multus-additional-cni-plugins
         component: network
@@ -720,6 +724,8 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        # prevent blocks when node critical pods get evicted prior to workloads
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
       labels:
         app: whereabouts-reconciler
         name: whereabouts-reconciler

--- a/bindata/network/network-metrics/001-daemonset.yaml
+++ b/bindata/network/network-metrics/001-daemonset.yaml
@@ -21,6 +21,8 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        # prevent blocks when node critical pods get evicted prior to workloads
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
       labels:
         app: network-metrics-daemon
         component: network

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -45,6 +45,8 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        # prevent blocks when node critical pods get evicted prior to workloads
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
       labels:
         app: sdn
         component: network

--- a/bindata/network/ovn-kubernetes/common/ipsec-containerized.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-containerized.yaml
@@ -20,6 +20,8 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        # prevent blocks when node critical pods get evicted prior to workloads
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
       labels:
         app: ovn-ipsec
         component: network

--- a/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
@@ -20,6 +20,8 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        # prevent blocks when node critical pods get evicted prior to workloads
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
       labels:
         app: ovn-ipsec
         component: network

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -35,6 +35,8 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         network.operator.openshift.io/ovnkube-script-lib-hash: "{{.OVNKubeConfigHash}}"
+        # prevent blocks when node critical pods get evicted prior to workloads
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
       labels:
         {{ if eq .OVN_NODE_MODE "dpu-host" }}
         app: ovnkube-node-dpu-host

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -35,6 +35,8 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         network.operator.openshift.io/ovnkube-script-lib-hash: "{{.OVNKubeConfigHash}}"
+        # prevent blocks when node critical pods get evicted prior to workloads
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
       labels:
         {{ if eq .OVN_NODE_MODE "dpu-host" }}
         app: ovnkube-node-dpu-host


### PR DESCRIPTION
This change updates the daemonsets of:

  - iptables-alerter
  - multus
  - network-metrics
  - ovnkube-node
  - kube-proxy
  - sdn/openshift-sdn
  - [ovn-ipsec-containerized|ovn-ipsec-host]/openshift-ovn-kubernetes
  - multus-networkpolicy
  - whereabouts-reconciler
  - cni-sysctl-allowlist-ds

with an annotation that prevents the cluster-autoscaler from evicting them during a scaling event.

This is to ensure that scaling can happen without stopping workloads from being evicted, due to critical components not being present on the node.