### PR TITLE
OCPBUGS-33497: Limit iptables-alerter's cpu

### DIFF
--- a/bindata/network/iptables-alerter/003-daemonset.yaml
+++ b/bindata/network/iptables-alerter/003-daemonset.yaml
@@ -44,6 +44,8 @@ spec:
           requests:
             cpu: 10m
             memory: 65Mi
+          limits:
+            cpu: 10m
         securityContext:
           privileged: true
         terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
It's supposed to be a background process, but it's not acting that way right now