### PR TITLE
CNTRLPLANE-112: Update managed Azure HCP cloud network config

### DIFF
--- a/bindata/cloud-network-config-controller/managed/controller.yaml
+++ b/bindata/cloud-network-config-controller/managed/controller.yaml
@@ -188,13 +188,15 @@ spec:
         - name: "NO_PROXY"
           value: "{{ .NO_PROXY}}"
 {{ end }}
-{{- if not (eq .AzureManagedClientID "")}}
+{{- if not (eq .AzureManagedSecretProviderClass "")}}
         - name: "ARO_HCP_MI_CLIENT_ID"
           value: "{{ .AzureManagedClientID }}"
         - name: "ARO_HCP_TENANT_ID"
           value: "{{ .AzureManagedTenantID }}"
         - name: "ARO_HCP_CLIENT_CERTIFICATE_PATH"
           value: "{{ .AzureManagedCertPath}}"
+        - name: "ARO_HCP_CLIENT_CREDENTIALS_PATH"
+          value: "{{ .AzureManagedCredsPath}}"
 {{ end }}
         resources:
           requests:
@@ -214,7 +216,7 @@ spec:
         - name: cloud-token
           mountPath: /var/run/secrets/openshift/serviceaccount
           readOnly: true
-{{- if not (eq .AzureManagedClientID "")}}
+{{- if not (eq .AzureManagedSecretProviderClass "")}}
         - name: cncc-cert
           mountPath: {{.AzureManagedCertDirectory}}
           readOnly: true
@@ -260,7 +262,7 @@ spec:
       - name: kube-cloud-config
         configMap:
           name: cloud-network-config-controller-kube-cloud-config
-{{- if not (eq .AzureManagedClientID "")}}
+{{- if not (eq .AzureManagedSecretProviderClass "")}}
       - name: cncc-cert
         csi:
           driver: secrets-store.csi.k8s.io

--- a/pkg/network/cloud_network.go
+++ b/pkg/network/cloud_network.go
@@ -109,6 +109,7 @@ func renderCloudNetworkConfigController(conf *operv1.NetworkSpec, bootstrapResul
 		data.Data["AzureManagedTenantID"] = os.Getenv("ARO_HCP_TENANT_ID")
 		data.Data["AzureManagedCertDirectory"] = azureCertPath
 		data.Data["AzureManagedCertPath"] = filepath.Join(azureCertPath, os.Getenv("ARO_HCP_CLIENT_CERTIFICATE_NAME"))
+		data.Data["AzureManagedCredsPath"] = filepath.Join(azureCertPath, os.Getenv("MANAGED_AZURE_HCP_CREDENTIALS_FILE_PATH"))
 		data.Data["AzureManagedSecretProviderClass"] = os.Getenv("ARO_HCP_SECRET_PROVIDER_CLASS")
 		caOverride.ObjectMeta = metav1.ObjectMeta{
 			Namespace:   hcpCfg.Namespace,


### PR DESCRIPTION
This PR updates the parameters needed for authentication with Azure on managed Azure HCP for the new managed Azure HCP authentication type, UserAssignedIdentityCredentials.

See [Persisting MSI Credentials](https://docs.google.com/document/d/1tX2avo8ORyjqL4GJNwxq-wQTM3-LC7zBTP5V9EgwU74/edit?tab=t.0#heading=h.12bfa2iapy8v) for more info.