### PR TITLE
OVN-K, CUDN CRD: Block namespace-selector with zero-rules

### DIFF
--- a/bindata/network/ovn-kubernetes/common/001-crd.yaml
+++ b/bindata/network/ovn-kubernetes/common/001-crd.yaml
@@ -3600,6 +3600,10 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: namespace selector must have at least one rule
+                  rule: has(self.matchLabels) && self.matchLabels.size() > 0 || has(self.matchExpressions)
+                    && self.matchExpressions.size() > 0
               network:
                 description: Network is the user-defined-network spec
                 properties:


### PR DESCRIPTION
This PR brings CUDN CRD bits from https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4963

