### PR TITLE
pkg/controller/statusmanager: Link docs.redhat.com

### DIFF
--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -379,7 +379,7 @@ func (status *StatusManager) set(reachedAvailableLevel bool, conditions ...operv
 					Reason: "OpenShiftSDNConfigured",
 					Message: "Cluster is configured with OpenShiftSDN, which is not supported in the next version. Please " +
 						"follow the documented steps to migrate from OpenShiftSDN to OVN-Kubernetes in order to be able to upgrade. " +
-						"https://docs.openshift.com/container-platform/4.16/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html",
+						"https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/networking/ovn-kubernetes-network-plugin",
 				},
 			)
 		} else {

--- a/pkg/controller/statusmanager/status_manager_test.go
+++ b/pkg/controller/statusmanager/status_manager_test.go
@@ -301,7 +301,7 @@ func TestStatusManager_set_OpenShiftSDN(t *testing.T) {
 		Reason: "OpenShiftSDNConfigured",
 		Message: "Cluster is configured with OpenShiftSDN, which is not supported in the next version. Please " +
 			"follow the documented steps to migrate from OpenShiftSDN to OVN-Kubernetes in order to be able to upgrade. " +
-			"https://docs.openshift.com/container-platform/4.16/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html",
+			"https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/networking/ovn-kubernetes-network-plugin",
 	}
 	status.set(true, condNoProgress, condAvailable)
 


### PR DESCRIPTION
docs.openshift.com is being folded into docs.redhat.com.  There will hopefully be a redirect system that takes folks from an old-location page straight to the new-location page.  But [4.16 has support through 2027-06-27][1], so point straight at the new location, which protects us against buggy or imprecise redirect implementations (e.g. we don't want customers dropped into the top-level 4.16 welcome page, or anything like that).  This patch will obviously only affect new 4.16.z releases; older 4.16.z will still point at docs.openshift.com, and will rely on the redirects or the tenacity of the cluster admin to work around a buggy or imprecise redirect.  And if redirects end up being great, we won't have needed this code change.  But with the redirect system currently untestable, it seems better to be cautious and avoid it as much as we can.

[1]: https://access.redhat.com/support/policy/updates/openshift#dates