### PR TITLE
SDN-5472: bindata, ovn-k: Add ClusterUserDefinedNetwork CRD and RBAC

### DIFF
--- a/bindata/network/ovn-kubernetes/common/001-crd.yaml
+++ b/bindata/network/ovn-kubernetes/common/001-crd.yaml
@@ -3491,4 +3491,334 @@ spec:
     storage: true
     subresources:
       status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: clusteruserdefinednetworks.k8s.ovn.org
+spec:
+  group: k8s.ovn.org
+  names:
+    kind: ClusterUserDefinedNetwork
+    listKind: ClusterUserDefinedNetworkList
+    plural: clusteruserdefinednetworks
+    singular: clusteruserdefinednetwork
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ClusterUserDefinedNetwork describe network request for a shared
+            network across namespaces.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterUserDefinedNetworkSpec defines the desired state of
+                ClusterUserDefinedNetwork.
+              properties:
+                namespaceSelector:
+                  description: NamespaceSelector Label selector for which namespace
+                    network should be available for.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                network:
+                  description: Network is the user-defined-network spec
+                  properties:
+                    layer2:
+                      description: Layer2 is the Layer2 topology configuration.
+                      properties:
+                        ipamLifecycle:
+                          description: |-
+                            IPAMLifecycle controls IP addresses management lifecycle.
+                            
+                            The only allowed value is Persistent. When set, OVN Kubernetes assigned IP addresses will be persisted in an
+                            `ipamclaims.k8s.cni.cncf.io` object. These IP addresses will be reused by other pods if requested.
+                            Only supported when "subnets" are set.
+                          enum:
+                            - Persistent
+                          type: string
+                        joinSubnets:
+                          description: |-
+                            JoinSubnets are used inside the OVN network topology.
+                            
+                            Dual-stack clusters may set 2 subnets (one for each IP family), otherwise only 1 subnet is allowed.
+                            This field is only allowed for "Primary" network.
+                            It is not recommended to set this field without explicit need and understanding of the OVN network topology.
+                            When omitted, the platform will choose a reasonable default which is subject to change over time.
+                          items:
+                            type: string
+                          maxItems: 2
+                          minItems: 1
+                          type: array
+                        mtu:
+                          description: |-
+                            MTU is the maximum transmission unit for a network.
+                            MTU is optional, if not provided, the globally configured value in OVN-Kubernetes (defaults to 1400) is used for the network.
+                          format: int32
+                          maximum: 65536
+                          minimum: 0
+                          type: integer
+                        role:
+                          description: |-
+                            Role describes the network role in the pod.
+                            
+                            Allowed value is "Secondary".
+                            Secondary network is only assigned to pods that use `k8s.v1.cni.cncf.io/networks` annotation to select given network.
+                          enum:
+                            - Primary
+                            - Secondary
+                          type: string
+                        subnets:
+                          description: |-
+                            Subnets are used for the pod network across the cluster.
+                            Dual-stack clusters may set 2 subnets (one for each IP family), otherwise only 1 subnet is allowed.
+                            
+                            The format should match standard CIDR notation (for example, "10.128.0.0/16").
+                            This field may be omitted. In that case the logical switch implementing the network only provides layer 2 communication,
+                            and users must configure IP addresses for the pods. As a consequence, Port security only prevents MAC spoofing.
+                          items:
+                            type: string
+                          maxItems: 2
+                          minItems: 1
+                          type: array
+                      required:
+                        - role
+                      type: object
+                      x-kubernetes-validations:
+                        - message: Subnets is required for Primary Layer2 topology
+                          rule: self.role != 'Primary' || has(self.subnets) && size(self.subnets)
+                            > 0
+                        - message: JoinSubnets is only supported for Primary network
+                          rule: '!has(self.joinSubnets) || has(self.role) && self.role
+                        == ''Primary'''
+                        - message: IPAMLifecycle is only supported when subnets are set
+                          rule: '!has(self.ipamLifecycle) || has(self.subnets) && size(self.subnets)
+                        > 0'
+                    layer3:
+                      description: Layer3 is the Layer3 topology configuration.
+                      properties:
+                        joinSubnets:
+                          description: |-
+                            JoinSubnets are used inside the OVN network topology.
+                            
+                            Dual-stack clusters may set 2 subnets (one for each IP family), otherwise only 1 subnet is allowed.
+                            This field is only allowed for "Primary" network.
+                            It is not recommended to set this field without explicit need and understanding of the OVN network topology.
+                            When omitted, the platform will choose a reasonable default which is subject to change over time.
+                          items:
+                            type: string
+                          maxItems: 2
+                          minItems: 1
+                          type: array
+                        mtu:
+                          description: |-
+                            MTU is the maximum transmission unit for a network.
+                            
+                            MTU is optional, if not provided, the globally configured value in OVN-Kubernetes (defaults to 1400) is used for the network.
+                          format: int32
+                          maximum: 65536
+                          minimum: 0
+                          type: integer
+                        role:
+                          description: |-
+                            Role describes the network role in the pod.
+                            
+                            Allowed values are "Primary" and "Secondary".
+                            Primary network is automatically assigned to every pod created in the same namespace.
+                            Secondary network is only assigned to pods that use `k8s.v1.cni.cncf.io/networks` annotation to select given network.
+                          enum:
+                            - Primary
+                            - Secondary
+                          type: string
+                        subnets:
+                          description: |-
+                            Subnets are used for the pod network across the cluster.
+                            
+                            Dual-stack clusters may set 2 subnets (one for each IP family), otherwise only 1 subnet is allowed.
+                            Given subnet is split into smaller subnets for every node.
+                          items:
+                            properties:
+                              cidr:
+                                description: CIDR specifies L3Subnet, which is split
+                                  into smaller subnets for every node.
+                                type: string
+                              hostSubnet:
+                                description: |-
+                                  HostSubnet specifies the subnet size for every node.
+                                  
+                                  When not set, it will be assigned automatically.
+                                format: int32
+                                maximum: 127
+                                minimum: 1
+                                type: integer
+                            required:
+                              - cidr
+                            type: object
+                          maxItems: 2
+                          minItems: 1
+                          type: array
+                      required:
+                        - role
+                        - subnets
+                      type: object
+                      x-kubernetes-validations:
+                        - message: Subnets is required for Layer3 topology
+                          rule: has(self.subnets) && size(self.subnets) > 0
+                        - message: JoinSubnets is only supported for Primary network
+                          rule: '!has(self.joinSubnets) || has(self.role) && self.role
+                        == ''Primary'''
+                    topology:
+                      description: |-
+                        Topology describes network configuration.
+                        
+                        Allowed values are "Layer3", "Layer2".
+                        Layer3 topology creates a layer 2 segment per node, each with a different subnet. Layer 3 routing is used to interconnect node subnets.
+                        Layer2 topology creates one logical switch shared by all nodes.
+                      enum:
+                        - Layer2
+                        - Layer3
+                      type: string
+                  required:
+                    - topology
+                  type: object
+                  x-kubernetes-validations:
+                    - message: Network spec is immutable
+                      rule: self == oldSelf
+              required:
+                - namespaceSelector
+                - network
+              type: object
+            status:
+              description: ClusterUserDefinedNetworkStatus contains the observed status
+                of the ClusterUserDefinedNetwork.
+              properties:
+                conditions:
+                  description: Conditions slice of condition objects indicating details
+                    about ClusterUserDefineNetwork status.
+                  items:
+                    description: Condition contains details for one aspect of the current
+                      state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 {{- end }}

