### PR TITLE
NP-1100: Enable fast ranges

### DIFF
--- a/bindata/network/multus/002-rbac.yaml
+++ b/bindata/network/multus/002-rbac.yaml
@@ -230,26 +230,32 @@ kind: ClusterRole
 metadata:
   name: whereabouts-cni
 rules:
-- apiGroups:
-  - whereabouts.cni.cncf.io
+- apiGroups: ["whereabouts.cni.cncf.io"]
   resources:
-  - ippools
-  - overlappingrangeipreservations
-  - nodesliceippools
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
+  - "nodeslicepools"
+  - "nodeslicepools/status"
+  - "nodeslicepools/finalizers"
+  - "ippools"
+  - "overlappingrangeipreservations"
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: [""]
   resources:
   - pods
-  verbs:
-  - list
-
+  - nodes
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["k8s.cni.cncf.io"]
+  resources:
+  - "network-attachment-definitions"
+  - "network-attachment-definitions/finalizers"
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["", "events.k8s.io"]
+  resources:
+  - events
+  verbs: ["create", "patch", "update"]
+- apiGroups: ["coordination.k8s.io"]
+  resources:
+  - leases
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -106,6 +106,24 @@ data:
     fi
     rm -Rf $UPGRADE_DIRECTORY
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: whereabouts-config
+  namespace: openshift-multus
+data:
+  whereabouts.conf: |
+    {
+      "datastore": "kubernetes",
+      "kubernetes": {
+        "kubeconfig": "/etc/kubernetes/cni/net.d/whereabouts.d/whereabouts.kubeconfig"
+      },
+      "reconciler_cron_expression": "30 4 * * *",
+      "log_level": "debug",
+      "log_file": "/tmp/whereabouts.log",
+      "configuration_path": "/etc/kubernetes/cni/net.d/whereabouts.d"
+    }
+---
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -156,8 +174,7 @@ data:
           "enabled": true,
           "bootstrapKubeconfig": "{{ .KubeletKubeconfigPath }}",
           "certDir": "/etc/cni/multus/certs",
-          "certDuration": "24h"
-        },
+          "certDuration"nodeName
 {{ end }}
         "cniConfigDir": "/host/etc/cni/net.d",
         "multusConfigFile": "auto",
@@ -558,6 +575,10 @@ spec:
             WHEREABOUTS_KUBECONFIG=$CNI_CONF_DIR/whereabouts.d/whereabouts.kubeconfig
             WHEREABOUTS_GLOBALCONFIG=$CNI_CONF_DIR/whereabouts.d/whereabouts.conf
 
+            # Write the nodename to the whereabouts.d directory for standardized hostname reference across cloud providers
+            
+            echo $NODENAME > $CNI_CONF_DIR/whereabouts.d/nodename
+
             # ------------------------------- Generate a "kube-config"
             SERVICE_ACCOUNT_PATH=/var/run/secrets/kubernetes.io/serviceaccount
             KUBE_CA_FILE=${KUBE_CA_FILE:-$SERVICE_ACCOUNT_PATH/ca.crt}
@@ -609,17 +630,8 @@ spec:
             current-context: whereabouts-context
             EOF
 
-            # Kubeconfig file for Whereabouts CNI plugin.
-            cat > $WHEREABOUTS_GLOBALCONFIG <<EOF
-            {
-              "datastore": "kubernetes",
-              "kubernetes": {
-                "kubeconfig": "/etc/kubernetes/cni/net.d/whereabouts.d/whereabouts.kubeconfig"
-              },
-              "reconciler_cron_expression": "30 4 * * *",
-              "log_level": "debug"
-            }
-            EOF
+            # Copy the config from ConfigMap to the desired directory
+            cp /etc/whereabouts/config/whereabouts.conf $WHEREABOUTS_GLOBALCONFIG
             chmod 600 $WHEREABOUTS_GLOBALCONFIG
 
             else
@@ -650,7 +662,14 @@ spec:
           name: cnibin
         - name: system-cni-dir
           mountPath: /host/etc/cni/net.d
+        - name: whereabouts-configmap
+          mountPath: /etc/whereabouts/config
         env:
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
         - name: KUBERNETES_SERVICE_PORT
           value: "{{.KUBERNETES_SERVICE_PORT}}"
         - name: KUBERNETES_SERVICE_HOST
