### PR TITLE
[wip] OCPBUGS-32752: allow user to specify interface for egress router

### DIFF
--- a/bindata/egress-router/000-nad.yaml
+++ b/bindata/egress-router/000-nad.yaml
@@ -11,6 +11,11 @@ spec:
     "cniVersion": "0.4.0",
     "type": "egress-router",
     "name": "egress-router-cni-nad",
+    {{ $masterinterface := .MasterInterface}} {{ if ne $masterinterface "" }}
+    "interfaceArgs": {
+      "master": "{{$masterinterface}}"
+    },
+    {{ end }}
     "ip": {
       "addresses": [
         "{{.Addresses}}"

--- a/pkg/controller/egress_router/egress_router_controller.go
+++ b/pkg/controller/egress_router/egress_router_controller.go
@@ -216,6 +216,8 @@ func (r *EgressRouterReconciler) ensureEgressRouter(ctx context.Context, manifes
 	data.Data["mode"] = router.Spec.Mode
 	data.Data["network_interfaces"] = router.Spec.NetworkInterface
 	data.Data["EgressRouterPodImage"] = os.Getenv("EGRESS_ROUTER_CNI_IMAGE")
+	data.Data["MasterInterface"] = router.Spec.NetworkInterface.Macvlan.Master
+
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "egress-router"), &data)
 	if err != nil {
 		return err


### PR DESCRIPTION
the egressRouter cni allows the secondary interface to be specified and before this we are not allowing that.