### PR TITLE
NO-JIRA: OVN-Kubernetes node RBAC tightening

### DIFF
--- a/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
+++ b/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
@@ -142,7 +142,9 @@ rules:
     - egressips
     - egressqoses
     - egressservices
+{{- if .OVN_NETWORK_SEGMENTATION_ENABLE }}
     - userdefinednetworks
+{{- end }}
   verbs:
     - get
     - list


### PR DESCRIPTION
This is a follow up to https://github.com/openshift/cluster-network-operator/pull/2524.
Allow to read userdefinednetworks only when the featuregate is enabled.

/cc @tssurya @trozet 