### PR TITLE
[release-4.18] OCPBUGS-48443: ovn-k, rbac: Enable users read & modify UserDefinedNetwork CRs

### DIFF
--- a/bindata/network/ovn-kubernetes/common/007-rbac-cluster-reader.yaml
+++ b/bindata/network/ovn-kubernetes/common/007-rbac-cluster-reader.yaml
@@ -13,7 +13,9 @@ rules:
   - egressqoses
   - egressservices
   - adminpolicybasedexternalroutes
+  {{- if .OVN_NETWORK_SEGMENTATION_ENABLE }}
   - userdefinednetworks
+  {{- end }}
   verbs:
   - get
   - list

--- a/bindata/network/ovn-kubernetes/common/007-rbac-cluster-reader.yaml
+++ b/bindata/network/ovn-kubernetes/common/007-rbac-cluster-reader.yaml
@@ -13,6 +13,7 @@ rules:
   - egressqoses
   - egressservices
   - adminpolicybasedexternalroutes
+  - userdefinednetworks
   verbs:
   - get
   - list

--- a/bindata/network/ovn-kubernetes/common/009-rbac-udn-editor.yaml
+++ b/bindata/network/ovn-kubernetes/common/009-rbac-udn-editor.yaml
@@ -1,0 +1,17 @@
+{{- if .OVN_NETWORK_SEGMENTATION_ENABLE }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openshift-ovn-kubernetes-udn-editor
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["k8s.ovn.org"]
+  resources:
+  - userdefinednetworks
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+{{- end}}

--- a/bindata/network/ovn-kubernetes/common/010-rbac-udn-viewer.yaml
+++ b/bindata/network/ovn-kubernetes/common/010-rbac-udn-viewer.yaml
@@ -1,0 +1,16 @@
+{{- if .OVN_NETWORK_SEGMENTATION_ENABLE }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openshift-ovn-kubernetes-udn-viewer
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
+rules:
+- apiGroups: ["k8s.ovn.org"]
+  resources:
+  - userdefinednetworks
+  verbs:
+  - get
+  - list
+  - watch
+{{- end}}

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -31,6 +32,7 @@ import (
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
+	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 	cnofake "github.com/openshift/cluster-network-operator/pkg/client/fake"
 	"github.com/openshift/cluster-network-operator/pkg/hypershift"
 	"github.com/openshift/cluster-network-operator/pkg/names"
@@ -3952,4 +3954,99 @@ func boolPtr(x bool) *bool {
 func networkOwnerRef() []metav1.OwnerReference {
 	isController := true
 	return []metav1.OwnerReference{{APIVersion: operv1.GroupVersion.String(), Kind: "Network", Controller: &isController, Name: "cluster"}}
+}
+
+func Test_renderOVNKubernetes(t *testing.T) {
+	fakeBootstrapResultOVN := func() *bootstrap.BootstrapResult {
+		bootstrapResult := fakeBootstrapResult()
+		bootstrapResult.OVN = bootstrap.OVNBootstrapResult{
+			ControlPlaneReplicaCount: 3,
+			OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
+				DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+				DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
+				SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+				MgmtPortResourceName: "",
+				HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
+					Enabled: false,
+				},
+			},
+		}
+		return bootstrapResult
+	}
+	fakeNetworkConf := func() *operv1.NetworkSpec {
+		config := OVNKubernetesConfig.DeepCopy()
+		config.Spec.DisableMultiNetwork = boolPtr(false)
+		config.Spec.DefaultNetwork.OVNKubernetesConfig.PolicyAuditConfig = &operv1.PolicyAuditConfig{}
+		return &config.Spec
+	}
+	noFeatureGates := func() featuregates.FeatureGate {
+		return featuregates.NewFeatureGate(
+			[]configv1.FeatureGateName{},
+			[]configv1.FeatureGateName{
+				apifeatures.FeatureGateAdminNetworkPolicy,
+				apifeatures.FeatureGateDNSNameResolver,
+				apifeatures.FeatureGateNetworkSegmentation,
+				apifeatures.FeatureGatePersistentIPsForVirtualization,
+				apifeatures.FeatureGateOVNObservability,
+			},
+		)
+	}
+	udnFeatureGate := func() featuregates.FeatureGate {
+		return featuregates.NewFeatureGate(
+			[]configv1.FeatureGateName{
+				apifeatures.FeatureGateNetworkSegmentation,
+			},
+			[]configv1.FeatureGateName{
+				apifeatures.FeatureGateAdminNetworkPolicy,
+				apifeatures.FeatureGateDNSNameResolver,
+				apifeatures.FeatureGatePersistentIPsForVirtualization,
+				apifeatures.FeatureGateOVNObservability,
+			},
+		)
+	}
+	type args struct {
+		conf            func() *operv1.NetworkSpec
+		bootstrapResult func() *bootstrap.BootstrapResult
+		manifestDir     string
+		client          cnoclient.Client
+		featureGates    func() featuregates.FeatureGate
+	}
+	tests := []struct {
+		name          string
+		args          args
+		expectNumObjs int
+		expectErr     error
+	}{
+		{
+			name: "default",
+			args: args{
+				conf:            fakeNetworkConf,
+				bootstrapResult: fakeBootstrapResultOVN,
+				manifestDir:     manifestDirOvn,
+				client:          cnofake.NewFakeClient(),
+				featureGates:    noFeatureGates,
+			},
+			expectNumObjs: 37,
+		},
+		{
+			name: "render with UDN",
+			args: args{
+				conf:            fakeNetworkConf,
+				bootstrapResult: fakeBootstrapResultOVN,
+				manifestDir:     manifestDirOvn,
+				client:          cnofake.NewFakeClient(),
+				featureGates:    udnFeatureGate,
+			},
+			expectNumObjs: 43,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _, err := renderOVNKubernetes(tt.args.conf(), tt.args.bootstrapResult(), tt.args.manifestDir, tt.args.client, tt.args.featureGates())
+			if !reflect.DeepEqual(tt.expectErr, err) {
+				t.Errorf("renderOVNKubernetes() err = %v, want %v", err, tt.expectErr)
+			}
+			assert.Equalf(t, tt.expectNumObjs, len(got), "renderOVNKubernetes() got %d objects, want %d", len(got), tt.expectNumObjs)
+		})
+	}
 }


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/cluster-network-operator/pull/2619 

The last commit add unit tests from [[1]](https://github.com/openshift/cluster-network-operator/pull/2442), except for the RA unit test because its not reach relase-4.18 branch yet.
Adding the those changes should help preventing cheery-pick conflicts with future PR that depends on those tests.

[1] https://github.com/openshift/cluster-network-operator/pull/2442
