### PR TITLE
OCPBUGS-34858, OCPBUGS-34916: Validate live migration before setting the progressing condition

### DIFF
--- a/pkg/controller/operconfig/cluster.go
+++ b/pkg/controller/operconfig/cluster.go
@@ -9,6 +9,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/apply"
+	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
 	"github.com/openshift/cluster-network-operator/pkg/names"
 	"github.com/openshift/cluster-network-operator/pkg/network"
 	k8sutil "github.com/openshift/cluster-network-operator/pkg/util/k8s"
@@ -68,7 +69,7 @@ func (r *ReconcileOperConfig) UpdateOperConfig(ctx context.Context, operConfig *
 
 // ClusterNetworkStatus generates the cluster config Status based on the operator
 // config.
-func (r *ReconcileOperConfig) ClusterNetworkStatus(ctx context.Context, operConfig *operv1.Network) (*uns.Unstructured, error) {
+func (r *ReconcileOperConfig) ClusterNetworkStatus(ctx context.Context, operConfig *operv1.Network, bootstrapResult *bootstrap.BootstrapResult) (*uns.Unstructured, error) {
 	// retrieve the existing cluster config object
 	clusterConfig := &configv1.Network{
 		TypeMeta:   metav1.TypeMeta{APIVersion: configv1.GroupVersion.String(), Kind: "Network"},
@@ -99,6 +100,10 @@ func (r *ReconcileOperConfig) ClusterNetworkStatus(ctx context.Context, operConf
 				return nil, err
 			}
 		} else if clusterConfig.Spec.NetworkType != clusterConfig.Status.NetworkType {
+			// Do not initialize live migration if it is not valid
+			if err := network.ValidateLiveMigration(clusterConfig, &bootstrapResult.Infra, r.client); err != nil {
+				return nil, err
+			}
 			initMigrationConditions(&clusterConfigWithConditions.Status.Conditions, nowTimestamp)
 		} else {
 			resetMigrationConditions(&clusterConfigWithConditions.Status.Conditions, nowTimestamp)

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -562,7 +562,7 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 	}
 
 	// Update Network.config.openshift.io.Status
-	status, err := r.ClusterNetworkStatus(ctx, operConfig)
+	status, err := r.ClusterNetworkStatus(ctx, operConfig, bootstrapResult)
 	if err != nil {
 		log.Printf("Could not generate network status: %v", err)
 		r.status.SetDegraded(statusmanager.OperatorConfig, "StatusError",

--- a/pkg/network/cluster_config.go
+++ b/pkg/network/cluster_config.go
@@ -123,7 +123,7 @@ func validateClusterConfig(clusterConfig *configv1.Network, infraRes *bootstrap.
 	}
 
 	if _, ok := clusterConfig.Annotations[names.NetworkTypeMigrationAnnotation]; ok {
-		return validateLiveMigration(clusterConfig, infraRes, client)
+		return ValidateLiveMigration(clusterConfig, infraRes, client)
 	}
 
 	return nil
@@ -206,7 +206,7 @@ func validateOVNKubernetesCIDROverlap(clusterCofnig *configv1.Network, operConfi
 	return nil
 }
 
-func validateLiveMigration(clusterConfig *configv1.Network, infraRes *bootstrap.InfraStatus, client cnoclient.Client) error {
+func ValidateLiveMigration(clusterConfig *configv1.Network, infraRes *bootstrap.InfraStatus, client cnoclient.Client) error {
 	// If the migration is completed or is already progressing do not run the validation
 	if clusterConfig.Spec.NetworkType == clusterConfig.Status.NetworkType ||
 		meta.IsStatusConditionPresentAndEqual(clusterConfig.Status.Conditions, names.NetworkTypeMigrationInProgress, metav1.ConditionTrue) {
@@ -221,20 +221,20 @@ func validateLiveMigration(clusterConfig *configv1.Network, infraRes *bootstrap.
 		return errors.Errorf("network type live migration is not supported on HyperShift clusters")
 	}
 
-	operNet := &operv1.Network{}
-	err := client.Default().CRClient().Get(context.TODO(), types.NamespacedName{Name: names.CLUSTER_CONFIG}, operNet)
+	operConfig := &operv1.Network{}
+	err := client.Default().CRClient().Get(context.TODO(), types.NamespacedName{Name: names.CLUSTER_CONFIG}, operConfig)
 	if err != nil {
 		return errors.Errorf("error getting network configuration: %v", err)
 	}
 
 	// Status contains the CNI we are migrating from
 	if clusterConfig.Status.NetworkType == string(operv1.NetworkTypeOpenShiftSDN) {
-		if operNet.Spec.DefaultNetwork.OpenShiftSDNConfig != nil &&
-			operNet.Spec.DefaultNetwork.OpenShiftSDNConfig.Mode == operv1.SDNModeMultitenant {
+		if operConfig.Spec.DefaultNetwork.OpenShiftSDNConfig != nil &&
+			operConfig.Spec.DefaultNetwork.OpenShiftSDNConfig.Mode == operv1.SDNModeMultitenant {
 			return errors.Errorf("network type live migration is not supported on SDN Multitenant clusters")
 		}
 
-		if err := validateOVNKubernetesCIDROverlap(clusterConfig, operNet); err != nil {
+		if err := validateOVNKubernetesCIDROverlap(clusterConfig, operConfig); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
The NetworkTypeMigrationInProgress is set in operconfig controller and not in the clusterconfig controller.
Ensure that the live migration is valid before initializing the condition.

/cc @martinkennelly @pliurh 