### PR TITLE
OCPBUGS-49662: Prevent resetting masquerade subnet

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
@@ -171,6 +171,15 @@ spec:
             ovn_v6_transit_switch_subnet_opt="--cluster-manager-v6-transit-switch-subnet {{.V6TransitSwitchSubnet}}"
           fi
 
+          ovn_v4_masquerade_subnet_opt=
+          if [[ "{{.V4MasqueradeSubnet}}" != "" ]]; then
+            ovn_v4_masquerade_subnet_opt="--gateway-v4-masquerade-subnet {{.V4MasqueradeSubnet}}"
+          fi
+          ovn_v6_masquerade_subnet_opt=
+          if [[ "{{.V6MasqueradeSubnet}}" != "" ]]; then
+            ovn_v6_masquerade_subnet_opt="--gateway-v6-masquerade-subnet {{.V6MasqueradeSubnet}}"
+          fi
+
           dns_name_resolver_enabled_flag=
           if [[ "{{.DNS_NAME_RESOLVER_ENABLE}}" == "true" ]]; then
             dns_name_resolver_enabled_flag="--enable-dns-name-resolver"
@@ -211,6 +220,8 @@ spec:
             ${ovn_v6_join_subnet_opt} \
             ${ovn_v4_transit_switch_subnet_opt} \
             ${ovn_v6_transit_switch_subnet_opt} \
+            ${ovn_v4_masquerade_subnet_opt} \
+            ${ovn_v6_masquerade_subnet_opt} \
             ${dns_name_resolver_enabled_flag} \
             ${persistent_ips_enabled_flag} \
             ${multi_network_enabled_flag} \

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
@@ -124,6 +124,15 @@ spec:
             ovn_v6_transit_switch_subnet_opt="--cluster-manager-v6-transit-switch-subnet {{.V6TransitSwitchSubnet}}"
           fi
 
+          ovn_v4_masquerade_subnet_opt=
+          if [[ "{{.V4MasqueradeSubnet}}" != "" ]]; then
+            ovn_v4_masquerade_subnet_opt="--gateway-v4-masquerade-subnet {{.V4MasqueradeSubnet}}"
+          fi
+          ovn_v6_masquerade_subnet_opt=
+          if [[ "{{.V6MasqueradeSubnet}}" != "" ]]; then
+            ovn_v6_masquerade_subnet_opt="--gateway-v6-masquerade-subnet {{.V6MasqueradeSubnet}}"
+          fi
+
           dns_name_resolver_enabled_flag=
           if [[ "{{.DNS_NAME_RESOLVER_ENABLE}}" == "true" ]]; then
             dns_name_resolver_enabled_flag="--enable-dns-name-resolver"
@@ -161,6 +170,8 @@ spec:
             ${ovn_v6_join_subnet_opt} \
             ${ovn_v4_transit_switch_subnet_opt} \
             ${ovn_v6_transit_switch_subnet_opt} \
+            ${ovn_v4_masquerade_subnet_opt} \
+            ${ovn_v6_masquerade_subnet_opt} \
             ${dns_name_resolver_enabled_flag} \
             ${persistent_ips_enabled_flag} \
             ${multi_network_enabled_flag} \

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -1306,7 +1306,7 @@ func bootstrapOVN(conf *operv1.Network, kubeClient cnoclient.Client, infraStatus
 	}
 
 	// set the default masquerade CIDR for new clusters while ignoring upgrades
-	if res.ControlPlaneUpdateStatus == nil && res.NodeUpdateStatus == nil {
+	if res.ControlPlaneUpdateStatus == nil || res.NodeUpdateStatus == nil {
 		klog.Infof("Configuring the default masquerade subnets to %q and %q", defaultV4MasqueradeSubnet, defaultV6MasqueradeSubnet)
 		res.DefaultV4MasqueradeSubnet = defaultV4MasqueradeSubnet
 		res.DefaultV6MasqueradeSubnet = defaultV6MasqueradeSubnet


### PR DESCRIPTION
Prevent resetting masquerade subnet to default value(169.254.169.0/29)
set at upstream ovn-kubernetes when ovnkube-node daemonset is removed
from the cluster.
This PR have an additional commit to update masquerade subnet to
ovnkube-control-plane deployment. This is required as masquerade
subnet is currently configurable at day 2.