### PR TITLE
OCPBUGS-37786: Add proxy env vars to onvkube-node

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -415,6 +415,18 @@ spec:
         - name: OVNKUBE_NODE_MGMT_PORT_DP_RESOURCE_NAME
           value: {{ .MgmtPortResourceName }}
         {{ end }}
+{{ if .HTTP_PROXY }}
+        - name: "HTTP_PROXY"
+          value: "{{ .HTTP_PROXY}}"
+{{ end }}
+{{ if .HTTPS_PROXY }}
+        - name: "HTTPS_PROXY"
+          value: "{{ .HTTPS_PROXY}}"
+{{ end }}
+{{ if .NO_PROXY }}
+        - name: "NO_PROXY"
+          value: "{{ .NO_PROXY}}"
+{{ end }}
         - name: K8S_NODE
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Fix the use case for Public clusters that require a proxy to access the kube apiserver.