### PR TITLE
HOSTEDCP-1981: Add controlplane cli image envar for use with hypershift

### DIFF
--- a/pkg/network/cloud_network.go
+++ b/pkg/network/cloud_network.go
@@ -84,6 +84,9 @@ func renderCloudNetworkConfigController(conf *operv1.NetworkSpec, bootstrapResul
 	manifestDirs = append(manifestDirs, filepath.Join(manifestDir, "cloud-network-config-controller/common"))
 	if hcpCfg := hypershift.NewHyperShiftConfig(); hcpCfg.Enabled {
 		data.Data["CLIImage"] = os.Getenv("CLI_IMAGE")
+		if os.Getenv("CLI_CONTROL_PLANE_IMAGE") != "" {
+			data.Data["CLIImage"] = os.Getenv("CLI_CONTROL_PLANE_IMAGE")
+		}
 		data.Data["TokenMinterImage"] = os.Getenv("TOKEN_MINTER_IMAGE")
 		data.Data["TokenAudience"] = os.Getenv("TOKEN_AUDIENCE")
 		data.Data["ManagementClusterName"] = names.ManagementClusterName

--- a/pkg/network/multus_admission_controller.go
+++ b/pkg/network/multus_admission_controller.go
@@ -88,6 +88,9 @@ func renderMultusAdmissonControllerConfig(manifestDir string, externalControlPla
 		data.Data["KubernetesServiceHost"] = bootstrapResult.Infra.APIServers[bootstrap.APIServerDefaultLocal].Host
 		data.Data["KubernetesServicePort"] = bootstrapResult.Infra.APIServers[bootstrap.APIServerDefaultLocal].Port
 		data.Data["CLIImage"] = os.Getenv("CLI_IMAGE")
+		if os.Getenv("CLI_CONTROL_PLANE_IMAGE") != "" {
+			data.Data["CLIImage"] = os.Getenv("CLI_CONTROL_PLANE_IMAGE")
+		}
 		data.Data["TokenMinterImage"] = os.Getenv("TOKEN_MINTER_IMAGE")
 		data.Data["TokenAudience"] = os.Getenv("TOKEN_AUDIENCE")
 		data.Data["RunAsUser"] = hsc.RunAsUser

--- a/pkg/network/node_identity.go
+++ b/pkg/network/node_identity.go
@@ -94,6 +94,9 @@ func renderNetworkNodeIdentity(conf *operv1.NetworkSpec, bootstrapResult *bootst
 		}
 		data.Data["ReleaseImage"] = hcpCfg.ReleaseImage
 		data.Data["CLIImage"] = os.Getenv("CLI_IMAGE")
+		if os.Getenv("CLI_CONTROL_PLANE_IMAGE") != "" {
+			data.Data["CLIImage"] = os.Getenv("CLI_CONTROL_PLANE_IMAGE")
+		}
 		data.Data["TokenMinterImage"] = os.Getenv("TOKEN_MINTER_IMAGE")
 		data.Data["TokenAudience"] = os.Getenv("TOKEN_AUDIENCE")
 		data.Data["HCPNodeSelector"] = bootstrapResult.Infra.HostedControlPlane.NodeSelector


### PR DESCRIPTION
Add CLI_CONTROL_PLANE_IMAGE enavr to
cloud-network, multus-admission-controller and node-identity to avoid
registryOverrides propagating to data plane components