### PR TITLE
OCPBUGS-44950: Propagate HCP pods labels to 2nd level operands

### DIFF
--- a/bindata/cloud-network-config-controller/managed/controller.yaml
+++ b/bindata/cloud-network-config-controller/managed/controller.yaml
@@ -34,6 +34,11 @@ spec:
         component: network
         type: infra
         openshift.io/component: network
+      {{ if .HCPLabels }}
+        {{ range $key, $value := .HCPLabels }}
+        "{{$key}}": "{{$value}}"
+        {{ end }}
+      {{ end }}
     spec:
       automountServiceAccountToken: false
       affinity:

--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -46,6 +46,11 @@ spec:
 {{- if .HyperShiftEnabled}}
         hypershift.openshift.io/hosted-control-plane: {{.AdmissionControllerNamespace}}
         hypershift.openshift.io/control-plane: "true"
+      {{ if .HCPLabels }}
+        {{ range $key, $value := .HCPLabels }}
+        "{{$key}}": "{{$value}}"
+        {{ end }}
+      {{ end }}
 {{- end }}
         component: network
         type: infra

--- a/bindata/network/node-identity/managed/node-identity.yaml
+++ b/bindata/network/node-identity/managed/node-identity.yaml
@@ -40,6 +40,11 @@ spec:
         hypershift.openshift.io/hosted-control-plane: {{.HostedClusterNamespace}}
         hypershift.openshift.io/control-plane: "true"
         kubernetes.io/os: "linux"
+      {{ if .HCPLabels }}
+        {{ range $key, $value := .HCPLabels }}
+        "{{$key}}": "{{$value}}"
+        {{ end }}
+      {{ end }}
     spec:
       affinity:
         nodeAffinity:

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
@@ -42,6 +42,11 @@ spec:
         hypershift.openshift.io/control-plane: "true"
         hypershift.openshift.io/hosted-control-plane: {{.HostedClusterNamespace}}
         kubernetes.io/os: "linux"
