### PR TITLE
[release-4.16] OCPBUGS-45593: Pass transit_switch_subnet options in ovnkube-node pod

### DIFF
--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -595,6 +595,15 @@ data:
         ovn_v6_join_subnet_opt="--gateway-v6-join-subnet {{.V6JoinSubnet}}"
       fi
 
+      ovn_v4_transit_switch_subnet_opt=
+      if [[ "{{.V4TransitSwitchSubnet}}" != "" ]]; then
+        ovn_v4_transit_switch_subnet_opt="--cluster-manager-v4-transit-switch-subnet {{.V4TransitSwitchSubnet}}"
+      fi
+      ovn_v6_transit_switch_subnet_opt=
+      if [[ "{{.V6TransitSwitchSubnet}}" != "" ]]; then
+        ovn_v6_transit_switch_subnet_opt="--cluster-manager-v6-transit-switch-subnet {{.V6TransitSwitchSubnet}}"
+      fi
+
       exec /usr/bin/ovnkube \
         --init-ovnkube-controller "${K8S_NODE}" \
         --init-node "${K8S_NODE}" \
@@ -626,5 +635,7 @@ data:
         ${ip_forwarding_flag} \
         ${NETWORK_NODE_IDENTITY_ENABLE} \
         ${ovn_v4_join_subnet_opt} \
-        ${ovn_v6_join_subnet_opt}
+        ${ovn_v6_join_subnet_opt} \
+        ${ovn_v4_transit_switch_subnet_opt} \
+        ${ovn_v6_transit_switch_subnet_opt}
     }


### PR DESCRIPTION
In OVN-K, we use function CheckForOverlaps() to check if there is any overlapping among the subnet CIDRs in the configuration. If we don't pass the transit_switch_subnet options, ovnkube will use the default transit_switch_subnet in this check instead of the real one. So we pass this options to in ovnkube-node pod, although it's not actually used there.

Signed-off-by: Peng Liu <pliu@redhat.com>
(cherry picked from commit 82c53dcfcc990ec449a217c47625bd8dccca8a87)

Conflict: Fixed a merge conflict and it was due to masquerade subnet not being added as a flag to ovnkube running in ovnkube-controller in release-4.16.