### PR TITLE
DNM - testing things with CloudConfig

### DIFF
--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -372,6 +372,7 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 			fmt.Sprintf("Internal error while reconciling platform networking resources: %v", err))
 		return reconcile.Result{}, err
 	}
+	log.Printf("EMILIEN Bootstrap infra kubeconfig: %v", bootstrapResult.Infra.KubeCloudConfig)
 
 	if !reflect.DeepEqual(operConfig, newOperConfig) {
 		if err := r.UpdateOperConfig(ctx, newOperConfig); err != nil {

--- a/pkg/network/cloud_network.go
+++ b/pkg/network/cloud_network.go
@@ -18,6 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog/v2"
 )
 
 // renderCloudNetworkConfigController renders the cloud network config controller
@@ -62,6 +63,7 @@ func renderCloudNetworkConfigController(conf *operv1.NetworkSpec, bootstrapResul
 		},
 		Data: cloudBootstrapResult.KubeCloudConfig,
 	}
+	klog.Infof("EMILIEN: KubeCloudConfig: %v", cloudBootstrapResult.KubeCloudConfig)
 	if cloudBootstrapResult.PlatformType == v1.AWSPlatformType {
 		for _, ep := range cloudBootstrapResult.PlatformStatus.AWS.ServiceEndpoints {
 			if ep.Name == "ec2" {

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -118,6 +118,10 @@ func InfraStatus(client cnoclient.Client) (*bootstrap.InfraStatus, error) {
 
 	// AWS and OpenStack specify a CA bundle via a config map; retrieve it.
 	if res.PlatformType == configv1.AWSPlatformType || res.PlatformType == configv1.OpenStackPlatformType {
+		// In HyperShift clusters, the kube-cloud-config ConfigMap should be retrieved from the hosted control plane namespace.
+		if hc := hypershift.NewHyperShiftConfig(); hc.Enabled {
+			cloudProviderConfig.Namespace = hc.Namespace
+		}
 		cm := &corev1.ConfigMap{}
 		if err := client.Default().CRClient().Get(context.TODO(), cloudProviderConfig, cm); err != nil {
 			if !apierrors.IsNotFound(err) {

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -119,10 +119,6 @@ func InfraStatus(client cnoclient.Client) (*bootstrap.InfraStatus, error) {
 	klog.Infof("EMILIEN: InfraStatus: %v", res)
 	// AWS and OpenStack specify a CA bundle via a config map; retrieve it.
 	if res.PlatformType == configv1.AWSPlatformType || res.PlatformType == configv1.OpenStackPlatformType {
-		// In HyperShift clusters, the kube-cloud-config ConfigMap should be retrieved from the hosted control plane namespace.
-		if hc := hypershift.NewHyperShiftConfig(); hc.Enabled {
-			cloudProviderConfig.Namespace = hc.Namespace
-		}
 		cm := &corev1.ConfigMap{}
 		if err := client.Default().CRClient().Get(context.TODO(), cloudProviderConfig, cm); err != nil {
 			if !apierrors.IsNotFound(err) {

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -116,7 +116,7 @@ func InfraStatus(client cnoclient.Client) (*bootstrap.InfraStatus, error) {
 		res.PlatformRegion = infraConfig.Status.PlatformStatus.GCP.Region
 	}
 
-	klog.Infof("EMILIEN: InfraStatus: %v", res)
+	klog.Infof("EMILIEN: KubeCloudConfig in InfraStatus func %v", res.KubeCloudConfig)
 	// AWS and OpenStack specify a CA bundle via a config map; retrieve it.
 	if res.PlatformType == configv1.AWSPlatformType || res.PlatformType == configv1.OpenStackPlatformType {
 		cm := &corev1.ConfigMap{}
@@ -124,6 +124,7 @@ func InfraStatus(client cnoclient.Client) (*bootstrap.InfraStatus, error) {
 			if !apierrors.IsNotFound(err) {
 				return nil, fmt.Errorf("failed to retrieve ConfigMap %s: %w", cloudProviderConfig, err)
 			}
+			klog.Infof("EMILIEN: ConfigMap %s not found", cloudProviderConfig)
 		} else {
 			klog.Infof("EMILIEN: Found kube-cloud-config ConfigMap %s", cloudProviderConfig)
 			klog.Infof("EMILIEN: Data: %v", cm.Data)

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -116,6 +116,7 @@ func InfraStatus(client cnoclient.Client) (*bootstrap.InfraStatus, error) {
 		res.PlatformRegion = infraConfig.Status.PlatformStatus.GCP.Region
 	}
 
+	klog.Infof("EMILIEN: InfraStatus: %v", res)
 	// AWS and OpenStack specify a CA bundle via a config map; retrieve it.
 	if res.PlatformType == configv1.AWSPlatformType || res.PlatformType == configv1.OpenStackPlatformType {
 		// In HyperShift clusters, the kube-cloud-config ConfigMap should be retrieved from the hosted control plane namespace.
@@ -128,6 +129,8 @@ func InfraStatus(client cnoclient.Client) (*bootstrap.InfraStatus, error) {
 				return nil, fmt.Errorf("failed to retrieve ConfigMap %s: %w", cloudProviderConfig, err)
 			}
 		} else {
+			klog.Infof("EMILIEN: Found kube-cloud-config ConfigMap %s", cloudProviderConfig)
+			klog.Infof("EMILIEN: Data: %v", cm.Data)
 			res.KubeCloudConfig = cm.Data
 		}
 	}


### PR DESCRIPTION
The kube-cloud-config ConfigMap should be retrieved from the HCP
namespace when Hypershift deployed the CNO.