@@ -704,7 +723,10 @@ spec:
           configMap:
             name: {{.CniSysctlAllowlist}}
             defaultMode: 0744
-{{if .RenderIpReconciler}}
+        - name: whereabouts-configmap
+          configMap:
+            name: whereabouts-config
+{{if .RenderWhereaboutsAuxillary}}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -783,4 +805,74 @@ spec:
             items:
             - key: reconciler_cron_expression
               path: config
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: whereabouts-controller
+  namespace: openshift-multus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: whereabouts-controller
+  template:
+    metadata:
+      labels:
+        app: whereabouts-controller
+    spec:
+      containers:
+        - command:
+            - /usr/src/whereabouts/bin/node-slice-controller
+          env:
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: WHEREABOUTS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+          image: {{.WhereaboutsImage}}
+          name: whereabouts
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cnibin
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+            - name: whereabouts-configmap
+              mountPath: /host/etc/cni/net.d/whereabouts.d/whereabouts.conf
+              subPath: whereabouts.conf
+      preemptionPolicy: PreemptLowerPriority
+      priorityClassName: "system-node-critical"
+      securityContext: {}
+      serviceAccountName: multus-ancillary-tools
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - hostPath:
+            path: {{ .CNIBinDir }}
+            type: Directory          
+          name: cnibin
+        - hostPath:
+            path: {{ .SystemCNIConfDir }}
+            type: Directory          
+          name: cni-net-dir
+        - name: whereabouts-configmap
+          configMap:
+            name: whereabouts-config
+            items:
+            - key: whereabouts.conf
+              path: whereabouts.conf
 {{- end}}
+---

--- a/pkg/network/multus.go
+++ b/pkg/network/multus.go
@@ -1,6 +1,10 @@
 package network
 
 import (
+	"os"
+	"path/filepath"
+	"strconv"
+
 	configv1 "github.com/openshift/api/config/v1"
 	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
@@ -8,9 +12,6 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/render"
 	"github.com/pkg/errors"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"os"
-	"path/filepath"
-	"strconv"
 )
 
 const (
@@ -81,7 +82,7 @@ func renderMultusConfig(manifestDir, defaultNetworkType string, useDHCP bool, us
 		data.Data["KUBERNETES_SERVICE_PORT"] = apiport
 	}
 	data.Data["RenderDHCP"] = useDHCP
-	data.Data["RenderIpReconciler"] = useWhereabouts
+	data.Data["RenderWhereaboutsAuxillary"] = useWhereabouts
 	data.Data["MultusCNIConfDir"] = MultusCNIConfDir
 	data.Data["SystemCNIConfDir"] = SystemCNIConfDir
 	data.Data["DefaultNetworkType"] = defaultNetworkType

--- a/pkg/network/multus_test.go
+++ b/pkg/network/multus_test.go
@@ -46,7 +46,7 @@ func TestRenderMultus(t *testing.T) {
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "multus")))
 
 	// It's important that the namespace is first
-	g.Expect(len(objs)).To(Equal(31), "Expected 31 multus related objects") //this seems like not a great test imo
+	g.Expect(len(objs)).To(Equal(32), "Expected 32 multus related objects")
 	g.Expect(objs[0]).To(HaveKubernetesID("CustomResourceDefinition", "", "network-attachment-definitions.k8s.cni.cncf.io"))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("Namespace", "", "openshift-multus")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ServiceAccount", "openshift-multus", "multus-ancillary-tools")))

--- a/pkg/network/network_metrics_test.go
+++ b/pkg/network/network_metrics_test.go
@@ -46,7 +46,7 @@ func TestRenderNetworkMetricsDaemon(t *testing.T) {
 
 	// Check rendered object
 
-	g.Expect(len(objs)).To(Equal(31), "Expected 31 multus related objects")
+	g.Expect(len(objs)).To(Equal(32), "Expected 32 multus related objects")
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "network-metrics-daemon")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("Service", "openshift-multus", "network-metrics-service")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "metrics-daemon-role")))


### PR DESCRIPTION
cc @dougbtv 

Add whereabouts controller and necessary RBAC to enable fast ranges in openshift

Currently pointing to personal image, but when dockerfile change merges in o/wherabouts i will correct the image ref and remove the hold