### PR TITLE
OCPBUGS-34359: Ensure that the node-identity webhook address contains colons for IPv6

### DIFF
--- a/bindata/network/node-identity/self-hosted/node-identity-pki.yaml
+++ b/bindata/network/node-identity/self-hosted/node-identity-pki.yaml
@@ -7,4 +7,4 @@ metadata:
   namespace: openshift-network-node-identity
 spec:
   targetCert:
-    commonName: {{.NetworkNodeIdentityAddress}}
+    commonName: {{.NetworkNodeIdentityIP}}

--- a/bindata/network/node-identity/self-hosted/node-identity-webhook.yaml
+++ b/bindata/network/node-identity/self-hosted/node-identity-webhook.yaml
@@ -6,7 +6,7 @@ webhooks:
 {{ if .ConfigureNodeAdmissionWebhook }}
   - name: node.network-node-identity.openshift.io
     clientConfig:
-      url: https://{{.NetworkNodeIdentityAddress}}:{{.NetworkNodeIdentityPort}}/node
+      url: https://{{.NetworkNodeIdentityAddress}}/node
       caBundle: {{.NetworkNodeIdentityCABundle}}
     admissionReviewVersions: ['v1']
     sideEffects: None
@@ -19,7 +19,7 @@ webhooks:
 {{ end }}
   - name: pod.network-node-identity.openshift.io
     clientConfig:
-      url: https://{{.NetworkNodeIdentityAddress}}:{{.NetworkNodeIdentityPort}}/pod
+      url: https://{{.NetworkNodeIdentityAddress}}/pod
       caBundle: {{.NetworkNodeIdentityCABundle}}
     admissionReviewVersions: ['v1']
     sideEffects: None

--- a/bindata/network/node-identity/self-hosted/node-identity.yaml
+++ b/bindata/network/node-identity/self-hosted/node-identity.yaml
@@ -52,7 +52,7 @@ spec:
             # sets pod annotations in multi-homing layer3 network controller (cluster-manager)
             exec /usr/bin/ovnkube-identity  --k8s-apiserver={{.K8S_APISERVER}} \
                 --webhook-cert-dir="/etc/webhook-cert" \
-                --webhook-host={{.NetworkNodeIdentityAddress}} \
+                --webhook-host={{.NetworkNodeIdentityIP}} \
                 --webhook-port={{.NetworkNodeIdentityPort}} \
                 ${ho_enable} \
                 --enable-interconnect \


### PR DESCRIPTION
For clusters with IPv6 as the primary network the `network-node-identity.openshift.io` admission webhook should have the IP address in brackets.
The only actual change is that we include brackets in the webhook address when using ipv6 (`url: https://::1:9743/node` changes to `url: https://[::1]:9743/node`)

The issue was observed during testing of the k8s 1.30 rebase in which the webhook client started using http2 for loopback IPs: https://github.com/kubernetes/kubernetes/pull/122558.
It looks like the issue is caused by how a http2 client handles this invalid address, I verified this change by setting up a cluster with https://github.com/openshift/kubernetes/pull/1953 and this pr.