### PR TITLE
[release-4.14] OCPBUGS-38073: Fix IC distributed control plane alerts

### DIFF
--- a/bindata/network/ovn-kubernetes/common/alert-rules.yaml
+++ b/bindata/network/ovn-kubernetes/common/alert-rules.yaml
@@ -89,3 +89,69 @@ spec:
       for: 15m
       labels:
         severity: warning
+    # OVN northbound and southbound databases functional alerts
+    - alert: NorthboundStale
+      annotations:
+        summary: OVN-Kubernetes controller {{"{{"}} $labels.instance {{"}}"}} has not successfully synced any changes to the northbound database for too long.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-network-operator/NorthboundStaleAlert.md
+        description: |
+          OVN-Kubernetes controller and/or OVN northbound database may cause a
+          degraded networking control plane for the affected node. Existing
+          workloads should continue to have connectivity but new workloads may
+          be impacted.
+      expr: |
+        # Without max_over_time, failed scrapes could create false negatives, see
+        # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+        time() - max_over_time(ovnkube_controller_nb_e2e_timestamp[5m]) > 120
+      for: 10m
+      labels:
+        severity: warning
+    - alert: SouthboundStale
+      annotations:
+        summary: OVN northd {{"{{"}} $labels.instance {{"}}"}} has not successfully synced any changes to the southbound database for too long.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-network-operator/SouthboundStaleAlert.md
+        description: |
+          OVN-Kubernetes controller and/or OVN northbound database may cause a
+          degraded networking control plane for the affected node. Existing
+          workloads should continue to have connectivity but new workloads may
+          be impacted.
+      expr: |
+        # Without max_over_time, failed scrapes could create false negatives, see
+        # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+        max_over_time(ovnkube_controller_nb_e2e_timestamp[5m]) - max_over_time(ovnkube_controller_sb_e2e_timestamp[5m]) > 120
+      for: 10m
+      labels:
+        severity: warning
+    # OVN northbound and southbound database performance alerts
+    - alert: OVNKubernetesNorthboundDatabaseCPUUsageHigh
+      annotations:
+        summary: OVN northbound database {{"{{"}} $labels.instance {{"}}"}} is greater than {{"{{"}} $value | humanizePercentage {{"}}"}} percent CPU usage for a period of time.
+        description: |
+          High OVN northbound CPU usage indicates high load on the networking
+          control plane for the affected node.
+      expr: (sum(rate(container_cpu_usage_seconds_total{container="nbdb"}[5m])) BY (instance, name, namespace)) > 0.8
+      for: 15m
+      labels:
+        severity: info
+    - alert: OVNKubernetesSouthboundDatabaseCPUUsageHigh
+      annotations:
+        summary: OVN southbound database {{"{{"}} $labels.instance {{"}}"}} is greater than {{"{{"}} $value | humanizePercentage {{"}}"}} percent CPU usage for a period of time.
+        description: |
+          High OVN southbound CPU usage indicates high load on the networking
+          control plane for the affected node.
+      expr: (sum(rate(container_cpu_usage_seconds_total{container="sbdb"}[5m])) BY (instance, name, namespace)) > 0.8
+      for: 15m
+      labels:
+        severity: info
+    - alert: OVNKubernetesNorthdInactive
+      annotations:
+        summary: OVN northd {{"{{"}} $labels.instance {{"}}"}} is not active.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-network-operator/OVNKubernetesNorthdInactive.md
+        description: |
+          An inactive OVN northd instance may cause a degraded networking
+          control plane for the affected node. Existing workloads should
+          continue to have connectivity but new workloads may be impacted.
+      expr: count(ovn_northd_status != 1) BY (instance, name, namespace) > 0
+      for: 10m
+      labels:
+        severity: warning

--- a/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/multi-zone-interconnect/alert-rules-control-plane.yaml
@@ -37,10 +37,10 @@ spec:
     - alert: NoRunningOvnControlPlane
       annotations:
         summary: There is no running ovn-kubernetes control plane.
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-network-operator/NoRunningOvnMaster.md
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-network-operator/NoRunningOvnControlPlane.md
         description: |
           Networking control plane is degraded. Networking configuration updates applied to the cluster will not be
-          implemented while there are no OVN Kubernetes pods.
+          implemented while there are no OVN Kubernetes control plane pods.
       expr: |
         absent(up{job="ovnkube-control-plane", namespace="openshift-ovn-kubernetes"} == 1)
       for: 5m
