### PR TITLE
OCPBUGS-52280: Move to use newer IPsec DaemonSets irrespective of MCP state

### DIFF
--- a/bindata/network/ovn-kubernetes/common/ipsec-containerized.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-containerized.yaml
@@ -49,6 +49,14 @@ spec:
         - |
           #!/bin/bash
           set -exuo pipefail
+
+{{ if .IPsecCheckForLibreswan }}
+          if rpm --dbpath=/usr/share/rpm -q libreswan; then
+            echo "host has libreswan and therefore ipsec will be configured by ipsec host daemonset, this ovn ipsec container doesnt need to init anything"
+            exit 0
+          fi
+{{ end }}
+
 {{ if .NETWORK_NODE_IDENTITY_ENABLE }}
           # When NETWORK_NODE_IDENTITY_ENABLE is true, use the per-node certificate to create a kubeconfig
           # that will be used to talk to the API
@@ -189,6 +197,9 @@ spec:
           name: signer-ca
         - mountPath: /etc/openvswitch
           name: etc-openvswitch
+        - mountPath: /usr/share/rpm
+          name: host-usr-share-rpm
+          readOnly: true
         resources:
           requests:
             cpu: 10m
@@ -219,6 +230,13 @@ spec:
             exit 0
           }
           trap cleanup SIGTERM
+
+{{ if .IPsecCheckForLibreswan }}
+          if rpm --dbpath=/usr/share/rpm -q libreswan; then
+            echo "host has libreswan and therefore ipsec will be configured by ipsec host daemonset, this ovn ipsec container will sleep to infinity"
+            sleep infinity
+          fi
+{{ end }}
 
           # Don't start IPsec until ovnkube-node has finished setting up the node
           counter=0
@@ -276,6 +294,9 @@ spec:
           name: host-var-log-ovs
         - mountPath: /etc/openvswitch
           name: etc-openvswitch
+        - mountPath: /usr/share/rpm
+          name: host-usr-share-rpm
+          readOnly: true
         resources:
           requests:
             cpu: 10m
@@ -288,6 +309,12 @@ spec:
             - -c
             - |
               #!/bin/bash
+{{ if .IPsecCheckForLibreswan }}
+              if rpm --dbpath=/usr/share/rpm -q libreswan; then
+                echo "host has libreswan and therefore ipsec will be configured by ipsec host daemonset, this ovn ipsec container is always \"alive\""
+                exit 0
+              fi
+{{ end }}
               if [[ $(ipsec whack --trafficstatus | wc -l) -eq 0 ]]; then
                 echo "no ipsec traffic configured"
                 exit 10
@@ -321,6 +348,10 @@ spec:
       - name: host-cni-netd
         hostPath:
           path: "{{.CNIConfDir}}"
+      - name: host-usr-share-rpm
+        hostPath:
+          path: /usr/share/rpm
+          type: DirectoryOrCreate
       tolerations:
       - operator: "Exists"
 {{end}}

--- a/bindata/network/ovn-kubernetes/common/ipsec-containerized.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-containerized.yaml
@@ -37,6 +37,9 @@ spec:
               - key: network.operator.openshift.io/dpu-host
                 operator: DoesNotExist
       serviceAccountName: ovn-kubernetes-node
+{{ if .IPsecServiceCheckOnHost }}
+      hostPID: true
+{{ end }}
       hostNetwork: true
       dnsPolicy: Default
       priorityClassName: "system-node-critical"
@@ -50,9 +53,9 @@ spec:
           #!/bin/bash
           set -exuo pipefail
 
-{{ if .IPsecCheckForLibreswan }}
-          if rpm --dbpath=/usr/share/rpm -q libreswan; then
-            echo "host has libreswan and therefore ipsec will be configured by ipsec host daemonset, this ovn ipsec container doesnt need to init anything"
+{{ if .IPsecServiceCheckOnHost }}
+          if chroot /proc/1/root systemctl is-active --quiet ipsec.service; then
+            echo "host has ipsec.service running and therefore ipsec will be configured by ipsec host daemonset, this ovn ipsec container doesnt need to init anything"
             exit 0
           fi
 {{ end }}
@@ -197,9 +200,6 @@ spec:
           name: signer-ca
         - mountPath: /etc/openvswitch
           name: etc-openvswitch
-        - mountPath: /usr/share/rpm
-          name: host-usr-share-rpm
-          readOnly: true
         resources:
           requests:
             cpu: 10m
@@ -231,9 +231,9 @@ spec:
           }
           trap cleanup SIGTERM
 
-{{ if .IPsecCheckForLibreswan }}
-          if rpm --dbpath=/usr/share/rpm -q libreswan; then
-            echo "host has libreswan and therefore ipsec will be configured by ipsec host daemonset, this ovn ipsec container will sleep to infinity"
+{{ if .IPsecServiceCheckOnHost }}
+          if chroot /proc/1/root systemctl is-active --quiet ipsec.service; then
+            echo "host has ipsec.service running and therefore ipsec will be configured by ipsec host daemonset, this ovn ipsec container will sleep to infinity"
             sleep infinity
           fi
 {{ end }}
@@ -294,9 +294,6 @@ spec:
           name: host-var-log-ovs
         - mountPath: /etc/openvswitch
           name: etc-openvswitch
-        - mountPath: /usr/share/rpm
-          name: host-usr-share-rpm
-          readOnly: true
         resources:
           requests:
             cpu: 10m
@@ -309,9 +306,9 @@ spec:
             - -c
             - |
               #!/bin/bash
-{{ if .IPsecCheckForLibreswan }}
-              if rpm --dbpath=/usr/share/rpm -q libreswan; then
-                echo "host has libreswan and therefore ipsec will be configured by ipsec host daemonset, this ovn ipsec container is always \"alive\""
+{{ if .IPsecServiceCheckOnHost }}
+              if chroot /proc/1/root systemctl is-active --quiet ipsec.service; then
+                echo "host has ipsec.service running and therefore ipsec will be configured by ipsec host daemonset, this ovn ipsec container is always \"alive\""
                 exit 0
               fi
 {{ end }}
@@ -348,10 +345,6 @@ spec:
       - name: host-cni-netd
         hostPath:
           path: "{{.CNIConfDir}}"
-      - name: host-usr-share-rpm
-        hostPath:
-          path: /usr/share/rpm
-          type: DirectoryOrCreate
       tolerations:
       - operator: "Exists"
 {{end}}

--- a/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
@@ -331,10 +331,10 @@ spec:
           name: host-var-lib
         - mountPath: /etc
           name: host-etc
-        - mountPath: /usr/sbin/ipsec
-          name: ipsec-bin
-        - mountPath: /usr/libexec/ipsec
-          name: ipsec-lib
+        - mountPath: /usr/sbin
+          name: usr-sbin
+        - mountPath: /usr/libexec
+          name: usr-libexec
         - mountPath: /usr/share/rpm
           name: host-usr-share-rpm
           readOnly: true
@@ -534,13 +534,13 @@ spec:
           type: Directory
         name: host-etc
       - hostPath:
-          path: /usr/sbin/ipsec
-          type: File
-        name: ipsec-bin
-      - hostPath:
-          path: /usr/libexec/ipsec
+          path: /usr/sbin
           type: Directory
-        name: ipsec-lib
+        name: usr-sbin
+      - hostPath:
+          path: /usr/libexec
+          type: Directory
+        name: usr-libexec
       - name: host-usr-share-rpm
         hostPath:
           path: /usr/share/rpm

