### PR TITLE
OCPBUGS-42609: Disable adding/removing the UDN namespace label

### DIFF
--- a/bindata/network/ovn-kubernetes/common/udn-admission-policy.yaml
+++ b/bindata/network/ovn-kubernetes/common/udn-admission-policy.yaml
@@ -1,0 +1,32 @@
+{{if .OVN_NETWORK_SEGMENTATION_ENABLE}}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: user-defined-networks-namespace-label
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups:   [""]
+        apiVersions: ["v1"]
+        operations:  ["UPDATE"]
+        resources:   ["namespaces"]
+  failurePolicy: Fail
+  validations:
+    - expression: "('k8s.ovn.org/primary-user-defined-network' in oldObject.metadata.labels) == ('k8s.ovn.org/primary-user-defined-network' in object.metadata.labels)"
+      message: "The 'k8s.ovn.org/primary-user-defined-network' label cannot be added/removed after the namespace was created"
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: user-defined-networks-namespace-label-binding
+spec:
+  policyName: disable-udn-label-change
+  validationActions: [Deny]
+  matchResources:
+    resourceRules:
+      - apiGroups:   [""]
+        apiVersions: ["v1"]
+        operations:  ["UPDATE"]
+        resources:   ["namespaces"]
+{{end}}

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -3991,6 +3991,19 @@ func Test_renderOVNKubernetes(t *testing.T) {
 			},
 		)
 	}
+	udnFeatureGate := func() featuregates.FeatureGate {
+		return featuregates.NewFeatureGate(
+			[]configv1.FeatureGateName{
+				apifeatures.FeatureGateNetworkSegmentation,
+			},
+			[]configv1.FeatureGateName{
+				apifeatures.FeatureGateAdminNetworkPolicy,
+				apifeatures.FeatureGateDNSNameResolver,
+				apifeatures.FeatureGatePersistentIPsForVirtualization,
+				apifeatures.FeatureGateOVNObservability,
+			},
+		)
+	}
 	type args struct {
 		conf            func() *operv1.NetworkSpec
 		bootstrapResult func() *bootstrap.BootstrapResult
@@ -4029,6 +4042,17 @@ func Test_renderOVNKubernetes(t *testing.T) {
 				featureGates:    noFeatureGates,
 			},
 			expectNumObjs: 38,
+		},
+		{
+			name: "render with UDN",
+			args: args{
+				conf:            fakeNetworkConf,
+				bootstrapResult: fakeBootstrapResultOVN,
+				manifestDir:     manifestDirOvn,
+				client:          cnofake.NewFakeClient(),
+				featureGates:    udnFeatureGate,
+			},
+			expectNumObjs: 41,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
UDN namespace label will be required when namespaces are created in order to use a primary UDN in that namespace.

Upstream PR: https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4912