### PR TITLE
SDN-4919: OVN-Kubernetes UDN: EndpointSlice mirror controller RBAC permissions

### DIFF
--- a/bindata/network/ovn-kubernetes/common/004-rbac-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/common/004-rbac-control-plane.yaml
@@ -156,6 +156,24 @@ rules:
     - ipamclaims/status
   verbs: [ "patch", "update" ]
 {{- end}}
+{{- if .OVN_NETWORK_SEGMENTATION_ENABLE }}
+- apiGroups:
+    - discovery.k8s.io
+  resources:
+    - endpointslices
+  verbs:
+    - create
+    - delete
+    - update
+    - get
+    - list
+    - watch
+- apiGroups: [""]
+  resources:
+    - services/finalizers
+  verbs:
+    - update
+{{- end}}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Add RBAC permissions for the new EndpointSlice mirror controller. 
The services/finalizer update is required because the controller copies the ownerReference that might block serivce deletion.