### PR TITLE
OCPBUGS-34524: Fix DNSResolver feature gate enablement

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
@@ -164,6 +164,11 @@ spec:
             ovn_v6_transit_switch_subnet_opt="--cluster-manager-v6-transit-switch-subnet {{.V6TransitSwitchSubnet}}"
           fi
 
+          dns_name_resolver_enabled_flag=
+          if [[ "{{.DNS_NAME_RESOLVER_ENABLE}}" == "true" ]]; then
+            dns_name_resolver_enabled_flag="--enable-dns-name-resolver"
+          fi
+
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-control-plane - start ovnkube --init-cluster-manager ${K8S_NODE}"
           exec /usr/bin/ovnkube \
             --enable-interconnect \
@@ -179,7 +184,8 @@ spec:
             ${ovn_v4_join_subnet_opt} \
             ${ovn_v6_join_subnet_opt} \
             ${ovn_v4_transit_switch_subnet_opt} \
-            ${ovn_v6_transit_switch_subnet_opt}
+            ${ovn_v6_transit_switch_subnet_opt} \
+            ${dns_name_resolver_enabled_flag}
         volumeMounts:
         - mountPath: /run/ovnkube-config/
           name: ovnkube-config

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
@@ -124,6 +124,11 @@ spec:
             ovn_v6_transit_switch_subnet_opt="--cluster-manager-v6-transit-switch-subnet {{.V6TransitSwitchSubnet}}"
           fi
 
+          dns_name_resolver_enabled_flag=
+          if [[ "{{.DNS_NAME_RESOLVER_ENABLE}}" == "true" ]]; then
+            dns_name_resolver_enabled_flag="--enable-dns-name-resolver"
+          fi
+
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-control-plane - start ovnkube --init-cluster-manager ${K8S_NODE}"
           exec /usr/bin/ovnkube \
             --enable-interconnect \
@@ -136,7 +141,8 @@ spec:
             ${ovn_v4_join_subnet_opt} \
             ${ovn_v6_join_subnet_opt} \
             ${ovn_v4_transit_switch_subnet_opt} \
-            ${ovn_v6_transit_switch_subnet_opt}
+            ${ovn_v6_transit_switch_subnet_opt} \
+            ${dns_name_resolver_enabled_flag}
         volumeMounts:
         - mountPath: /run/ovnkube-config/
           name: ovnkube-config


### PR DESCRIPTION
Put feature-gate flag to the control-plane pod spec to make sure control-plane pods are restarted on feature gate enablement. ovnkube-node is fine, as this flag is enabled via script-lib.