### PR TITLE
SDN-4934: Enable TechPreview FeatureGate for NetworkSegmentation

### DIFF
--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -547,6 +547,12 @@ data:
         multi_network_enabled_flag="--enable-multi-network"
       fi
 
+      network_segmentation_enabled_flag=
+      if [[ "{{.OVN_NETWORK_SEGMENTATION_ENABLE}}" == "true" ]]; then
+        multi_network_enabled_flag="--enable-multi-network"
+        network_segmentation_enabled_flag="--enable-network-segmentation"
+      fi
+
       multi_network_policy_enabled_flag=
       if [[ "{{.OVN_MULTI_NETWORK_POLICY_ENABLE}}" == "true" ]]; then
         multi_network_policy_enabled_flag="--enable-multi-networkpolicy"
@@ -615,6 +621,7 @@ data:
         --disable-snat-multiple-gws \
         ${export_network_flows_flags} \
         ${multi_network_enabled_flag} \
+        ${network_segmentation_enabled_flag} \
         ${multi_network_policy_enabled_flag} \
         ${admin_network_policy_enabled_flag} \
         ${dns_name_resolver_enabled_flag} \

--- a/bindata/network/ovn-kubernetes/managed/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/004-config.yaml
@@ -42,6 +42,12 @@ data:
 {{- if .OVN_MULTI_NETWORK_ENABLE }}
     enable-multi-network=true
 {{- end }}
+{{- if .OVN_NETWORK_SEGMENTATION_ENABLE }}
+    {{- if not .OVN_MULTI_NETWORK_ENABLE }}
+    enable-multi-network=true
+    {{- end }}
+    enable-network-segmentation=true
+{{- end }}
 {{- if .OVN_MULTI_NETWORK_POLICY_ENABLE }}
     enable-multi-networkpolicy=true
 {{- end }}
@@ -132,6 +138,12 @@ data:
 {{- end }}
 {{- if .OVN_MULTI_NETWORK_ENABLE }}
     enable-multi-network=true
+{{- end }}
+{{- if .OVN_NETWORK_SEGMENTATION_ENABLE }}
+    {{- if not .OVN_MULTI_NETWORK_ENABLE }}
+    enable-multi-network=true
+    {{- end }}
+    enable-network-segmentation=true
 {{- end }}
 {{- if .OVN_MULTI_NETWORK_POLICY_ENABLE }}
     enable-multi-networkpolicy=true

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
@@ -174,6 +174,15 @@ spec:
             persistent_ips_enabled_flag="--enable-persistent-ips"
           fi
 
+          # This is needed so that converting clusters from GA to TP
+          # will rollout control plane pods as well
+          network_segmentation_enabled_flag=
+          multi_network_enabled_flag=
+          if [[ "{{.OVN_NETWORK_SEGMENTATION_ENABLE}}" == "true" ]]; then
+            multi_network_enabled_flag="--enable-multi-network"
+            network_segmentation_enabled_flag="--enable-network-segmentation"
+          fi
+
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-control-plane - start ovnkube --init-cluster-manager ${K8S_NODE}"
           exec /usr/bin/ovnkube \
             --enable-interconnect \
@@ -191,7 +200,9 @@ spec:
             ${ovn_v4_transit_switch_subnet_opt} \
             ${ovn_v6_transit_switch_subnet_opt} \
             ${dns_name_resolver_enabled_flag} \
-            ${persistent_ips_enabled_flag}
+            ${persistent_ips_enabled_flag} \
+            ${multi_network_enabled_flag} \
+            ${network_segmentation_enabled_flag}
         volumeMounts:
         - mountPath: /run/ovnkube-config/
           name: ovnkube-config

--- a/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
@@ -48,6 +48,12 @@ data:
 {{- if .OVN_MULTI_NETWORK_ENABLE }}
     enable-multi-network=true
 {{- end }}
+{{- if .OVN_NETWORK_SEGMENTATION_ENABLE }}
+    {{- if not .OVN_MULTI_NETWORK_ENABLE }}
+    enable-multi-network=true
+    {{- end }}
+    enable-network-segmentation=true
+{{- end }}
 {{- if .OVN_MULTI_NETWORK_POLICY_ENABLE }}
     enable-multi-networkpolicy=true
 {{- end }}

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
@@ -134,6 +134,15 @@ spec:
             persistent_ips_enabled_flag="--enable-persistent-ips"
           fi
 
+          # This is needed so that converting clusters from GA to TP
+          # will rollout control plane pods as well
+          network_segmentation_enabled_flag=
+          multi_network_enabled_flag=
+          if [[ "{{.OVN_NETWORK_SEGMENTATION_ENABLE}}" == "true" ]]; then
+            multi_network_enabled_flag="--enable-multi-network"
+            network_segmentation_enabled_flag="--enable-network-segmentation"
+          fi
+
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-control-plane - start ovnkube --init-cluster-manager ${K8S_NODE}"
           exec /usr/bin/ovnkube \
             --enable-interconnect \
@@ -148,7 +157,9 @@ spec:
             ${ovn_v4_transit_switch_subnet_opt} \
             ${ovn_v6_transit_switch_subnet_opt} \
             ${dns_name_resolver_enabled_flag} \
-            ${persistent_ips_enabled_flag}
+            ${persistent_ips_enabled_flag} \
+            ${multi_network_enabled_flag} \
+            ${network_segmentation_enabled_flag}
         volumeMounts:
         - mountPath: /run/ovnkube-config/
           name: ovnkube-config

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -307,6 +307,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	// leverage feature gates
 	data.Data["OVN_ADMIN_NETWORK_POLICY_ENABLE"] = featureGates.Enabled(apifeatures.FeatureGateAdminNetworkPolicy)
 	data.Data["DNS_NAME_RESOLVER_ENABLE"] = featureGates.Enabled(apifeatures.FeatureGateDNSNameResolver)
+	data.Data["OVN_NETWORK_SEGMENTATION_ENABLE"] = featureGates.Enabled(apifeatures.FeatureGateNetworkSegmentation)
 
 	data.Data["ReachabilityTotalTimeoutSeconds"] = c.EgressIPConfig.ReachabilityTotalTimeoutSeconds
 

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -625,6 +625,7 @@ func renderCRDForMigration(conf *operv1.NetworkSpec, manifestDir string, feature
 		// in the cluster
 		data := render.MakeRenderData()
 		data.Data["OVN_ADMIN_NETWORK_POLICY_ENABLE"] = featureGates.Enabled(apifeatures.FeatureGateAdminNetworkPolicy)
+		data.Data["OVN_NETWORK_SEGMENTATION_ENABLE"] = featureGates.Enabled(apifeatures.FeatureGateNetworkSegmentation)
 		manifests, err := render.RenderTemplate(filepath.Join(manifestDir, "network/ovn-kubernetes/common/001-crd.yaml"), &data)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to render OVNKubernetes CRDs")


### PR DESCRIPTION
Enables TechPreview feature gate for NetworkSegmentation
Builds on top of https://github.com/openshift/cluster-network-operator/pull/2428
We will GA in the last sprint but we don't have to do anything given
we just need to bump it to default ON in API repo.

The new network CRD can also use this gate to be installed if the flag is ON