### PR TITLE
NO-JIRA: more openshift-sdn cleanup

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -126,7 +126,7 @@ it is also consumed by third-party network operators that replace the Network Co
 
 For more detailed documentation, see [operands.md](https://github.com/openshift/cluster-network-operator/blob/master/docs/operands.md).
 
-This is the "main" controller, in that it is responsible for rendering the core networking components (Openshift-SDN / OVN-Kubernetes, Multus, etc). It is broken down into stages:
+This is the "main" controller, in that it is responsible for rendering the core networking components (OVN-Kubernetes, Multus, etc). It is broken down into stages:
 
 1. **Validate** - Check the supplied configuration.
 2. **Fill** - Determine any unsupplied default values.

--- a/docs/operands.md
+++ b/docs/operands.md
@@ -86,19 +86,12 @@ because they depend on other things that aren't ready yet).
 
 ## Network Plugins
 
-CNO renders (at most) one of `bindata/network/openshift-sdn` or
-`bindata/network/ovn-kubernetes`, depending on the `spec.defaultNetwork.type`
-of the `network.operator.openshift.io` configuration object (which in turn is
-copied there from the `.spec.networkType` of the
-`network.config.openshift.io` configuration). If the specified network
-type is not one of "`OpenShiftSDN`" or "`OVNKubernetes`", the CNO will not 
-render any network plugin.
-
-Note that the CRDs for the `network.openshift.io` types
-(`ClusterNetwork`, `HostSubnet`, `NetNamespace`, and
-`EgressNetworkPolicy`) are defined in
-`bindata/network/openshift-sdn/001-crd.yaml` and so are only created
-when using OpenShift SDN.
+CNO renders `bindata/network/ovn-kubernetes` if the
+`spec.defaultNetwork.type` of the `network.operator.openshift.io`
+configuration object (which in turn is copied there from the
+`.spec.networkType` of the `network.config.openshift.io`
+configuration) is "`OVNKubernetes`". If the specified network type is
+not "`OVNKubernetes`", the CNO will not render any network plugin.
 
 ## Multus
 

--- a/hack/run-locally.sh
+++ b/hack/run-locally.sh
@@ -194,7 +194,6 @@ The following options are always accepted but only used for new clusters:
  -e EXPORT_ENV_ONLY  exports cluster environment only, used as a helper which allows you to modify the image you want to target later
  -f CONFIG           the path to an openshift-install-created install-config.yaml file; if not given one will be created
  -i INSTALLER        path to the openshift-install binary; if not given PATH will be searched
- -n PLUGIN           the name of the network plugin to deploy; one of [sdn|OpenShiftSDN|ovn|OVNKubernetes]
  -w                  pause after creating manifests to allow manual overrides
 
 The following environment variables are honored:
@@ -207,8 +206,8 @@ The following environment variables are honored:
 
 EXPORT_ENV_ONLY=false
 PLUGIN_IMAGE="${PLUGIN_IMAGE:-}"
-NETWORK_PLUGIN="OpenShiftSDN"
-IMAGE_ENV_KEY="SDN_IMAGE"
+NETWORK_PLUGIN="OVNKubernetes"
+IMAGE_ENV_KEY="OVN_IMAGE"
 CLUSTER_DIR="${CLUSTER_DIR:-}"
 INSTALLER_PATH="${INSTALLER_PATH:-}"
 INSTALL_CONFIG="${INSTALL_CONFIG:-}"
@@ -224,20 +223,6 @@ while getopts "e?c:f:i:m:k:n:w" opt; do
         i) INSTALLER_PATH="${OPTARG}";;
         m) PLUGIN_IMAGE="${OPTARG}";;
         k) KUBECONFIG="${OPTARG}";;
-        n)
-            case ${OPTARG} in
-                ovn|OVNKubernetes)
-                    NETWORK_PLUGIN="OVNKubernetes"
-                    IMAGE_ENV_KEY="OVN_IMAGE"
-                    ;;
-                sdn|OpenShiftSDN)
-                    ;;
-                *)
-                    echo "Unknown network plugin ${OPTARG}" >&2
-                    exit 1
-                ;;
-            esac
-            ;;
         w)
             WAIT_FOR_MANIFEST_UPDATES=1
             ;;

--- a/pkg/network/bootstrap.go
+++ b/pkg/network/bootstrap.go
@@ -16,7 +16,7 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Bootstrap creates resources required by SDN on the cloud.
+// Bootstrap creates resources required by the network plugin on the cloud.
 func Bootstrap(conf *operv1.Network, client cnoclient.Client) (*bootstrap.BootstrapResult, error) {
 	out := &bootstrap.BootstrapResult{}
 

--- a/pkg/network/cluster_config.go
+++ b/pkg/network/cluster_config.go
@@ -298,7 +298,6 @@ func MergeClusterConfig(operConf *operv1.NetworkSpec, clusterConf configv1.Netwo
 		})
 	}
 
