### PR TITLE
[Release 4.16] OCPBUGS-50712: Not update status.migration of the network.config CR to empty

### DIFF
--- a/pkg/controller/clusterconfig/migration.go
+++ b/pkg/controller/clusterconfig/migration.go
@@ -103,7 +103,7 @@ func (r *ReconcileClusterConfig) prepareOperatorConfigForNetworkTypeMigration(ct
 		return nil
 	}
 
-	if !cniReady && clusterConfig.Status.Migration == nil {
+	if !cniReady && (clusterConfig.Status.Migration == nil || clusterConfig.Status.Migration.NetworkType == "") {
 		klog.Infof("step-1: deploy target CNI: %s", clusterConfig.Spec.NetworkType)
 		operConfig.Spec.Migration = &operv1.NetworkMigration{
 			Mode:        operv1.LiveNetworkMigrationMode,

--- a/pkg/network/cluster_config.go
+++ b/pkg/network/cluster_config.go
@@ -359,13 +359,16 @@ func StatusFromOperatorConfig(operConf *operv1.NetworkSpec, oldStatus *configv1.
 			status.Migration = &configv1.NetworkMigration{
 				NetworkType: string(operConf.DefaultNetwork.Type),
 			}
-		} else {
+		} else if operConf.Migration.NetworkType != "" {
 			status.Migration = &configv1.NetworkMigration{
 				NetworkType: operConf.Migration.NetworkType,
 			}
 		}
 
 		if operConf.Migration.MTU != nil {
+			if status.Migration == nil {
+				status.Migration = &configv1.NetworkMigration{}
+			}
 			status.Migration.MTU = &configv1.MTUMigration{
 				Network: (*configv1.MTUMigrationValues)(operConf.Migration.MTU.Network),
 				Machine: (*configv1.MTUMigrationValues)(operConf.Migration.MTU.Machine),


### PR DESCRIPTION
If spec.migration.features of the network.operator CR, CNO will update the status.migration of the network.config CR to an empty value '{}'. It prevents CNO from proceeding with live migration. This shall be fixed in CNO.

Only update status.migration.network of the network.config CR when the spec.migration.network of network.operator CR is set.