### PR TITLE
OCPBUGS-42472: Add certificatesigningrequests/watch RBAC to ovnkube-node

### DIFF
--- a/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
+++ b/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
@@ -127,6 +127,7 @@ rules:
     - create
     - get
     - list
+    - watch
 - apiGroups: ["security.openshift.io"]
   resources:
   - securitycontextconstraints


### PR DESCRIPTION
Allow ovnkube-node to watch CSRs to avoid unecessary warnings in the API audit logs.