### PR TITLE
OCPBUGS-34885:[release-4.14] Fix 4.13->4.14 upgrade with ipsec enabled

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -14,6 +14,9 @@ const OVN_MASTER = "ovnkube-master"
 const OVN_CONTROL_PLANE = "ovnkube-control-plane"
 const OVN_NODE = "ovnkube-node"
 const OVN_CONTROLLER = "ovnkube-controller"
+const OVN_IPSEC = "ovn-ipsec"                             // 4.13 ipsec daemonset
+const OVN_IPSEC_HOST = "ovn-ipsec-host"                   // 4.14 ipsec daemonset
+const OVN_IPSEC_CONTAINERIZED = "ovn-ipsec-containerized" // 4.14 ipsec daemonset
 
 func GetInterConnectConfigMap(kubeClient kubernetes.Interface) (*corev1.ConfigMap, error) {
 	return kubeClient.CoreV1().ConfigMaps(OVN_NAMESPACE).Get(context.TODO(), OVN_INTERCONNECT_CONFIGMAP_NAME, metav1.GetOptions{})


### PR DESCRIPTION
Ipsec is currently not functional all throughout the 4.13->4.14 upgrade, until the new ovnkube-node pods are deployed on each node.  

4.13 deploys `ovn-ipsec` daemonset, while 4.14 deploys `ovn-ipsec-host` and `ovn-ipsec-containerized` daemonsets, which require the certificates issued by ovnkube-node-identity, otherwise they are in crashloopbackoff
until the new ovnkube-node pods are running.

The idea is that, during 4.13->4.14 upgrades,we should run the 4.13 ovn-ipsec daemonset until phase 2 of the upgrade to IC is done, that is until all multizone ovnkube-node pods are deployed, at which point the new 4.14 daemonsets can be created and the 4.13 one is removed.

```                    
        │ 4.13          │   4.14              │  4.14                  │ 4.14                    
────────┼───────────────┼─────────────────────┼────────────────────────┼─────────────────────────
        │               │   phase1            │  phase2                │ upgrade is done                      
        │               │   single-zone folder│  multi-zone-tmp folder │ multi-zone folder       
        │               │                     │                        │                         
 OVN    │ 3 ovnk-master │   3 ovnk-master     │  3 ovnk-master         │ /                       
        │ 3 ovnk-node   │   3 ovnk-node       │  6 ovnk-node           │ 6 ovnk-node             
        │               │                     │  2 ovnk-control-plane  │ 2 ovnk-control-plane    
        │               │                     │                        │                         
 IPSEC  │ ovn-ipsec     │   ovn-ipsec         │  ovn-ipsec             │ ovn-ipsec-host          
                        │                                                ovn-ipsec-containerized    
```                                                            


https://issues.redhat.com/browse/OCPBUGS-33500

Fixes #OCPBUGS-33500