-	// OpenShiftSDN (default), OVNKubernetes
 	operConf.DefaultNetwork.Type = operv1.NetworkType(clusterConf.NetworkType)
 	if operConf.ManagementState == "" {
 		operConf.ManagementState = "Managed"

--- a/pkg/network/cluster_config_test.go
+++ b/pkg/network/cluster_config_test.go
@@ -436,11 +436,11 @@ func TestMergeClusterConfig(t *testing.T) {
 func TestStatusFromConfig(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	crd := OpenShiftSDNConfig.DeepCopy()
+	crd := OVNKubernetesConfig.DeepCopy()
 	fillDefaults(&crd.Spec, nil)
 
 	var mtu uint32 = 1300
-	crd.Spec.DefaultNetwork.OpenShiftSDNConfig.MTU = &mtu
+	crd.Spec.DefaultNetwork.OVNKubernetesConfig.MTU = &mtu
 
 	status := StatusFromOperatorConfig(&crd.Spec, &configv1.NetworkStatus{})
 	g.Expect(status).To(Equal(&configv1.NetworkStatus{
@@ -457,10 +457,10 @@ func TestStatusFromConfig(t *testing.T) {
 		ServiceNetwork:    []string{"172.30.0.0/16"},
 		ClusterNetworkMTU: 1300,
 
-		NetworkType: "OpenShiftSDN",
+		NetworkType: "OVNKubernetes",
 	}))
 
-	*crd.Spec.DefaultNetwork.OpenShiftSDNConfig.MTU = 1500
+	*crd.Spec.DefaultNetwork.OVNKubernetesConfig.MTU = 1500
 	status = StatusFromOperatorConfig(&crd.Spec, status)
 	g.Expect(status).To(Equal(&configv1.NetworkStatus{
 		ClusterNetwork: []configv1.ClusterNetworkEntry{
@@ -476,7 +476,7 @@ func TestStatusFromConfig(t *testing.T) {
 		ServiceNetwork:    []string{"172.30.0.0/16"},
 		ClusterNetworkMTU: 1500,
 
-		NetworkType: "OpenShiftSDN",
+		NetworkType: "OVNKubernetes",
 	}))
 
 	// If someone manually edits the status we will overwrite them
@@ -499,14 +499,14 @@ func TestStatusFromConfig(t *testing.T) {
 		ServiceNetwork:    []string{"172.30.0.0/16"},
 		ClusterNetworkMTU: 1500,
 
-		NetworkType: "OpenShiftSDN",
+		NetworkType: "OVNKubernetes",
 	}))
 }
 
 func TestStatusFromConfigUnknown(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	crd := OpenShiftSDNConfig.DeepCopy()
+	crd := OVNKubernetesConfig.DeepCopy()
 	fillDefaults(&crd.Spec, nil)
 
 	crd.Spec.DefaultNetwork.Type = "None"

--- a/pkg/network/multi_network_policy_test.go
+++ b/pkg/network/multi_network_policy_test.go
@@ -17,10 +17,7 @@ var MultiNetworkPolicyConfig = operv1.Network{
 			},
 		},
 		DefaultNetwork: operv1.DefaultNetworkDefinition{
-			Type: operv1.NetworkTypeOpenShiftSDN,
-			OpenShiftSDNConfig: &operv1.OpenShiftSDNConfig{
-				Mode: operv1.SDNModeNetworkPolicy,
-			},
+			Type: operv1.NetworkTypeOVNKubernetes,
 		},
 	},
 }

--- a/pkg/network/multus_admission_controller_test.go
+++ b/pkg/network/multus_admission_controller_test.go
@@ -23,10 +23,7 @@ var MultusAdmissionControllerConfig = operv1.Network{
 			},
 		},
 		DefaultNetwork: operv1.DefaultNetworkDefinition{
-			Type: operv1.NetworkTypeOpenShiftSDN,
-			OpenShiftSDNConfig: &operv1.OpenShiftSDNConfig{
-				Mode: operv1.SDNModeNetworkPolicy,
-			},
+			Type: operv1.NetworkTypeOVNKubernetes,
 		},
 	},
 }

--- a/pkg/network/multus_ipam_test.go
+++ b/pkg/network/multus_ipam_test.go
@@ -21,10 +21,7 @@ var NoIPAMConfig = operv1.Network{
 			},
 		},
 		DefaultNetwork: operv1.DefaultNetworkDefinition{
-			Type: operv1.NetworkTypeOpenShiftSDN,
-			OpenShiftSDNConfig: &operv1.OpenShiftSDNConfig{
-				Mode: operv1.SDNModeNetworkPolicy,
-			},
+			Type: operv1.NetworkTypeOVNKubernetes,
 		},
 	},
 }
@@ -46,10 +43,7 @@ var DHCPConfig = operv1.Network{
 			},
 		},
 		DefaultNetwork: operv1.DefaultNetworkDefinition{
-			Type: operv1.NetworkTypeOpenShiftSDN,
-			OpenShiftSDNConfig: &operv1.OpenShiftSDNConfig{
-				Mode: operv1.SDNModeNetworkPolicy,
-			},
+			Type: operv1.NetworkTypeOVNKubernetes,
 		},
 	},
 }
