### PR TITLE
OCPBUGS-39189: fix annotation from deployment to pod

### DIFF
--- a/bindata/networking-console-plugin/002-deployment.yaml
+++ b/bindata/networking-console-plugin/002-deployment.yaml
@@ -9,7 +9,6 @@ metadata:
       the contents of the Networking section in OpenShift Console
     release.openshift.io/version: "{{.ReleaseVersion}}"
     networkoperator.openshift.io/non-critical: ""
-    openshift.io/required-scc: restricted-v2
   labels:
     app.kubernetes.io/component: networking-console-plugin
     app.kubernetes.io/managed-by: cluster-network-operator
@@ -33,6 +32,7 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted-v2
       labels:
         app.kubernetes.io/component: networking-console-plugin
         app.kubernetes.io/managed-by: cluster-network-operator


### PR DESCRIPTION
The annotation should not be added to the deployment but should be added to the pod.