### PR TITLE
OCPBUGS-44344: The sysctl allowlist daemonset should set requests for memory and cpu

### DIFF
--- a/bindata/allowlist/daemonset/daemonset.yaml
+++ b/bindata/allowlist/daemonset/daemonset.yaml
@@ -22,6 +22,10 @@ spec:
         - name: kube-multus-additional-cni-plugins
           image:  {{.MultusImage}}
           command: ["/bin/bash", "-c", "cp /entrypoint/allowlist.conf /host/etc/cni/tuning/ && touch /ready/ready && sleep INF"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 10Mi
           securityContext:
             privileged: true
           readinessProbe:


### PR DESCRIPTION
Otherwise, sometimes this fails intermittently in CI. Borrowed request amount pattern from other CNI plugin installations.