--- a/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
@@ -50,6 +50,12 @@ spec:
         - |
           #!/bin/bash
           set -exuo pipefail
+{{ if .IPsecCheckForLibreswan }}
+          if ! rpm --dbpath=/usr/share/rpm -q libreswan; then
+            echo "host doesnt have libreswan, therefore ipsec will be configured by ipsec-containerized daemonset, this ovn ipsec container has nothing to init"
+            exit 0
+          fi
+{{ end }}
 {{ if .NETWORK_NODE_IDENTITY_ENABLE }}
           # When NETWORK_NODE_IDENTITY_ENABLE is true, use the per-node certificate to create a kubeconfig
           # that will be used to talk to the API
@@ -194,6 +200,9 @@ spec:
           name: etc-openvswitch
         - mountPath: /etc
           name: host-etc
+        - mountPath: /usr/share/rpm
+          name: host-usr-share-rpm
+          readOnly: true
         resources:
           requests:
             cpu: 10m
@@ -209,6 +218,13 @@ spec:
         - |
           #!/bin/bash
           set -exuo pipefail
+
+{{ if .IPsecCheckForLibreswan }}
+          if ! rpm --dbpath=/usr/share/rpm -q libreswan; then
+            echo "host doesnt have libreswan, therefore ipsec will be configured by ipsec-containerized daemonset, this ovn ipsec container will sleep to infinity"
+            sleep infinity
+          fi
+{{ end }}
 
           # Don't start IPsec until ovnkube-node has finished setting up the node
           counter=0
@@ -285,6 +301,13 @@ spec:
                    # In order to maintain traffic flows during container restart, we
                    # need to ensure that xfrm state and policies are not flushed.
 
+{{ if .IPsecCheckForLibreswan }}
+                   if ! rpm --dbpath=/usr/share/rpm -q libreswan; then
+                     echo "host doesnt have libreswan, therefore ipsec will be configured by ipsec-containerized daemonset, preStop wont do anything"
+                     exit 0
+                   fi
+{{ end }}
+
                    # Don't allow ovs monitor to cleanup persistent state
                    kill "$(cat /var/run/openvswitch/ovs-monitor-ipsec.pid 2>/dev/null)" 2>/dev/null || true
         env:
@@ -312,6 +335,9 @@ spec:
           name: ipsec-bin
         - mountPath: /usr/libexec/ipsec
           name: ipsec-lib
+        - mountPath: /usr/share/rpm
+          name: host-usr-share-rpm
+          readOnly: true
         resources:
           requests:
             cpu: 10m
@@ -324,6 +350,12 @@ spec:
             - -c
             - |
               #!/bin/bash
+{{ if .IPsecCheckForLibreswan }}
+              if ! rpm --dbpath=/usr/share/rpm -q libreswan; then
+                echo "host doesnt have libreswan, therefore ipsec will be configured by ipsec-containerized daemonset, this ovn ipsec container is always \"alive\""
+                exit 0
+              fi
+{{ end }}
               if [[ $(ipsec whack --trafficstatus | wc -l) -eq 0 ]]; then
                 echo "no ipsec traffic configured"
                 exit 10
@@ -509,6 +541,10 @@ spec:
           path: /usr/libexec/ipsec
           type: Directory
         name: ipsec-lib
+      - name: host-usr-share-rpm
+        hostPath:
+          path: /usr/share/rpm
+          type: DirectoryOrCreate
       tolerations:
       - operator: "Exists"
 {{end}}

--- a/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
@@ -50,9 +50,9 @@ spec:
         - |
           #!/bin/bash
           set -exuo pipefail
-{{ if .IPsecCheckForLibreswan }}
-          if ! rpm --dbpath=/usr/share/rpm -q libreswan; then
-            echo "host doesnt have libreswan, therefore ipsec will be configured by ipsec-containerized daemonset, this ovn ipsec container has nothing to init"
+{{ if .IPsecServiceCheckOnHost }}
+          if ! chroot /proc/1/root systemctl is-active --quiet ipsec.service; then
+            echo "host doesn't have ipsec.service running, therefore ipsec will be configured by ipsec-containerized daemonset, this ovn ipsec container has nothing to init"
             exit 0
           fi
 {{ end }}
@@ -200,9 +200,6 @@ spec:
           name: etc-openvswitch
         - mountPath: /etc
           name: host-etc
-        - mountPath: /usr/share/rpm
-          name: host-usr-share-rpm
-          readOnly: true
         resources:
           requests:
             cpu: 10m
@@ -219,9 +216,9 @@ spec:
           #!/bin/bash
           set -exuo pipefail
 
-{{ if .IPsecCheckForLibreswan }}
-          if ! rpm --dbpath=/usr/share/rpm -q libreswan; then
-            echo "host doesnt have libreswan, therefore ipsec will be configured by ipsec-containerized daemonset, this ovn ipsec container will sleep to infinity"
+{{ if .IPsecServiceCheckOnHost }}
+          if ! chroot /proc/1/root systemctl is-active --quiet ipsec.service; then
+            echo "host doesn't have ipsec.service running, therefore ipsec will be configured by ipsec-containerized daemonset, this ovn ipsec container will sleep to infinity"
             sleep infinity
           fi
 {{ end }}
@@ -301,9 +298,9 @@ spec:
                    # In order to maintain traffic flows during container restart, we
                    # need to ensure that xfrm state and policies are not flushed.
 
-{{ if .IPsecCheckForLibreswan }}
-                   if ! rpm --dbpath=/usr/share/rpm -q libreswan; then
-                     echo "host doesnt have libreswan, therefore ipsec will be configured by ipsec-containerized daemonset, preStop wont do anything"
+{{ if .IPsecServiceCheckOnHost }}
+                   if ! chroot /proc/1/root systemctl is-active --quiet ipsec.service; then
+                     echo "host doesn't have ipsec.service running, therefore ipsec will be configured by ipsec-containerized daemonset, preStop wont do anything"
                      exit 0
                    fi
 {{ end }}
@@ -335,9 +332,6 @@ spec:
           name: usr-sbin
         - mountPath: /usr/libexec
           name: usr-libexec
-        - mountPath: /usr/share/rpm
-          name: host-usr-share-rpm
-          readOnly: true
         resources:
           requests:
             cpu: 10m
@@ -350,9 +344,9 @@ spec:
             - -c
             - |
               #!/bin/bash
-{{ if .IPsecCheckForLibreswan }}
-              if ! rpm --dbpath=/usr/share/rpm -q libreswan; then
-                echo "host doesnt have libreswan, therefore ipsec will be configured by ipsec-containerized daemonset, this ovn ipsec container is always \"alive\""
+{{ if .IPsecServiceCheckOnHost }}
+              if ! chroot /proc/1/root systemctl is-active --quiet ipsec.service; then
+                echo "host doesn't have ipsec.service running, therefore ipsec will be configured by ipsec-containerized daemonset, this ovn ipsec container is always \"alive\""
                 exit 0
               fi
 {{ end }}
@@ -541,10 +535,6 @@ spec:
           path: /usr/libexec
           type: Directory
         name: usr-libexec
