### PR TITLE
SDN-5029: linter: removed deprecated linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,7 +6,6 @@ run:
 linters:
   disable-all: true #so that lint version bumps don't change results
   enable:
-    - deadcode
     - errcheck
     - exportloopref
     - gosimple
@@ -16,10 +15,8 @@ linters:
     - nolintlint
     - nosprintfhostport
     - staticcheck
-    - structcheck
     - tenv
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - wastedassign


### PR DESCRIPTION
This commit removes the linters deprecated from 0.53.0 to 0.59.0. 

It is required for a follow-up PR which will update CNO to use golang 1.22 (which requires golangci-lint >= 0.56.0).