### PR TITLE
controller/managed: add trusted-ca mount

### DIFF
--- a/bindata/cloud-network-config-controller/managed/003-configmaps.yaml
+++ b/bindata/cloud-network-config-controller/managed/003-configmaps.yaml
@@ -6,3 +6,13 @@ metadata:
   annotations:
     network.operator.openshift.io/cluster-name:  {{.ManagementClusterName}}
 # placeholder; will be replaced in render.go
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  namespace: {{.HostedClusterNamespace}}
+  name: trusted-ca-bundle-managed
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+# will have CA-bundle injected by the CNO

--- a/bindata/cloud-network-config-controller/managed/controller.yaml
+++ b/bindata/cloud-network-config-controller/managed/controller.yaml
@@ -189,6 +189,9 @@ spec:
         volumeMounts:
         - mountPath: /hosted-ca
           name: hosted-ca-cert
+        - name: trusted-ca
+          mountPath: /etc/pki/ca-trust/extracted/pem
+          readOnly: true
         - mountPath: /var/run/secrets/hosted_cluster
           name: hosted-cluster-api-access
         - name: cloud-provider-secret
@@ -227,6 +230,12 @@ spec:
           items:
             - key: ca.crt
               path: ca.crt
+      - name: trusted-ca
+        configMap:
+          name: trusted-ca-bundle-managed
+          items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
       - name: admin-kubeconfig
         secret:
           secretName: service-network-admin-kubeconfig


### PR DESCRIPTION
When running Hypershift with OpenStack, we need to have the trusted-ca
mounted because sometimes an OpenStack cloud can have a self signed
certificate and the controller communicates to the OpenStack endpoint.

The mount is present on self-hosted but not in manage, this patch adds
and handle the ConfigMap based on how it's created by Hypershift: 
https://github.com/openshift/hypershift/blob/1f9c369e5905137cbeccd452e4ba94c406657bd2/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go#L89