-      - name: host-usr-share-rpm
-        hostPath:
-          path: /usr/share/rpm
-          type: DirectoryOrCreate
       tolerations:
       - operator: "Exists"
 {{end}}

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -49,8 +49,6 @@ type OVNUpdateStatus struct {
 // OVNIPsecStatus contains status of current IPsec configuration
 // in the cluster.
 type OVNIPsecStatus struct {
-	// LegacyIPsecUpgrade true if IPsec in 4.14.x cluster is upgraded to 4.15.x version.
-	LegacyIPsecUpgrade bool
 	// IsOVNIPsecActiveOrRollingOut set to true unless we are sure it is not. Note that this is
 	// set to true when ovnkube-node daemonset is in progressing state which is not reflecting
 	// actual ovn ipsec state. so must be precautious in making decisions at the time of machine

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -46,6 +46,7 @@ import (
 	iputil "github.com/openshift/cluster-network-operator/pkg/util/ip"
 	"github.com/openshift/cluster-network-operator/pkg/util/k8s"
 	mcutil "github.com/openshift/cluster-network-operator/pkg/util/machineconfig"
+	"github.com/openshift/cluster-network-operator/pkg/version"
 )
 
 const CLUSTER_CONFIG_NAME = "cluster-config-v1"
@@ -598,6 +599,34 @@ func shouldRenderIPsec(conf *operv1.OVNKubernetesConfig, bootstrapResult *bootst
 	// with the the IPsec MachineConfig extensions active, the containerized
 	// daemonset is dormant and the host daemonset is active. When the upgrade
 	// finishes, the containerized daemonset is then not rendered.
+	//
+	// The upgrade from 4.14 is handled very carefully to correctly migrate
+	// from containerized ipsec deployment to the host ipsec deployment.
+	//  1. OCP 4.14 with container ipsec deployment is active using libreswan
+	//     4.6.3; and host ipsec deployment is dormant.
+	//  2. Start the 4.15 upgrade.
+	//  3. CNO upgrades to 4.15.
+	//  4. CNO renders 4.15 versions of the container ipsec deployment and
+	//     host ipsec deployment with no state change. However the host ipsec
+	//     deployment mounts to top system level directories for the host ipsec
+	//     path for this upgrade scenario. It fixes two problems.
+	//     a) version mismatch between libreswan installed on the host and
+	//        host ipsec deployment pod container.
+	//     b) host ipsec deployment pod goes into pending state if we mount the
+	//        binaries directly and libreswan has not been installed yet
+	//        on the host by IPsec machine configs.
+	//  5. CNO waits until MCO is upgraded to 4.15 and then deploys CNO ipsec
+	//     machine configs that will install and run libreswan 4.6.3 on the
+	//     host. Otherwise, without waiting for MCO 4.15, libreswan 4.9 may
+	//     be installed from 4.14 MCO which has all known stability problems
+	//     found from the bugs.
+	//     https://issues.redhat.com/browse/OCPBUGS-41823
+	//     https://issues.redhat.com/browse/OCPBUGS-42952
+	//  6. Host ipsec deployment becomes active using libreswan 4.6.3 from the
+	//     container which can successfully run against libreswan 4.6.3 running
+	//     on the host.
+	//  7. At the same time as step 6, containerized ipsec deployment becomes
+	//     dormant, and eventually gets removed when the upgrade is done.
 
 	isHypershiftHostedCluster := bootstrapResult.Infra.HostedControlPlane != nil
 	isOVNIPsecActiveOrRollingOut := bootstrapResult.OVN.IPsecUpdateStatus != nil && bootstrapResult.OVN.IPsecUpdateStatus.IsOVNIPsecActiveOrRollingOut
@@ -1486,10 +1515,10 @@ func shouldUpdateOVNKonUpgrade(ovn bootstrap.OVNBootstrapResult, releaseVersion 
 
 	// compute version delta
 	// versionUpgrade means the existing daemonSet needs an upgrade.
-	controlPlaneDelta := compareVersions(controlPlaneVersion, releaseVersion)
-	nodeDelta := compareVersions(nodeVersion, releaseVersion)
+	controlPlaneDelta := version.CompareVersions(controlPlaneVersion, releaseVersion)
+	nodeDelta := version.CompareVersions(nodeVersion, releaseVersion)
 
-	if controlPlaneDelta == versionUnknown || nodeDelta == versionUnknown {
+	if controlPlaneDelta == version.VersionUnknown || nodeDelta == version.VersionUnknown {
 		klog.Warningf("could not determine ovn-kubernetes daemonset update directions; node: %s, control-plane: %s, release: %s",
 			nodeVersion, controlPlaneVersion, releaseVersion)
 		return true, true
@@ -1513,14 +1542,14 @@ func shouldUpdateOVNKonUpgrade(ovn bootstrap.OVNBootstrapResult, releaseVersion 
 
 	// both older (than CNO)
 	// Update node only.
-	if controlPlaneDelta == versionUpgrade && nodeDelta == versionUpgrade {
+	if controlPlaneDelta == version.VersionUpgrade && nodeDelta == version.VersionUpgrade {
 		klog.V(2).Infof("Upgrading OVN-Kubernetes node before control-plane")
 		return true, false
 	}
 
 	// control plane older, node updated
 	// update control plane if node is rolled out
-	if controlPlaneDelta == versionUpgrade && nodeDelta == versionSame {
+	if controlPlaneDelta == version.VersionUpgrade && nodeDelta == version.VersionSame {
 		if ovn.NodeUpdateStatus.Progressing {
 			klog.V(2).Infof("Waiting for OVN-Kubernetes node update to roll out before updating control-plane")
 			return true, false
@@ -1531,14 +1560,14 @@ func shouldUpdateOVNKonUpgrade(ovn bootstrap.OVNBootstrapResult, releaseVersion 
 
 	// both newer
 	// downgrade control plane before node
-	if controlPlaneDelta == versionDowngrade && nodeDelta == versionDowngrade {
+	if controlPlaneDelta == version.VersionDowngrade && nodeDelta == version.VersionDowngrade {
 		klog.V(2).Infof("Downgrading OVN-Kubernetes control-plane before node")
 		return false, true
 	}
 
 	// control plane same, node needs downgrade
 	// wait for control plane rollout
-	if controlPlaneDelta == versionSame && nodeDelta == versionDowngrade {
+	if controlPlaneDelta == version.VersionSame && nodeDelta == version.VersionDowngrade {
 		if ovn.ControlPlaneUpdateStatus.Progressing {
 			klog.V(2).Infof("Waiting for OVN-Kubernetes control-plane downgrade to roll out before downgrading node")
 			return false, true
@@ -1548,7 +1577,7 @@ func shouldUpdateOVNKonUpgrade(ovn bootstrap.OVNBootstrapResult, releaseVersion 
 	}
 
 	// unlikely, should be caught above
-	if controlPlaneDelta == versionSame && nodeDelta == versionSame {
+	if controlPlaneDelta == version.VersionSame && nodeDelta == version.VersionSame {
 		return true, true
 	}
 
@@ -1701,7 +1730,7 @@ func isOVNIPsecNotActiveInDaemonSet(ds *appsv1.DaemonSet) bool {
 		return false
 	}
 	// If IPsec is running with older version and ipsec=true is found from nbdb container, then return false.
-	if !isVersionGreaterThanOrEqualTo(annotations["release.openshift.io/version"], 4, 15) &&
+	if !version.IsVersionGreaterThanOrEqualTo(annotations["release.openshift.io/version"], 4, 15) &&
 		isIPSecEnabledInPod(ds.Spec.Template, util.OVN_NBDB) {
 		return false
 	}

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -292,7 +292,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["IPsecMachineConfigEnable"] = IPsecMachineConfigEnable
 	data.Data["OVNIPsecDaemonsetEnable"] = OVNIPsecDaemonsetEnable
 	data.Data["OVNIPsecEnable"] = OVNIPsecEnable
-	data.Data["IPsecCheckForLibreswan"] = renderIPsecHostDaemonSet && renderIPsecContainerizedDaemonSet
+	data.Data["IPsecServiceCheckOnHost"] = renderIPsecHostDaemonSet && renderIPsecContainerizedDaemonSet
 
 	klog.V(5).Infof("IPsec: is MachineConfig enabled: %v, is East-West DaemonSet enabled: %v", data.Data["IPsecMachineConfigEnable"], data.Data["OVNIPsecDaemonsetEnable"])
 

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -291,6 +291,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["IPsecMachineConfigEnable"] = IPsecMachineConfigEnable
 	data.Data["OVNIPsecDaemonsetEnable"] = OVNIPsecDaemonsetEnable
 	data.Data["OVNIPsecEnable"] = OVNIPsecEnable
+	data.Data["IPsecCheckForLibreswan"] = renderIPsecHostDaemonSet && renderIPsecContainerizedDaemonSet
 
 	klog.V(5).Infof("IPsec: is MachineConfig enabled: %v, is East-West DaemonSet enabled: %v", data.Data["IPsecMachineConfigEnable"], data.Data["OVNIPsecDaemonsetEnable"])
 
@@ -493,8 +494,8 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 		objs = k8s.RemoveObjByGroupKindName(objs, "apps", "DaemonSet", util.OVN_NAMESPACE, "ovn-ipsec-containerized")
 	}
 
-	// When upgrading a legacy IPsec deployment, avoid any updates until IPsec MachineConfigs
-	// are active.
+	// When disabling IPsec deployment, avoid any updates until IPsec is completely
+	// disabled from OVN.
 	if renderIPsecDaemonSetAsCreateWaitOnly {
 		k8s.UpdateObjByGroupKindName(objs, "apps", "DaemonSet", util.OVN_NAMESPACE, "ovn-ipsec-host", func(o *uns.Unstructured) {
 			anno := o.GetAnnotations()
@@ -589,8 +590,8 @@ func IsIPsecLegacyAPI(conf *operv1.OVNKubernetesConfig) bool {
 func shouldRenderIPsec(conf *operv1.OVNKubernetesConfig, bootstrapResult *bootstrap.BootstrapResult) (renderCNOIPsecMachineConfig, renderIPsecDaemonSet,
 	renderIPsecOVN, renderIPsecHostDaemonSet, renderIPsecContainerizedDaemonSet, renderIPsecDaemonSetAsCreateWaitOnly bool) {
 
-	// Note on 4.14 to 4.15 legacy IPsec upgrade for self managed clusters:
-	// during this upgrade both host and containerized daemonsets are rendered.
+	// Note on IPsec install (or) upgrade for self managed clusters:
+	// During this process both host and containerized daemonsets are rendered.
 	// Internally, these damonsets coordinate when they are active or dormant:
 	// before the IPsec MachineConfig extensions are active, the containerized
 	// daemonset is active and the host daemonset is dormant; after rebooting
@@ -599,15 +600,15 @@ func shouldRenderIPsec(conf *operv1.OVNKubernetesConfig, bootstrapResult *bootst
 	// finishes, the containerized daemonset is then not rendered.
 
 	isHypershiftHostedCluster := bootstrapResult.Infra.HostedControlPlane != nil
-	isIpsecLegacyUpgrade := bootstrapResult.OVN.IPsecUpdateStatus != nil && bootstrapResult.OVN.IPsecUpdateStatus.LegacyIPsecUpgrade
 	isOVNIPsecActiveOrRollingOut := bootstrapResult.OVN.IPsecUpdateStatus != nil && bootstrapResult.OVN.IPsecUpdateStatus.IsOVNIPsecActiveOrRollingOut
 	isCNOIPsecMachineConfigPresent := isCNOIPsecMachineConfigPresent(bootstrapResult.Infra)
 	isUserDefinedIPsecMachineConfigPresent := isUserDefinedIPsecMachineConfigPresent(bootstrapResult.Infra)
+	isIPsecMachineConfigActive := isIPsecMachineConfigActive(bootstrapResult.Infra)
 	isMachineConfigClusterOperatorReady := bootstrapResult.Infra.MachineConfigClusterOperatorReady
 
 	mode := GetIPsecMode(conf)
 
-	// when OVN is rolling out, OVN IPsec might be fully or partially active or inactive.
+	// When OVN is rolling out, OVN IPsec might be fully or partially active or inactive.
 	// If MachineConfigs are not present, we know its inactive since we only stop rendering them once inactive.
 	isOVNIPsecActive := isOVNIPsecActiveOrRollingOut && (isCNOIPsecMachineConfigPresent || isUserDefinedIPsecMachineConfigPresent || isHypershiftHostedCluster)
 
@@ -625,35 +626,28 @@ func shouldRenderIPsec(conf *operv1.OVNKubernetesConfig, bootstrapResult *bootst
 	// Wait for MCO to be ready unless we had already rendered the IPsec MachineConfig.
 	renderCNOIPsecMachineConfig = renderCNOIPsecMachineConfig && (isCNOIPsecMachineConfigPresent || isMachineConfigClusterOperatorReady)
 
-	// As a general rule, we need to wait until the IPsec MachineConfig
-	// extensions are active before rendendering the IPsec daemonsets. Note that
-	// during upgrades or node reboots there is a period of time where the IPsec
-	// machine configs are not active and the daemonset won't be rendered but
-	// that is fine since the IPsec configuration should persist. The exception
-	// is 4.14 to 4.15 legacy IPsec upgrade as noted above.
-	isIPsecMachineConfigActive := isIPsecMachineConfigActive(bootstrapResult.Infra)
-	isIPsecMachineConfigNotActiveOnLegacyUpgrade := isIpsecLegacyUpgrade && !isIPsecMachineConfigActive && !isHypershiftHostedCluster
+	// We render the host ipsec deployment except for hypershift hosted clusters.
+	// Until IPsec machine configs are rolled out completely, then its daemonset
+	// pod(s) may be active or dormant based on machine config rollout progress
+	// state on the node, Once it is completely rolled out, then daemonset pods
+	// become active on all nodes.
+	renderIPsecHostDaemonSet = renderIPsecDaemonSet && !isHypershiftHostedCluster
 
-	// We render the host ipsec deployment for self managed clusters after the
-	// ipsec MachineConfig extensions have been rolled out, except for the 4.14
-	// to 4.15 legacy IPsec upgrade as noted above.
-	renderIPsecHostDaemonSet = (renderIPsecDaemonSet && isIPsecMachineConfigActive && !isHypershiftHostedCluster) || isIPsecMachineConfigNotActiveOnLegacyUpgrade
-
-	// We render the containerized ipsec deployment for hosted clusters. It does
-	// not depend on any machine config extension however we also render it for
-	// the 4.14 to 4.15 legacy IPsec upgrade as noted above.
-	renderIPsecContainerizedDaemonSet = (renderIPsecDaemonSet && isHypershiftHostedCluster) || isIPsecMachineConfigNotActiveOnLegacyUpgrade
+	// We render the containerized ipsec deployment for hypershift hosted clusters.
+	// It's also rendered until IPsec machine configs are active on all nodes in the
+	// cluster. This daemonset pod is active until IPsec machine config is rolled out
+	// on the node, Once Machine Config rollout is complete, we stop rendering
+	// containerized ipsec deployment.
+	renderIPsecContainerizedDaemonSet = (renderIPsecDaemonSet && isHypershiftHostedCluster) || !isIPsecMachineConfigActive
 
 	// We render OVN IPsec if EW IPsec is enabled and before the daemon sets are
 	// rendered. If it is already rendered, keep it rendered unless disabled.
 	renderIPsecOVN = (renderIPsecHostDaemonSet || renderIPsecContainerizedDaemonSet || isOVNIPsecActive) && mode == operv1.IPsecModeFull
 
-	// Keep IPsec daemonsets updated (but avoid creating) in the following circumstances:
-	// - on the 4.14 to 4.15 legacy IPsec upgrade, where we just want to update
-	// them as noted above
+	// Keep IPsec daemonsets updated (but avoid creating) in the following circumstance:
 	// - when disabling OVN IPsec, we want to keep the daemonsets until after
-	// OVN IPsec is disabled
-	renderIPsecDaemonSetAsCreateWaitOnly = isIPsecMachineConfigNotActiveOnLegacyUpgrade || (isOVNIPsecActive && !renderIPsecOVN)
+	// OVN IPsec is disabled.
+	renderIPsecDaemonSetAsCreateWaitOnly = isOVNIPsecActive && !renderIPsecOVN
 
 	return
 }
@@ -1162,7 +1156,7 @@ func bootstrapOVN(conf *operv1.Network, kubeClient cnoclient.Client, infraStatus
 		nodeStatus.Version = nodeDaemonSet.GetAnnotations()["release.openshift.io/version"]
 		nodeStatus.Progressing = daemonSetProgressing(nodeDaemonSet, true)
 		// Retrieve OVN IPsec status from ovnkube-node daemonset as this is being used to rollout IPsec
-		// config from 4.14.
+		// config.
 		ovnIPsecStatus.IsOVNIPsecActiveOrRollingOut = !isOVNIPsecNotActiveInDaemonSet(nodeDaemonSet)
 		klog.Infof("ovnkube-node DaemonSet status: progressing=%t", nodeStatus.Progressing)
 
@@ -1187,41 +1181,6 @@ func bootstrapOVN(conf *operv1.Network, kubeClient cnoclient.Client, infraStatus
 		prepullerStatus.IPFamilyMode = prePullerDaemonSet.GetAnnotations()[names.NetworkIPFamilyModeAnnotation]
 		prepullerStatus.Version = prePullerDaemonSet.GetAnnotations()["release.openshift.io/version"]
 		prepullerStatus.Progressing = daemonSetProgressing(prePullerDaemonSet, true)
-	}
-
-	ipsecContainerizedDaemonSet := &appsv1.DaemonSet{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "DaemonSet",
-			APIVersion: appsv1.SchemeGroupVersion.String(),
-		},
-	}
-	ipsecHostDaemonSet := &appsv1.DaemonSet{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "DaemonSet",
-			APIVersion: appsv1.SchemeGroupVersion.String(),
-		},
-	}
-	// Retrieve container based IPsec daemonset with name ovn-ipsec-containerized.
-	nsn = types.NamespacedName{Namespace: util.OVN_NAMESPACE, Name: "ovn-ipsec-containerized"}
-	if err := kubeClient.ClientFor("").CRClient().Get(context.TODO(), nsn, ipsecContainerizedDaemonSet); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return nil, fmt.Errorf("Failed to retrieve existing ipsec containerized DaemonSet: %w", err)
-		} else {
-			ipsecContainerizedDaemonSet = nil
-		}
-	}
-	// Retrieve host based IPsec daemonset with name ovn-ipsec-host
-	nsn = types.NamespacedName{Namespace: util.OVN_NAMESPACE, Name: "ovn-ipsec-host"}
-	if err := kubeClient.ClientFor("").CRClient().Get(context.TODO(), nsn, ipsecHostDaemonSet); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return nil, fmt.Errorf("Failed to retrieve existing ipsec host DaemonSet: %w", err)
-		} else {
-			ipsecHostDaemonSet = nil
-		}
-	}
-	if ipsecContainerizedDaemonSet != nil && ipsecHostDaemonSet != nil {
-		// Both IPsec daemonset versions exist, so this is an upgrade from 4.14.
-		ovnIPsecStatus.LegacyIPsecUpgrade = true
 	}
 
 	res := bootstrap.OVNBootstrapResult{

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -2435,12 +2435,19 @@ func TestRenderOVNKubernetesEnableIPsec(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	renderedIPsec := findInObjs("apps", "DaemonSet", "ovn-ipsec-host", "openshift-ovn-kubernetes", objs)
-	if renderedIPsec != nil {
-		t.Errorf("ovn-ipsec-host DaemonSet must not exist, but it's available")
+	if renderedIPsec == nil {
+		t.Errorf("ovn-ipsec-host DaemonSet must exist, but it's not available")
 	}
 	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-containerized", "openshift-ovn-kubernetes", objs)
-	if renderedIPsec != nil {
-		t.Errorf("ovn-ipsec-containerized DaemonSet must not exist, but it's available")
+	if renderedIPsec == nil {
+		t.Errorf("ovn-ipsec-containerized DaemonSet must exist, but it's not available")
+	}
+	renderedNode := findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
+	if renderedNode == nil {
+		t.Errorf("ovnkube-node DaemonSet must exist, but it's not available")
+	}
+	if _, ok := renderedNode.GetAnnotations()[names.IPsecEnableAnnotation]; !ok {
+		t.Errorf("ovn-ipsec DaemonSet should have ipsec-enabled annotation, but it doesn't %v", renderedNode)
 	}
 	renderedMasterIPsecExtension := findInObjs("machineconfiguration.openshift.io", "MachineConfig", masterMachineConfigIPsecExtName, "", objs)
 	if renderedMasterIPsecExtension != nil {
@@ -2458,12 +2465,19 @@ func TestRenderOVNKubernetesEnableIPsec(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-host", "openshift-ovn-kubernetes", objs)
-	if renderedIPsec != nil {
-		t.Errorf("ovn-ipsec-host DaemonSet must not exist, but it's available")
+	if renderedIPsec == nil {
+		t.Errorf("ovn-ipsec-host DaemonSet must exist, but it's not available")
 	}
 	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-containerized", "openshift-ovn-kubernetes", objs)
-	if renderedIPsec != nil {
-		t.Errorf("ovn-ipsec-containerized DaemonSet must not exist, but it's available")
+	if renderedIPsec == nil {
+		t.Errorf("ovn-ipsec-containerized DaemonSet must exist, but it's not available")
+	}
+	renderedNode = findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
+	if renderedNode == nil {
+		t.Errorf("ovnkube-node DaemonSet must exist, but it's not available")
+	}
+	if _, ok := renderedNode.GetAnnotations()[names.IPsecEnableAnnotation]; !ok {
+		t.Errorf("ovn-ipsec DaemonSet should have ipsec-enabled annotation, but it doesn't %v", renderedNode)
 	}
 	renderedMasterIPsecExtension = findInObjs("machineconfiguration.openshift.io", "MachineConfig", masterMachineConfigIPsecExtName, "", objs)
 	if renderedMasterIPsecExtension == nil {
@@ -2485,12 +2499,19 @@ func TestRenderOVNKubernetesEnableIPsec(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-host", "openshift-ovn-kubernetes", objs)
-	if renderedIPsec != nil {
-		t.Errorf("ovn-ipsec-host DaemonSet must not exist, but it's available")
+	if renderedIPsec == nil {
+		t.Errorf("ovn-ipsec-host DaemonSet must exist, but it's not available")
 	}
 	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-containerized", "openshift-ovn-kubernetes", objs)
-	if renderedIPsec != nil {
-		t.Errorf("ovn-ipsec-containerized DaemonSet must not exist, but it's available")
+	if renderedIPsec == nil {
+		t.Errorf("ovn-ipsec-containerized DaemonSet must exist, but it's not available")
+	}
+	renderedNode = findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
+	if renderedNode == nil {
+		t.Errorf("ovnkube-node DaemonSet must exist, but it's not available")
+	}
+	if _, ok := renderedNode.GetAnnotations()[names.IPsecEnableAnnotation]; !ok {
+		t.Errorf("ovn-ipsec DaemonSet should have ipsec-enabled annotation, but it doesn't %v", renderedNode)
 	}
 	renderedMasterIPsecExtension = findInObjs("machineconfiguration.openshift.io", "MachineConfig", masterMachineConfigIPsecExtName, "", objs)
 	if renderedMasterIPsecExtension == nil {
@@ -2512,12 +2533,19 @@ func TestRenderOVNKubernetesEnableIPsec(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-host", "openshift-ovn-kubernetes", objs)
-	if renderedIPsec != nil {
-		t.Errorf("ovn-ipsec-host DaemonSet must not exist, but it's available")
+	if renderedIPsec == nil {
+		t.Errorf("ovn-ipsec-host DaemonSet must exist, but it's not available")
 	}
 	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-containerized", "openshift-ovn-kubernetes", objs)
-	if renderedIPsec != nil {
-		t.Errorf("ovn-ipsec-containerized DaemonSet must not exist, but it's available")
+	if renderedIPsec == nil {
+		t.Errorf("ovn-ipsec-containerized DaemonSet must exist, but it's not available")
+	}
+	renderedNode = findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
+	if renderedNode == nil {
+		t.Errorf("ovnkube-node DaemonSet must exist, but it's not available")
+	}
+	if _, ok := renderedNode.GetAnnotations()[names.IPsecEnableAnnotation]; !ok {
+		t.Errorf("ovn-ipsec DaemonSet should have ipsec-enabled annotation, but it doesn't %v", renderedNode)
 	}
 	renderedMasterIPsecExtension = findInObjs("machineconfiguration.openshift.io", "MachineConfig", masterMachineConfigIPsecExtName, "", objs)
 	if renderedMasterIPsecExtension == nil {
@@ -2558,7 +2586,7 @@ func TestRenderOVNKubernetesEnableIPsec(t *testing.T) {
 	if renderedIPsec != nil {
 		t.Errorf("ovn-ipsec-containerized DaemonSet must not exist, but it's available")
 	}
-	renderedNode := findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
+	renderedNode = findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
 	if renderedNode == nil {
 		t.Errorf("ovnkube-node DaemonSet must exist, but it's not available")
 	}
@@ -2714,7 +2742,6 @@ func TestRenderOVNKubernetesIPsecUpgradeWithMachineConfig(t *testing.T) {
 			IPFamilyMode: names.IPFamilySingleStack,
 		},
 		IPsecUpdateStatus: &bootstrap.OVNIPsecStatus{
-			LegacyIPsecUpgrade:           true,
 			IsOVNIPsecActiveOrRollingOut: true,
 		},
 		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
@@ -2827,7 +2854,6 @@ func TestRenderOVNKubernetesIPsecUpgradeWithNoMachineConfig(t *testing.T) {
 			IPFamilyMode: names.IPFamilySingleStack,
 		},
 		IPsecUpdateStatus: &bootstrap.OVNIPsecStatus{
-			LegacyIPsecUpgrade:           true,
 			IsOVNIPsecActiveOrRollingOut: true,
 		},
 		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
@@ -2857,20 +2883,21 @@ func TestRenderOVNKubernetesIPsecUpgradeWithNoMachineConfig(t *testing.T) {
 	if renderedWorkerIPsecExtension == nil {
 		t.Errorf("The MachineConfig %s must exist, but it's not available", workerMachineConfigIPsecExtName)
 	}
-	// Make sure IPsec DaemonSets are set with create-wait annotation.
+	// Make sure IPsec DaemonSets are not set with create-wait annotation. It ensures ipsec daemonsets
+	// are upgraded to newer version.
 	renderedIPsec := findInObjs("apps", "DaemonSet", "ovn-ipsec-host", "openshift-ovn-kubernetes", objs)
 	if renderedIPsec == nil {
 		t.Errorf("ovn-ipsec-host DaemonSet must exist, but it's not available")
 	}
-	if _, ok := renderedIPsec.GetAnnotations()[names.CreateWaitAnnotation]; !ok {
-		t.Errorf("ovn-ipsec-host DaemonSet should have create-wait annotation, does not")
+	if _, ok := renderedIPsec.GetAnnotations()[names.CreateWaitAnnotation]; ok {
+		t.Errorf("ovn-ipsec-host DaemonSet shouldn't have create-wait annotation, does not")
 	}
 	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-containerized", "openshift-ovn-kubernetes", objs)
 	if renderedIPsec == nil {
 		t.Errorf("ovn-ipsec-containerized DaemonSet must exist, but it's not available")
 	}
-	if _, ok := renderedIPsec.GetAnnotations()[names.CreateWaitAnnotation]; !ok {
-		t.Errorf("ovn-ipsec-containerized DaemonSet should have create-wait annotation, does not")
+	if _, ok := renderedIPsec.GetAnnotations()[names.CreateWaitAnnotation]; ok {
+		t.Errorf("ovn-ipsec-containerized DaemonSet shouldn't have create-wait annotation, does not")
 	}
 	// The ovnkube-node must set with ipsec-enabled annotation.
 	renderedNode := findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
@@ -2975,7 +3002,6 @@ func TestRenderOVNKubernetesIPsecUpgradeWithHypershiftHostedCluster(t *testing.T
 			IPFamilyMode: names.IPFamilySingleStack,
 		},
 		IPsecUpdateStatus: &bootstrap.OVNIPsecStatus{
-			LegacyIPsecUpgrade:           true,
 			IsOVNIPsecActiveOrRollingOut: true,
 		},
 		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
@@ -3119,13 +3145,17 @@ func TestRenderOVNKubernetesDisableIPsec(t *testing.T) {
 	if renderedWorkerIPsecExtension == nil {
 		t.Errorf("The MachineConfig %s must exist, but it's not available", workerMachineConfigIPsecExtName)
 	}
-	// Ensure ovn-ipsec-host daemonset exists with create wait annotation.
+	// Ensure only ovn-ipsec-host daemonset exists with create wait annotation.
 	renderedIPsec := findInObjs("apps", "DaemonSet", "ovn-ipsec-host", "openshift-ovn-kubernetes", objs)
 	if renderedIPsec == nil {
 		t.Errorf("ovn-ipsec-host DaemonSet must exist, but it's not available")
 	}
 	if _, ok := renderedIPsec.GetAnnotations()[names.CreateWaitAnnotation]; !ok {
-		t.Errorf("node DaemonSet should have create-wait annotation, does not")
+		t.Errorf("ovn-ipsec-host DaemonSet should have create-wait annotation, but it does not")
+	}
+	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-containerized", "openshift-ovn-kubernetes", objs)
+	if renderedIPsec != nil {
+		t.Errorf("ovn-ipsec-containerized DaemonSet must not exist, but it's available")
 	}
 	// Ensure ovnkube-node DS is not set with ipsec-enabled annotation.
 	renderedNode := findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
@@ -3154,6 +3184,10 @@ func TestRenderOVNKubernetesDisableIPsec(t *testing.T) {
 	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-host", "openshift-ovn-kubernetes", objs)
 	if renderedIPsec != nil {
 		t.Errorf("ovn-ipsec-host DaemonSet must not exist, but it's available")
+	}
+	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-containerized", "openshift-ovn-kubernetes", objs)
+	if renderedIPsec != nil {
+		t.Errorf("ovn-ipsec-containerized DaemonSet must not exist, but it's available")
 	}
 	renderedNode = findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
 	if renderedNode == nil {
@@ -3188,6 +3222,10 @@ func TestRenderOVNKubernetesDisableIPsec(t *testing.T) {
 	if renderedIPsec != nil {
 		t.Errorf("ovn-ipsec-host DaemonSet must not exist, but it's available")
 	}
+	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-containerized", "openshift-ovn-kubernetes", objs)
+	if renderedIPsec != nil {
+		t.Errorf("ovn-ipsec-containerized DaemonSet must not exist, but it's available")
+	}
 	renderedNode = findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
 	if renderedNode == nil {
 		t.Errorf("ovnkube-node DaemonSet must exist, but it's not available")
@@ -3216,6 +3254,10 @@ func TestRenderOVNKubernetesDisableIPsec(t *testing.T) {
 	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-host", "openshift-ovn-kubernetes", objs)
 	if renderedIPsec != nil {
 		t.Errorf("ovn-ipsec-host DaemonSet must not exist, but it's available")
+	}
+	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-containerized", "openshift-ovn-kubernetes", objs)
+	if renderedIPsec != nil {
+		t.Errorf("ovn-ipsec-containerized DaemonSet must not exist, but it's available")
 	}
 	renderedNode = findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
 	if renderedNode == nil {
@@ -3315,18 +3357,22 @@ func TestRenderOVNKubernetesEnableIPsecWithUserInstalledIPsecMachineConfigs(t *t
 	if renderedWorkerIPsecExtension != nil {
 		t.Errorf("The MachineConfig %s must not exist, but it's available", workerMachineConfigIPsecExtName)
 	}
-	// Ensure ovn-ipsec-host daemonset doesn't exist.
+	// Ensure both ovn-ipsec-host and  ovn-ipsec-containerized daemonsets are rendered.
 	renderedIPsec := findInObjs("apps", "DaemonSet", "ovn-ipsec-host", "openshift-ovn-kubernetes", objs)
-	if renderedIPsec != nil {
-		t.Errorf("ovn-ipsec-host DaemonSet must not exist, but it's available")
+	if renderedIPsec == nil {
+		t.Errorf("ovn-ipsec-host DaemonSet must exist, but it's not available")
 	}
-	// Ensure ovnkube-node DaemonSet exists without ipsec-enabled annotation.
+	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-containerized", "openshift-ovn-kubernetes", objs)
+	if renderedIPsec == nil {
+		t.Errorf("ovn-ipsec-containerized DaemonSet must exist, but it's not available")
+	}
+	// Ensure ovnkube-node DaemonSet exists with ipsec-enabled annotation.
 	renderedNode := findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
 	if renderedNode == nil {
 		t.Errorf("ovnkube-node DaemonSet must exist, but it's not available")
 	}
-	if _, ok := renderedNode.GetAnnotations()[names.IPsecEnableAnnotation]; ok {
-		t.Errorf("ovn-ipsec DaemonSet should not have ipsec-enabled annotation, but it does %v", renderedNode)
+	if _, ok := renderedNode.GetAnnotations()[names.IPsecEnableAnnotation]; !ok {
+		t.Errorf("ovnkube-node DaemonSet should have ipsec-enabled annotation, but it does not %v", renderedNode)
 	}
 
 	// Step 2: Check renderOVNKubernetes behavior after user defined machine configs rollout is complete.
@@ -3347,10 +3393,14 @@ func TestRenderOVNKubernetesEnableIPsecWithUserInstalledIPsecMachineConfigs(t *t
 	if renderedWorkerIPsecExtension != nil {
 		t.Errorf("The MachineConfig %s must not exist, but it's available", workerMachineConfigIPsecExtName)
 	}
-	// Ensure ovn-ipsec-host daemonset exists.
+	// Ensure only ovn-ipsec-host daemonset exists.
 	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-host", "openshift-ovn-kubernetes", objs)
 	if renderedIPsec == nil {
 		t.Errorf("ovn-ipsec-host DaemonSet must exist, but it's not available")
+	}
+	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-containerized", "openshift-ovn-kubernetes", objs)
+	if renderedIPsec != nil {
+		t.Errorf("ovn-ipsec-containerized DaemonSet must not exist, but it's available")
 	}
 	// Ensure ovnkube-node DaemonSet exists with ipsec-enabled annotation.
 	renderedNode = findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
@@ -3450,7 +3500,7 @@ func TestRenderOVNKubernetesDisableIPsecWithUserInstalledIPsecMachineConfigs(t *
 	if renderedWorkerIPsecExtension != nil {
 		t.Errorf("The MachineConfig %s must not exist, but it's available", workerMachineConfigIPsecExtName)
 	}
-	// Ensure ovn-ipsec-host daemonset exists with create wait annotation.
+	// Ensure only ovn-ipsec-host daemonset exists with create wait annotation.
 	renderedIPsec := findInObjs("apps", "DaemonSet", "ovn-ipsec-host", "openshift-ovn-kubernetes", objs)
 	if renderedIPsec == nil {
 		t.Errorf("ovn-ipsec-host DaemonSet must exist, but it's not available")
@@ -3458,13 +3508,17 @@ func TestRenderOVNKubernetesDisableIPsecWithUserInstalledIPsecMachineConfigs(t *
 	if _, ok := renderedIPsec.GetAnnotations()[names.CreateWaitAnnotation]; !ok {
 		t.Errorf("node DaemonSet should have create-wait annotation, does not")
 	}
+	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-containerized", "openshift-ovn-kubernetes", objs)
+	if renderedIPsec != nil {
+		t.Errorf("ovn-ipsec-containerized DaemonSet must not exist, but it's available")
+	}
 	// Ensure ovnkube-node DS is not set with ipsec-enabled annotation.
 	renderedNode := findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
 	if renderedNode == nil {
 		t.Errorf("ovnkube-node DaemonSet must exist, but it's not available")
 	}
 	if _, ok := renderedNode.GetAnnotations()[names.IPsecEnableAnnotation]; ok {
-		t.Errorf("ovn-ipsec DaemonSet shouldn't have ipsec-enable annotation, but it does")
+		t.Errorf("ovnkube-node DaemonSet shouldn't have ipsec-enable annotation, but it does")
 	}
 
 	// Ensure renderOVNKubernetes removes IPsec daemonset.
@@ -3485,6 +3539,10 @@ func TestRenderOVNKubernetesDisableIPsecWithUserInstalledIPsecMachineConfigs(t *
 	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-host", "openshift-ovn-kubernetes", objs)
 	if renderedIPsec != nil {
 		t.Errorf("ovn-ipsec-host DaemonSet must not exist, but it's available")
+	}
+	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-containerized", "openshift-ovn-kubernetes", objs)
+	if renderedIPsec != nil {
+		t.Errorf("ovn-ipsec-containerized DaemonSet must not exist, but it's available")
 	}
 	renderedNode = findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
 	if renderedNode == nil {

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/hypershift"
 	"github.com/openshift/cluster-network-operator/pkg/names"
 	mcutil "github.com/openshift/cluster-network-operator/pkg/util/machineconfig"
+	"github.com/openshift/cluster-network-operator/pkg/version"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -234,7 +235,16 @@ func isMachineConfigClusterOperatorReady(client cnoclient.Client) (bool, error) 
 			progressing = isConditionTrue
 		}
 	}
-	machineConfigClusterOperatorReady := available && !degraded && !progressing
+	// The network operator is supporting machine configs starting with IPsec machine configs from 4.15, so
+	// we need to consider it has to be >= 4.15 as well.
+	var isDesiredOperatorVersion bool
+	for _, v := range machineConfigClusterOperator.Status.Versions {
+		if v.Name == "operator" {
+			isDesiredOperatorVersion = version.IsVersionGreaterThanOrEqualTo(v.Version, 4, 15)
+			break
+		}
+	}
+	machineConfigClusterOperatorReady := available && !degraded && !progressing && isDesiredOperatorVersion
 	return machineConfigClusterOperatorReady, nil
 }
 

--- a/pkg/version/semver.go
+++ b/pkg/version/semver.go
@@ -1,4 +1,4 @@
-package network
+package version
 
 import (
 	"github.com/Masterminds/semver"
@@ -8,49 +8,51 @@ import (
 type versionChange int
 
 const (
-	versionUpgrade   versionChange = -1
-	versionSame      versionChange = 0
-	versionDowngrade versionChange = 1
-	versionUnknown   versionChange = 2
+	VersionUpgrade   versionChange = -1
+	VersionSame      versionChange = 0
+	VersionDowngrade versionChange = 1
+	VersionUnknown   versionChange = 2
 )
 
 func (v versionChange) String() string {
 	switch v {
-	case versionUpgrade:
+	case VersionUpgrade:
 		return "upgrade"
-	case versionSame:
+	case VersionSame:
 		return "same"
-	case versionDowngrade:
+	case VersionDowngrade:
 		return "downgrade"
-	case versionUnknown:
+	case VersionUnknown:
 		return "unknown"
 	}
 	klog.Warningf("unhandled versionChange value %d", v)
 	return "UNHANDLED"
 }
 
-// compareVersions compares two semver versions
+// CompareVersions compares two semver versions
 // if fromVersion is older than toVersion, returns versionOlder
 // likewise, if fromVersion is newer, returns versionNewer
-func compareVersions(fromVersion, toVersion string) versionChange {
+func CompareVersions(fromVersion, toVersion string) versionChange {
 	if fromVersion == toVersion {
-		return versionSame
+		return VersionSame
 	}
 
 	v1, err := semver.NewVersion(fromVersion)
 	if err != nil {
-		return versionUnknown
+		return VersionUnknown
 	}
 
 	v2, err := semver.NewVersion(toVersion)
 	if err != nil {
-		return versionUnknown
+		return VersionUnknown
 	}
 
 	return versionChange(v1.Compare(v2))
 }
 
-func isVersionGreaterThanOrEqualTo(version string, major int, minor int) bool {
+// IsVersionGreaterThanOrEqualTo returns true if given version string
+// in greater than or equal to major.min version, otherwise returns false.
+func IsVersionGreaterThanOrEqualTo(version string, major int, minor int) bool {
 	v, err := semver.NewVersion(version)
 	if err != nil {
 		klog.Errorf("failed to parse version %s: %v", version, err)

--- a/pkg/version/semver_test.go
+++ b/pkg/version/semver_test.go
@@ -1,4 +1,4 @@
-package network
+package version
 
 import (
 	"strconv"
@@ -16,47 +16,47 @@ func TestDirection(t *testing.T) {
 		{
 			"1.2.3",
 			"1.2.4",
-			versionUpgrade,
+			VersionUpgrade,
 		},
 		{
 			"1.2.4",
 			"1.2.3",
-			versionDowngrade,
+			VersionDowngrade,
 		},
 		{
 			"asdf",
 			"fdsa",
-			versionUnknown,
+			VersionUnknown,
 		},
 		{
 			"1.1.1",
 			"1.1.1",
-			versionSame,
+			VersionSame,
 		},
 		{
 			"4.7.0-0.ci-2021-01-16-102811",
 			"4.7.0-0.ci-2021-01-18-121038",
-			versionUpgrade,
+			VersionUpgrade,
 		},
 		{
 			"4.7.0-0.ci-2021-01-18-121038",
 			"4.7.0-0.ci-2021-01-16-102811",
-			versionDowngrade,
+			VersionDowngrade,
 		},
 		{
 			"4.6.0-0.ci-2021-01-18-121038",
 			"4.7.0-0.ci-2021-01-16-102811",
-			versionUpgrade,
+			VersionUpgrade,
 		},
 		{
 			"4.6.5",
 			"4.7.0-0.ci-2021-01-16-102811",
-			versionUpgrade,
+			VersionUpgrade,
 		},
 	} {
 		t.Run(strconv.Itoa(idx), func(t *testing.T) {
 			g := NewGomegaWithT(t)
-			g.Expect(compareVersions(tc.from, tc.to)).To(Equal(tc.result))
+			g.Expect(CompareVersions(tc.from, tc.to)).To(Equal(tc.result))
 		})
 	}
 }
@@ -102,7 +102,7 @@ func TestVersionComparison(t *testing.T) {
 		t.Run(strconv.Itoa(idx), func(t *testing.T) {
 			g := NewGomegaWithT(t)
 
-			g.Expect(isVersionGreaterThanOrEqualTo(tc.version, tc.otherVersionMajor, tc.otherVersionMinor)).To(Equal(tc.resultGreaterThanOrEqualTo))
+			g.Expect(IsVersionGreaterThanOrEqualTo(tc.version, tc.otherVersionMajor, tc.otherVersionMinor)).To(Equal(tc.resultGreaterThanOrEqualTo))
 		})
 	}
 }


### PR DESCRIPTION
When a machine config pool is in a paused state, then it doesn't process any machine config. so during legacy IPsec upgrade (`4.14->4.15`), IPsec machine configs may not be installed on the nodes when its pool is in paused state.
In those cases the network operator continues to render older IPsec daemonsets which blocks network components from not getting upgraded to newer versions.

Hence this PR renders newer IPsec daemonsets immediately, with new `IPsecCheckForLibreswan` check ensures one of the pods serves IPsec for the node. When MCPs are fully rolled out with ipsec machine config, then it goes ahead with rendering only host flavored IPsec daemonset.

It brings in new behavior on IPsec daemonset rendering during IPsec deployment, upgrade and node reboot scenarios.

1. Users would notice both daemonsets being rendered at the time of IPsec install (or) upgrade for a temporary period until IPsec machine configs are fully deployed.
2. At the time of node reboot or machine config pool goes into progressing state, both daemonsets being rendered. In this scenario, the containerized ipsec daemonset pods are dormant.
3. It removes legacy upgrade case as every upgrade would be considered as the same with this approach.
4. It now mounts top level system directories `/usr/sbin` and `/usr/libexec` instead of specific ipsec host paths. The ipsec paths are available only when libreswan is installed on the node (as mentioned in step 1). 
5. For the upgrades `4.14->4.15` which moves IPsec from container to host deployment, so adding mco version to be at least 4.15 to start rendering IPsec machine configs.

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>
