### PR TITLE
SDN-4919: Change the masquerade subnet default value for new clusters 

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -13,6 +13,9 @@ metadata:
     kubernetes.io/description: |
       This daemonset launches the ovn-kubernetes per node networking components.
     release.openshift.io/version: "{{.ReleaseVersion}}"
+    {{ if .DefaultMasqueradeNetworkCIDRs }}
+    networkoperator.openshift.io/default-masquerade-network-cidrs: "{{.DefaultMasqueradeNetworkCIDRs}}"
+    {{ end }}
     {{ if .OVNIPsecEnable }}
     networkoperator.openshift.io/ipsec-enabled: "true"
     {{ end }}

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -16,6 +16,9 @@ metadata:
     {{ if .OVNIPsecEnable }}
     networkoperator.openshift.io/ipsec-enabled: "true"
     {{ end }}
+    {{ if .DefaultMasqueradeNetworkCIDRs }}
+    networkoperator.openshift.io/default-masquerade-network-cidrs: "{{.DefaultMasqueradeNetworkCIDRs}}"
+    {{ end }}
 spec:
   selector:
     matchLabels:

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -2,8 +2,9 @@ package bootstrap
 
 import (
 	configv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/cluster-network-operator/pkg/hypershift"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+
+	"github.com/openshift/cluster-network-operator/pkg/hypershift"
 )
 
 type OVNHyperShiftBootstrapResult struct {
@@ -61,9 +62,11 @@ type OVNBootstrapResult struct {
 	// IPsecUpdateStatus is the status of ovn-ipsec config
 	IPsecUpdateStatus *OVNIPsecStatus
 	// PrePullerUpdateStatus is the status of ovnkube-upgrades-prepuller daemonset
-	PrePullerUpdateStatus *OVNUpdateStatus
-	OVNKubernetesConfig   *OVNConfigBoostrapResult
-	FlowsConfig           *FlowsConfig
+	PrePullerUpdateStatus     *OVNUpdateStatus
+	OVNKubernetesConfig       *OVNConfigBoostrapResult
+	FlowsConfig               *FlowsConfig
+	DefaultV4MasqueradeSubnet string
+	DefaultV6MasqueradeSubnet string
 }
 
 // IPTablesAlerterBootstrapResult contains configuration for the iptables-alerter

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -76,6 +76,12 @@ const NetworkIPFamilyModeAnnotation = "networkoperator.openshift.io/ip-family-mo
 // to indicate the current list of clusterNetwork CIDRs available to the cluster.
 const ClusterNetworkCIDRsAnnotation = "networkoperator.openshift.io/cluster-network-cidr"
 
+// MasqueradeCIDRsAnnotation is an annotation on the OVN networks.operator.openshift.io resources
+// to indicate the list of default masquerade CIDRs. The default masquerade network CIDRs can differ
+// from the actual masquerade network CIDRs if it was specified through the
+// OVNKubernetesConfig.GatewayConfig.IPv[4|6].InternalMasqueradeSubnet API field.
+const MasqueradeCIDRsAnnotation = "networkoperator.openshift.io/default-masquerade-network-cidrs"
+
 // NetworkHybridOverlayAnnotatiion is an annotation on the OVN networks.operator.io.daemonsets
 // to indicate the current state of of the Hybrid overlay on the cluster: "enabled" or "disabled"
 const NetworkHybridOverlayAnnotation = "networkoperator.openshift.io/hybrid-overlay-status"


### PR DESCRIPTION
Set the following default masquerade CIDRs in OVNKubernetes for new clusters:
IPv4: `169.254.0.0/17`
IPv6: `fd69::/112`
If the masquerade subnet is provided through the API it takes precedence over
the defaults.

There is no change for upgraded clusters. If not specified through the API the
default masquerade CIDRs are decided by OVNKubernetes and currently are:
IPv4: `169.254.169.0/29`
IPv6: `fd69::/125`

We went with  `169.254.0.0/17` instead of  `169.254.0.0/16` to avoid catching 169.254.169.254(cloud metadata IP).

Introduced the `networkoperator.openshift.io/default-masquerade-network-cidrs` annotation on the ovnkube-node daemonset that stores the new default CIDRs. This is needed to ensure that the values set during cluster creation are retained. The value of this annotation can differ from what is set in the `OVNKubernetesConfig.GatewayConfig.IPv[4|6].InternalMasqueradeSubnet` API field, in this case the API value takes precedence. It's done this way to ensure that if the API field is cleared we fallback to the new default value.

Note that the change to `defaultV4MasqueradeSubnet/defaultV6MasqueradeSubnet` consts is safe since it was only used in live migration checks and live migration is not supported in 4.17 (SDN is deprecated). There is a plan to cleanup this code and this is tracked elsewhere. 