### PR TITLE
[release-4.17] OCPBUGS-44807, SDN-4930, SDN-5297: OVN-Kubernetes node RBAC tightening

### DIFF
--- a/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
+++ b/bindata/network/ovn-kubernetes/common/002-rbac-node.yaml
@@ -141,7 +141,9 @@ rules:
     - egressips
     - egressqoses
     - egressservices
+{{- if .OVN_NETWORK_SEGMENTATION_ENABLE }}
     - userdefinednetworks
+{{- end }}
   verbs:
     - get
     - list


### PR DESCRIPTION
Allow to read userdefinednetworks only when the featuregate is enabled