### PR TITLE
OCPBUGS-29497: HyperShift: do not use antiaffinity on single replica control planes

### DIFF
--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -80,12 +80,14 @@ spec:
                   matchLabels:
                     hypershift.openshift.io/hosted-control-plane: {{.AdmissionControllerNamespace}}
                 topologyKey: kubernetes.io/hostname
+{{- if (gt .Replicas 1) }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
                 app: multus-admission-controller
             topologyKey: topology.kubernetes.io/zone
+{{- end }}
       initContainers:
         - name: hosted-cluster-kubecfg-setup
           image: "{{.CLIImage}}"

--- a/bindata/network/node-identity/managed/node-identity.yaml
+++ b/bindata/network/node-identity/managed/node-identity.yaml
@@ -58,12 +58,14 @@ spec:
                     operator: In
                     values:
                       - {{.HostedClusterNamespace}}
+{{- if (gt .NetworkNodeIdentityReplicas 1)}}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchLabels:
                   app: network-node-identity
               topologyKey: topology.kubernetes.io/zone
+{{- end }}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
@@ -60,12 +60,14 @@ spec:
                   operator: In
                   values:
                     - {{.HostedClusterNamespace}}
+{{- if (gt .ClusterManagerReplicas 1) }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
                 app: ovnkube-control-plane
             topologyKey: topology.kubernetes.io/zone
+{{- end }}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100


### PR DESCRIPTION
The combination of PDBs and antiaffinity rules prevent a rolling update with a surge of pods that have antiaffinity rules when a control plane lives in a single zone. This change ensures antiaffinity rules only apply when running HA in multiple zones.