### PR TITLE
Revert "OCPBUGS-45341: iptables-alerter daemonset should run everywhere"

### DIFF
--- a/bindata/network/iptables-alerter/003-daemonset.yaml
+++ b/bindata/network/iptables-alerter/003-daemonset.yaml
@@ -35,7 +35,9 @@ spec:
       serviceAccountName: iptables-alerter
       priorityClassName: "openshift-user-critical"
       tolerations:
-      - operator: "Exists"
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
       containers:
       - name: iptables-alerter
         image: {{.CLIImage}}


### PR DESCRIPTION
Reverts openshift/cluster-network-operator#2581

https://github.com/openshift/origin/pull/29357 will allow the alert we're experiencing to fire on managed services until it resolves itself.  Open tolerations in general are a bad idea (even if the platform allows it).  See Dan's comment about the implications of my change https://github.com/openshift/cluster-network-operator/pull/2581#issuecomment-2518035157

The iptables-alerter tolerations is less broken in its original state, so let's return it there.