### PR TITLE
OCPBUGS-42449: Use CNIConfDir for mounting directory to ovn-ipsec-host pod

### DIFF
--- a/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
@@ -345,8 +345,7 @@ spec:
           type: DirectoryOrCreate
         name: etc-openvswitch
       - hostPath:
-          path: /var/run/multus/cni/net.d
-          type: ""
+          path: "{{.CNIConfDir}}"
         name: host-cni-netd
       - hostPath:
           path: /var/run


### PR DESCRIPTION
The `ovn-ipsec-host` DaemonSet manifest file hardcoded `host-cni-netd` mount point with `/var/run/multus/cni/net.d `directory, but this won't work when multi network is disabled via `disableMultiNetwork` parameter as ovn-k uses `/etc/kubernetes/cni/net.d` directory to write cni config file for this case. So this PR fixes host path to use `CNIConfDir` tag.