--- a/bindata/network/ovn-kubernetes/common/004-rbac-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/common/004-rbac-control-plane.yaml
@@ -176,6 +176,7 @@ rules:
 - apiGroups: ["k8s.ovn.org"]
   resources:
     - userdefinednetworks
+    - clusteruserdefinednetworks
   verbs:
     - get
     - list
@@ -184,12 +185,15 @@ rules:
   resources:
     - userdefinednetworks
     - userdefinednetworks/status
+    - clusteruserdefinednetworks
+    - clusteruserdefinednetworks/status
   verbs:
     - patch
     - update
 - apiGroups: [ "k8s.ovn.org" ]
   resources:
     - userdefinednetworks/finalizers
+    - clusteruserdefinednetworks/finalizers
   verbs:
     - update
 - apiGroups: [ "k8s.cni.cncf.io" ]
@@ -200,6 +204,13 @@ rules:
     - update
     - create
     - delete
+- apiGroups: [""]
+  resources:
+    - namespaces
+  verbs:
+    - get
+    - list
+    - watch
 {{- end}}
 
 ---

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -138,6 +138,7 @@ func TestRenderOVNKubernetes(t *testing.T) {
 	}
 
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("CustomResourceDefinition", "", "userdefinednetworks.k8s.ovn.org")), "UDN CRD should exist")
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("CustomResourceDefinition", "", "clusteruserdefinednetworks.k8s.ovn.org")), "UDN CRD should exist")
 
 	for _, obj := range objs {
 		if obj.GetKind() == "ClusterRole" && obj.GetName() == "openshift-ovn-kubernetes-control-plane-limited" {
@@ -146,23 +147,39 @@ func TestRenderOVNKubernetes(t *testing.T) {
 			expectedRules := []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{"k8s.ovn.org"},
-					Resources: []string{"userdefinednetworks"},
-					Verbs:     []string{"get", "list", "watch"},
+					Resources: []string{
+						"userdefinednetworks",
+						"clusteruserdefinednetworks",
+					},
+					Verbs: []string{"get", "list", "watch"},
 				},
 				{
 					APIGroups: []string{"k8s.ovn.org"},
-					Resources: []string{"userdefinednetworks", "userdefinednetworks/status"},
-					Verbs:     []string{"patch", "update"},
+					Resources: []string{
+						"userdefinednetworks",
+						"userdefinednetworks/status",
+						"clusteruserdefinednetworks",
+						"clusteruserdefinednetworks/status",
+					},
+					Verbs: []string{"patch", "update"},
 				},
 				{
 					APIGroups: []string{"k8s.ovn.org"},
-					Resources: []string{"userdefinednetworks/finalizers"},
-					Verbs:     []string{"update"},
+					Resources: []string{
+						"userdefinednetworks/finalizers",
+						"clusteruserdefinednetworks/finalizers",
+					},
+					Verbs: []string{"update"},
 				},
 				{
 					APIGroups: []string{"k8s.cni.cncf.io"},
 					Resources: []string{"network-attachment-definitions"},
 					Verbs:     []string{"patch", "update", "create", "delete"},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"namespaces"},
+					Verbs:     []string{"get", "list", "watch"},
 				},
 			}
 			g.Expect(clusterRole.Rules).To(ContainElements(expectedRules))


### PR DESCRIPTION
Add the `ClusterUserDefinedNetwork` CRD definition and the backing controller required RBAC, introduced by https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4612.