### PR TITLE
[release-4.16] OCPBUGS-43803: Start feature migration when the cluster CNI is changed to the target type

### DIFF
--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -540,26 +540,29 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 			return reconcile.Result{}, err
 		}
 
-		migration := operConfig.Spec.Migration
-		if migration.Features == nil || migration.Features.EgressFirewall {
-			err = migrateEgressFirewallCRs(ctx, operConfig, r.client)
-			if err != nil {
-				log.Printf("Could not migrate EgressFirewall CRs: %v", err)
-				return reconcile.Result{}, err
+		// start feature migration when the cluster CNI is changed to the target type
+		if operConfig.Spec.Migration.NetworkType == string(operConfig.Spec.DefaultNetwork.Type) {
+			migration := operConfig.Spec.Migration
+			if migration.Features == nil || migration.Features.EgressFirewall {
+				err = migrateEgressFirewallCRs(ctx, operConfig, r.client)
+				if err != nil {
+					log.Printf("Could not migrate EgressFirewall CRs: %v", err)
+					return reconcile.Result{}, err
+				}
 			}
-		}
-		if migration.Features == nil || migration.Features.Multicast {
-			err = migrateMulticastEnablement(ctx, operConfig, r.client)
-			if err != nil {
-				log.Printf("Could not migrate Multicast settings: %v", err)
-				return reconcile.Result{}, err
+			if migration.Features == nil || migration.Features.Multicast {
+				err = migrateMulticastEnablement(ctx, operConfig, r.client)
+				if err != nil {
+					log.Printf("Could not migrate Multicast settings: %v", err)
+					return reconcile.Result{}, err
+				}
 			}
-		}
-		if migration.Features == nil || migration.Features.EgressIP {
-			err = migrateEgressIpCRs(ctx, operConfig, r.client)
-			if err != nil {
-				log.Printf("Could not migrate EgressIP CRs: %v", err)
-				return reconcile.Result{}, err
+			if migration.Features == nil || migration.Features.EgressIP {
+				err = migrateEgressIpCRs(ctx, operConfig, r.client)
+				if err != nil {
+					log.Printf("Could not migrate EgressIP CRs: %v", err)
+					return reconcile.Result{}, err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The first step in an offline migration is settingspec.migration.networkType, which triggers the cluster to update the MachineConfigPools. It also triggers feature migration, the egress IP previously assigned by the SDN will be released. At this stage, however, OVN-K is not yet deployed; the SDN continues to manage networking, allowing the egress IP functionality to remain operational. Therefore, we postpone the feature migration until after spec.default.type has been
modified. It can help to reduce the downtime for egressIP during SDN migration. The impact for live migration is similar.