### PR TITLE
OCPBUGS-49621:Fix UDN and CUDN hostSubnet validation

### DIFF
--- a/bindata/network/ovn-kubernetes/common/001-crd.yaml
+++ b/bindata/network/ovn-kubernetes/common/001-crd.yaml
@@ -3396,7 +3396,7 @@ spec:
                           > cidr(self.cidr).prefixLength()'
                       - message: HostSubnet must < 32 for ipv4 CIDR
                         rule: '!has(self.hostSubnet) || !isCIDR(self.cidr) || (cidr(self.cidr).ip().family()
-                          == 4 && self.hostSubnet < 32)'
+                          != 4 || self.hostSubnet < 32)'
                     maxItems: 2
                     minItems: 1
                     type: array
@@ -3807,7 +3807,7 @@ spec:
                               self.hostSubnet > cidr(self.cidr).prefixLength()'
                           - message: HostSubnet must < 32 for ipv4 CIDR
                             rule: '!has(self.hostSubnet) || !isCIDR(self.cidr) ||
-                              (cidr(self.cidr).ip().family() == 4 && self.hostSubnet
+                              (cidr(self.cidr).ip().family() != 4 || self.hostSubnet
                               < 32)'
                         maxItems: 2
                         minItems: 1


### PR DESCRIPTION
In the previous validation rule, valid IPv6 subnets would mistakenly invalidate the CustomResource.

Reflecting the changes happening upstream in https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5018