### PR TITLE
ovn-k, cudn: Add missing permissions to ovnkube-node

### DIFF
--- a/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
+++ b/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
@@ -144,6 +144,7 @@ rules:
     - egressservices
 {{- if .OVN_NETWORK_SEGMENTATION_ENABLE }}
     - userdefinednetworks
+    - clusteruserdefinednetworks
 {{- end }}
   verbs:
     - get


### PR DESCRIPTION
Following #2558, add missing permission of OVN-K ovnkube-node role to the CUDN CRD.