### PR TITLE
SDN-5070: Allow day 2 customization of masquerade subnet

### DIFF
--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -590,12 +590,12 @@ data:
       fi
 
       ovn_v4_masquerade_subnet_opt=
-      if [[ "{{.V4InternalMasqueradeSubnet}}" != "" ]]; then
-        ovn_v4_masquerade_subnet_opt="--gateway-v4-masquerade-subnet {{.V4InternalMasqueradeSubnet}}"
+      if [[ "{{.V4MasqueradeSubnet}}" != "" ]]; then
+        ovn_v4_masquerade_subnet_opt="--gateway-v4-masquerade-subnet {{.V4MasqueradeSubnet}}"
       fi
       ovn_v6_masquerade_subnet_opt=
-      if [[ "{{.V6InternalMasqueradeSubnet}}" != "" ]]; then
-        ovn_v6_masquerade_subnet_opt="--gateway-v6-masquerade-subnet {{.V6InternalMasqueradeSubnet}}"
+      if [[ "{{.V6MasqueradeSubnet}}" != "" ]]; then
+        ovn_v6_masquerade_subnet_opt="--gateway-v6-masquerade-subnet {{.V6MasqueradeSubnet}}"
       fi
 
       exec /usr/bin/ovnkube \

--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -589,6 +589,15 @@ data:
         ovn_v6_join_subnet_opt="--gateway-v6-join-subnet {{.V6JoinSubnet}}"
       fi
 
+      ovn_v4_masquerade_subnet_opt=
+      if [[ "{{.V4InternalMasqueradeSubnet}}" != "" ]]; then
+        ovn_v4_masquerade_subnet_opt="--gateway-v4-masquerade-subnet {{.V4InternalMasqueradeSubnet}}"
+      fi
+      ovn_v6_masquerade_subnet_opt=
+      if [[ "{{.V6InternalMasqueradeSubnet}}" != "" ]]; then
+        ovn_v6_masquerade_subnet_opt="--gateway-v6-masquerade-subnet {{.V6InternalMasqueradeSubnet}}"
+      fi
+
       exec /usr/bin/ovnkube \
         --init-ovnkube-controller "${K8S_NODE}" \
         --init-node "${K8S_NODE}" \
@@ -620,5 +629,7 @@ data:
         ${ip_forwarding_flag} \
         ${NETWORK_NODE_IDENTITY_ENABLE} \
         ${ovn_v4_join_subnet_opt} \
-        ${ovn_v6_join_subnet_opt}
+        ${ovn_v6_join_subnet_opt} \
+        ${ovn_v4_masquerade_subnet_opt} \
+        ${ovn_v6_masquerade_subnet_opt} 
     }

--- a/bindata/network/ovn-kubernetes/managed/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/004-config.yaml
@@ -56,12 +56,6 @@ data:
     [gateway]
     mode={{.OVN_GATEWAY_MODE}}
     nodeport=true
-{{- if (index . "V4InternalMasqueradeSubnet")}}
-    v4-masquerade-subnet="{{.V4InternalMasqueradeSubnet}}"
-{{- end }}
-{{- if (index . "V6InternalMasqueradeSubnet")}}
-    v6-masquerade-subnet="{{.V6InternalMasqueradeSubnet}}"
-{{- end }}
 {{- if .OVNHybridOverlayEnable }}
 
     [hybridoverlay]
@@ -147,12 +141,6 @@ data:
     [gateway]
     mode={{.OVN_GATEWAY_MODE}}
     nodeport=true
-{{- if (index . "V4InternalMasqueradeSubnet")}}
-    v4-masquerade-subnet="{{.V4InternalMasqueradeSubnet}}"
-{{- end }}
-{{- if (index . "V6InternalMasqueradeSubnet")}}
-    v6-masquerade-subnet="{{.V6InternalMasqueradeSubnet}}"
-{{- end }}
 
 
     [logging]

--- a/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
@@ -62,12 +62,6 @@ data:
     [gateway]
     mode={{.OVN_GATEWAY_MODE}}
     nodeport=true
-{{- if (index . "V4InternalMasqueradeSubnet")}}
-    v4-masquerade-subnet="{{.V4InternalMasqueradeSubnet}}"
-{{- end }}
-{{- if (index . "V6InternalMasqueradeSubnet")}}
-    v6-masquerade-subnet="{{.V6InternalMasqueradeSubnet}}"
-{{- end }}
 
     [logging]
     libovsdblogfile=/var/log/ovnkube/libovsdb.log

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -132,8 +132,8 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["V6JoinSubnet"] = ""
 	data.Data["V4TransitSwitchSubnet"] = ""
 	data.Data["V6TransitSwitchSubnet"] = ""