@@ -50,10 +50,10 @@ spec:
     - alert: NoOvnClusterManagerLeader
       annotations:
         summary: There is no ovn-kubernetes cluster manager leader.
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-network-operator/NoOvnMasterLeader.md
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-network-operator/NoOvnClusterManagerLeader.md
         description: |
           Networking control plane is degraded. Networking configuration updates applied to the cluster will not be
-          implemented while there is no OVN Kubernetes leader. Existing workloads should continue to have connectivity.
+          implemented while there is no OVN Kubernetes cluster manager leader. Existing workloads should continue to have connectivity.
           OVN-Kubernetes control plane is not functional.
       expr: |
         # Without max_over_time, failed scrapes could create false negatives, see
@@ -62,65 +62,3 @@ spec:
       for: 5m
       labels:
         severity: critical
-    # OVN northbound and southbound databases functional alerts
-    - alert: NorthboundStale
-      annotations:
-        summary: ovn-kubernetes has not written anything to the northbound database for too long.
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-network-operator/NorthboundStaleAlert.md
-        description: |
-          Networking control plane is degraded. Networking configuration updates applied to the cluster will not be
-          implemented. Existing workloads should continue to have connectivity. OVN-Kubernetes control plane and/or
-          OVN northbound database may not be functional.
-      expr: |
-        # Without max_over_time, failed scrapes could create false negatives, see
-        # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
-        time() - max_over_time(ovnkube_controller_nb_e2e_timestamp[5m]) > 120
-      for: 10m
-      labels:
-        severity: critical
-    - alert: SouthboundStale
-      annotations:
-        summary: ovn-northd has not successfully synced any changes to the southbound DB for too long.
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-network-operator/SouthboundStaleAlert.md
-        description: |
-          Networking control plane is degraded. Networking configuration updates may not be applied to the cluster or
-          taking a long time to apply. This usually means there is a large load on OVN component 'northd' or it is not
-          functioning.
-      expr: |
-        # Without max_over_time, failed scrapes could create false negatives, see
-        # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
-        max_over_time(ovnkube_controller_nb_e2e_timestamp[5m]) - max_over_time(ovnkube_controller_sb_e2e_timestamp[5m]) > 120
-      for: 10m
-      labels:
-        severity: critical
-    # OVN northbound and southbound database performance alerts
-    - alert: OVNKubernetesNorthboundDatabaseCPUUsageHigh
-      annotations:
-        summary: OVN northbound database {{"{{"}} $labels.instance {{"}}"}} is greater than {{"{{"}} $value | humanizePercentage {{"}}"}} percent CPU usage for a period of time.
-        description: High OVN northbound CPU usage indicates high load on the networking control plane.
-      expr: (sum(rate(container_cpu_usage_seconds_total{container="nbdb"}[5m])) BY (instance, name, namespace)) > 0.8
-      for: 15m
-      labels:
-        severity: info
-    - alert: OVNKubernetesSouthboundDatabaseCPUUsageHigh
-      annotations:
-        summary: OVN southbound database {{"{{"}} $labels.instance {{"}}"}} is greater than {{"{{"}} $value | humanizePercentage {{"}}"}} percent CPU usage for a period of time.
-        description: High OVN southbound CPU usage indicates high load on the networking control plane.
-      expr: (sum(rate(container_cpu_usage_seconds_total{container="sbdb"}[5m])) BY (instance, name, namespace)) > 0.8
-      for: 15m
-      labels:
-        severity: info
-      # OVN northd functional alerts
-      # TODO fix this metrics https://github.com/ovn-org/ovn-kubernetes/issues/3774
-#    - alert: OVNKubernetesNorthdInactive
-#      annotations:
-#        summary: Exactly one OVN northd instance must have an active status.
-#        description: Exactly one OVN northd must have an active status within the high availability set.
-#          Networking control plane is degraded.
-#      expr: |
-#        # Without max_over_time, failed scrapes could create false negatives, see
-#        # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
-#        count(ovn_northd_status == 1) by (namespace) != 1
-#      for: 5m
-#      labels:
-#        severity: critical

--- a/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/multi-zone-interconnect/alert-rules-control-plane.yaml
@@ -36,10 +36,10 @@ spec:
     - alert: NoRunningOvnControlPlane
       annotations:
         summary: There is no running ovn-kubernetes control plane.
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-network-operator/NoRunningOvnMaster.md
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-network-operator/NoRunningOvnControlPlane.md
         description: |
           Networking control plane is degraded. Networking configuration updates applied to the cluster will not be
-          implemented while there are no OVN Kubernetes pods.
+          implemented while there are no OVN Kubernetes control plane pods.
       expr: |
         absent(up{job="ovnkube-control-plane", namespace="openshift-ovn-kubernetes"} == 1)
       for: 5m
