### PR TITLE
OCPBUGS-34613,OCPBUGS-34726,OCPBUGS-34727: Live migration backports

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -67,26 +67,45 @@ spec:
           #!/bin/bash
           set -euo pipefail
 {{- if .IsNetworkTypeLiveMigration }}
-          # In case of rollback, openshift-sdn need to reuse the host subnet used by ovn-kube, so we need to create the hostsubnet CR for the local node if it doesn't exist.
+          set -x
+          NODE_CNI="OpenShiftSDN"
+          if ip link show br-ex; then
+            echo "br-ex exists"
+            NODE_CNI="OVNKubernetes"
+          else
+            echo "br-ex doesn't exist"
+          fi
+
           # retry loop
           RETRY_INTERVAL=3
-          MAX_RETRIES=10
+          MAX_RETRIES=100
           for ((retry_count=1; retry_count<=MAX_RETRIES; retry_count++)); do
-              # Get SDN subnet
-              SDN_SUBNET=$(oc get hostsubnet ${K8S_NODE_NAME} -o jsonpath="{.subnet}"||true)
+            # Get SDN subnet
+            SDN_SUBNET=$(oc get hostsubnet ${K8S_NODE_NAME} -o jsonpath="{.subnet}"||true)
 
-              # Get OVN subnet
-              OVN_SUBNET=$(oc get node ${K8S_NODE_NAME} -o jsonpath='{.metadata.annotations.k8s\.ovn\.org/node-subnets}' | grep -o -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,3}'||true)
+            # Get OVN subnet
+            OVN_SUBNET=$(oc get node ${K8S_NODE_NAME} -o jsonpath='{.metadata.annotations.k8s\.ovn\.org/node-subnets}' | grep -o -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,3}'||true)
 
