### PR TITLE
Add resource requests to allowlist daemonset

### DIFF
--- a/bindata/allowlist/daemonset/daemonset.yaml
+++ b/bindata/allowlist/daemonset/daemonset.yaml
@@ -22,6 +22,10 @@ spec:
         - name: kube-multus-additional-cni-plugins
           image:  {{.MultusImage}}
           command: ["/bin/bash", "-c", "cp /entrypoint/allowlist.conf /host/etc/cni/tuning/ && touch /ready/ready && sleep INF"]
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "50Mi"
           securityContext:
             privileged: true
           readinessProbe:


### PR DESCRIPTION
The pods on openshift namespace require to have resource requests.

https://github.com/openshift/origin/blob/master/test/extended/operators/resources.go#L165