### PR TITLE
SDN-4952:Add new parameter namespaces-for-inter-network-service-access

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/004-config.yaml
@@ -18,6 +18,7 @@ data:
     lflow-cache-limit-kb=1048576
     enable-udp-aggregation={{.EnableUDPAggregation}}
     udn-allowed-default-services="default/kubernetes,openshift-dns/dns-default"
+    namespaces-for-inter-network-service-access="openshift-ingress"
 
     [kubernetes]
     service-cidrs="{{.OVN_service_cidr}}"
@@ -110,6 +111,7 @@ data:
     enable-lflow-cache=true
     lflow-cache-limit-kb=1048576
     udn-allowed-default-services="default/kubernetes,openshift-dns/dns-default"
+    namespaces-for-inter-network-service-access="openshift-ingress"
 
     [kubernetes]
     service-cidrs="{{.OVN_service_cidr}}"

--- a/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
@@ -18,6 +18,7 @@ data:
     lflow-cache-limit-kb=1048576
     enable-udp-aggregation={{.EnableUDPAggregation}}
     udn-allowed-default-services="default/kubernetes,openshift-dns/dns-default"
+    namespaces-for-inter-network-service-access="openshift-ingress"
 
     [kubernetes]
     service-cidrs="{{.OVN_service_cidr}}"
@@ -34,7 +35,7 @@ data:
     healthz-bind-address="0.0.0.0:10256"
     dns-service-namespace="openshift-dns"
     dns-service-name="dns-default"
- 
+
     [ovnkubernetesfeature]
     enable-egress-ip=true
     enable-egress-firewall=true
@@ -89,10 +90,10 @@ data:
 {{- if .IsSNO }}
 
     [clustermgrha]
-    {{- /* 
-    Even in case of SNO there will be only one ovn-master, we set dedicated values for leader election 
-    durations in SNO, as disabling it can cause issues on scaling out SNO again. 
-    The whole discussion can be found at https://coreos.slack.com/archives/CDCP2LA9L/p1627402405090600. 
+    {{- /*
+    Even in case of SNO there will be only one ovn-master, we set dedicated values for leader election
+    durations in SNO, as disabling it can cause issues on scaling out SNO again.
+    The whole discussion can be found at https://coreos.slack.com/archives/CDCP2LA9L/p1627402405090600.
     Recommended values at https://github.com/openshift/enhancements/blame/84e894ead7b188a1013556e0ba6973b8463995f1/CONVENTIONS.md#L183
     */}}
     election-lease-duration=137

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -280,6 +280,7 @@ enable-lflow-cache=true
 lflow-cache-limit-kb=1048576
 enable-udp-aggregation=true
 udn-allowed-default-services="default/kubernetes,openshift-dns/dns-default"
+namespaces-for-inter-network-service-access="openshift-ingress"
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -322,6 +323,7 @@ enable-lflow-cache=true
 lflow-cache-limit-kb=1048576
 enable-udp-aggregation=true
 udn-allowed-default-services="default/kubernetes,openshift-dns/dns-default"
+namespaces-for-inter-network-service-access="openshift-ingress"
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -378,6 +380,7 @@ enable-lflow-cache=true
 lflow-cache-limit-kb=1048576
 enable-udp-aggregation=true
 udn-allowed-default-services="default/kubernetes,openshift-dns/dns-default"
+namespaces-for-inter-network-service-access="openshift-ingress"
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -437,6 +440,7 @@ enable-lflow-cache=true
 lflow-cache-limit-kb=1048576
 enable-udp-aggregation=true
 udn-allowed-default-services="default/kubernetes,openshift-dns/dns-default"
+namespaces-for-inter-network-service-access="openshift-ingress"
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -496,6 +500,7 @@ enable-lflow-cache=true
 lflow-cache-limit-kb=1048576
 enable-udp-aggregation=true
 udn-allowed-default-services="default/kubernetes,openshift-dns/dns-default"
+namespaces-for-inter-network-service-access="openshift-ingress"
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -554,6 +559,7 @@ enable-lflow-cache=true
 lflow-cache-limit-kb=1048576
 enable-udp-aggregation=true
 udn-allowed-default-services="default/kubernetes,openshift-dns/dns-default"
+namespaces-for-inter-network-service-access="openshift-ingress"
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -602,6 +608,7 @@ enable-lflow-cache=true
 lflow-cache-limit-kb=1048576
 enable-udp-aggregation=true
 udn-allowed-default-services="default/kubernetes,openshift-dns/dns-default"
+namespaces-for-inter-network-service-access="openshift-ingress"
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -652,6 +659,7 @@ enable-lflow-cache=true
 lflow-cache-limit-kb=1048576
 enable-udp-aggregation=false
 udn-allowed-default-services="default/kubernetes,openshift-dns/dns-default"
+namespaces-for-inter-network-service-access="openshift-ingress"
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -695,6 +703,7 @@ enable-lflow-cache=true
 lflow-cache-limit-kb=1048576
 enable-udp-aggregation=true
 udn-allowed-default-services="default/kubernetes,openshift-dns/dns-default"
+namespaces-for-inter-network-service-access="openshift-ingress"
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -738,6 +747,7 @@ enable-lflow-cache=true
 lflow-cache-limit-kb=1048576
 enable-udp-aggregation=true
 udn-allowed-default-services="default/kubernetes,openshift-dns/dns-default"
+namespaces-for-inter-network-service-access="openshift-ingress"
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -785,6 +795,7 @@ enable-lflow-cache=true
 lflow-cache-limit-kb=1048576
 enable-udp-aggregation=true
 udn-allowed-default-services="default/kubernetes,openshift-dns/dns-default"
+namespaces-for-inter-network-service-access="openshift-ingress"
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -829,6 +840,7 @@ enable-lflow-cache=true
 lflow-cache-limit-kb=1048576
 enable-udp-aggregation=true
 udn-allowed-default-services="default/kubernetes,openshift-dns/dns-default"
+namespaces-for-inter-network-service-access="openshift-ingress"
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"
@@ -874,6 +886,7 @@ enable-lflow-cache=true
 lflow-cache-limit-kb=1048576
 enable-udp-aggregation=true
 udn-allowed-default-services="default/kubernetes,openshift-dns/dns-default"
+namespaces-for-inter-network-service-access="openshift-ingress"
 
 [kubernetes]
 service-cidrs="172.30.0.0/16"


### PR DESCRIPTION
New config parameter namespaces-for-inter-network-service-access holds a list of namespaces to which ovn kubernetes will allow access to cluster IP services that are in UDNs.

Depends on an OVNK PR (work in progress)