### PR TITLE
OCPBUGS-33728: use v4-masquerade-subnet config str

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/004-config.yaml
@@ -133,7 +133,7 @@ data:
     mode={{.OVN_GATEWAY_MODE}}
     nodeport=true
 {{- if (index . "V4InternalMasqueradeSubnet")}}
-    v4-internal-masquerade-subnet="{{.V4InternalMasqueradeSubnet}}"
+    v4-masquerade-subnet="{{.V4InternalMasqueradeSubnet}}"
 {{- end }}
 {{- if (index . "V6InternalMasqueradeSubnet")}}
     v6-internal-masquerade-subnet="{{.V6InternalMasqueradeSubnet}}"

--- a/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
@@ -60,7 +60,7 @@ data:
     mode={{.OVN_GATEWAY_MODE}}
     nodeport=true
 {{- if (index . "V4InternalMasqueradeSubnet")}}
-    v4-internal-masquerade-subnet="{{.V4InternalMasqueradeSubnet}}"
+    v4-masquerade-subnet="{{.V4InternalMasqueradeSubnet}}"
 {{- end }}
 {{- if (index . "V6InternalMasqueradeSubnet")}}
     v6-internal-masquerade-subnet="{{.V6InternalMasqueradeSubnet}}"

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -266,7 +266,7 @@ enable-multi-external-gateway=true
 [gateway]
 mode=shared
 nodeport=true
-v4-internal-masquerade-subnet="100.98.0.0/16"
+v4-masquerade-subnet="100.98.0.0/16"
 
 [logging]
 libovsdblogfile=/var/log/ovnkube/libovsdb.log


### PR DESCRIPTION
ovn-kubernetes expects v4-masquerade-subnet not
v4-internal-masquerade-subnet:

  https://github.com/ovn-org/ovn-kubernetes/blob/f5d4dfb6acef57d9a4cad95fedd672dfe4112f9a/go-controller/pkg/config/config.go#L444