### PR TITLE
SDN-5225: Mount systemd/private to the ovnkube containers.

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -499,6 +499,10 @@ spec:
           name: ovnkube-config
         - mountPath: /env
           name: env-overrides
+        - mountPath: /run/systemd/private
+          name: run-systemd
+          subPath: private
+          readOnly: true
         resources:
           requests:
             cpu: 10m
@@ -700,5 +704,9 @@ spec:
         configMap:
           name: ovnkube-script-lib
           defaultMode: 0744
+      # for kubelet restarts tracking
+      - name: run-systemd
+        hostPath:
+          path: /run/systemd
       tolerations:
       - operator: "Exists"

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -631,6 +631,10 @@ spec:
           name: ovnkube-config
         - mountPath: /env
           name: env-overrides
+        - mountPath: /run/systemd/private
+          name: run-systemd
+          subPath: private
+          readOnly: true
         resources:
           requests:
             cpu: 10m
@@ -828,5 +832,9 @@ spec:
         configMap:
           name: ovnkube-script-lib
           defaultMode: 0744
+      # for kubelet restarts tracking
+      - name: run-systemd
+        hostPath:
+          path: /run/systemd
       tolerations:
       - operator: "Exists"


### PR DESCRIPTION
It allows listening for systemd events, we use it to track kubelet restarts.
D/s merge part for https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4799/commits/6d091b97aa0d792e9d174d1006c29b9a8d40489f