### PR TITLE
Add ipsec state metric

### DIFF
--- a/bindata/cluster-network-operator/prometheus.yaml
+++ b/bindata/cluster-network-operator/prometheus.yaml
@@ -1,0 +1,18 @@
+##
+# This file is not applied correctly during cluster installation when located in
+# the manifests directory, this is the reason why it is located in the bindata directory.
+##
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+    name: openshift-network-operator-ipsec-rules
+    namespace: openshift-network-operator
+spec:
+    groups:
+    - name: openshift-network.rules
+      rules:
+      - expr: |-
+          sum by (mode,is_legacy_api) (
+            openshift_network_operator_ipsec_state{namespace=~"openshift-network-operator"}
+          )
+        record: openshift:openshift_network_operator_ipsec_state:sum

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/names"
 	"github.com/openshift/cluster-network-operator/pkg/network"
 	"github.com/openshift/cluster-network-operator/pkg/platform"
+	ipsecMetrics "github.com/openshift/cluster-network-operator/pkg/util/ipsec"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/events"
 
@@ -354,6 +355,7 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 		}
 	}
 
+	updateIPsecMetric(&newOperConfig.Spec)
 	// once updated, use the new config
 	operConfig = newOperConfig
 
@@ -554,6 +556,23 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 	// so we can reconcile state again.
 	log.Printf("Operconfig Controller complete")
 	return reconcile.Result{RequeueAfter: ResyncPeriod}, nil
+}
+
+func updateIPsecMetric(newOperConfigSpec *operv1.NetworkSpec) {
+	if newOperConfigSpec == nil {
+		// spec is not initilized yet
+		klog.V(5).Infof("IPsec: << updateIPsecTelemetry, new spec is nil, skipping")
+	} else if newOperConfigSpec.DefaultNetwork.OVNKubernetesConfig == nil {
+		// non ovn-k network, ipsec is not supported
+		ipsecMetrics.UpdateIPsecMetricNA()
+	} else {
+		// ovn-k network, ipsec is supported, update the ipsec state metric
+		newOVNKubeConfig := newOperConfigSpec.DefaultNetwork.OVNKubernetesConfig
+		mode := string(network.GetIPsecMode(newOVNKubeConfig))
+		legacyAPI := network.IsIPsecLegacyAPI(newOVNKubeConfig)
+
+		ipsecMetrics.UpdateIPsecMetric(mode, legacyAPI)
+	}
 }
 
 func reconcileOperConfig(ctx context.Context, obj crclient.Object) []reconcile.Request {

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -517,12 +517,12 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	return objs, progressing, nil
 }
 
-// getIPsecMode return the ipsec mode accounting for upgrade scenarios
+// GetIPsecMode return the ipsec mode accounting for upgrade scenarios
 // Find the IPsec mode from Ipsec.config
 // Ipsec.config == nil (bw compatibility) || ipsecConfig == Off ==> ipsec is disabled
 // ipsecConfig.mode == "" (bw compatibility) || ipsec.Config == Full ==> ipsec is enabled for NS and EW
 // ipsecConfig.mode == External ==> ipsec is enabled for NS only