-              if [ -n "${SDN_SUBNET}" ] && [ -z "${OVN_SUBNET}" ]; then
-                  echo "SDN_SUBNET is ${SDN_SUBNET}"
-                  break
-              elif [ -z "${SDN_SUBNET}" ] && [ -n "${OVN_SUBNET}" ]; then
+            if [ "${NODE_CNI}" == "OpenShiftSDN" ]; then
+              if [ -z "${SDN_SUBNET}" ]; then
+                echo "SDN node subnet is not found, retry..."
+                sleep $RETRY_INTERVAL
+              else
+                break
+              fi
+            else
+              if [ -z "${OVN_SUBNET}" ]; then
+                echo "OVN node subnet is not found, retry..."
+                sleep $RETRY_INTERVAL
+              else
+                # When rolling back, SDN controll plane will not start until the hostsubnet has been created here.
+                echo "Use OVN-K subnet ${OVN_SUBNET}, when the node CNI is OVN-K"
+                if [ -z "${SDN_SUBNET}" ]; then
                   echo "SDN_SUBNET is empty, create the hostsubnet CR with OVN_SUBNET ${OVN_SUBNET}"
                   SUBNET=${OVN_SUBNET}
                   NODE_UID=$(oc get node ${K8S_NODE_NAME} -o jsonpath='{.metadata.uid}')
                   NODE_IP=$(oc get node ${K8S_NODE_NAME} -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
-          cat <<EOF | oc apply -f -
+                  cat <<EOF | oc apply -f -
           apiVersion: network.openshift.io/v1
           kind: HostSubnet
           metadata:
@@ -97,27 +116,21 @@ spec:
           hostIP: ${NODE_IP}
           subnet: ${SUBNET}
           EOF
-              elif [ -n "${SDN_SUBNET}" ] && [ -n "${OVN_SUBNET}" ] && [ "${SDN_SUBNET}" == "${OVN_SUBNET}" ]; then
-                  echo "Subnets matched! SDN_SUBNET: ${SDN_SUBNET}, OVN_SUBNET: ${OVN_SUBNET}"
-                  break
-              elif [ -n "${SDN_SUBNET}" ] && [ -n "${OVN_SUBNET}" ] && ! [ "${SDN_SUBNET}" == "${OVN_SUBNET}" ]; then
-                  echo "Subnets don't match! SDN_SUBNET: ${SDN_SUBNET}, OVN_SUBNET: ${OVN_SUBNET}"
-                  exit 1
-              else
-                  echo "Round ${retry_count}/${MAX_RETRIES} - Retrying... SDN_SUBNET: ${SDN_SUBNET}, OVN_SUBNET: ${OVN_SUBNET}"
-                  sleep $RETRY_INTERVAL
+                fi
+                break
               fi
+            fi
           done
           if [ ${retry_count} -gt ${MAX_RETRIES} ]; then
-              echo "All retries failed. Exiting."
-              exit 1
+            echo "All retries failed. Exiting."
+            exit 1
           fi
-          if ovs-vsctl br-exists br-ex; then
-            echo "br-ex exists, sleep..."
+          if [ "${NODE_CNI}" == "OVNKubernetes" ]; then
+            echo "sleep..."
             trap : TERM INT; sleep infinity & wait
             exit
           else
-            echo "br-ex doesn't exist"
+            echo "run openshift-sdn-node"
           fi
           ovs-vsctl --if-exists del-br br-int
           ovs-vsctl --if-exists del-br br-ext
@@ -315,7 +328,7 @@ spec:
               #!/bin/bash
               set -euo pipefail
 {{- if .IsNetworkTypeLiveMigration }}
-              if ovs-vsctl br-exists br-ex; then
+              if ip link show br-ex; then
                 exit 0
               fi
 {{- end}}

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -434,49 +434,39 @@ spec:
         - |
           set -xe
 {{- if .IsNetworkTypeLiveMigration }}
-          # In case of rollback, ovnkube need to reuse the host subnet used by openshift-sdn, so we need to create the node subnets annotations for the local node if it doesn't exist.
-          # retry loop
+          NODE_CNI="OVNKubernetes"
+          if ip link show br-ex; then
+            echo "br-ex exists"
+            kubectl label node --overwrite ${K8S_NODE} migration.network.openshift.io/plugin-
+          else
+            echo "br-ex doesn't exist"
+            NODE_CNI="OpenShiftSDN"
+            kubectl label node --overwrite ${K8S_NODE} migration.network.openshift.io/plugin=
+          fi
+
           RETRY_INTERVAL=3
-          MAX_RETRIES=10
+          MAX_RETRIES=100
           for ((retry_count=1; retry_count<=MAX_RETRIES; retry_count++)); do
-              # Get SDN subnet
-              SDN_SUBNET=$(kubectl get hostsubnet ${K8S_NODE} -o jsonpath="{.subnet}"||true)
-
-              # Get OVN subnet
-              OVN_SUBNET=$(kubectl get node ${K8S_NODE} -o jsonpath='{.metadata.annotations.k8s\.ovn\.org/node-subnets}' | grep -o -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,3}'||true)
-
-              if [ -n "${SDN_SUBNET}" ] && [ -z "${OVN_SUBNET}" ]; then
-                  echo "OVN_SUBNET is empty, create the node-subnets annotation with the SDN_SUBNET ${SDN_SUBNET}"
-                  SUBNET=${SDN_SUBNET}
-                  break
-              elif [ -z "${SDN_SUBNET}" ] && [ -n "${OVN_SUBNET}" ]; then
-                  echo "OVN_SUBNET is ${OVN_SUBNET}"
-                  break
-              elif [ -n "${SDN_SUBNET}" ] && [ -n "${OVN_SUBNET}" ] && [ "${SDN_SUBNET}" == "${OVN_SUBNET}" ]; then
-                  echo "Subnets matched! SDN_SUBNET: ${SDN_SUBNET}, OVN_SUBNET: ${OVN_SUBNET}"
-                  SUBNET=${SDN_SUBNET}
-                  break
-              elif [ -n "${SDN_SUBNET}" ] && [ -n "${OVN_SUBNET}" ] && ! [ "${SDN_SUBNET}" == "${OVN_SUBNET}" ]; then
-                  echo "Subnets don't match! SDN_SUBNET: ${SDN_SUBNET}, OVN_SUBNET: ${OVN_SUBNET}"
-                  exit 1
-              else
-                  echo "Round ${retry_count}/${MAX_RETRIES} - Retrying... SDN_SUBNET: ${SDN_SUBNET}, OVN_SUBNET: ${OVN_SUBNET}"
-                  sleep $RETRY_INTERVAL
-              fi
+            # Align the node subnet with SDN
+            SDN_SUBNET=$(kubectl get hostsubnet ${K8S_NODE} -o jsonpath="{.subnet}"||true)
+            if [ -z "${SDN_SUBNET}" ]; then
+              echo "SDN node subnet is not found, retry..."
+              sleep $RETRY_INTERVAL
+            else
+              echo "use SDN node subnet ${SDN_SUBNET}"
+              SUBNET=${SDN_SUBNET}
+              break
+            fi
           done
           if [ ${retry_count} -gt ${MAX_RETRIES} ]; then
-              echo "All retries failed. Exiting."
-              exit 1
+            echo "All retries failed. Exiting."
+            exit 1
           fi
 
           kubectl annotate node ${K8S_NODE} --overwrite k8s.ovn.org/node-subnets={\"default\":[\"${SUBNET}\"]}
           kubectl annotate node ${K8S_NODE} --overwrite k8s.ovn.org/hybrid-overlay-node-subnet=${SUBNET}
-          if ip link show br-ex; then
-            echo "br-ex exists, run ovnkube"
-            kubectl label node --overwrite ${K8S_NODE} migration.network.openshift.io/plugin-
-          else
-            echo "br-ex doesn't exist"
-            kubectl label node --overwrite ${K8S_NODE} migration.network.openshift.io/plugin=
+
+          if [ "${NODE_CNI}" == "OpenShiftSDN" ]; then
             echo "run hybrid-overlay-node"
             NETWORK_NODE_IDENTITY_ENABLE=
             if [[ "{{.NETWORK_NODE_IDENTITY_ENABLE}}" == "true" ]]; then

--- a/pkg/client/list_pager.go
+++ b/pkg/client/list_pager.go
@@ -33,3 +33,17 @@ func ListAllNamespaces(ctx context.Context, client Client) ([]*v1.Namespace, err
 	})
 	return list, err
 }
