### PR TITLE
Bidirectional mount propagation for `hostroot`

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -284,7 +284,7 @@ spec:
           mountPath: /var/lib/kubelet
         - name: hostroot
           mountPath: /hostroot
-          mountPropagation: HostToContainer
+          mountPropagation: Bidirectional
         - name: multus-conf-dir
           mountPath: /etc/cni/multus/net.d
         - name: multus-daemon-config


### PR DESCRIPTION
…e `multus-daemonset-thick.yml` example/quickstart deployment file from `HostToContainer` to `Bidirectional`. This change enables the volume to be accessible in both directions, which is necessary for users who need to share a mount with another container/pod.

This is motivated by the fact that in thin plugin mode, since all things were run on the host directly, CNI plugins wouldn't be limited by the mount propagation.

One example that has come up recently is userspace CNI interaction with kubevirt, and sharing the usage of the socket as mounted by kubevirt.

This does expose some level of risk (as noted in the mount propagation docs regarding changing of mounts), however, I don't believe it's significantly more than would've been the case in thin plugin mode.

References
- [Kubernetes Volume Mount Propagation Documentation](https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation)