### PR TITLE
SDN-4168: Cleanup ipsec state only when ipsec is not full mode

### DIFF
--- a/bindata/network/ovn-kubernetes/common/80-ipsec-master-extensions.yaml
+++ b/bindata/network/ovn-kubernetes/common/80-ipsec-master-extensions.yaml
@@ -20,6 +20,7 @@ spec:
 
          [Service]
          Type=oneshot
+         ExecStartPre=rm -f /etc/ipsec.d/cno.conf
          ExecStart=systemctl enable --now ipsec.service
 
          [Install]

--- a/bindata/network/ovn-kubernetes/common/80-ipsec-worker-extensions.yaml
+++ b/bindata/network/ovn-kubernetes/common/80-ipsec-worker-extensions.yaml
@@ -20,6 +20,7 @@ spec:
 
          [Service]
          Type=oneshot
+         ExecStartPre=rm -f /etc/ipsec.d/cno.conf
          ExecStart=systemctl enable --now ipsec.service
 
          [Install]

--- a/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
@@ -407,7 +407,7 @@ spec:
           # When east-west ipsec is not disabled, then do not flush xfrm states and
           # policies in order to maintain traffic flows during container restart.
           ipsecflush() {
-            if [ "$(kubectl get networks.operator.openshift.io cluster -ojsonpath='{.spec.defaultNetwork.ovnKubernetesConfig.ipsecConfig.mode}')" != "Full" ] || \
+            if [ "$(kubectl get networks.operator.openshift.io cluster -ojsonpath='{.spec.defaultNetwork.ovnKubernetesConfig.ipsecConfig.mode}')" != "Full" ] && \
                [ "$(kubectl get networks.operator.openshift.io cluster -ojsonpath='{.spec.defaultNetwork.ovnKubernetesConfig.ipsecConfig}')" != "{}" ]; then
               ip x s flush
               ip x p flush

--- a/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
@@ -239,23 +239,22 @@ spec:
           defaultcpinclude="include \/etc\/crypto-policies\/back-ends\/libreswan.config"
           if ! grep -q "# ${defaultcpinclude}" /etc/ipsec.conf; then
             sed -i "/${defaultcpinclude}/s/^/# /" /etc/ipsec.conf
+            # since pluto is on the host, we need to restart it after changing connection
+            # parameters.
+            chroot /proc/1/root ipsec restart
+
+            counter=0
+            until [ -r /run/pluto/pluto.ctl ]; do
+              counter=$((counter+1))
+              sleep 1
+              if [ $counter -gt 300 ];
+              then
+                echo "ipsec has not started after $counter seconds"
+                exit 1
+              fi
+            done
+            echo "ipsec service is restarted"
           fi
-
-          # since pluto is on the host, we need to restart it after changing connection
-          # parameters.
-          chroot /proc/1/root ipsec restart
-
-          counter=0
-          until [ -r /run/pluto/pluto.ctl ]; do
-            counter=$((counter+1))
-            sleep 1
-            if [ $counter -gt 300 ];
-            then
-              echo "ipsec has not started after $counter seconds"
-              exit 1
-            fi
-          done
-          echo "ipsec service is restarted"
 
           # Workaround for https://github.com/libreswan/libreswan/issues/373
           ulimit -n 1024

--- a/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
@@ -241,20 +241,6 @@ spec:
             sed -i "/${defaultcpinclude}/s/^/# /" /etc/ipsec.conf
           fi
 
-          # Use /etc/ipsec.d/cno.conf file to write our own default IPsec connection parameters.
-          # The /etc/ipsec.d/openshift.conf file can not be used because it is managed by openvswitch.
-          touch /etc/ipsec.d/cno.conf
-          if ! grep -q "narrowing=yes" /etc/ipsec.d/cno.conf; then
-          cat <<EOF > /etc/ipsec.d/cno.conf
-          # Default IPsec connection parameters rendered by network operator.
-          # The narrowing=yes is needed to narrow down the proposals exchanged
-          # by two peers to a mutually acceptable set, otherwise it sometimes
-          # have traffic hit between peer nodes.
-          conn %default
-              narrowing=yes
-          EOF
-          fi
-
           # since pluto is on the host, we need to restart it after changing connection
           # parameters.
           chroot /proc/1/root ipsec restart


### PR DESCRIPTION
This PR does the following to fixes to prevent unnecessary ipsec service restart, ip xfrm state policy cleanups while bringing up ipsec-host pod. This would potentially avoid reestablishment of IKE SAs during ipsec pod restarts and let OVN networking pods traffic go on without any packet drops.

1. There is an incorrect check in ipsec pod clean up logic which removes `/etc/ipsec.d/openshift.conf` file, ip xfrm state and policy entries in all cases, but these must be removed only when ipsec mode is changed from full to external or disabled.
2. We don't need narrowing=yes option to be set explicitly anymore because system default crypto policies are commented out now, otherwise `TS_UNACCEPTABLE` error is seen temporarily at the time of ipsec service restart.
3. The IPsec service restart is needed only at the time of specific IPsec config changes, so doing ipsec service only at the time commenting out default crypto-policies conf file.