+
+func ListAllPodsWithAnnotationKey(ctx context.Context, client Client, annotationKey string) ([]*v1.Pod, error) {
+	list := []*v1.Pod{}
+	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return client.Default().Kubernetes().CoreV1().Pods("").List(ctx, opts)
+	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+		pod := obj.(*v1.Pod)
+		if _, ok := pod.Annotations[annotationKey]; ok {
+			list = append(list, pod)
+		}
+		return nil
+	})
+	return list, err
+}

--- a/pkg/controller/operconfig/cluster.go
+++ b/pkg/controller/operconfig/cluster.go
@@ -112,6 +112,7 @@ func (r *ReconcileOperConfig) ClusterNetworkStatus(ctx context.Context, operConf
 		} else {
 			resetMigrationConditions(&clusterConfigWithConditions.Status.Conditions, nowTimestamp)
 		}
+		syncLiveMigrationConditionMetric(clusterConfigWithConditions.Status.Conditions)
 	}
 
 	status.Conditions = clusterConfigWithConditions.Status.Conditions

--- a/pkg/controller/operconfig/cluster.go
+++ b/pkg/controller/operconfig/cluster.go
@@ -9,6 +9,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/apply"
+	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
 	"github.com/openshift/cluster-network-operator/pkg/names"
 	"github.com/openshift/cluster-network-operator/pkg/network"
 	k8sutil "github.com/openshift/cluster-network-operator/pkg/util/k8s"
