### PR TITLE
SDN-5436: Provide support for user owned IPsec machine configs

### DIFF
--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -34,6 +34,7 @@ import (
 	cnofake "github.com/openshift/cluster-network-operator/pkg/client/fake"
 	"github.com/openshift/cluster-network-operator/pkg/hypershift"
 	"github.com/openshift/cluster-network-operator/pkg/names"
+	"github.com/openshift/cluster-network-operator/pkg/platform"
 )
 
 var (
@@ -3206,6 +3207,145 @@ func TestRenderOVNKubernetesDisableIPsec(t *testing.T) {
 	}
 }
 
+func TestRenderOVNKubernetesEnableIPsecWithUserInstalledIPsecMachineConfigs(t *testing.T) {
+	g := NewGomegaWithT(t)
+	config := &operv1.NetworkSpec{
+		ServiceNetwork: []string{"172.30.0.0/16", "fd00:3:2:1::/112"},
+		ClusterNetwork: []operv1.ClusterNetworkEntry{
+			{
+				CIDR:       "10.128.0.0/15",
+				HostPrefix: 23,
+			},
+			{
+				CIDR:       "fd00:1:2:3::/64",
+				HostPrefix: 56,
+			},
+		},
+		DefaultNetwork: operv1.DefaultNetworkDefinition{
+			Type: operv1.NetworkTypeOVNKubernetes,
+			OVNKubernetesConfig: &operv1.OVNKubernetesConfig{
+				GenevePort:  ptrToUint32(8061),
+				IPsecConfig: &operv1.IPsecConfig{Mode: operv1.IPsecModeFull},
+			},
+		},
+	}
+	errs := validateOVNKubernetes(config)
+	if len(errs) > 0 {
+		t.Errorf("Unexpected error: %v", errs)
+	}
+	fillDefaults(config, nil)
+
+	// at the same time we have an upgrade
+	t.Setenv("RELEASE_VERSION", "2.0.0")
+
+	// bootstrap also represents current status
+	// the current cluster is single-stack and has version 1.9.9
+	bootstrapResult := fakeBootstrapResult()
+	bootstrapResult.Infra = bootstrap.InfraStatus{}
+	bootstrapResult.OVN = bootstrap.OVNBootstrapResult{
+		ControlPlaneUpdateStatus: &bootstrap.OVNUpdateStatus{
+			Kind:         "Deployment",
+			Namespace:    "openshift-ovn-kubernetes",
+			Name:         "ovnkube-control-plane",
+			Version:      "1.9.9",
+			IPFamilyMode: names.IPFamilySingleStack,
+		},
+		NodeUpdateStatus: &bootstrap.OVNUpdateStatus{
+			Kind:         "DaemonSet",
+			Namespace:    "openshift-ovn-kubernetes",
+			Name:         "ovnkube-node",
+			Version:      "1.9.9",
+			IPFamilyMode: names.IPFamilySingleStack,
+		},
+		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
+			DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+			DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
+			SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+			MgmtPortResourceName: "",
+			HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
+				Enabled: false,
+			},
+		},
+	}
+
+	featureGatesCNO := getDefaultFeatureGates()
+
+	fakeClient := cnofake.NewFakeClient()
+	bootstrapResult.Infra = bootstrap.InfraStatus{}
+	bootstrapResult.Infra.MasterIPsecMachineConfigs = []*mcfgv1.MachineConfig{{}}
+	bootstrapResult.Infra.MasterIPsecMachineConfigs[0].Name = masterMachineConfigIPsecExtName
+	bootstrapResult.Infra.MasterIPsecMachineConfigs[0].Annotations = platform.UserDefinedIPsecMachineConfigAnnotation
+	bootstrapResult.Infra.WorkerIPsecMachineConfigs = []*mcfgv1.MachineConfig{{}}
+	bootstrapResult.Infra.WorkerIPsecMachineConfigs[0].Name = workerMachineConfigIPsecExtName
+	bootstrapResult.Infra.WorkerIPsecMachineConfigs[0].Annotations = platform.UserDefinedIPsecMachineConfigAnnotation
+
+	// Step 1: Check renderOVNKubernetes behavior when user defined machine configs are in rolling out stage.
+	bootstrapResult.Infra.MasterMCPStatuses = []mcfgv1.MachineConfigPoolStatus{{MachineCount: 1, ReadyMachineCount: 0, UpdatedMachineCount: 0,
+		Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{Source: []v1.ObjectReference{{Name: masterMachineConfigIPsecExtName}}}}}
+	bootstrapResult.Infra.WorkerMCPStatuses = []mcfgv1.MachineConfigPoolStatus{{MachineCount: 1, ReadyMachineCount: 0, UpdatedMachineCount: 0,
+		Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{Source: []v1.ObjectReference{{Name: workerMachineConfigIPsecExtName}}}}}
+	objs, progressing, err := renderOVNKubernetes(config, bootstrapResult, manifestDirOvn, fakeClient, featureGatesCNO)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	g.Expect(progressing).To(BeTrue())
+	// Ensure operator owned IPsec MachineConfigs are not rolled out.
+	renderedMasterIPsecExtension := findInObjs("machineconfiguration.openshift.io", "MachineConfig", masterMachineConfigIPsecExtName, "", objs)
+	if renderedMasterIPsecExtension != nil {
+		t.Errorf("The MachineConfig %s must not exist, but it's available", masterMachineConfigIPsecExtName)
+	}
+	renderedWorkerIPsecExtension := findInObjs("machineconfiguration.openshift.io", "MachineConfig", workerMachineConfigIPsecExtName, "", objs)
+	if renderedWorkerIPsecExtension != nil {
+		t.Errorf("The MachineConfig %s must not exist, but it's available", workerMachineConfigIPsecExtName)
+	}
+	// Ensure ovn-ipsec-host daemonset doesn't exist.
+	renderedIPsec := findInObjs("apps", "DaemonSet", "ovn-ipsec-host", "openshift-ovn-kubernetes", objs)
+	if renderedIPsec != nil {
+		t.Errorf("ovn-ipsec-host DaemonSet must not exist, but it's available")
+	}
+	// Ensure ovnkube-node DaemonSet exists without ipsec-enabled annotation.
+	renderedNode := findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
+	if renderedNode == nil {
+		t.Errorf("ovnkube-node DaemonSet must exist, but it's not available")
+	}
+	if _, ok := renderedNode.GetAnnotations()[names.IPsecEnableAnnotation]; ok {
+		t.Errorf("ovn-ipsec DaemonSet should not have ipsec-enabled annotation, but it does %v", renderedNode)
+	}
+
+	// Step 2: Check renderOVNKubernetes behavior after user defined machine configs rollout is complete.
+	bootstrapResult.Infra.MasterMCPStatuses[0].ReadyMachineCount = 1
+	bootstrapResult.Infra.MasterMCPStatuses[0].UpdatedMachineCount = 1
+	bootstrapResult.Infra.WorkerMCPStatuses[0].ReadyMachineCount = 1
+	bootstrapResult.Infra.WorkerMCPStatuses[0].UpdatedMachineCount = 1
+	objs, progressing, err = renderOVNKubernetes(config, bootstrapResult, manifestDirOvn, fakeClient, featureGatesCNO)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	g.Expect(progressing).To(BeFalse())
+	// Ensure operator owned IPsec MachineConfigs are not rolled out.
+	renderedMasterIPsecExtension = findInObjs("machineconfiguration.openshift.io", "MachineConfig", masterMachineConfigIPsecExtName, "", objs)
+	if renderedMasterIPsecExtension != nil {
+		t.Errorf("The MachineConfig %s must not exist, but it's available", masterMachineConfigIPsecExtName)
+	}
+	renderedWorkerIPsecExtension = findInObjs("machineconfiguration.openshift.io", "MachineConfig", workerMachineConfigIPsecExtName, "", objs)
+	if renderedWorkerIPsecExtension != nil {
+		t.Errorf("The MachineConfig %s must not exist, but it's available", workerMachineConfigIPsecExtName)
+	}
+	// Ensure ovn-ipsec-host daemonset exists.
+	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-host", "openshift-ovn-kubernetes", objs)
+	if renderedIPsec == nil {
+		t.Errorf("ovn-ipsec-host DaemonSet must exist, but it's not available")
+	}
+	// Ensure ovnkube-node DaemonSet exists with ipsec-enabled annotation.
+	renderedNode = findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
+	if renderedNode == nil {
+		t.Errorf("ovnkube-node DaemonSet must exist, but it's not available")
+	}
+	if _, ok := renderedNode.GetAnnotations()[names.IPsecEnableAnnotation]; !ok {
+		t.Errorf("ovn-ipsec DaemonSet should have ipsec-enabled annotation, but it doesn't %v", renderedNode)
+	}
+}
+
 func TestRenderOVNKubernetesDisableIPsecWithUserInstalledIPsecMachineConfigs(t *testing.T) {
 	g := NewGomegaWithT(t)
 	config := &operv1.NetworkSpec{
@@ -3274,8 +3414,10 @@ func TestRenderOVNKubernetesDisableIPsecWithUserInstalledIPsecMachineConfigs(t *
 	bootstrapResult.Infra = bootstrap.InfraStatus{}
 	bootstrapResult.Infra.MasterIPsecMachineConfigs = []*mcfgv1.MachineConfig{{}}
 	bootstrapResult.Infra.MasterIPsecMachineConfigs[0].Name = masterMachineConfigIPsecExtName
+	bootstrapResult.Infra.MasterIPsecMachineConfigs[0].Annotations = platform.UserDefinedIPsecMachineConfigAnnotation
 	bootstrapResult.Infra.WorkerIPsecMachineConfigs = []*mcfgv1.MachineConfig{{}}
 	bootstrapResult.Infra.WorkerIPsecMachineConfigs[0].Name = workerMachineConfigIPsecExtName
+	bootstrapResult.Infra.WorkerIPsecMachineConfigs[0].Annotations = platform.UserDefinedIPsecMachineConfigAnnotation
 	bootstrapResult.Infra.MasterMCPStatuses = []mcfgv1.MachineConfigPoolStatus{{MachineCount: 1, ReadyMachineCount: 1, UpdatedMachineCount: 1,
 		Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{Source: []v1.ObjectReference{{Name: masterMachineConfigIPsecExtName}}}}}
 	bootstrapResult.Infra.WorkerMCPStatuses = []mcfgv1.MachineConfigPoolStatus{{MachineCount: 1, ReadyMachineCount: 1, UpdatedMachineCount: 1,

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -33,6 +33,11 @@ var cloudProviderConfig = types.NamespacedName{
 var (
 	masterRoleMachineConfigLabel = map[string]string{"machineconfiguration.openshift.io/role": "master"}
 	workerRoleMachineConfigLabel = map[string]string{"machineconfiguration.openshift.io/role": "worker"}
+	// When user deploys their own machine config for installing and configuring specific version of libreswan, then
+	// corresponding master and worker role machine configs annotation must have `user-ipsec-machine-config: true`.
+	// When CNO finds machine configs with the annotation, then it skips rendering its own IPsec machine configs
+	// and reuse already deployed user machine configs for the ovn-ipsec-host daemonset.
+	UserDefinedIPsecMachineConfigAnnotation = map[string]string{"user-ipsec-machine-config": "true"}
 )
 
 // isNetworkNodeIdentityEnabled determines if network node identity should be enabled.
@@ -213,7 +218,8 @@ func findIPsecMachineConfigsWithLabel(client cnoclient.Client, mcLabel labels.Se
 	}
 	var ipsecMachineConfigs []*mcfgv1.MachineConfig
 	for i, machineConfig := range machineConfigs.Items {
-		if sets.New(machineConfig.Spec.Extensions...).Has("ipsec") {
+		if sets.New(machineConfig.Spec.Extensions...).Has("ipsec") ||
+			IsUserDefinedIPsecMachineConfig(&machineConfigs.Items[i]) {
 			ipsecMachineConfigs = append(ipsecMachineConfigs, &machineConfigs.Items[i])
 		}
 	}
@@ -274,4 +280,21 @@ func consolePluginCRDExists(cl cnoclient.Client) (bool, error) {
 		}
 	}
 	return true, nil
+}
+
+// IsUserDefinedIPsecMachineConfig return true if machine config's annotation is set with
+// `user-ipsec-machine-config: true`, otherwise returns false.
+func IsUserDefinedIPsecMachineConfig(machineConfig *mcfgv1.MachineConfig) bool {
+	if machineConfig == nil {
+		return false
+	}
+	isSubset := func(mcAnnotations, ipsecAnnotation map[string]string) bool {
+		for ipsecKey, ipsecValue := range ipsecAnnotation {
+			if mcAnnotationValue, ok := mcAnnotations[ipsecKey]; !ok || mcAnnotationValue != ipsecValue {
+				return false
+			}
+		}
+		return true
+	}
+	return isSubset(machineConfig.Annotations, UserDefinedIPsecMachineConfigAnnotation)
 }


### PR DESCRIPTION
There was a regression issue found with libreswan 4.9 which breaks pod-to-pod traffic over ipsec tunnels. The libreswan and its dependent packages are installed by ipsec machine config extension which is rolled out by network operator.   So we must rollback to libreswan 4.5 to fix the problem, but this is not directly possible with ipsec machine config extension.

As an immediate workaround (until it gets fixed properly in next libreswan release), we must skip network operator from rendering its own machine config and allow users to install their own machine config and it can install previous version of libreswan (say 4.5) which is working fine now with OCP. 

This PR adds required changes to allow for user owned ipsec machine configs to be present with a condition that it must have `ipsec-machine-config: true` set on it's annotation and skips rendering operator owned ipsec machine configs to avoid conflict.