### PR TITLE
[release-4.16] OCPBUGS-34013: Add custom masquerade subnet against right key at ovnkube-config CM

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/004-config.yaml
@@ -56,6 +56,12 @@ data:
     [gateway]
     mode={{.OVN_GATEWAY_MODE}}
     nodeport=true
+{{- if (index . "V4InternalMasqueradeSubnet")}}
+    v4-masquerade-subnet="{{.V4InternalMasqueradeSubnet}}"
+{{- end }}
+{{- if (index . "V6InternalMasqueradeSubnet")}}
+    v6-masquerade-subnet="{{.V6InternalMasqueradeSubnet}}"
+{{- end }}
 {{- if .OVNHybridOverlayEnable }}
 
     [hybridoverlay]
@@ -139,10 +145,10 @@ data:
     mode={{.OVN_GATEWAY_MODE}}
     nodeport=true
 {{- if (index . "V4InternalMasqueradeSubnet")}}
-    v4-internal-masquerade-subnet="{{.V4InternalMasqueradeSubnet}}"
+    v4-masquerade-subnet="{{.V4InternalMasqueradeSubnet}}"
 {{- end }}
 {{- if (index . "V6InternalMasqueradeSubnet")}}
-    v6-internal-masquerade-subnet="{{.V6InternalMasqueradeSubnet}}"
+    v6-masquerade-subnet="{{.V6InternalMasqueradeSubnet}}"
 {{- end }}
 
 

--- a/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
@@ -63,10 +63,10 @@ data:
     mode={{.OVN_GATEWAY_MODE}}
     nodeport=true
 {{- if (index . "V4InternalMasqueradeSubnet")}}
-    v4-internal-masquerade-subnet="{{.V4InternalMasqueradeSubnet}}"
+    v4-masquerade-subnet="{{.V4InternalMasqueradeSubnet}}"
 {{- end }}
 {{- if (index . "V6InternalMasqueradeSubnet")}}
-    v6-internal-masquerade-subnet="{{.V6InternalMasqueradeSubnet}}"
+    v6-masquerade-subnet="{{.V6InternalMasqueradeSubnet}}"
 {{- end }}
 
     [logging]

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -276,7 +276,7 @@ enable-multi-external-gateway=true
 [gateway]
 mode=shared
 nodeport=true
-v4-internal-masquerade-subnet="100.98.0.0/16"
+v4-masquerade-subnet="100.98.0.0/16"
 
 [logging]
 libovsdblogfile=/var/log/ovnkube/libovsdb.log


### PR DESCRIPTION
CNO is writing custom masquerade subnet into ovnkube-config CM but against key v4-internal-masquerade-subnet and v6-internal-masquerade-subnet. However ovnkube is expecting custom masquerade subnet from v4-masquerade-subnet and v6-masquerade-subnet keys.

Additionally custom masquerade subnet needs to be added for managed hub cluster as well. This PR also takes care of that part.

Signed-off-by: Arnab Ghosh <arnabghosh89@gmail.com>
(cherry picked from commit aeb0b1cb239d24798a06ca66b95a008adc7fd4c9)