### PR TITLE
OCPBUGS-23758: Set global IP forwarding sysctl parameters while starting ovnkube-node

### DIFF
--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -562,13 +562,19 @@ data:
         dns_name_resolver_enabled_flag="--enable-dns-name-resolver"
       fi
 
-      # If IP Forwarding mode is global set it in the host here.
+      # If IP Forwarding mode is global set it in the host here. IPv6 IP Forwarding shuld be
+      # enabled for all interfaces at all times if cluster is configured as single stack IPv6
+      # or dual stack. This will be taken care by ovn-kubernetes(ovn-org/ovn-kubernetes#4376).
+      # Setting net.ipv6.conf.all.forwarding to '0' when ipForwarding is Restricted to make 
+      # sure IPv6 IP Forwarding is disabled when cluster is configured as single stack IPv4.
       ip_forwarding_flag=
       if [ "{{.IP_FORWARDING_MODE}}" == "Global" ]; then
         sysctl -w net.ipv4.ip_forward=1
         sysctl -w net.ipv6.conf.all.forwarding=1
       else
         ip_forwarding_flag="--disable-forwarding"
+        sysctl -w net.ipv4.ip_forward=0
+        sysctl -w net.ipv6.conf.all.forwarding=0
       fi
 
       NETWORK_NODE_IDENTITY_ENABLE=


### PR DESCRIPTION
This PR is to set IPv4 and IPv6 IP forwarding sysctl parameter when ipForwarding mode is set to Restricted.

If ipForwarding is set to 'Restricted':

sysctl -w net.ipv4.ip_forward=0
sysctl -w net.ipv6.conf.all.forwarding=0