-	data.Data["V4InternalMasqueradeSubnet"] = ""
-	data.Data["V6InternalMasqueradeSubnet"] = ""
+	data.Data["V4MasqueradeSubnet"] = ""
+	data.Data["V6MasqueradeSubnet"] = ""
 
 	data.Data["V4JoinSubnet"] = c.V4InternalSubnet
 	data.Data["V6JoinSubnet"] = c.V6InternalSubnet
@@ -155,10 +155,10 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	}
 	// v4 and v6InternalMasqueradeSubnet are used when the user wants to use the addresses that we reserve in ovn-k for ip masquerading
 	if c.GatewayConfig != nil && c.GatewayConfig.IPv4.InternalMasqueradeSubnet != "" {
-		data.Data["V4InternalMasqueradeSubnet"] = c.GatewayConfig.IPv4.InternalMasqueradeSubnet
+		data.Data["V4MasqueradeSubnet"] = c.GatewayConfig.IPv4.InternalMasqueradeSubnet
 	}
 	if c.GatewayConfig != nil && c.GatewayConfig.IPv6.InternalMasqueradeSubnet != "" {
-		data.Data["V6InternalMasqueradeSubnet"] = c.GatewayConfig.IPv6.InternalMasqueradeSubnet
+		data.Data["V6MasqueradeSubnet"] = c.GatewayConfig.IPv6.InternalMasqueradeSubnet
 	}
 	data.Data["EnableUDPAggregation"] = !bootstrapResult.OVN.OVNKubernetesConfig.DisableUDPAggregation
 	data.Data["NETWORK_NODE_IDENTITY_ENABLE"] = bootstrapResult.Infra.NetworkNodeIdentityEnabled

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -132,6 +132,8 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["V6JoinSubnet"] = ""
 	data.Data["V4TransitSwitchSubnet"] = ""
 	data.Data["V6TransitSwitchSubnet"] = ""
+	data.Data["V4InternalMasqueradeSubnet"] = ""
+	data.Data["V6InternalMasqueradeSubnet"] = ""
 
 	data.Data["V4JoinSubnet"] = c.V4InternalSubnet
 	data.Data["V6JoinSubnet"] = c.V6InternalSubnet

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -244,53 +244,6 @@ logfile-maxage=0`,
 			controlPlaneReplicaCount: 2,
 		},
 		{
-			desc: "custom masquerade subnet",
-			expected: `
-[default]
-mtu="1500"
-cluster-subnets="10.128.0.0/15/23,10.0.0.0/14/24"
-encap-port="8061"
-enable-lflow-cache=true
-lflow-cache-limit-kb=1048576
-enable-udp-aggregation=true
-
-[kubernetes]
-service-cidrs="172.30.0.0/16"
-ovn-config-namespace="openshift-ovn-kubernetes"
-apiserver="https://testing.test:8443"
-host-network-namespace="openshift-host-network"
-platform-type="GCP"
-healthz-bind-address="0.0.0.0:10256"
-dns-service-namespace="openshift-dns"
-dns-service-name="dns-default"
-
-[ovnkubernetesfeature]
-enable-egress-ip=true
-enable-egress-firewall=true
-enable-egress-qos=true
-enable-egress-service=true
-egressip-node-healthcheck-port=9107
-enable-multi-network=true
-enable-multi-external-gateway=true
-
-[gateway]
-mode=shared
-nodeport=true
-v4-masquerade-subnet="100.98.0.0/16"
-
-[logging]
-libovsdblogfile=/var/log/ovnkube/libovsdb.log
-logfile-maxsize=100
-logfile-maxbackups=5
-logfile-maxage=0`,
-			controlPlaneReplicaCount: 2,
-			gatewayConfig: &operv1.GatewayConfig{
-				IPv4: operv1.IPv4GatewayConfig{
-					InternalMasqueradeSubnet: "100.98.0.0/16",
-				},
-			},
-		},
-		{
 			desc: "HybridOverlay",
 			expected: `
 [default]


### PR DESCRIPTION
This PR is to rollout ovnkube-node when there is a change in either ipv4 or ipv6 internalMasqueradeSubnet and done after cluster installation.

This PR also stops updating ovnkube-config configmap with ipv4 or ipv6 internalMasqueradeSubnet and instead updates ovnkube-script-lib configmap in openshift-ovn-kubernetes namespace so that CNO inbuilt logic can trigger ovnkube-node rollout.