@@ -77,7 +78,7 @@ func (r *ReconcileOperConfig) UpdateOperConfig(ctx context.Context, operConfig *
 
 // ClusterNetworkStatus generates the cluster config Status based on the operator
 // config.
-func (r *ReconcileOperConfig) ClusterNetworkStatus(ctx context.Context, operConfig *operv1.Network) (*uns.Unstructured, error) {
+func (r *ReconcileOperConfig) ClusterNetworkStatus(ctx context.Context, operConfig *operv1.Network, bootstrapResult *bootstrap.BootstrapResult) (*uns.Unstructured, error) {
 	// retrieve the existing cluster config object
 	clusterConfig := &configv1.Network{
 		TypeMeta:   metav1.TypeMeta{APIVersion: configv1.GroupVersion.String(), Kind: "Network"},
@@ -108,6 +109,10 @@ func (r *ReconcileOperConfig) ClusterNetworkStatus(ctx context.Context, operConf
 				return nil, err
 			}
 		} else if clusterConfig.Spec.NetworkType != clusterConfig.Status.NetworkType {
+			// Do not initialize live migration if it is not valid
+			if err := network.ValidateLiveMigration(clusterConfig, &bootstrapResult.Infra, r.client); err != nil {
+				return nil, err
+			}
 			initMigrationConditions(&clusterConfigWithConditions.Status.Conditions, nowTimestamp)
 		} else {
 			resetMigrationConditions(&clusterConfigWithConditions.Status.Conditions, nowTimestamp)

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -534,7 +534,7 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 	}
 
 	// Update Network.config.openshift.io.Status
-	status, err := r.ClusterNetworkStatus(ctx, operConfig)
+	status, err := r.ClusterNetworkStatus(ctx, operConfig, bootstrapResult)
 	if err != nil {
 		log.Printf("Could not generate network status: %v", err)
 		r.status.SetDegraded(statusmanager.OperatorConfig, "StatusError",

--- a/pkg/network/cluster_config.go
+++ b/pkg/network/cluster_config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync"
 
 	configv1 "github.com/openshift/api/config/v1"
 	v1 "github.com/openshift/api/network/v1"
@@ -19,9 +20,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
 	utilnet "k8s.io/utils/net"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // list of known plugins that require hostPrefix to be set
@@ -197,6 +201,7 @@ func validateOVNKubernetesCIDROverlap(clusterCofnig *configv1.Network, operConfi
 				return errors.Wrapf(err, "could not parse %s:%s", subnetB.name, subnetB.cidr)
 			}
 			if netA.Contains(netB.IP) || netB.Contains(netA.IP) {
+				metricLiveMigrationBlocked.With(prometheus.Labels{metricLiveMigrationBlockedLabelKey: fmt.Sprintf("overlapping_networks_%s_%s", subnetA.name, subnetB.name)}).Set(1)
 				return fmt.Errorf("network %s(%s) overlaps with network %s(%s)",
 					subnetA.name, subnetA.cidr, subnetB.name, subnetB.cidr)
 			}
@@ -206,7 +211,30 @@ func validateOVNKubernetesCIDROverlap(clusterCofnig *configv1.Network, operConfi
 	return nil
 }
 
+const metricLiveMigrationBlockedLabelKey = "reason"
+
+// openshift_network_operator_live_migration_blocked metric 'reason' label key name values
+const (
+	unsupportedCNI                     = "UnsupportedCNI"
+	unsupportedHCPCluster              = "UnsupportedHyperShiftCluster"
+	unsupportedSDNNetworkIsolationMode = "UnsupportedSDNNetworkIsolationMode"
+	unsupportedMACVlanInterface        = "UnsupportedMACVLANInterface"
+)
+
+var metricLiveMigrationBlocked = metrics.NewGaugeVec(&metrics.GaugeOpts{
+	Namespace: "openshift_network_operator",
+	Name:      "live_migration_blocked",
+	Help: "A metric which contains a constant '1' value labeled with the reason CNI live migration may not begin. " +
+		"The metric is available when CNI live migration has started by annotating the Network CR.",
+}, []string{metricLiveMigrationBlockedLabelKey})
+
+var liveMigrationBlockedMetricOnce sync.Once
+
 func validateLiveMigration(clusterConfig *configv1.Network, infraRes *bootstrap.InfraStatus, client cnoclient.Client) error {
+	liveMigrationBlockedMetricOnce.Do(func() {
+		legacyregistry.MustRegister(metricLiveMigrationBlocked)
+	})
+	metricLiveMigrationBlocked.Reset()
 	// If the migration is completed or is already progressing do not run the validation
 	if clusterConfig.Spec.NetworkType == clusterConfig.Status.NetworkType ||
 		meta.IsStatusConditionPresentAndEqual(clusterConfig.Status.Conditions, names.NetworkTypeMigrationInProgress, metav1.ConditionTrue) {
@@ -214,10 +242,12 @@ func validateLiveMigration(clusterConfig *configv1.Network, infraRes *bootstrap.
 	}
 	if clusterConfig.Spec.NetworkType != string(operv1.NetworkTypeOpenShiftSDN) &&
 		clusterConfig.Spec.NetworkType != string(operv1.NetworkTypeOVNKubernetes) {
+		metricLiveMigrationBlocked.With(prometheus.Labels{metricLiveMigrationBlockedLabelKey: unsupportedCNI}).Set(1)
 		return fmt.Errorf("network type live migration is only supported for OVNKubernetes and OpenShiftSDN CNI")
 	}
 
 	if infraRes.HostedControlPlane != nil {
+		metricLiveMigrationBlocked.With(prometheus.Labels{metricLiveMigrationBlockedLabelKey: unsupportedHCPCluster}).Set(1)
 		return errors.Errorf("network type live migration is not supported on HyperShift clusters")
 	}
 
@@ -235,6 +265,7 @@ func validateLiveMigration(clusterConfig *configv1.Network, infraRes *bootstrap.
 	if clusterConfig.Status.NetworkType == string(operv1.NetworkTypeOpenShiftSDN) {
 		if operNet.Spec.DefaultNetwork.OpenShiftSDNConfig != nil &&
 			operNet.Spec.DefaultNetwork.OpenShiftSDNConfig.Mode == operv1.SDNModeMultitenant {
+			metricLiveMigrationBlocked.With(prometheus.Labels{metricLiveMigrationBlockedLabelKey: unsupportedSDNNetworkIsolationMode}).Set(1)
 			return errors.Errorf("network type live migration is not supported on SDN Multitenant clusters")
 		}
 
@@ -248,6 +279,7 @@ func validateLiveMigration(clusterConfig *configv1.Network, infraRes *bootstrap.
 			return errors.Wrapf(err, "error listing macvlan pods")
 		}
 		if len(macVlanPods) != 0 {
+			metricLiveMigrationBlocked.With(prometheus.Labels{metricLiveMigrationBlockedLabelKey: unsupportedMACVlanInterface}).Set(1)
 			return fmt.Errorf("network type live migration is not supported for pods with %q annotation."+
 				" Please remove all egress router pods", v1.AssignMacvlanAnnotation)
 		}

--- a/pkg/network/cluster_config.go
+++ b/pkg/network/cluster_config.go
@@ -127,7 +127,7 @@ func validateClusterConfig(clusterConfig *configv1.Network, infraRes *bootstrap.
 	}
 
 	if _, ok := clusterConfig.Annotations[names.NetworkTypeMigrationAnnotation]; ok {
-		return validateLiveMigration(clusterConfig, infraRes, client)
+		return ValidateLiveMigration(clusterConfig, infraRes, client)
 	}
 
 	return nil
@@ -230,7 +230,7 @@ var metricLiveMigrationBlocked = metrics.NewGaugeVec(&metrics.GaugeOpts{
 
 var liveMigrationBlockedMetricOnce sync.Once
 
-func validateLiveMigration(clusterConfig *configv1.Network, infraRes *bootstrap.InfraStatus, client cnoclient.Client) error {
+func ValidateLiveMigration(clusterConfig *configv1.Network, infraRes *bootstrap.InfraStatus, client cnoclient.Client) error {
 	liveMigrationBlockedMetricOnce.Do(func() {
 		legacyregistry.MustRegister(metricLiveMigrationBlocked)
 	})
@@ -263,13 +263,13 @@ func validateLiveMigration(clusterConfig *configv1.Network, infraRes *bootstrap.
 
 	// Status contains the CNI we are migrating from
 	if clusterConfig.Status.NetworkType == string(operv1.NetworkTypeOpenShiftSDN) {
-		if operNet.Spec.DefaultNetwork.OpenShiftSDNConfig != nil &&
-			operNet.Spec.DefaultNetwork.OpenShiftSDNConfig.Mode == operv1.SDNModeMultitenant {
+		if operConfig.Spec.DefaultNetwork.OpenShiftSDNConfig != nil &&
+			operConfig.Spec.DefaultNetwork.OpenShiftSDNConfig.Mode == operv1.SDNModeMultitenant {
 			metricLiveMigrationBlocked.With(prometheus.Labels{metricLiveMigrationBlockedLabelKey: unsupportedSDNNetworkIsolationMode}).Set(1)
 			return errors.Errorf("network type live migration is not supported on SDN Multitenant clusters")
 		}
 
-		if err := validateOVNKubernetesCIDROverlap(clusterConfig, operNet); err != nil {
+		if err := validateOVNKubernetesCIDROverlap(clusterConfig, operConfig); err != nil {
 			return err
 		}
 

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -65,8 +65,14 @@ const OVN_NODE_IDENTITY_CERT_DURATION = "24h"
 const OVN_EGRESSIP_HEALTHCHECK_PORT = "9107"
 
 const (
-	OVSFlowsConfigMapName   = "ovs-flows-config"
-	OVSFlowsConfigNamespace = names.APPLIED_NAMESPACE
+	OVSFlowsConfigMapName        = "ovs-flows-config"
+	OVSFlowsConfigNamespace      = names.APPLIED_NAMESPACE
+	defaultV4InternalSubnet      = "100.64.0.0/16"
+	defaultV6InternalSubnet      = "fd98::/64"
+	defaultV4TransitSwitchSubnet = "100.88.0.0/16"
+	defaultV6TransitSwitchSubnet = "fd97::/64"
+	defaultV4MasqueradeSubnet    = "169.254.169.0/29"
+	defaultV6MasqueradeSubnet    = "fd69::/125"
 )
 
 // renderOVNKubernetes returns the manifests for the ovn-kubernetes.
@@ -1879,4 +1885,81 @@ func validateOVNKubernetesSubnet(name, subnet string, otherSubnets *iputil.IPPoo
 		return fmt.Errorf("Whole or subset of %s CIDR %s is already in use: %s", name, subnet, err)
 	}
 	return nil
+}
+
+// GetInternalSubnets returns internal subnet values for both IP families
+// It returns default values if conf is nil or the subnets are not configured
+func GetInternalSubnets(conf *operv1.OVNKubernetesConfig) (v4Subnet, v6Subnet string) {
+	v4Subnet = defaultV4InternalSubnet
+	v6Subnet = defaultV6InternalSubnet
+
+	if conf == nil {
+		return
+	}
+
+	if conf.V4InternalSubnet != "" {
+		v4Subnet = conf.V4InternalSubnet
+	}
+	if conf.IPv4 != nil {
+		// conf.IPv4.InternalJoinSubnet takes precedence over conf.V4InternalSubnet
+		if conf.IPv4.InternalJoinSubnet != "" {
+			v4Subnet = conf.IPv4.InternalJoinSubnet
+		}
+	}
+
+	if conf.V6InternalSubnet != "" {
+		v6Subnet = conf.V6InternalSubnet
+	}
+	if conf.IPv6 != nil {
+		// conf.IPv6.InternalJoinSubnet takes precedence over conf.V6InternalSubnet
+		if conf.IPv6.InternalJoinSubnet != "" {
+			v6Subnet = conf.IPv6.InternalJoinSubnet
+		}
+	}
+	return
+}
+
+// GetTransitSwitchSubnets returns transit switch subnet values for both IP families
+// It returns default values if conf is nil or the subnets are not configured
+func GetTransitSwitchSubnets(conf *operv1.OVNKubernetesConfig) (v4Subnet, v6Subnet string) {
+	v4Subnet = defaultV4TransitSwitchSubnet
+	v6Subnet = defaultV6TransitSwitchSubnet
+
+	if conf == nil {
+		return
+	}
+
+	if conf.IPv4 != nil {
+		if conf.IPv4.InternalTransitSwitchSubnet != "" {
+			v4Subnet = conf.IPv4.InternalTransitSwitchSubnet
+		}
+	}
+
+	if conf.IPv6 != nil {
+		if conf.IPv6.InternalTransitSwitchSubnet != "" {
+			v6Subnet = conf.IPv6.InternalTransitSwitchSubnet
+		}
+	}
+	return
+}
+
+// GetMasqueradeSubnet returns masquerade subnet values for both IP families
+// It returns default values if conf is nil or the subnets are not configured
+func GetMasqueradeSubnet(conf *operv1.OVNKubernetesConfig) (v4Subnet, v6Subnet string) {
+	v4Subnet = defaultV4MasqueradeSubnet
+	v6Subnet = defaultV6MasqueradeSubnet
+
+	if conf == nil {
+		return
+	}
+
+	if conf.GatewayConfig != nil {
+		if conf.GatewayConfig.IPv4.InternalMasqueradeSubnet != "" {
+			v4Subnet = conf.GatewayConfig.IPv4.InternalMasqueradeSubnet
+		}
+		if conf.GatewayConfig.IPv6.InternalMasqueradeSubnet != "" {
+			v4Subnet = conf.GatewayConfig.IPv6.InternalMasqueradeSubnet
+		}
+	}
+	return
 }


### PR DESCRIPTION
Depends on https://github.com/openshift/cluster-network-operator/pull/2392

Metrics docs: https://docs.google.com/document/d/1QQJDtipDqSyLnOYkoEJ12QnV-g61d6BwDLY-aOpdZVw/edit

Cherry-picks was clean except 7d31ad2a3aea0bd6467dc760e98a0cdc752ecf8f
I needed to modify it to remove the config for masq and transit switch subnets.