### PR TITLE
OCPBUGS-38176: multus, Add openshift-cnv to globalNamespace

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -134,7 +134,7 @@ data:
         "multusConfigFile": "auto",
         "multusAutoconfigDir": "/host/run/multus/cni/net.d",
         "namespaceIsolation": true,
-        "globalNamespaces": "default,openshift-multus,openshift-sriov-network-operator",
+        "globalNamespaces": "default,openshift-multus,openshift-sriov-network-operator,openshift-cnv",
 {{- if eq .DefaultNetworkType "OpenShiftSDN"}}
         "readinessindicatorfile": "/host/run/multus/cni/net.d/80-openshift-network.conf",
 {{- else if eq .DefaultNetworkType "OVNKubernetes"}}
@@ -163,7 +163,7 @@ data:
         "multusConfigFile": "auto",
         "multusAutoconfigDir": "/host/run/multus/cni/net.d",
         "namespaceIsolation": true,
-        "globalNamespaces": "default,openshift-multus,openshift-sriov-network-operator",
+        "globalNamespaces": "default,openshift-multus,openshift-sriov-network-operator,openshift-cnv",
         "readinessindicatorfile": "/host/run/multus/cni/net.d/10-ovn-kubernetes.conf",
         "daemonSocketDir": "/run/multus/socket",
         "socketDir": "/host{{ .MultusSocketParentDir }}/socket"
@@ -187,7 +187,7 @@ data:
         "multusConfigFile": "auto",
         "multusAutoconfigDir": "/host/run/multus/cni/net.d",
         "namespaceIsolation": true,
-        "globalNamespaces": "default,openshift-multus,openshift-sriov-network-operator",
+        "globalNamespaces": "default,openshift-multus,openshift-sriov-network-operator,openshift-cnv",
         "readinessindicatorfile": "/host/run/multus/cni/net.d/80-openshift-network.conf",
         "daemonSocketDir": "/run/multus/socket",
         "socketDir": "/host{{ .MultusSocketParentDir }}/socket"


### PR DESCRIPTION
For kubevirt passt binding to work a global nad is needed to be configured, this change allow nads being created at openshift-cnv namespace to be read from pods at different namespace kubevirt VMs can use passt with the nad at openshift-cnv