-func getIPsecMode(conf *operv1.OVNKubernetesConfig) operv1.IPsecMode {
+func GetIPsecMode(conf *operv1.OVNKubernetesConfig) operv1.IPsecMode {
 	mode := operv1.IPsecModeDisabled // Should stay so if conf.IPsecConfig == nil
 	if conf.IPsecConfig != nil {
 		if conf.IPsecConfig.Mode != "" {
@@ -534,6 +534,11 @@ func getIPsecMode(conf *operv1.OVNKubernetesConfig) operv1.IPsecMode {
 
 	klog.V(5).Infof("IPsec: after looking at %+v, ipsec mode=%s", conf.IPsecConfig, mode)
 	return mode
+}
+
+// IsIPsecLegacyAPI returns true if the old (pre 4.15) IPsec API is used, and false otherwise.
+func IsIPsecLegacyAPI(conf *operv1.OVNKubernetesConfig) bool {
+	return conf.IPsecConfig == nil || conf.IPsecConfig.Mode == ""
 }
 
 // shouldRenderIPsec method ensures the have following IPsec states for upgrade path from 4.14 to 4.15 or later versions:
@@ -557,7 +562,7 @@ func shouldRenderIPsec(conf *operv1.OVNKubernetesConfig, bootstrapResult *bootst
 	isIpsecUpgrade := bootstrapResult.OVN.IPsecUpdateStatus != nil && bootstrapResult.OVN.IPsecUpdateStatus.LegacyIPsecUpgrade
 	isOVNIPsecActive := bootstrapResult.OVN.IPsecUpdateStatus != nil && bootstrapResult.OVN.IPsecUpdateStatus.OVNIPsecActive
 
-	mode := getIPsecMode(conf)
+	mode := GetIPsecMode(conf)
 
 	// On upgrade, we will just remove any existing ipsec deployment without making any
 	// change to them. So during upgrade, we must keep track if IPsec MachineConfigs are
@@ -906,8 +911,8 @@ func getOVNEncapOverhead(conf *operv1.NetworkSpec) uint32 {
 	const geneveOverhead = 100
 	const ipsecOverhead = 46 // Transport mode, AES-GCM
 	var encapOverhead uint32 = geneveOverhead
-	mode := getIPsecMode(conf.DefaultNetwork.OVNKubernetesConfig)
-	if mode == operv1.IPsecModeFull || mode == "" {
+	mode := GetIPsecMode(conf.DefaultNetwork.OVNKubernetesConfig)
+	if mode == operv1.IPsecModeFull {
 		encapOverhead += ipsecOverhead
 	}
 	return encapOverhead

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -124,6 +124,12 @@ func Render(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapResult
 	}
 	objs = append(objs, o...)
 
+	o, err = renderCNO(manifestDir)
+	if err != nil {
+		return nil, progressing, err
+	}
+	objs = append(objs, o...)
+
 	log.Printf("Render phase done, rendered %d objects", len(objs))
 	return objs, progressing, nil
 }
@@ -827,6 +833,17 @@ func renderNetworkPublic(manifestDir string) ([]*uns.Unstructured, error) {
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network", "public"), &data)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to render network/public manifests")
+	}
+	return manifests, nil
+}
+
+// renderCNO renders the common objects in the cluster-network-operator directory
+func renderCNO(manifestDir string) ([]*uns.Unstructured, error) {
+	data := render.MakeRenderData()
+
+	manifests, err := render.RenderDir(filepath.Join(manifestDir, "cluster-network-operator"), &data)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to render cluster-network-operator manifests")
 	}
 	return manifests, nil
 }

--- a/pkg/util/ipsec/metrics.go
+++ b/pkg/util/ipsec/metrics.go
@@ -1,0 +1,44 @@
+package ipsec
+
+import (
+	"strconv"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/klog/v2"
+)
+
+const (
+	cnoNamespace  = "openshift_network_operator"
+	ipsecStateNA  = "N/A - ipsec not supported (non-OVN network)"
+	ipsecDisabled = "Disabled"
+)
+
+var (
+	ipsecStateGauge *metrics.GaugeVec
+)
+
+func init() {
+	ipsecStateGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
+		Namespace: cnoNamespace,
+		Name:      "ipsec_state",
+		Help: "A metric with a constant '1' value labeled by the latest ipsecMode of the cluster, " +
+			"and the API that invoked it, legacy (pre OCP 4.14) or new. " +
+			"In case the network doesn't support ipsec (non-OVN network), " +
+			"the 'is_legacy_api' value is set to '" + ipsecStateNA + "'.",
+	}, []string{"mode", "is_legacy_api"})
+	legacyregistry.MustRegister(ipsecStateGauge)
+}
+
+func UpdateIPsecMetric(state string, isLegacyAPI bool) {
+	klog.V(5).Infof("IPsec mode: %s, isLegacyAPI: %v",
+		state, isLegacyAPI)
+	ipsecStateGauge.Reset()
+	ipsecStateGauge.WithLabelValues(state, strconv.FormatBool(isLegacyAPI)).Set(1)
+}
+
+func UpdateIPsecMetricNA() {
+	klog.V(5).Infof("IPsec is not supported by non-OVN network (disabled)")
+	ipsecStateGauge.Reset()
+	ipsecStateGauge.WithLabelValues(ipsecDisabled, ipsecStateNA).Set(1)
+}


### PR DESCRIPTION
This commit adds a metric for the ipsec mode. The metric created is a Gauge named "openshift_network_operator_ipsec_state" with a constant value of 1 and 2 labels:
1. "mode" which lists the ipsec mode, one of "Disabled" "External" or "Full"
2. "is_legacy_api" which states the flavor of the API used - either "true" for legacy API (up to OCP V4.14) or "false" for the new API (OCP 4.15+)
   -- If the cluster uses non ovn-k network (a network that does not support ipsec) the value of this label is "N/A - ipsec not supported (non-OVN network)" The telemetry is collected by a rule
"openshift:openshift_network_operator_ipsec_state:sum" that strips unwanted dimentions from the Gauge