### PR TITLE
OCPBUGS-48323: Pass transit_switch_subnet options in ovnkube-node pod for single-zone

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/common/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/common/004-config.yaml
@@ -60,6 +60,14 @@ data:
 {{- end }}
 {{- if .OVNHybridOverlayEnable }}
 
+    [clustermanager]
+{{- if .V4TransitSwitchSubnet }}
+    v4-transit-switch-subnet="{{.V4TransitSwitchSubnet}}"
+{{- end }}
+{{- if .V6TransitSwitchSubnet }}
+    v6-transit-switch-subnet="{{.V6TransitSwitchSubnet}}"
+{{- end }}
+
     [hybridoverlay]
     enabled=true
     {{- if .OVNHybridOverlayNetCIDR }}
@@ -143,6 +151,13 @@ data:
     v6-masquerade-subnet="{{.V6InternalMasqueradeSubnet}}"
 {{- end }}
 
+    [clustermanager]
+{{- if .V4TransitSwitchSubnet }}
+    v4-transit-switch-subnet="{{.V4TransitSwitchSubnet}}"
+{{- end }}
+{{- if .V6TransitSwitchSubnet }}
+    v6-transit-switch-subnet="{{.V6TransitSwitchSubnet}}"
+{{- end }}
 
     [logging]
     libovsdblogfile=/var/log/ovnkube/libovsdb.log

--- a/bindata/network/ovn-kubernetes/self-hosted/common/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/common/004-config.yaml
@@ -62,6 +62,14 @@ data:
     v6-masquerade-subnet="{{.V6InternalMasqueradeSubnet}}"
 {{- end }}
 
+    [clustermanager]
+{{- if .V4TransitSwitchSubnet }}
+    v4-transit-switch-subnet="{{.V4TransitSwitchSubnet}}"
+{{- end }}
+{{- if .V6TransitSwitchSubnet }}
+    v6-transit-switch-subnet="{{.V6TransitSwitchSubnet}}"
+{{- end }}
+
     [logging]
     libovsdblogfile=/var/log/ovnkube/libovsdb.log
     logfile-maxsize=100

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -222,6 +222,8 @@ enable-multi-network=true
 mode=shared
 nodeport=true
 
+[clustermanager]
+
 [logging]
 libovsdblogfile=/var/log/ovnkube/libovsdb.log
 logfile-maxsize=100
@@ -262,6 +264,8 @@ enable-multi-network=true
 mode=shared
 nodeport=true
 v4-masquerade-subnet="100.98.0.0/16"
+
+[clustermanager]
 
 [logging]
 libovsdblogfile=/var/log/ovnkube/libovsdb.log
@@ -309,6 +313,8 @@ enable-multi-network=true
 [gateway]
 mode=local
 nodeport=true
+
+[clustermanager]
 
 [logging]
 libovsdblogfile=/var/log/ovnkube/libovsdb.log
@@ -364,6 +370,8 @@ enable-multi-network=true
 [gateway]
 mode=local
 nodeport=true
+
+[clustermanager]
 
 [logging]
 libovsdblogfile=/var/log/ovnkube/libovsdb.log
@@ -422,6 +430,8 @@ enable-multi-network=true
 mode=local
 nodeport=true
 
+[clustermanager]
+
 [logging]
 libovsdblogfile=/var/log/ovnkube/libovsdb.log
 logfile-maxsize=100
@@ -477,6 +487,8 @@ enable-multi-network=true
 [gateway]
 mode=local
 nodeport=true
+
+[clustermanager]
 
 [logging]
 libovsdblogfile=/var/log/ovnkube/libovsdb.log
@@ -534,6 +546,8 @@ enable-multi-network=true
 mode=shared
 nodeport=true
 
+[clustermanager]
+
 [logging]
 libovsdblogfile=/var/log/ovnkube/libovsdb.log
 logfile-maxsize=100
@@ -578,6 +592,8 @@ enable-multi-network=true
 [gateway]
 mode=shared
 nodeport=true
+
+[clustermanager]
 
 [logging]
 libovsdblogfile=/var/log/ovnkube/libovsdb.log
@@ -627,6 +643,8 @@ enable-multi-network=true
 mode=shared
 nodeport=true
 
+[clustermanager]
+
 [logging]
 libovsdblogfile=/var/log/ovnkube/libovsdb.log
 logfile-maxsize=100
@@ -666,6 +684,8 @@ egressip-node-healthcheck-port=9107
 [gateway]
 mode=shared
 nodeport=true
+
+[clustermanager]
 
 [logging]
 libovsdblogfile=/var/log/ovnkube/libovsdb.log
@@ -710,6 +730,8 @@ enable-admin-network-policy=true
 mode=shared
 nodeport=true
 
+[clustermanager]
+
 [logging]
 libovsdblogfile=/var/log/ovnkube/libovsdb.log
 logfile-maxsize=100
@@ -751,6 +773,8 @@ enable-admin-network-policy=true
 [gateway]
 mode=shared
 nodeport=true
+
+[clustermanager]
 
 [logging]
 libovsdblogfile=/var/log/ovnkube/libovsdb.log


### PR DESCRIPTION
The single-zone mode is a phase in the multi-step upgrade process for IC. To ensure the subnet overlapping check uses the customized value, it is necessary to pass the transit_switch_subnet parameter to ovn-k when configuring this mode.