### PR TITLE
OCPBUGS-43740: Pass transit_switch_subnet options in ovnkube-node pod

### DIFF
--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -615,6 +615,15 @@ data:
         ovn_v6_masquerade_subnet_opt="--gateway-v6-masquerade-subnet {{.V6MasqueradeSubnet}}"
       fi
 
+      ovn_v4_transit_switch_subnet_opt=
+      if [[ "{{.V4TransitSwitchSubnet}}" != "" ]]; then
+        ovn_v4_transit_switch_subnet_opt="--cluster-manager-v4-transit-switch-subnet {{.V4TransitSwitchSubnet}}"
+      fi
+      ovn_v6_transit_switch_subnet_opt=
+      if [[ "{{.V6TransitSwitchSubnet}}" != "" ]]; then
+        ovn_v6_transit_switch_subnet_opt="--cluster-manager-v6-transit-switch-subnet {{.V6TransitSwitchSubnet}}"
+      fi
+
       exec /usr/bin/ovnkube \
         --init-ovnkube-controller "${K8S_NODE}" \
         --init-node "${K8S_NODE}" \
@@ -650,5 +659,7 @@ data:
         ${ovn_v4_join_subnet_opt} \
         ${ovn_v6_join_subnet_opt} \
         ${ovn_v4_masquerade_subnet_opt} \
-        ${ovn_v6_masquerade_subnet_opt} 
+        ${ovn_v6_masquerade_subnet_opt} \
+        ${ovn_v4_transit_switch_subnet_opt} \
+        ${ovn_v6_transit_switch_subnet_opt}
     }


### PR DESCRIPTION
In OVN-K, we use function CheckForOverlaps() to check if there is any overlapping among the subnet CIDRs in the configuration. If we don't pass the transit_switch_subnet options, ovnkube will use the default transit_switch_subnet in this check instead of the real one. So we pass this options to in ovnkube-node pod, although it's not actually used there.