### PR TITLE
CNF-13671: Adjust frr-k8s metrics

### DIFF
--- a/bindata/network/frr-k8s/frr-k8s.yaml
+++ b/bindata/network/frr-k8s/frr-k8s.yaml
@@ -258,7 +258,7 @@ spec:
         - --tls-cert-file=/etc/metrics/tls.crt
         ports:
         - containerPort: 9141
-          name: metricshttps
+          name: frrmetricshttps
         resources:
           requests:
             cpu: 10m

--- a/bindata/network/frr-k8s/monitor.yaml
+++ b/bindata/network/frr-k8s/monitor.yaml
@@ -36,22 +36,20 @@ metadata:
     networkoperator.openshift.io/ignore-errors: ""
 spec:
   endpoints:
-    - port: metricshttps
-      honorLabels: true
-      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      scheme: https
-      tlsConfig:
-        caFile: /etc/prometheus/configmaps/prometheus.io/scrape/service-ca.crt
-        serverName: openshift-frr-k8s-metrics-service.openshift-frr-k8s.svc
-        insecureSkipVerify: false
-    - port: frrmetricshttps
-      honorLabels: true
-      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      scheme: https
-      tlsConfig:
-        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-        serverName: openshift-frr-k8s-metrics-service.openshift-frr-k8s.svc
-        insecureSkipVerify: false
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    honorLabels: true
+    port: metricshttps
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: frr-k8s-monitor-service.openshift-frr-k8s.svc
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    honorLabels: true
+    port: frrmetricshttps
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: frr-k8s-monitor-service.openshift-frr-k8s.svc
   jobLabel: app
   namespaceSelector:
     matchNames:
@@ -59,3 +57,34 @@ spec:
   selector:
     matchLabels:
       name: frr-k8s-monitor-service
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-frr-k8s
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-frr-k8s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/pkg/network/render_test.go
+++ b/pkg/network/render_test.go
@@ -641,7 +641,7 @@ func Test_renderAdditionalRoutingCapabilities(t *testing.T) {
 					},
 				},
 			},
-			want:        16,
+			want:        18,
 			expectedErr: nil,
 		},
 	}


### PR DESCRIPTION
Few adjustments required to make the frr-k8s metrics to appear under prometheus.

Tested locally, will be tested under CI.