### PR TITLE
OCPBUGS-42605: OCPBUGS-42244: Exporting environment varialbe NODE_CNI for live migration

### DIFF
--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -77,6 +77,7 @@ spec:
           else
             echo "br-ex doesn't exist"
           fi
+          export NODE_CNI
 
           # retry loop
           RETRY_INTERVAL=3

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -449,6 +449,7 @@ spec:
             NODE_CNI="OpenShiftSDN"
             kubectl label node --overwrite ${K8S_NODE} migration.network.openshift.io/plugin=
           fi
+          export NODE_CNI
 
           RETRY_INTERVAL=3
           MAX_RETRIES=100


### PR DESCRIPTION
By checking the environment varialbe NODE_CNI, the CNI processes can know if it shall run in the live migration mode.