### PR TITLE
CNF-14257, CNF-14251: multi-networkpolicy: Enable for `ipvlan` and `bond` networkds

### DIFF
--- a/bindata/network/multus-networkpolicy/multus-networkpolicy.yaml
+++ b/bindata/network/multus-networkpolicy/multus-networkpolicy.yaml
@@ -36,7 +36,7 @@ spec:
         - "--host-prefix=/host"
         - "--container-runtime-endpoint=/run/crio/crio.sock"
         - "--pod-iptables=/var/lib/multi-networkpolicy/iptables"
-        - "--network-plugins=macvlan,sriov"
+        - "--network-plugins=macvlan,sriov,ipvlan,bond"
         - "--custom-v6-ingress-rule-file=/etc/multi-networkpolicy/rules/custom-v6-rules.txt"
         - "--custom-v6-egress-rule-file=/etc/multi-networkpolicy/rules/custom-v6-rules.txt"
         resources:


### PR DESCRIPTION
Make the multus-networkpolicies iptables implementation work with `ipvlan` and `bond` network types.