### PR TITLE
OCPBUGS-43821: manifests/02-cncc-credentials: Set skipServiceCheck for GCP

### DIFF
--- a/manifests/02-cncc-credentials.yaml
+++ b/manifests/02-cncc-credentials.yaml
@@ -21,6 +21,7 @@ spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: GCPProviderSpec
+    skipServiceCheck: true
     predefinedRoles:
     - roles/compute.admin 
 ---


### PR DESCRIPTION
GCP recently [added new permissions to roles/compute.admin][1]:

> h2. Upcoming IAM changes for the week of 2024-10-21
> ...
> Compute Engine
> The following permissions have been added to the Compute Admin role (roles/compute.admin):
>
> * `backupdr.backupPlanAssociations.create`
> * `backupdr.backupPlanAssociations.createForComputeInstance`
> ...

The network operator doesn't need those permissions, but it confuses the cloud credential operator, resulting in failures issues [like][2]:

```console
level=error msg=Cluster operator cloud-credential Degraded is True with CredentialsFailing: 2 of 7 credentials requests are failing to sync.
level=info msg=Cluster operator cloud-credential Progressing is True with Reconciling: 5 of 7 credentials requests provisioned, 2 reporting errors.
...
level=error msg=Cluster operator machine-api Degraded is True with SyncingFailed: Failed when progressing towards operator: 4.14.0-0.nightly-2024-10-25-153502 because minimum worker replica count (2) not yet met: current running replicas 0, waiting for [ci-op-nsl57y3j-c731f-8rp6f-worker-a-bhp4m ci-op-nsl57y3j-c731f-8rp6f-worker-b-79b5s ci-op-nsl57y3j-c731f-8rp6f-worker-c-xwhp9]
level=error msg=Cluster operator machine-api Available is False with Initializing: Operator is initializing
...
level=error msg=failed to initialize the cluster: Cluster operators authentication, console, control-plane-machine-set, image-registry, ingress, machine-api, monitoring are not available Installer exit with code 6
```

and:

```console
$ oc -n openshift-cloud-credential-operator get -o json credentialsrequests | jq -r '.items[] | .metadata.name as $n | .spec.providerSpec.skipServiceCheck as $s | .status | (.conditions // [])[] | select(.reason == "CredentialsProvisionFailure") | $n + " skipServiceCheck:" + ($s | tostring) + " " + .message'
openshift-cloud-network-config-controller-gcp skipServiceCheck:null failed to grant creds: not all required service APIs are enabled
openshift-machine-api-gcp skipServiceCheck:null failed to grant creds: not all required service APIs are enabled
```

With this commit, I'm telling the credentials operator to not worry about whether we have all the possible permissions `roles/compute.admin` might grant, so cluster administrators don't have to enable `backupdr` and other permissions not needed by the network operator.

4.15 and later have 353e4d66aa (#2069), so they are not exposed to these shifting role definitions.

[1]: https://cloud.google.com/iam/docs/permissions-change-log
[2]: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.14-e2e-gcp-ovn/1849838522425413632