### PR TITLE
NP-976,OCPBUGS-34658: Live migration: add metrics to observe CNI live migration

### DIFF
--- a/pkg/controller/operconfig/cluster.go
+++ b/pkg/controller/operconfig/cluster.go
@@ -108,6 +108,7 @@ func (r *ReconcileOperConfig) ClusterNetworkStatus(ctx context.Context, operConf
 		} else {
 			resetMigrationConditions(&clusterConfigWithConditions.Status.Conditions, nowTimestamp)
 		}
+		syncLiveMigrationConditionMetric(clusterConfigWithConditions.Status.Conditions)
 	}
 
 	status.Conditions = clusterConfigWithConditions.Status.Conditions


### PR DESCRIPTION
Add metric to publish the reason why live migration may not begin. Add metric to publish whether live migration is in progress or not. Add metric to publish the current live migration status condition type.

/cc
~/hold~

~testing..~