@@ -71,10 +65,7 @@ var WhereaboutsConfig = operv1.Network{
 			},
 		},
 		DefaultNetwork: operv1.DefaultNetworkDefinition{
-			Type: operv1.NetworkTypeOpenShiftSDN,
-			OpenShiftSDNConfig: &operv1.OpenShiftSDNConfig{
-				Mode: operv1.SDNModeNetworkPolicy,
-			},
+			Type: operv1.NetworkTypeOVNKubernetes,
 		},
 	},
 }
@@ -96,10 +87,7 @@ var WhereaboutsConflistConfig = operv1.Network{
 			},
 		},
 		DefaultNetwork: operv1.DefaultNetworkDefinition{
-			Type: operv1.NetworkTypeOpenShiftSDN,
-			OpenShiftSDNConfig: &operv1.OpenShiftSDNConfig{
-				Mode: operv1.SDNModeNetworkPolicy,
-			},
+			Type: operv1.NetworkTypeOVNKubernetes,
 		},
 	},
 }
@@ -121,10 +109,7 @@ var InvalidIPAMConfig = operv1.Network{
 			},
 		},
 		DefaultNetwork: operv1.DefaultNetworkDefinition{
-			Type: operv1.NetworkTypeOpenShiftSDN,
-			OpenShiftSDNConfig: &operv1.OpenShiftSDNConfig{
-				Mode: operv1.SDNModeNetworkPolicy,
-			},
+			Type: operv1.NetworkTypeOVNKubernetes,
 		},
 	},
 }
@@ -152,10 +137,7 @@ var DHCPConfigSimpleMacvlan = operv1.Network{
 			},
 		},
 		DefaultNetwork: operv1.DefaultNetworkDefinition{
-			Type: operv1.NetworkTypeOpenShiftSDN,
-			OpenShiftSDNConfig: &operv1.OpenShiftSDNConfig{
-				Mode: operv1.SDNModeNetworkPolicy,
-			},
+			Type: operv1.NetworkTypeOVNKubernetes,
 		},
 	},
 }
@@ -205,10 +187,7 @@ var NoDHCPConfigSimpleMacvlan = operv1.Network{
 			},
 		},
 		DefaultNetwork: operv1.DefaultNetworkDefinition{
-			Type: operv1.NetworkTypeOpenShiftSDN,
-			OpenShiftSDNConfig: &operv1.OpenShiftSDNConfig{
-				Mode: operv1.SDNModeNetworkPolicy,
-			},
+			Type: operv1.NetworkTypeOVNKubernetes,
 		},
 	},
 }

--- a/pkg/network/multus_test.go
+++ b/pkg/network/multus_test.go
@@ -18,10 +18,7 @@ var MultusConfig = operv1.Network{
 			},
 		},
 		DefaultNetwork: operv1.DefaultNetworkDefinition{
-			Type: operv1.NetworkTypeOpenShiftSDN,
-			OpenShiftSDNConfig: &operv1.OpenShiftSDNConfig{
-				Mode: operv1.SDNModeNetworkPolicy,
-			},
+			Type: operv1.NetworkTypeOVNKubernetes,
 		},
 	},
 }

--- a/pkg/network/network_metrics_test.go
+++ b/pkg/network/network_metrics_test.go
@@ -17,10 +17,7 @@ var NetworkMetricsDaemonConfig = operv1.Network{
 			},
 		},
 		DefaultNetwork: operv1.DefaultNetworkDefinition{
-			Type: operv1.NetworkTypeOpenShiftSDN,
-			OpenShiftSDNConfig: &operv1.OpenShiftSDNConfig{
-				Mode: operv1.SDNModeNetworkPolicy,
-			},
+			Type: operv1.NetworkTypeOVNKubernetes,
 		},
 	},
 }

--- a/sample-cluster-network-config.yaml
+++ b/sample-cluster-network-config.yaml
@@ -8,4 +8,4 @@ spec:
   clusterNetwork: 
     - cidr: "10.128.0.0/14"
       hostPrefix: 23 
-  networkType: OpenShiftSDN
+  networkType: OVNKubernetes

--- a/sample-config.yaml
+++ b/sample-config.yaml
@@ -9,6 +9,4 @@ spec:
     - cidr: "10.128.0.0/14"
       hostPrefix: 23
   defaultNetwork:
-    type: OpenShiftSDN
-    openshiftSDNConfig:
-      mode: NetworkPolicy
+    type: OVNKubernetes


### PR DESCRIPTION
#2384 dropped support for deploying openshift-sdn, but (to make it easier to review and merge) it didn't actually fully get rid of it. This PR does a little more:
1. In unit tests that are testing something non-plugin-specific, fix them to use ovn-k rather than openshift-sdn in the configuration.
2. Fix a bunch of docs, sample configs, comments, etc.

It would be nice to merge this for 1.17 but it's not necessary.