@@ -49,10 +49,10 @@ spec:
     - alert: NoOvnClusterManagerLeader
       annotations:
         summary: There is no ovn-kubernetes cluster manager leader.
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-network-operator/NoOvnMasterLeader.md
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-network-operator/NoOvnClusterManagerLeader.md
         description: |
           Networking control plane is degraded. Networking configuration updates applied to the cluster will not be
-          implemented while there is no OVN Kubernetes leader. Existing workloads should continue to have connectivity.
+          implemented while there is no OVN Kubernetes cluster manager leader. Existing workloads should continue to have connectivity.
           OVN-Kubernetes control plane is not functional.
       expr: |
         # Without max_over_time, failed scrapes could create false negatives, see
@@ -61,65 +61,3 @@ spec:
       for: 5m
       labels:
         severity: critical
-    # OVN northbound and southbound databases functional alerts
-    - alert: NorthboundStale
-      annotations:
-        summary: ovn-kubernetes has not written anything to the northbound database for too long.
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-network-operator/NorthboundStaleAlert.md
-        description: |
-          Networking control plane is degraded. Networking configuration updates applied to the cluster will not be
-          implemented. Existing workloads should continue to have connectivity. OVN-Kubernetes control plane and/or
-          OVN northbound database may not be functional.
-      expr: |
-        # Without max_over_time, failed scrapes could create false negatives, see
-        # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
-        time() - max_over_time(ovnkube_controller_nb_e2e_timestamp[5m]) > 120
-      for: 10m
-      labels:
-        severity: critical
-    - alert: SouthboundStale
-      annotations:
-        summary: ovn-northd has not successfully synced any changes to the southbound DB for too long.
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-network-operator/SouthboundStaleAlert.md
-        description: |
-          Networking control plane is degraded. Networking configuration updates may not be applied to the cluster or
-          taking a long time to apply. This usually means there is a large load on OVN component 'northd' or it is not
-          functioning.
-      expr: |
-        # Without max_over_time, failed scrapes could create false negatives, see
-        # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
-        max_over_time(ovnkube_controller_nb_e2e_timestamp[5m]) - max_over_time(ovnkube_controller_sb_e2e_timestamp[5m]) > 120
-      for: 10m
-      labels:
-        severity: critical
-    # OVN northbound and southbound database performance alerts
-    - alert: OVNKubernetesNorthboundDatabaseCPUUsageHigh
-      annotations:
-        summary: OVN northbound database {{"{{"}} $labels.instance {{"}}"}} is greater than {{"{{"}} $value | humanizePercentage {{"}}"}} percent CPU usage for a period of time.
-        description: High OVN northbound CPU usage indicates high load on the networking control plane.
-      expr: (sum(rate(container_cpu_usage_seconds_total{container="nbdb"}[5m])) BY (instance, name, namespace)) > 0.8
-      for: 15m
-      labels:
-        severity: info
-    - alert: OVNKubernetesSouthboundDatabaseCPUUsageHigh
-      annotations:
-        summary: OVN southbound database {{"{{"}} $labels.instance {{"}}"}} is greater than {{"{{"}} $value | humanizePercentage {{"}}"}} percent CPU usage for a period of time.
-        description: High OVN southbound CPU usage indicates high load on the networking control plane.
-      expr: (sum(rate(container_cpu_usage_seconds_total{container="sbdb"}[5m])) BY (instance, name, namespace)) > 0.8
-      for: 15m
-      labels:
-        severity: info
-    # OVN northd functional alerts
-    # TODO fix this metrics https://github.com/ovn-org/ovn-kubernetes/issues/3774
-#    - alert: OVNKubernetesNorthdInactive
-#      annotations:
-#        summary: Exactly one OVN northd instance must have an active status.
-#        description: Exactly one OVN northd must have an active status within the high availability set.
-#          Networking control plane is degraded.
-#      expr: |
-#        # Without max_over_time, failed scrapes could create false negatives, see
-#        # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
-#        count(ovn_northd_status == 1) by (namespace) != 1
-#      for: 5m
-#      labels:
-#        severity: critical


### PR DESCRIPTION
* Moved distributed control plane alerts from master-rules to alert-rules.
* Tweaked the wording of the alerts to either reflect the enw component names or the distributed nature of them.
* Added OVNKubernetesNorthdInactive alert back with adjusted severity and duration.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>
(cherry picked from commit 53804c56a6a88950a59565f637d6bb4c31dccec7)