### PR TITLE
[release-4.14] OCPBUGS-37468: Backport ipsec state metric

### DIFF
--- a/bindata/cluster-network-operator/prometheus.yaml
+++ b/bindata/cluster-network-operator/prometheus.yaml
@@ -1,0 +1,18 @@
+##
+# This file is not applied correctly during cluster installation when located in
+# the manifests directory, this is the reason why it is located in the bindata directory.
+##
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+    name: openshift-network-operator-ipsec-rules
+    namespace: openshift-network-operator
+spec:
+    groups:
+    - name: openshift-network.rules
+      rules:
+      - expr: |-
+          group by (mode,is_legacy_api) (
+            openshift_network_operator_ipsec_state{namespace=~"openshift-network-operator"}
+          )
+        record: openshift:openshift_network_operator_ipsec_state:info

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/names"
 	"github.com/openshift/cluster-network-operator/pkg/network"
 	"github.com/openshift/cluster-network-operator/pkg/platform"
+	ipsecMetrics "github.com/openshift/cluster-network-operator/pkg/util/ipsec"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/events"
 
@@ -343,6 +344,7 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 		}
 	}
 
+	updateIPsecMetric(&newOperConfig.Spec)
 	// once updated, use the new config
 	operConfig = newOperConfig
 
@@ -545,6 +547,21 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 	// so we can reconcile state again.
 	log.Printf("Operconfig Controller complete")
 	return reconcile.Result{RequeueAfter: ResyncPeriod}, nil
+}
+
+func updateIPsecMetric(newOperConfigSpec *operv1.NetworkSpec) {
+	if newOperConfigSpec == nil {
+		// spec is not initilized yet
+		klog.V(5).Infof("IPsec: << updateIPsecTelemetry, new spec is nil, skipping")
+	} else if newOperConfigSpec.DefaultNetwork.OVNKubernetesConfig == nil {
+		// non ovn-k network, ipsec is not supported
+		ipsecMetrics.UpdateIPsecMetricNA()
+	} else {
+		// ovn-k network, ipsec is supported, update the ipsec state metric
+		newOVNKubeConfigIpsec := newOperConfigSpec.DefaultNetwork.OVNKubernetesConfig.IPsecConfig
+		isIpsecEnabled := newOVNKubeConfigIpsec != nil
+		ipsecMetrics.UpdateIPsecMetric(isIpsecEnabled)
+	}
 }
 
 func reconcileOperConfig(ctx context.Context, obj crclient.Object) []reconcile.Request {

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -124,6 +124,12 @@ func Render(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapResult
 	}
 	objs = append(objs, o...)
 
+	o, err = renderCNO(manifestDir)
+	if err != nil {
+		return nil, progressing, err
+	}
+	objs = append(objs, o...)
+
 	log.Printf("Render phase done, rendered %d objects", len(objs))
 	return objs, progressing, nil
 }
@@ -809,6 +815,17 @@ func renderNetworkPublic(manifestDir string) ([]*uns.Unstructured, error) {
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "network", "public"), &data)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to render network/public manifests")
+	}
+	return manifests, nil
+}
+
+// renderCNO renders the common objects in the cluster-network-operator directory
+func renderCNO(manifestDir string) ([]*uns.Unstructured, error) {
+	data := render.MakeRenderData()
+
+	manifests, err := render.RenderDir(filepath.Join(manifestDir, "cluster-network-operator"), &data)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to render cluster-network-operator manifests")
 	}
 	return manifests, nil
 }

--- a/pkg/util/ipsec/metrics.go
+++ b/pkg/util/ipsec/metrics.go
@@ -1,0 +1,50 @@
+package ipsec
+
+import (
+	"strconv"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/klog/v2"
+)
+
+const (
+	cnoNamespace  = "openshift_network_operator"
+	ipsecStateNA  = "N/A - ipsec not supported (non-OVN network)"
+	ipsecDisabled = "Disabled"
+	ipsecInternal = "Internal"
+)
+
+var (
+	ipsecStateGauge *metrics.GaugeVec
+	trueStr         string
+)
+
+func init() {
+	ipsecStateGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
+		Namespace: cnoNamespace,
+		Name:      "ipsec_state",
+		Help: "A metric with a constant '1' value labeled by the latest ipsecMode of the cluster, " +
+			"and the API that invoked it, legacy (pre OCP 4.14) or new. " +
+			"In case the network doesn't support ipsec (non-OVN network), " +
+			"the 'is_legacy_api' value is set to '" + ipsecStateNA + "'.",
+	}, []string{"mode", "is_legacy_api"})
+	legacyregistry.MustRegister(ipsecStateGauge)
+	trueStr = strconv.FormatBool(true)
+}
+
+func UpdateIPsecMetric(enabled bool) {
+	klog.V(5).Infof("IPsec mode: %v", enabled)
+	state := ipsecDisabled
+	if enabled {
+		state = ipsecInternal
+	}
+	ipsecStateGauge.Reset()
+	ipsecStateGauge.WithLabelValues(state, trueStr).Set(1)
+}
+
+func UpdateIPsecMetricNA() {
+	klog.V(5).Infof("IPsec is not supported by non-OVN network (disabled)")
+	ipsecStateGauge.Reset()
+	ipsecStateGauge.WithLabelValues(ipsecDisabled, ipsecStateNA).Set(1)
+}


### PR DESCRIPTION
This is a backport of PR #[2270](https://github.com/openshift/cluster-network-operator/pull/2270) which added ipsec state metric to OCP V4.16, and PR #[2389](https://github.com/openshift/cluster-network-operator/pull/2389) which backported this to V4.15. Both these PRs are based on API change that was added to V4.15 - therefore this PR is a manual backport and not a cherry-pick since the API does not exist in V4.14 and will not be ported to this version due to compatibiilty reasons.