+      {{ if .HCPLabels }}
+        {{ range $key, $value := .HCPLabels }}
+        "{{$key}}": "{{$value}}"
+        {{ end }}
+      {{ end }}
     spec:
       affinity:
         nodeAffinity:

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -12,6 +12,7 @@ type OVNHyperShiftBootstrapResult struct {
 	ClusterID            string
 	Namespace            string
 	HCPNodeSelector      map[string]string
+	HCPLabels            map[string]string
 	HCPTolerations       []string
 	ControlPlaneReplicas int
 	ReleaseImage         string

--- a/pkg/hypershift/hypershift.go
+++ b/pkg/hypershift/hypershift.go
@@ -58,6 +58,7 @@ type HostedControlPlane struct {
 	ClusterID                    string
 	ControllerAvailabilityPolicy AvailabilityPolicy
 	NodeSelector                 map[string]string
+	Labels                       map[string]string
 	Tolerations                  []string
 	AdvertiseAddress             string
 	AdvertisePort                int
@@ -153,6 +154,11 @@ func ParseHostedControlPlane(hcp *unstructured.Unstructured) (*HostedControlPlan
 	nodeSelector, _, err := unstructured.NestedStringMap(hcp.UnstructuredContent(), "spec", "nodeSelector")
 	if err != nil {
 		return nil, fmt.Errorf("failed extract nodeSelector: %v", err)
+	}
+
+	labels, _, err := unstructured.NestedStringMap(hcp.UnstructuredContent(), "spec", "labels")
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract labels: %v", err)
 	}
 
 	var tolerations []corev1.Toleration
@@ -253,6 +259,7 @@ func ParseHostedControlPlane(hcp *unstructured.Unstructured) (*HostedControlPlan
 		ControllerAvailabilityPolicy: AvailabilityPolicy(controllerAvailabilityPolicy),
 		ClusterID:                    clusterID,
 		NodeSelector:                 nodeSelector,
+		Labels:                       labels,
 		Tolerations:                  tolerationsYaml,
 		AdvertiseAddress:             advertiseAddress,
 		AdvertisePort:                int(advertisePort),

--- a/pkg/network/cloud_network.go
+++ b/pkg/network/cloud_network.go
@@ -95,6 +95,7 @@ func renderCloudNetworkConfigController(conf *operv1.NetworkSpec, bootstrapResul
 		data.Data["HostedClusterNamespace"] = hcpCfg.Namespace
 		data.Data["ReleaseImage"] = hcpCfg.ReleaseImage
 		data.Data["HCPNodeSelector"] = cloudBootstrapResult.HostedControlPlane.NodeSelector
+		data.Data["HCPLabels"] = cloudBootstrapResult.HostedControlPlane.Labels
 		data.Data["HCPTolerations"] = cloudBootstrapResult.HostedControlPlane.Tolerations
 		data.Data["RunAsUser"] = hcpCfg.RunAsUser
 		// In HyperShift CloudNetworkConfigController is deployed as a part of the hosted cluster controlplane

--- a/pkg/network/multus_admission_controller.go
+++ b/pkg/network/multus_admission_controller.go
@@ -113,6 +113,7 @@ func renderMultusAdmissonControllerConfig(manifestDir string, externalControlPla
 		data.Data["ClusterIDLabel"] = hypershift.ClusterIDLabel
 		data.Data["ClusterID"] = bootstrapResult.Infra.HostedControlPlane.ClusterID
 		data.Data["HCPNodeSelector"] = bootstrapResult.Infra.HostedControlPlane.NodeSelector
+		data.Data["HCPLabels"] = bootstrapResult.Infra.HostedControlPlane.Labels
 		data.Data["HCPTolerations"] = bootstrapResult.Infra.HostedControlPlane.Tolerations
 		data.Data["PriorityClass"] = bootstrapResult.Infra.HostedControlPlane.PriorityClass
 

--- a/pkg/network/node_identity.go
+++ b/pkg/network/node_identity.go
@@ -100,6 +100,7 @@ func renderNetworkNodeIdentity(conf *operv1.NetworkSpec, bootstrapResult *bootst
 		data.Data["TokenMinterImage"] = os.Getenv("TOKEN_MINTER_IMAGE")
 		data.Data["TokenAudience"] = os.Getenv("TOKEN_AUDIENCE")
 		data.Data["HCPNodeSelector"] = bootstrapResult.Infra.HostedControlPlane.NodeSelector
+		data.Data["HCPLabels"] = bootstrapResult.Infra.HostedControlPlane.Labels
 		data.Data["HCPTolerations"] = bootstrapResult.Infra.HostedControlPlane.Tolerations
 
 		data.Data["NetworkNodeIdentityImage"] = hcpCfg.ControlPlaneImage // OVN_CONTROL_PLANE_IMAGE

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -231,6 +231,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["ClusterID"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.ClusterID
 	data.Data["ClusterIDLabel"] = hypershift.ClusterIDLabel
 	data.Data["HCPNodeSelector"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.HCPNodeSelector
+	data.Data["HCPLabels"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.HCPLabels
 	data.Data["HCPTolerations"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.HCPTolerations
 	data.Data["OVN_NB_INACTIVITY_PROBE"] = nb_inactivity_probe
 	data.Data["OVN_CERT_CN"] = OVN_CERT_CN
@@ -724,6 +725,7 @@ func bootstrapOVNHyperShiftConfig(hc *hypershift.HyperShiftConfig, kubeClient cn
 
 	ovnHypershiftResult.ClusterID = hcp.ClusterID
 	ovnHypershiftResult.HCPNodeSelector = hcp.NodeSelector
+	ovnHypershiftResult.HCPLabels = hcp.Labels
 	ovnHypershiftResult.HCPTolerations = hcp.Tolerations
 
 	switch hcp.ControllerAvailabilityPolicy {


### PR DESCRIPTION
HCP is adding a new API field to allow users creating HCP clusters to set custom labels on all HCP pods https://github.com/openshift/hypershift/pull/5114. The CNO needs to integrate this feature in the same way it integrated the NodeSelector feature for HCP.