### PR TITLE
OCPBUGS-39096: Live migration: report network overlap via live_migration_blocked metric

### DIFF
--- a/pkg/network/cluster_config.go
+++ b/pkg/network/cluster_config.go
@@ -219,6 +219,7 @@ const (
 	unsupportedHCPCluster              = "UnsupportedHyperShiftCluster"
 	unsupportedSDNNetworkIsolationMode = "UnsupportedSDNNetworkIsolationMode"
 	unsupportedMACVlanInterface        = "UnsupportedMACVLANInterface"
+	networkOverlap                     = "NetworkOverlap"
 )
 
 var metricLiveMigrationBlocked = metrics.NewGaugeVec(&metrics.GaugeOpts{
@@ -266,6 +267,7 @@ func ValidateLiveMigration(clusterConfig *configv1.Network, infraRes *bootstrap.
 		}
 
 		if err := validateOVNKubernetesCIDROverlap(clusterConfig, operConfig); err != nil {
+			metricLiveMigrationBlocked.With(prometheus.Labels{metricLiveMigrationBlockedLabelKey: networkOverlap}).Set(1)
 			return err
 		}
 


### PR DESCRIPTION
cc @kyrtapz 