### PR TITLE
OCPBUGS-38326: OVN-K, UDN CRD: Add missing permissions to control-plane

### DIFF
--- a/bindata/network/ovn-kubernetes/common/004-rbac-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/common/004-rbac-control-plane.yaml
@@ -187,6 +187,11 @@ rules:
   verbs:
     - patch
     - update
+- apiGroups: [ "k8s.ovn.org" ]
+  resources:
+    - userdefinednetworks/finalizers
+  verbs:
+    - update
 - apiGroups: [ "k8s.cni.cncf.io" ]
   resources:
     - network-attachment-definitions

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -149,6 +149,11 @@ func TestRenderOVNKubernetes(t *testing.T) {
 					Verbs:     []string{"patch", "update"},
 				},
 				{
+					APIGroups: []string{"k8s.ovn.org"},
+					Resources: []string{"userdefinednetworks/finalizers"},
+					Verbs:     []string{"update"},
+				},
+				{
 					APIGroups: []string{"k8s.cni.cncf.io"},
 					Resources: []string{"network-attachment-definitions"},
 					Verbs:     []string{"patch", "update", "create", "delete"},


### PR DESCRIPTION
The UDN CRD controller fails to create NAD objects due to the following error:
```
  failed to create NetworkAttachmentDefinition: network-attachment-definitions.k8s.cni.cncf.io
    "test-net1" is forbidden: cannot set blockOwnerDeletion if an ownerReference
     refers to a resource you can''t set finalizers on: , <nil>
```

On OCP, the `OwnerReferencesPermissionEnforcement` [1] plugin is enabled.
It enforces the controller managed CRD object which is referred to as owner of another CRD
object has permissions to the managed CRD finalizers sub-resource [2].

The UDN CRD controller create NAD objects with owner-reference to the request UDN CR.
It fails to create NAD because it creates the NAD object with owner-reference to the
request UDN CR object, but the controller has no permissions to the referred object,
UDN CR, finalizers sub-resource.

This PR add the UDN CRD controller RBAC permissions for the UDN CRD sub-resource.

[1] https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
[2] https://sdk.operatorframework.io/docs/faqs/#after-deploying-my-operator-why-do-i-see-errors-like-is-forbidden-cannot-set-blockownerdeletion-if-an-ownerreference-refers-to-a-resource-you-cant-set-finalizers-on-