### PR TITLE
[release-4.15] NP-1064, OCPBUGS-39336: Remove managed cluster checking for live migration

### DIFF
--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -75,8 +75,6 @@ type InfraStatus struct {
 	ControlPlaneTopology   configv1.TopologyMode
 	InfrastructureTopology configv1.TopologyMode
 	InfraName              string
-	// StandaloneManagedCluster is set to true when the cluster is a standalone managed cluster (excl HyperShift)
-	StandaloneManagedCluster bool
 
 	// KubeCloudConfig is the contents of the openshift-config-managed/kube-cloud-config ConfigMap
 	KubeCloudConfig map[string]string

--- a/pkg/network/cluster_config.go
+++ b/pkg/network/cluster_config.go
@@ -251,10 +251,6 @@ func ValidateLiveMigration(clusterConfig *configv1.Network, infraRes *bootstrap.
 		return errors.Errorf("network type live migration is not supported on HyperShift clusters")
 	}
 
-	if !infraRes.StandaloneManagedCluster {
-		return errors.Errorf("network type live migration is not supported on self managed clusters")
-	}
-
 	operConfig := &operv1.Network{}
 	err := client.Default().CRClient().Get(context.TODO(), types.NamespacedName{Name: names.CLUSTER_CONFIG}, operConfig)
 	if err != nil {

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -681,10 +681,6 @@ func isMigrationChangeSafe(prev, next *operv1.NetworkSpec, infraStatus *bootstra
 	if next.Migration != nil && next.Migration.Mode == operv1.LiveNetworkMigrationMode && infraStatus.HostedControlPlane != nil {
 		return []error{errors.Errorf("live migration is unsupported in a HyperShift environment")}
 	}
-	if next.Migration != nil && next.Migration.Mode == operv1.LiveNetworkMigrationMode &&
-		!infraStatus.StandaloneManagedCluster {
-		return []error{errors.Errorf("live migration is unsupported on a self managed cluster")}
-	}
 	if prev.Migration != nil && next.Migration != nil && prev.Migration.NetworkType != next.Migration.NetworkType && next.Migration.Mode != operv1.LiveNetworkMigrationMode {
 		return []error{errors.Errorf("cannot change migration network type after migration has started")}
 	}

--- a/pkg/network/render_test.go
+++ b/pkg/network/render_test.go
@@ -120,13 +120,6 @@ func TestDisallowLiveMigrationHyperShiftCluster(t *testing.T) {
 	g.Expect(err).To(MatchError(ContainSubstring("live migration is unsupported in a HyperShift environment")))
 }
 
-func TestDisallowLiveMigrationSelfManagedCluster(t *testing.T) {
-	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OpenShiftSDNConfig, OpenShiftSDNConfig)
-	next.Migration = &operv1.NetworkMigration{Mode: operv1.LiveNetworkMigrationMode}
-	err := IsChangeSafe(prev, next, infra)
-	g.Expect(err).To(MatchError(ContainSubstring("live migration is unsupported on a self managed cluster")))
-}
-
 func TestDisallowMigrationTypeChangeWhenNotNull(t *testing.T) {
 	g, infra, prev, next := setupTestInfraAndBasicRenderConfigs(t, OpenShiftSDNConfig, OVNKubernetesConfig)
 

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -10,7 +10,6 @@ import (
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 	"github.com/openshift/cluster-network-operator/pkg/hypershift"
 	"github.com/openshift/cluster-network-operator/pkg/names"
-	"github.com/openshift/cluster-network-operator/pkg/util"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -148,13 +147,6 @@ func InfraStatus(client cnoclient.Client) (*bootstrap.InfraStatus, error) {
 		return nil, fmt.Errorf("failed to determine if network node identity should be enabled: %w", err)
 	}
 	res.NetworkNodeIdentityEnabled = netIDEnabled
-
-	// standalone managed clusters is a set managed clusters (excl HyperShift clusters).
-	isStandaloneManagedCluster, err := util.IsStandaloneManagedCluster(context.TODO(), client, res.PlatformType)
-	if err != nil {
-		return nil, fmt.Errorf("failed to detect if standalone managed cluster: %v", err)
-	}
-	res.StandaloneManagedCluster = isStandaloneManagedCluster
 
 	// Skip retrieving IPsec MachineConfig and MachineConfigPool if it's a hypershift cluster because
 	// those object kinds are not supported there.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
-	v1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -25,8 +23,6 @@ const SDN_NAMESPACE = "openshift-sdn"
 const MTU_CM_NAMESPACE = "openshift-network-operator"
 const MTU_CM_NAME = "mtu"
 const OVN_NBDB = "nbdb"
-const STANDALONE_MANAGED_CLUSTER_NAMESPACE = "dedicated-admin"      // namespace required for standalone managed clusters (excluding hypershift and ARO)
-const STANDALONE_ARO_CLUSTER_NAMESPACE = "openshift-azure-operator" // namespace required for standalone ARO clusters
 
 func GetInterConnectConfigMap(kubeClient kubernetes.Interface) (*corev1.ConfigMap, error) {
 	return kubeClient.CoreV1().ConfigMaps(OVN_NAMESPACE).Get(context.TODO(), OVN_INTERCONNECT_CONFIGMAP_NAME, metav1.GetOptions{})
@@ -46,23 +42,4 @@ func ReadMTUConfigMap(ctx context.Context, client cnoclient.Client) (int, error)
 
 	klog.V(2).Infof("Found mtu %d", mtu)
 	return mtu, nil
-}
-
-// IsStandaloneManagedCluster returns true if the operator is running in a managed cluster that isn't managed by HyperShift.
-// It checks for the existence of the openshift-azure-operator namespace on azure and dedicated-admin namespace otherwise.
-func IsStandaloneManagedCluster(ctx context.Context, client cnoclient.Client, platform v1.PlatformType) (bool, error) {
-	// TODO(martinkennelly): replace detection of a standalone managed cluster with a metric instead of a namespace when that metric
-	// becomes available.
-	namespace := STANDALONE_MANAGED_CLUSTER_NAMESPACE
-	if platform == v1.AzurePlatformType {
-		namespace = STANDALONE_ARO_CLUSTER_NAMESPACE
-	}
-	err := client.Default().CRClient().Get(ctx, types.NamespacedName{Name: namespace}, &corev1.Namespace{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }


### PR DESCRIPTION
In 4.15, we want to support SDN live migration for unmanaged clusters.

This's a manual cherrypick of #2321