### PR TITLE
OCPBUGS-49670: OVNK should be able to annotate network ID on NADs

### DIFF
--- a/bindata/network/ovn-kubernetes/common/004-rbac-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/common/004-rbac-control-plane.yaml
@@ -144,6 +144,12 @@ rules:
   - network-attachment-definitions
   - multi-networkpolicies
   verbs: ["list", "get", "watch"]
+- apiGroups:
+  - k8s.cni.cncf.io
+  resources:
+  - network-attachment-definitions
+  verbs:
+  - patch
 {{- if .OVN_PERSISTENT_IPS_ENABLE }}
 - apiGroups:
     - k8s.cni.cncf.io
@@ -200,7 +206,6 @@ rules:
   resources:
     - network-attachment-definitions
   verbs:
-    - patch
     - update
     - create
     - delete

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -177,7 +177,12 @@ func TestRenderOVNKubernetes(t *testing.T) {
 				{
 					APIGroups: []string{"k8s.cni.cncf.io"},
 					Resources: []string{"network-attachment-definitions"},
-					Verbs:     []string{"patch", "update", "create", "delete"},
+					Verbs:     []string{"patch"},
+				},
+				{
+					APIGroups: []string{"k8s.cni.cncf.io"},
+					Resources: []string{"network-attachment-definitions"},
+					Verbs:     []string{"update", "create", "delete"},
 				},
 				{
 					APIGroups: []string{""},


### PR DESCRIPTION
Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>
(cherry picked from commit ce522688ae00349fc0aa438de4d99835ed80f6c8)