### PR TITLE
OCPBUGS-49744: OVN-K, CUDN CRD: Block namespace-selector with zero-rules

### DIFF
--- a/bindata/network/ovn-kubernetes/common/001-crd.yaml
+++ b/bindata/network/ovn-kubernetes/common/001-crd.yaml
@@ -3604,6 +3604,10 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: namespace selector must have at least one rule
+                  rule: has(self.matchLabels) && self.matchLabels.size() > 0 || has(self.matchExpressions)
+                    && self.matchExpressions.size() > 0
               network:
                 description: Network is the user-defined-network spec
                 properties:


### PR DESCRIPTION
Update CUDN CRD according to [1]: add API validation to prevent CUDN CR selection all namespaces in the cluster.

[1] https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4963