### PR TITLE
OCPBUGS-40906: Implement IPsec NAT-Traversal encapsulation option

### DIFF
--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -326,8 +326,15 @@ data:
       local ipsec_encapsulation=false
 {{ if .OVNIPsecEnable }}
       ipsec=true
+      # Check for rendered IPsec encapsulation type, if it's set with "Always",
+      # then force NAT-T encapsulation option on the OVN.
+{{ if eq .OVNIPsecEncap "Always" }}
+      ipsec_encapsulation=true
+{{ end }}
       # IBMCloud does not forward ESP (IP proto 50)
       # Instead, force IBMCloud IPsec to always use NAT-T
+      # So for IBMCloud, NAT-T will be set irrespective of whatever
+      # value set in the .OVNIPsecEncap parameter.
       if [ "{{.PlatformType}}" == "IBMCloud" ]; then
         ipsec_encapsulation=true
       fi

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -293,6 +293,10 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["OVNIPsecDaemonsetEnable"] = OVNIPsecDaemonsetEnable
 	data.Data["OVNIPsecEnable"] = OVNIPsecEnable
 	data.Data["IPsecServiceCheckOnHost"] = renderIPsecHostDaemonSet && renderIPsecContainerizedDaemonSet
+	data.Data["OVNIPsecEncap"] = operv1.EncapsulationAuto
+	if OVNIPsecEnable && c.IPsecConfig.Full != nil {
+		data.Data["OVNIPsecEncap"] = c.IPsecConfig.Full.Encapsulation
+	}
 
 	klog.V(5).Infof("IPsec: is MachineConfig enabled: %v, is East-West DaemonSet enabled: %v", data.Data["IPsecMachineConfigEnable"], data.Data["OVNIPsecDaemonsetEnable"])
 


### PR DESCRIPTION
There is a requirement to encapsulate IPsec east west traffic in UDP via NAT-T so that those packets are compatible with intermediate NAT device(s) if present. This PR consumes new API to enable or disable encap option and applies to
OVN to configure east west ipsec tunnel connections accordingly.

API PRs:
https://github.com/openshift/api/pull/1472
https://github.com/openshift/api/pull/2199