### PR TITLE
OCPBUGS-42238: Updates terminationGracePeriodSeconds to 30 seconds for Multus daemonset

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -328,7 +328,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: system-cni-dir
           hostPath:


### PR DESCRIPTION
Necessary integration for https://github.com/openshift/multus-cni/pull/252 for graceful termination of the multus daemon.