### PR TITLE
OCPBUGS-33921: infraconfig: allow VIPs outside machine networks for ELB

### DIFF
--- a/pkg/controller/infrastructureconfig/sync_specstatus.go
+++ b/pkg/controller/infrastructureconfig/sync_specstatus.go
@@ -112,11 +112,14 @@ func (*synchronizer) SpecStatusSynchronize(infraConfig *configv1.Infrastructure)
 	if err := validateVipsWithVips(*specApiVips, *specIngressVips, elb); err != nil {
 		return nil, fmt.Errorf("Error on validating VIPs: %v", err)
 	}
-	if err := validateVipsWithMachineNetworks(*specApiVips, *specMachineNetworks); err != nil {
-		return nil, fmt.Errorf("Error on validating API VIPs and Machine Networks: %v", err)
-	}
-	if err := validateVipsWithMachineNetworks(*specIngressVips, *specMachineNetworks); err != nil {
-		return nil, fmt.Errorf("Error on validating Ingress VIPs and Machine Networks: %v", err)
+
+	if !elb {
+		if err := validateVipsWithMachineNetworks(*specApiVips, *specMachineNetworks); err != nil {
+			return nil, fmt.Errorf("Error on validating API VIPs and Machine Networks: %v", err)
+		}
+		if err := validateVipsWithMachineNetworks(*specIngressVips, *specMachineNetworks); err != nil {
+			return nil, fmt.Errorf("Error on validating Ingress VIPs and Machine Networks: %v", err)
+		}
 	}
 
 	if err := syncVips(specApiVips, statusApiVips); err != nil {

--- a/pkg/controller/infrastructureconfig/sync_specstatus_test.go
+++ b/pkg/controller/infrastructureconfig/sync_specstatus_test.go
@@ -336,6 +336,57 @@ func Test_SpecStatusSynchronizer(t *testing.T) {
 			},
 		},
 		{
+			name: "succeed: duplicate vips outside machine network with ELB",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.2.1"},
+							IngressIPs:           []configv1.IP{"224.0.2.1"},
+							MachineNetworks:      []configv1.CIDR{"224.0.0.1/24", "224.0.1.1/24"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "BareMetal",
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.2.1"},
+							IngressIPs:           []string{"224.0.2.1"},
+							MachineNetworks:      []configv1.CIDR{"224.0.0.1/24"},
+							LoadBalancer:         &configv1.BareMetalPlatformLoadBalancer{Type: configv1.LoadBalancerTypeUserManaged},
+						},
+					},
+				},
+			},
+			wantedInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						BareMetal: &configv1.BareMetalPlatformSpec{
+							APIServerInternalIPs: []configv1.IP{"224.0.2.1"},
+							IngressIPs:           []configv1.IP{"224.0.2.1"},
+							MachineNetworks:      []configv1.CIDR{"224.0.0.1/24", "224.0.1.1/24"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.BareMetalPlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "BareMetal",
+						BareMetal: &configv1.BareMetalPlatformStatus{
+							APIServerInternalIPs: []string{"224.0.2.1"},
+							IngressIPs:           []string{"224.0.2.1"},
+							MachineNetworks:      []configv1.CIDR{"224.0.0.1/24", "224.0.1.1/24"},
+							LoadBalancer:         &configv1.BareMetalPlatformLoadBalancer{Type: configv1.LoadBalancerTypeUserManaged},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "fail: non-equal number of vips",
 			givenInfra: configv1.Infrastructure{
 				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},


### PR DESCRIPTION
With this PR we are allowing VIPs to exist outside of defined machine networks if External Load Balancer is used.

Forcing this validation was an oversight as we already allow VIPs to be equal (API and Ingress using the same IP) for the ELB setups. As in principle it would be desired for people to feed Machine Networks with all subnets that are used (so they just append the VIP subnet if they use ELB), it makes some sense to soften the validation.

Fixes: OCPBUGS-33921