### PR TITLE
SDN-5330: Keep rendering OVN IPsec when its daemonset not available

### DIFF
--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -49,8 +49,13 @@ type OVNUpdateStatus struct {
 // OVNIPsecStatus contains status of current IPsec configuration
 // in the cluster.
 type OVNIPsecStatus struct {
-	LegacyIPsecUpgrade bool // true if IPsec in 4.14 cluster is upgraded to latest version
-	OVNIPsecActive     bool // set to true unless we are sure it is not.
+	// LegacyIPsecUpgrade true if IPsec in 4.14.x cluster is upgraded to 4.15.x version.
+	LegacyIPsecUpgrade bool
+	// IsOVNIPsecActiveOrRollingOut set to true unless we are sure it is not. Note that this is
+	// set to true when ovnkube-node daemonset is in progressing state which is not reflecting
+	// actual ovn ipsec state. so must be precautious in making decisions at the time of machine
+	// configs rollout and node reboot scenarios.
+	IsOVNIPsecActiveOrRollingOut bool
 }
 
 type OVNBootstrapResult struct {

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -49,7 +49,7 @@ type OVNUpdateStatus struct {
 // OVNIPsecStatus contains status of current IPsec configuration
 // in the cluster.
 type OVNIPsecStatus struct {
-	LegacyIPsecUpgrade bool // true if IPsec in 4.14 or Pre-4.14 cluster is upgraded to latest version
+	LegacyIPsecUpgrade bool // true if IPsec in 4.14 cluster is upgraded to latest version
 	OVNIPsecActive     bool // set to true unless we are sure it is not.
 }
 

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -610,9 +610,16 @@ func shouldRenderIPsec(conf *operv1.OVNKubernetesConfig, bootstrapResult *bootst
 
 	isHypershiftHostedCluster := bootstrapResult.Infra.HostedControlPlane != nil
 	isIpsecLegacyUpgrade := bootstrapResult.OVN.IPsecUpdateStatus != nil && bootstrapResult.OVN.IPsecUpdateStatus.LegacyIPsecUpgrade
-	isOVNIPsecActive := bootstrapResult.OVN.IPsecUpdateStatus != nil && bootstrapResult.OVN.IPsecUpdateStatus.OVNIPsecActive
+	isOVNIPsecActiveOrRollingOut := bootstrapResult.OVN.IPsecUpdateStatus != nil && bootstrapResult.OVN.IPsecUpdateStatus.IsOVNIPsecActiveOrRollingOut
+	isCNOIPsecMachineConfigPresent := isCNOIPsecMachineConfigPresent(bootstrapResult.Infra)
+	isUserDefinedIPsecMachineConfigPresent := isUserDefinedIPsecMachineConfigPresent(bootstrapResult.Infra)
+	isMachineConfigClusterOperatorReady := bootstrapResult.Infra.MachineConfigClusterOperatorReady
 
 	mode := GetIPsecMode(conf)
+
+	// when OVN is rolling out, OVN IPsec might be fully or partially active or inactive.
+	// If MachineConfigs are not present, we know its inactive since we only stop rendering them once inactive.
+	isOVNIPsecActive := isOVNIPsecActiveOrRollingOut && (isCNOIPsecMachineConfigPresent || isUserDefinedIPsecMachineConfigPresent || isHypershiftHostedCluster)
 
 	// We render the ipsec deployment if IPsec is already active in OVN
 	// or if EW IPsec config is enabled.
@@ -623,9 +630,6 @@ func shouldRenderIPsec(conf *operv1.OVNKubernetesConfig, bootstrapResult *bootst
 	// - not needed for the containerized deployment is used in hypershift
 	// hosted clusters
 	// - not needed if the user already created their own
-	isMachineConfigClusterOperatorReady := bootstrapResult.Infra.MachineConfigClusterOperatorReady
-	isCNOIPsecMachineConfigPresent := isCNOIPsecMachineConfigPresent(bootstrapResult.Infra)
-	isUserDefinedIPsecMachineConfigPresent := isUserDefinedIPsecMachineConfigPresent(bootstrapResult.Infra)
 	renderCNOIPsecMachineConfig = (mode != operv1.IPsecModeDisabled || renderIPsecDaemonSet) && !isHypershiftHostedCluster &&
 		!isUserDefinedIPsecMachineConfigPresent
 	// Wait for MCO to be ready unless we had already rendered the IPsec MachineConfig.
@@ -650,7 +654,7 @@ func shouldRenderIPsec(conf *operv1.OVNKubernetesConfig, bootstrapResult *bootst
 	// the 4.14 to 4.15 legacy IPsec upgrade as noted above.
 	renderIPsecContainerizedDaemonSet = (renderIPsecDaemonSet && isHypershiftHostedCluster) || isIPsecMachineConfigNotActiveOnLegacyUpgrade
 
-	// We render OVN IPsec if EW IPsec is enabled not before the daemon sets are
+	// We render OVN IPsec if EW IPsec is enabled and before the daemon sets are
 	// rendered. If it is already rendered, keep it rendered unless disabled.
 	renderIPsecOVN = (renderIPsecHostDaemonSet || renderIPsecContainerizedDaemonSet || isOVNIPsecActive) && mode == operv1.IPsecModeFull
 
@@ -1169,7 +1173,7 @@ func bootstrapOVN(conf *operv1.Network, kubeClient cnoclient.Client, infraStatus
 		nodeStatus.Progressing = daemonSetProgressing(nodeDaemonSet, true)
 		// Retrieve OVN IPsec status from ovnkube-node daemonset as this is being used to rollout IPsec
 		// config from 4.14.
-		ovnIPsecStatus.OVNIPsecActive = !isOVNIPsecNotActiveInDaemonSet(nodeDaemonSet)
+		ovnIPsecStatus.IsOVNIPsecActiveOrRollingOut = !isOVNIPsecNotActiveInDaemonSet(nodeDaemonSet)
 		klog.Infof("ovnkube-node DaemonSet status: progressing=%t", nodeStatus.Progressing)
 
 	}
@@ -1228,9 +1232,6 @@ func bootstrapOVN(conf *operv1.Network, kubeClient cnoclient.Client, infraStatus
 	if ipsecContainerizedDaemonSet != nil && ipsecHostDaemonSet != nil {
 		// Both IPsec daemonset versions exist, so this is an upgrade from 4.14.
 		ovnIPsecStatus.LegacyIPsecUpgrade = true
-	} else if ipsecContainerizedDaemonSet == nil && ipsecHostDaemonSet == nil {
-		// set OVN IPsec status to nil since none of the IPsec daemonset(s) exists in the cluster.
-		ovnIPsecStatus = nil
 	}
 
 	res := bootstrap.OVNBootstrapResult{

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -523,25 +523,6 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 			anno[names.CreateWaitAnnotation] = "true"
 			o.SetAnnotations(anno)
 		})
-		// The legacy ovn-ipsec deployment is only rendered during upgrades until we
-		// are ready to remove it.
-		ovnIPsecLegacyDS := &appsv1.DaemonSet{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "DaemonSet",
-				APIVersion: appsv1.SchemeGroupVersion.String(),
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "ovn-ipsec",
-				Namespace: util.OVN_NAMESPACE,
-				// We never update the legacy ovn-ipsec daemonset.
-				Annotations: map[string]string{names.CreateWaitAnnotation: "true"},
-			},
-		}
-		obj, err := k8s.ToUnstructured(ovnIPsecLegacyDS)
-		if err != nil {
-			return nil, progressing, fmt.Errorf("unable to render legacy ovn-ipsec daemonset: %w", err)
-		}
-		objs = append(objs, obj)
 	}
 
 	klog.Infof("ovnk components: ovnkube-node: isRunning=%t, update=%t; ovnkube-control-plane: isRunning=%t, update=%t",
@@ -1214,77 +1195,49 @@ func bootstrapOVN(conf *operv1.Network, kubeClient cnoclient.Client, infraStatus
 		prepullerStatus.Progressing = daemonSetProgressing(prePullerDaemonSet, true)
 	}
 
-	ipsecDaemonSet := &appsv1.DaemonSet{
+	ipsecContainerizedDaemonSet := &appsv1.DaemonSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DaemonSet",
 			APIVersion: appsv1.SchemeGroupVersion.String(),
 		},
 	}
-
-	ipsecStatus := &bootstrap.OVNIPsecStatus{}
-
-	// The IPsec daemonset name is ovn-ipsec if we are upgrading from <= 4.13.
-	nsn = types.NamespacedName{Namespace: util.OVN_NAMESPACE, Name: "ovn-ipsec"}
-	if err := kubeClient.ClientFor("").CRClient().Get(context.TODO(), nsn, ipsecDaemonSet); err != nil {
+	ipsecHostDaemonSet := &appsv1.DaemonSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DaemonSet",
+			APIVersion: appsv1.SchemeGroupVersion.String(),
+		},
+	}
+	// Retrieve container based IPsec daemonset with name ovn-ipsec-containerized.
+	nsn = types.NamespacedName{Namespace: util.OVN_NAMESPACE, Name: "ovn-ipsec-containerized"}
+	if err := kubeClient.ClientFor("").CRClient().Get(context.TODO(), nsn, ipsecContainerizedDaemonSet); err != nil {
 		if !apierrors.IsNotFound(err) {
-			return nil, fmt.Errorf("Failed to retrieve existing pre-4.14 ipsec DaemonSet: %w", err)
+			return nil, fmt.Errorf("Failed to retrieve existing ipsec containerized DaemonSet: %w", err)
 		} else {
-			ipsecStatus = nil
-		}
-	} else {
-		ipsecStatus.LegacyIPsecUpgrade = true
-	}
-
-	if ipsecStatus == nil {
-		ipsecStatus = &bootstrap.OVNIPsecStatus{}
-		ipsecContainerizedDaemonSet := &appsv1.DaemonSet{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "DaemonSet",
-				APIVersion: appsv1.SchemeGroupVersion.String(),
-			},
-		}
-		ipsecHostDaemonSet := &appsv1.DaemonSet{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "DaemonSet",
-				APIVersion: appsv1.SchemeGroupVersion.String(),
-			},
-		}
-		// Retrieve container based IPsec daemonset with name ovn-ipsec-containerized.
-		nsn = types.NamespacedName{Namespace: util.OVN_NAMESPACE, Name: "ovn-ipsec-containerized"}
-		if err := kubeClient.ClientFor("").CRClient().Get(context.TODO(), nsn, ipsecContainerizedDaemonSet); err != nil {
-			if !apierrors.IsNotFound(err) {
-				return nil, fmt.Errorf("Failed to retrieve existing ipsec containerized DaemonSet: %w", err)
-			} else {
-				ipsecContainerizedDaemonSet = nil
-			}
-		}
-		// Retrieve host based IPsec daemonset with name ovn-ipsec-host
-		nsn = types.NamespacedName{Namespace: util.OVN_NAMESPACE, Name: "ovn-ipsec-host"}
-		if err := kubeClient.ClientFor("").CRClient().Get(context.TODO(), nsn, ipsecHostDaemonSet); err != nil {
-			if !apierrors.IsNotFound(err) {
-				return nil, fmt.Errorf("Failed to retrieve existing ipsec host DaemonSet: %w", err)
-			} else {
-				ipsecHostDaemonSet = nil
-			}
-		}
-		if ipsecContainerizedDaemonSet != nil && ipsecHostDaemonSet != nil {
-			// Both IPsec daemonset versions exist, so this is an upgrade from 4.14.
-			ipsecStatus.LegacyIPsecUpgrade = true
-		} else if ipsecContainerizedDaemonSet == nil && ipsecHostDaemonSet == nil {
-			ipsecStatus = nil
+			ipsecContainerizedDaemonSet = nil
 		}
 	}
-
-	// set OVN IPsec status into ipsecStatus only when IPsec daemonset(s) exists in the cluster.
-	if ipsecStatus != nil {
-		ipsecStatus.OVNIPsecActive = ovnIPsecStatus.OVNIPsecActive
+	// Retrieve host based IPsec daemonset with name ovn-ipsec-host
+	nsn = types.NamespacedName{Namespace: util.OVN_NAMESPACE, Name: "ovn-ipsec-host"}
+	if err := kubeClient.ClientFor("").CRClient().Get(context.TODO(), nsn, ipsecHostDaemonSet); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("Failed to retrieve existing ipsec host DaemonSet: %w", err)
+		} else {
+			ipsecHostDaemonSet = nil
+		}
+	}
+	if ipsecContainerizedDaemonSet != nil && ipsecHostDaemonSet != nil {
+		// Both IPsec daemonset versions exist, so this is an upgrade from 4.14.
+		ovnIPsecStatus.LegacyIPsecUpgrade = true
+	} else if ipsecContainerizedDaemonSet == nil && ipsecHostDaemonSet == nil {
+		// set OVN IPsec status to nil since none of the IPsec daemonset(s) exists in the cluster.
+		ovnIPsecStatus = nil
 	}
 
 	res := bootstrap.OVNBootstrapResult{
 		ControlPlaneReplicaCount: controlPlaneReplicaCount,
 		ControlPlaneUpdateStatus: controlPlaneStatus,
 		NodeUpdateStatus:         nodeStatus,
-		IPsecUpdateStatus:        ipsecStatus,
+		IPsecUpdateStatus:        ovnIPsecStatus,
 		PrePullerUpdateStatus:    prepullerStatus,
 		OVNKubernetesConfig:      ovnConfigResult,
 		FlowsConfig:              bootstrapFlowsConfig(kubeClient.ClientFor("").CRClient()),

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -2724,8 +2724,8 @@ func TestRenderOVNKubernetesIPsecUpgradeWithMachineConfig(t *testing.T) {
 			IPFamilyMode: names.IPFamilySingleStack,
 		},
 		IPsecUpdateStatus: &bootstrap.OVNIPsecStatus{
-			LegacyIPsecUpgrade: true,
-			OVNIPsecActive:     true,
+			LegacyIPsecUpgrade:           true,
+			IsOVNIPsecActiveOrRollingOut: true,
 		},
 		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
 			DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
@@ -2839,8 +2839,8 @@ func TestRenderOVNKubernetesIPsecUpgradeWithNoMachineConfig(t *testing.T) {
 			IPFamilyMode: names.IPFamilySingleStack,
 		},
 		IPsecUpdateStatus: &bootstrap.OVNIPsecStatus{
-			LegacyIPsecUpgrade: true,
-			OVNIPsecActive:     true,
+			LegacyIPsecUpgrade:           true,
+			IsOVNIPsecActiveOrRollingOut: true,
 		},
 		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
 			DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
@@ -2990,8 +2990,8 @@ func TestRenderOVNKubernetesIPsecUpgradeWithHypershiftHostedCluster(t *testing.T
 			IPFamilyMode: names.IPFamilySingleStack,
 		},
 		IPsecUpdateStatus: &bootstrap.OVNIPsecStatus{
-			LegacyIPsecUpgrade: true,
-			OVNIPsecActive:     true,
+			LegacyIPsecUpgrade:           true,
+			IsOVNIPsecActiveOrRollingOut: true,
 		},
 		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
 			DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
@@ -3096,7 +3096,7 @@ func TestRenderOVNKubernetesDisableIPsec(t *testing.T) {
 			Progressing:  false,
 		},
 		IPsecUpdateStatus: &bootstrap.OVNIPsecStatus{
-			OVNIPsecActive: true,
+			IsOVNIPsecActiveOrRollingOut: true,
 		},
 		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
 			DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
@@ -3155,11 +3155,71 @@ func TestRenderOVNKubernetesDisableIPsec(t *testing.T) {
 	}
 
 	// Ensure renderOVNKubernetes removes MachineConfigs and IPsec daemonset.
-	bootstrapResult.OVN.IPsecUpdateStatus.OVNIPsecActive = false
+	bootstrapResult.OVN.IPsecUpdateStatus.IsOVNIPsecActiveOrRollingOut = false
 	objs, progressing, err = renderOVNKubernetes(config, bootstrapResult, manifestDirOvn, fakeClient, featureGatesCNO)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
+	g.Expect(progressing).To(BeFalse())
+	renderedMasterIPsecExtension = findInObjs("machineconfiguration.openshift.io", "MachineConfig", masterMachineConfigIPsecExtName, "", objs)
+	if renderedMasterIPsecExtension != nil {
+		t.Errorf("The MachineConfig %s must not exist, but it's available", masterMachineConfigIPsecExtName)
+	}
+	renderedWorkerIPsecExtension = findInObjs("machineconfiguration.openshift.io", "MachineConfig", workerMachineConfigIPsecExtName, "", objs)
+	if renderedWorkerIPsecExtension != nil {
+		t.Errorf("The MachineConfig %s must not exist, but it's available", workerMachineConfigIPsecExtName)
+	}
+	// Ensure ovn-ipsec-host daemonset is removed and ovnkube-node doesn't contain ipsec-enabled annotation.
+	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-host", "openshift-ovn-kubernetes", objs)
+	if renderedIPsec != nil {
+		t.Errorf("ovn-ipsec-host DaemonSet must not exist, but it's available")
+	}
+	renderedNode = findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
+	if renderedNode == nil {
+		t.Errorf("ovnkube-node DaemonSet must exist, but it's not available")
+	}
+	if _, ok := renderedNode.GetAnnotations()[names.IPsecEnableAnnotation]; ok {
+		t.Errorf("ovnkube-node DaemonSet shouldn't have ipsec-enabled annotation, but it does")
+	}
+
+	// While IPsec machine configs removal in progress, ensure MachineConfigs and IPsec daemonset are not rendered.
+	bootstrapResult.OVN.IPsecUpdateStatus.IsOVNIPsecActiveOrRollingOut = true
+	bootstrapResult.Infra.MasterMCPStatuses = []mcfgv1.MachineConfigPoolStatus{{MachineCount: 1, ReadyMachineCount: 0, UpdatedMachineCount: 0,
+		Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{}}}
+	bootstrapResult.Infra.WorkerMCPStatuses = []mcfgv1.MachineConfigPoolStatus{{MachineCount: 1, ReadyMachineCount: 1, UpdatedMachineCount: 1,
+		Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{}}}
+	bootstrapResult.Infra.MasterIPsecMachineConfigs = []*mcfgv1.MachineConfig{{}}
+	bootstrapResult.Infra.WorkerIPsecMachineConfigs = []*mcfgv1.MachineConfig{{}}
+	objs, progressing, err = renderOVNKubernetes(config, bootstrapResult, manifestDirOvn, fakeClient, featureGatesCNO)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	g.Expect(progressing).To(BeFalse())
+	renderedMasterIPsecExtension = findInObjs("machineconfiguration.openshift.io", "MachineConfig", masterMachineConfigIPsecExtName, "", objs)
+	if renderedMasterIPsecExtension != nil {
+		t.Errorf("The MachineConfig %s must not exist, but it's available", masterMachineConfigIPsecExtName)
+	}
+	renderedWorkerIPsecExtension = findInObjs("machineconfiguration.openshift.io", "MachineConfig", workerMachineConfigIPsecExtName, "", objs)
+	if renderedWorkerIPsecExtension != nil {
+		t.Errorf("The MachineConfig %s must not exist, but it's available", workerMachineConfigIPsecExtName)
+	}
+	// Ensure ovn-ipsec-host daemonset is removed and ovnkube-node doesn't contain ipsec-enabled annotation.
+	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-host", "openshift-ovn-kubernetes", objs)
+	if renderedIPsec != nil {
+		t.Errorf("ovn-ipsec-host DaemonSet must not exist, but it's available")
+	}
+	renderedNode = findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
+	if renderedNode == nil {
+		t.Errorf("ovnkube-node DaemonSet must exist, but it's not available")
+	}
+	if _, ok := renderedNode.GetAnnotations()[names.IPsecEnableAnnotation]; ok {
+		t.Errorf("ovnkube-node DaemonSet shouldn't have ipsec-enabled annotation, but it does")
+	}
+
+	// Ensure MachineConfigs and IPsec daemonset are not rendered once machine config pools settles.
+	bootstrapResult.OVN.IPsecUpdateStatus.IsOVNIPsecActiveOrRollingOut = false
+	bootstrapResult.Infra.MasterMCPStatuses = []mcfgv1.MachineConfigPoolStatus{{MachineCount: 1, ReadyMachineCount: 1, UpdatedMachineCount: 1,
+		Configuration: mcfgv1.MachineConfigPoolStatusConfiguration{}}}
 	g.Expect(progressing).To(BeFalse())
 	renderedMasterIPsecExtension = findInObjs("machineconfiguration.openshift.io", "MachineConfig", masterMachineConfigIPsecExtName, "", objs)
 	if renderedMasterIPsecExtension != nil {
@@ -3372,7 +3432,7 @@ func TestRenderOVNKubernetesDisableIPsecWithUserInstalledIPsecMachineConfigs(t *
 			Progressing:  false,
 		},
 		IPsecUpdateStatus: &bootstrap.OVNIPsecStatus{
-			OVNIPsecActive: true,
+			IsOVNIPsecActiveOrRollingOut: true,
 		},
 		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
 			DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
@@ -3430,7 +3490,7 @@ func TestRenderOVNKubernetesDisableIPsecWithUserInstalledIPsecMachineConfigs(t *
 	}
 
 	// Ensure renderOVNKubernetes removes IPsec daemonset.
-	bootstrapResult.OVN.IPsecUpdateStatus.OVNIPsecActive = false
+	bootstrapResult.OVN.IPsecUpdateStatus.IsOVNIPsecActiveOrRollingOut = false
 	objs, progressing, err = renderOVNKubernetes(config, bootstrapResult, manifestDirOvn, fakeClient, featureGatesCNO)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -2445,10 +2445,6 @@ func TestRenderOVNKubernetesEnableIPsec(t *testing.T) {
 	if renderedIPsec != nil {
 		t.Errorf("ovn-ipsec-containerized DaemonSet must not exist, but it's available")
 	}
-	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec", "openshift-ovn-kubernetes", objs)
-	if renderedIPsec != nil {
-		t.Errorf("ovn-ipsec DaemonSet must not exist, but it's available")
-	}
 	renderedMasterIPsecExtension := findInObjs("machineconfiguration.openshift.io", "MachineConfig", masterMachineConfigIPsecExtName, "", objs)
 	if renderedMasterIPsecExtension != nil {
 		t.Errorf("The MachineConfig %s must not exist, but it's available", masterMachineConfigIPsecExtName)
@@ -2472,10 +2468,6 @@ func TestRenderOVNKubernetesEnableIPsec(t *testing.T) {
 	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-containerized", "openshift-ovn-kubernetes", objs)
 	if renderedIPsec != nil {
 		t.Errorf("ovn-ipsec-containerized DaemonSet must not exist, but it's available")
-	}
-	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec", "openshift-ovn-kubernetes", objs)
-	if renderedIPsec != nil {
-		t.Errorf("ovn-ipsec DaemonSet must not exist, but it's available")
 	}
 	renderedMasterIPsecExtension = findInObjs("machineconfiguration.openshift.io", "MachineConfig", masterMachineConfigIPsecExtName, "", objs)
 	if renderedMasterIPsecExtension == nil {
@@ -2505,10 +2497,6 @@ func TestRenderOVNKubernetesEnableIPsec(t *testing.T) {
 	if renderedIPsec != nil {
 		t.Errorf("ovn-ipsec-containerized DaemonSet must not exist, but it's available")
 	}
-	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec", "openshift-ovn-kubernetes", objs)
-	if renderedIPsec != nil {
-		t.Errorf("ovn-ipsec DaemonSet must not exist, but it's available")
-	}
 	renderedMasterIPsecExtension = findInObjs("machineconfiguration.openshift.io", "MachineConfig", masterMachineConfigIPsecExtName, "", objs)
 	if renderedMasterIPsecExtension == nil {
 		t.Errorf("The MachineConfig %s must exist, but it's not available", masterMachineConfigIPsecExtName)
@@ -2536,10 +2524,6 @@ func TestRenderOVNKubernetesEnableIPsec(t *testing.T) {
 	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-containerized", "openshift-ovn-kubernetes", objs)
 	if renderedIPsec != nil {
 		t.Errorf("ovn-ipsec-containerized DaemonSet must not exist, but it's available")
-	}
-	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec", "openshift-ovn-kubernetes", objs)
-	if renderedIPsec != nil {
-		t.Errorf("ovn-ipsec DaemonSet must not exist, but it's available")
 	}
 	renderedMasterIPsecExtension = findInObjs("machineconfiguration.openshift.io", "MachineConfig", masterMachineConfigIPsecExtName, "", objs)
 	if renderedMasterIPsecExtension == nil {
@@ -2580,10 +2564,6 @@ func TestRenderOVNKubernetesEnableIPsec(t *testing.T) {
 	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-containerized", "openshift-ovn-kubernetes", objs)
 	if renderedIPsec != nil {
 		t.Errorf("ovn-ipsec-containerized DaemonSet must not exist, but it's available")
-	}
-	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec", "openshift-ovn-kubernetes", objs)
-	if renderedIPsec != nil {
-		t.Errorf("ovn-ipsec DaemonSet must not exist, but it's available")
 	}
 	renderedNode := findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
 	if renderedNode == nil {
@@ -2675,10 +2655,6 @@ func TestRenderOVNKubernetesEnableIPsecForHostedControlPlane(t *testing.T) {
 	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-host", "openshift-ovn-kubernetes", objs)
 	if renderedIPsec != nil {
 		t.Errorf("ovn-ipsec-host DaemonSet must not exist, but it's available")
-	}
-	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec", "openshift-ovn-kubernetes", objs)
-	if renderedIPsec != nil {
-		t.Errorf("ovn-ipsec DaemonSet must not exist, but it's available")
 	}
 	renderedNode := findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
 	if renderedNode == nil {
@@ -2802,10 +2778,6 @@ func TestRenderOVNKubernetesIPsecUpgradeWithMachineConfig(t *testing.T) {
 	if renderedIPsec != nil {
 		t.Errorf("ovn-ipsec-containerized DaemonSet must not exist, but it's available")
 	}
-	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec", "openshift-ovn-kubernetes", objs)
-	if renderedIPsec != nil {
-		t.Errorf("ovn-ipsec DaemonSet must not exist, but it's available")
-	}
 	renderedNode := findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
 	if renderedNode == nil {
 		t.Errorf("ovnkube-node DaemonSet must exist, but it's not available")
@@ -2913,13 +2885,6 @@ func TestRenderOVNKubernetesIPsecUpgradeWithNoMachineConfig(t *testing.T) {
 	if _, ok := renderedIPsec.GetAnnotations()[names.CreateWaitAnnotation]; !ok {
 		t.Errorf("ovn-ipsec-containerized DaemonSet should have create-wait annotation, does not")
 	}
-	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec", "openshift-ovn-kubernetes", objs)
-	if renderedIPsec == nil {
-		t.Errorf("ovn-ipsec DaemonSet must exist, but it's not available")
-	}
-	if _, ok := renderedIPsec.GetAnnotations()[names.CreateWaitAnnotation]; !ok {
-		t.Errorf("ovn-ipsec DaemonSet should have create-wait annotation, does not")
-	}
 	// The ovnkube-node must set with ipsec-enabled annotation.
 	renderedNode := findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
 	if renderedNode == nil {
@@ -2965,10 +2930,6 @@ func TestRenderOVNKubernetesIPsecUpgradeWithNoMachineConfig(t *testing.T) {
 	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-containerized", "openshift-ovn-kubernetes", objs)
 	if renderedIPsec != nil {
 		t.Errorf("ovn-ipsec-containerized DaemonSet must not exist, but it's available")
-	}
-	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec", "openshift-ovn-kubernetes", objs)
-	if renderedIPsec != nil {
-		t.Errorf("ovn-ipsec DaemonSet must not exist, but it's available")
 	}
 	renderedNode = findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
 	if renderedNode == nil {
@@ -3075,10 +3036,6 @@ func TestRenderOVNKubernetesIPsecUpgradeWithHypershiftHostedCluster(t *testing.T
 	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec-host", "openshift-ovn-kubernetes", objs)
 	if renderedIPsec != nil {
 		t.Errorf("ovn-ipsec-host DaemonSet must not exist, but it's available")
-	}
-	renderedIPsec = findInObjs("apps", "DaemonSet", "ovn-ipsec", "openshift-ovn-kubernetes", objs)
-	if renderedIPsec != nil {
-		t.Errorf("ovn-ipsec DaemonSet must not exist, but it's available")
 	}
 	renderedNode := findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
 	if renderedNode == nil {


### PR DESCRIPTION
The commit https://github.com/openshift/cluster-network-operator/commit/4e57dcd195992dd6d19b2d1a731d6673c9ee2e4b is not complete because `OVNIPsecStatus` is still not set when none of the IPsec daemonset exists on the cluster at the time of machine config pools are updating
(or) node is rebooted. Hence fixing it by `OVNIPsecStatus` is always set to reflect ipsec deployment state of the cluster
and update the render pipeline to render ovn ipsec for the above mentioned scenarios.

It renders ovn ipsec even before ipsec daemonsets are deployed when IPsec is freshly enabled on the cluster. That's ok	because It will be effective only when the `ovs-monitor-ipsec `script is started and that's going to be done only when the ipsec pod is running. so we are safe to ignore it now.

When IPsec is disabled from API, ovn ipsec is disabled followed by stop	rendering ipsec machine config and ipsec daemonset. While ipsec machine configs are removed which	would make `ovnkube-node` daemonset into progressing state and `OVNIPsecActive` condition becomes true again. Hence this pr considers machine config
status as well so that the rendering pipeline will not render IPsec machine configs again.

It also removes dead code related to IPsec 4.13 upgrade which is no longer valid for upgrade scenarios beyond >= 4.15. This change is intended to be backported until 4.15 so still keeping legacy upgrade scenarios.