### PR TITLE
OCPBUGS-33728: Add custom masquerade subnet against right key at ovnkube-config CM

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/004-config.yaml
@@ -53,6 +53,12 @@ data:
     [gateway]
     mode={{.OVN_GATEWAY_MODE}}
     nodeport=true
+{{- if (index . "V4InternalMasqueradeSubnet")}}
+    v4-masquerade-subnet="{{.V4InternalMasqueradeSubnet}}"
+{{- end }}
+{{- if (index . "V6InternalMasqueradeSubnet")}}
+    v6-masquerade-subnet="{{.V6InternalMasqueradeSubnet}}"
+{{- end }}
 {{- if .OVNHybridOverlayEnable }}
 
     [hybridoverlay]
@@ -133,10 +139,10 @@ data:
     mode={{.OVN_GATEWAY_MODE}}
     nodeport=true
 {{- if (index . "V4InternalMasqueradeSubnet")}}
-    v4-internal-masquerade-subnet="{{.V4InternalMasqueradeSubnet}}"
+    v4-masquerade-subnet="{{.V4InternalMasqueradeSubnet}}"
 {{- end }}
 {{- if (index . "V6InternalMasqueradeSubnet")}}
-    v6-internal-masquerade-subnet="{{.V6InternalMasqueradeSubnet}}"
+    v6-masquerade-subnet="{{.V6InternalMasqueradeSubnet}}"
 {{- end }}
 
 

--- a/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
@@ -60,10 +60,10 @@ data:
     mode={{.OVN_GATEWAY_MODE}}
     nodeport=true
 {{- if (index . "V4InternalMasqueradeSubnet")}}
-    v4-internal-masquerade-subnet="{{.V4InternalMasqueradeSubnet}}"
+    v4-masquerade-subnet="{{.V4InternalMasqueradeSubnet}}"
 {{- end }}
 {{- if (index . "V6InternalMasqueradeSubnet")}}
-    v6-internal-masquerade-subnet="{{.V6InternalMasqueradeSubnet}}"
+    v6-masquerade-subnet="{{.V6InternalMasqueradeSubnet}}"
 {{- end }}
 
     [logging]

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -266,7 +266,7 @@ enable-multi-external-gateway=true
 [gateway]
 mode=shared
 nodeport=true
-v4-internal-masquerade-subnet="100.98.0.0/16"
+v4-masquerade-subnet="100.98.0.0/16"
 
 [logging]
 libovsdblogfile=/var/log/ovnkube/libovsdb.log


### PR DESCRIPTION
CNO is writing custom masquerade subnet into ovnkube-config CM but against key v4-internal-masquerade-subnet and v6-internal-masquerade-subnet. However ovnkube is expecting custom masquerade subnet from v4-masquerade-subnet and v6-masquerade-subnet keys.

Additionally custom masquerade subnet needs to be added for managed hub cluster as well. This PR also takes care of that part.