### PR TITLE
Change the default ip forward policy to DROP

### DIFF
--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -569,6 +569,8 @@ data:
         sysctl -w net.ipv6.conf.all.forwarding=1
       else
         ip_forwarding_flag="--disable-forwarding"
+        iptables -P FORWARD DROP
+        ip6tables -P FORWARD DROP
       fi
 
       NETWORK_NODE_IDENTITY_ENABLE=


### PR DESCRIPTION
When an OCP node has many interfaces, this node can act as router because the current default forward is ACCEPT. The current solution which is blocking ip forwarding only in sysctl level `net.ipv4.ip_forward=0` that is inherited to all interfaces is not working because it breaks the external LB (metallb) case and therefore forwarding on those interface must be on.

The IP_FORWARD_MODE to Global is an opt-out option if for any reason there is a use case that accidentally works due to previous ACCEPT policy.

https://issues.redhat.com/browse/OCPBUGS-3176