### PR TITLE
CNTRLPLANE-341: Issue shorter certificates when ShortRotation featuregate is enabled

### DIFF
--- a/pkg/controller/allowlist/allowlist_controller.go
+++ b/pkg/controller/allowlist/allowlist_controller.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/controller/statusmanager"
 	"github.com/openshift/cluster-network-operator/pkg/names"
 	"github.com/openshift/cluster-network-operator/pkg/render"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -41,7 +42,7 @@ const (
 	allowlistManifestDir = "../../bindata/network/multus/004-sysctl-configmap.yaml"
 )
 
-func Add(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client) error {
+func Add(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client, _ featuregates.FeatureGate) error {
 	return add(mgr, newReconciler(mgr, status, c))
 }
 

--- a/pkg/controller/clusterconfig/clusterconfig_controller.go
+++ b/pkg/controller/clusterconfig/clusterconfig_controller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/controller/statusmanager"
 	"github.com/openshift/cluster-network-operator/pkg/names"
 	"github.com/openshift/cluster-network-operator/pkg/network"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -26,7 +27,7 @@ import (
 )
 
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client) error {
+func Add(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client, _ featuregates.FeatureGate) error {
 	return add(mgr, newReconciler(mgr, status, c))
 }
 

--- a/pkg/controller/configmap_ca_injector/controller.go
+++ b/pkg/controller/configmap_ca_injector/controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/controller/statusmanager"
 	"github.com/openshift/cluster-network-operator/pkg/names"
 	"github.com/openshift/cluster-network-operator/pkg/util/validation"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -34,7 +35,7 @@ import (
 
 var labelSelector = labels.Set{names.TRUSTED_CA_BUNDLE_CONFIGMAP_LABEL: "true"}
 
-func Add(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client) error {
+func Add(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client, _ featuregates.FeatureGate) error {
 	reconciler := newReconciler(mgr, status, c)
 	if reconciler == nil {
 		return fmt.Errorf("failed to create reconciler")

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -3,16 +3,17 @@ package controller
 import (
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 	"github.com/openshift/cluster-network-operator/pkg/controller/statusmanager"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-var AddToManagerFuncs []func(manager.Manager, *statusmanager.StatusManager, cnoclient.Client) error
+var AddToManagerFuncs []func(manager.Manager, *statusmanager.StatusManager, cnoclient.Client, featuregates.FeatureGate) error
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(m manager.Manager, sm *statusmanager.StatusManager, c cnoclient.Client) error {
+func AddToManager(m manager.Manager, sm *statusmanager.StatusManager, c cnoclient.Client, featureGates featuregates.FeatureGate) error {
 	for _, f := range AddToManagerFuncs {
-		if err := f(m, sm, c); err != nil {
+		if err := f(m, sm, c, featureGates); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/dashboards/dashboard_controller.go
+++ b/pkg/controller/dashboards/dashboard_controller.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/controller/statusmanager"
 	"github.com/openshift/cluster-network-operator/pkg/names"
 	"github.com/openshift/cluster-network-operator/pkg/render"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -58,7 +59,7 @@ type dashboardRef struct {
 	tplSuffix string
 }
 
-func Add(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client) error {
+func Add(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client, _ featuregates.FeatureGate) error {
 	return add(mgr, newReconciler(mgr, status, c))
 }
 

--- a/pkg/controller/egress_router/egress_router_controller.go
+++ b/pkg/controller/egress_router/egress_router_controller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/apply"
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 	"github.com/openshift/cluster-network-operator/pkg/render"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/pkg/errors"
 
 	"path/filepath"
@@ -38,7 +39,7 @@ import (
 )
 
 // Attach control loop to the manager and watch for Egress Router objects
-func Add(mgr manager.Manager, status *statusmanager.StatusManager, cli cnoclient.Client) error {
+func Add(mgr manager.Manager, status *statusmanager.StatusManager, cli cnoclient.Client, _ featuregates.FeatureGate) error {
 	r, err := newEgressRouterReconciler(mgr, status, cli)
 	if err != nil {
 		return err

--- a/pkg/controller/infrastructureconfig/infrastructureconfig_controller.go
+++ b/pkg/controller/infrastructureconfig/infrastructureconfig_controller.go
@@ -11,6 +11,7 @@ import (
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 	"github.com/openshift/cluster-network-operator/pkg/controller/statusmanager"
 	"github.com/openshift/cluster-network-operator/pkg/names"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -27,7 +28,7 @@ import (
 const ControllerName = "infrastructureconfig"
 
 // Add attaches our control loop to the manager and watches for infrastructure objects
-func Add(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client) error {
+func Add(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client, _ featuregates.FeatureGate) error {
 	return add(mgr, newReconciler(mgr, status, c))
 }
 

--- a/pkg/controller/ingressconfig/ingressconfig_controller.go
+++ b/pkg/controller/ingressconfig/ingressconfig_controller.go
@@ -9,6 +9,7 @@ import (
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 	"github.com/openshift/cluster-network-operator/pkg/controller/statusmanager"
 	"github.com/openshift/cluster-network-operator/pkg/names"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -35,7 +36,7 @@ var ManifestPath = "./bindata"
 
 // Add creates a new ingressConfig controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, status *statusmanager.StatusManager, _ cnoclient.Client) error {
+func Add(mgr manager.Manager, status *statusmanager.StatusManager, _ cnoclient.Client, _ featuregates.FeatureGate) error {
 
 	return add(mgr, newIngressConfigReconciler(mgr.GetClient(), status))
 }

--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -15,8 +14,6 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	operv1 "github.com/openshift/api/operator/v1"
-	configclient "github.com/openshift/client-go/config/clientset/versioned"
-	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	"github.com/openshift/cluster-network-operator/pkg/apply"
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 	"github.com/openshift/cluster-network-operator/pkg/controller/statusmanager"
@@ -26,7 +23,6 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/util"
 	ipsecMetrics "github.com/openshift/cluster-network-operator/pkg/util/ipsec"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
-	"github.com/openshift/library-go/pkg/operator/events"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -36,11 +32,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	v1coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/clock"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -63,8 +57,8 @@ var ManifestPath = "./bindata"
 
 // Add creates a new OperConfig Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client) error {
-	rc, err := newReconciler(mgr, status, c)
+func Add(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client, featureGates featuregates.FeatureGate) error {
+	rc, err := newReconciler(mgr, status, c, featureGates)
 	if err != nil {
 		return err
 	}
@@ -74,52 +68,7 @@ func Add(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.C
 const ControllerName = "operconfig"
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client) (*ReconcileOperConfig, error) {
-	kubeConfig := c.Default().Config()
-	kubeClient := c.Default().Kubernetes()
-	configClient, err := configclient.NewForConfig(kubeConfig)
-	if err != nil {
-		return nil, err
-	}
-	configInformers := configinformers.NewSharedInformerFactory(configClient, 10*time.Minute)
-	desiredVersion := os.Getenv("RELEASE_VERSION")
-	missingVersion := "0.0.1-snapshot"
-
-	eventRecorder := events.NewKubeRecorder(kubeClient.CoreV1().Events("openshift-network-operator"), "cluster-network-operator", &corev1.ObjectReference{
-		APIVersion: "apps/v1",
-		Kind:       "Deployment",
-		Namespace:  "openshift-network-operator",
-		Name:       "network-operator",
-	}, clock.RealClock{})
-
-	// By default, this will exit(0) the process if the featuregates ever change to a different set of values.
-	featureGateAccessor := featuregates.NewFeatureGateAccess(
-		desiredVersion, missingVersion,
-		configInformers.Config().V1().ClusterVersions(), configInformers.Config().V1().FeatureGates(),
-		eventRecorder,
-	)
-	// TODO: 1) If other controllers in CNO also want to use featureGates then we should move this code to outside
-	// operconfig-controller 2) For now we pass the neverStop channel; FIXME: use c.Default().AddCustomInformer and
-	// change this to pass a proper stop channel and context which are closed and cancelled properly upon exit.
-	go featureGateAccessor.Run(context.TODO())
-	go configInformers.Start(wait.NeverStop)
-	klog.Infof("Waiting for feature gates initialization...")
-	select {
-	case <-featureGateAccessor.InitialFeatureGatesObserved():
-		featureGates, err := featureGateAccessor.CurrentFeatureGates()
-		if err != nil {
-			return nil, err
-		} else {
-			klog.Infof("FeatureGates initialized: knownFeatureGates=%v", featureGates.KnownFeatures())
-		}
-	case <-time.After(1 * time.Minute):
-		return nil, fmt.Errorf("timed out waiting for FeatureGate detection")
-	}
-
-	featureGates, err := featureGateAccessor.CurrentFeatureGates()
-	if err != nil {
-		return nil, err
-	}
+func newReconciler(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client, featureGates featuregates.FeatureGate) (*ReconcileOperConfig, error) {
 	return &ReconcileOperConfig{
 		client:       c,
 		status:       status,

--- a/pkg/controller/proxyconfig/controller.go
+++ b/pkg/controller/proxyconfig/controller.go
@@ -9,6 +9,7 @@ import (
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 	"github.com/openshift/cluster-network-operator/pkg/controller/statusmanager"
 	"github.com/openshift/cluster-network-operator/pkg/names"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -27,7 +28,7 @@ import (
 )
 
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client) error {
+func Add(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client, _ featuregates.FeatureGate) error {
 	reconciler := newReconciler(mgr, status, c)
 	if reconciler == nil {
 		return fmt.Errorf("failed to create reconciler")

--- a/pkg/controller/signer/signer.go
+++ b/pkg/controller/signer/signer.go
@@ -13,11 +13,7 @@ import (
 	"time"
 )
 
-const (
-	oneYear = 365 * 24 * time.Hour
-)
-
-func newCertificateTemplate(certReq *x509.CertificateRequest) *x509.Certificate {
+func newCertificateTemplate(certReq *x509.CertificateRequest, certDuration time.Duration) *x509.Certificate {
 	// Like in openshift/library-go/pkg/crypto/crypto.go, we will generate a random
 	// serial number
 	serialNumber := mathrand.New(mathrand.NewSource(time.Now().UTC().UnixNano())).Int63()
@@ -28,7 +24,7 @@ func newCertificateTemplate(certReq *x509.CertificateRequest) *x509.Certificate 
 		SignatureAlgorithm: x509.SHA512WithRSA,
 
 		NotBefore:    time.Now().Add(-1 * time.Second),
-		NotAfter:     time.Now().Add(5 * oneYear),
+		NotAfter:     time.Now().Add(certDuration),
 		SerialNumber: big.NewInt(serialNumber),
 
 		DNSNames:              certReq.DNSNames,


### PR DESCRIPTION
Implements https://github.com/openshift/enhancements/pull/1670

Short Cert Rotation [job](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-launch-gcp-modern/1928000959246503936)