### PR TITLE
SDN-4896: Drop openshift-sdn support

### DIFF
--- a/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
@@ -50,8 +50,6 @@ spec:
         env:
         - name: RELEASE_VERSION
           value: 0.0.1-snapshot
-        - name: SDN_IMAGE
-          value: quay.io/openshift/origin-sdn:latest
         - name: KUBE_PROXY_IMAGE
           value: quay.io/openshift/origin-kube-proxy:latest
         - name: KUBE_RBAC_PROXY_IMAGE

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -62,8 +62,6 @@ spec:
         env:
         - name: RELEASE_VERSION
           value: "0.0.1-snapshot"
-        - name: SDN_IMAGE
-          value: "quay.io/openshift/origin-sdn:latest"
         - name: KUBE_PROXY_IMAGE
           value: "quay.io/openshift/origin-kube-proxy:latest"
         - name: KUBE_RBAC_PROXY_IMAGE

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -6,10 +6,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-cluster-network-operator:latest
-  - name: sdn
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-sdn:latest
   - name: kube-proxy
     from:
       kind: DockerImage

--- a/pkg/network/openshift_sdn_test.go
+++ b/pkg/network/openshift_sdn_test.go
@@ -138,8 +138,13 @@ func TestValidateOpenShiftSDN(t *testing.T) {
 	config := &crd.Spec
 	sdnConfig := config.DefaultNetwork.OpenShiftSDNConfig
 
-	err := validateOpenShiftSDN(config)
-	g.Expect(err).To(BeEmpty())
+	// Top-level validation should fail
+	err := Validate(config)
+	g.Expect(err).To(HaveOccurred(), "expected openshift-sdn config to be rejected")
+	g.Expect(err.Error()).To(ContainSubstring("unsupported network type"))
+
+	errs := validateOpenShiftSDN(config)
+	g.Expect(errs).To(BeEmpty())
 	fillDefaults(config, nil)
 
 	errExpect := func(substr string) {

--- a/pkg/network/previous_test.go
+++ b/pkg/network/previous_test.go
@@ -26,13 +26,15 @@ func TestPreviousVersionsSafe(t *testing.T) {
 		appliedConfig string
 	}{
 
-		// The default configuration for a 4.1.0 cluster
+		// The default configuration for an ovn-kubernetes-based 4.4.0 cluster;
+		// this is the oldest configuration that it would be possible to
+		// successfully update to 4.17 or later.
 		{
-			name: "4.1.0 openshift-sdn",
+			name: "4.4.0 ovn-kubernetes",
 
-			inputConfig: `{"clusterNetwork":[{"cidr":"10.128.0.0/14","hostPrefix":23}],"defaultNetwork":{"type":"OpenShiftSDN"},"serviceNetwork":["172.30.0.0/16"]}`,
+			inputConfig: `{"clusterNetwork":[{"cidr":"10.128.0.0/14","hostPrefix":23}],"defaultNetwork":{"type":"OVNKubernetes"},"serviceNetwork":["172.30.0.0/16"]}`,
 
-			appliedConfig: `{"clusterNetwork":[{"cidr":"10.128.0.0/14","hostPrefix":23}],"serviceNetwork":["172.30.0.0/16"],"defaultNetwork":{"type":"OpenShiftSDN","openshiftSDNConfig":{"mode":"NetworkPolicy","vxlanPort":4789,"mtu":8951}},"disableMultiNetwork":false,"deployKubeProxy":false,"kubeProxyConfig":{"bindAddress":"0.0.0.0","proxyArguments":{"metrics-bind-address":["0.0.0.0"],"metrics-port":["9101"]}}}'`,
+			appliedConfig: `{"clusterNetwork":[{"cidr":"10.128.0.0/14","hostPrefix":23}],"serviceNetwork":["172.30.0.0/16"],"defaultNetwork":{"type":"OVNKubernetes","ovnKubernetesConfig":null,"disableMultiNetwork":false,"deployKubeProxy":false,"kubeProxyConfig":null}}'`,
 		},
 	}
 

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -568,7 +568,7 @@ func validateMultus(conf *operv1.NetworkSpec) []error {
 func validateDefaultNetwork(conf *operv1.NetworkSpec) []error {
 	switch conf.DefaultNetwork.Type {
 	case operv1.NetworkTypeOpenShiftSDN:
-		return validateOpenShiftSDN(conf)
+		return []error{errors.Errorf("unsupported network type %q", conf.DefaultNetwork.Type)}
 	case operv1.NetworkTypeOVNKubernetes:
 		return validateOVNKubernetes(conf)
 	default:


### PR DESCRIPTION
It's time...

~I removed live migration and offline migration in two separate pieces because I realized belatedly I had to be somewhat careful about it because we still need _some_ of the migration code in place to support "MTU migration"...~

UPDATED: this now leaves most of the sdn code there, it just removes support for actually _deploying_ sdn (and in particular, removes the references to the SDN image, which is needed so we can start the process of removing the image from the release). We can do followups to clean up the dead code.