### PR TITLE
NO-JIRA: Add "centos" to supported OS ids

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -42,7 +42,7 @@ data:
         RHEL_VERSION=$(echo "${CPE_NAME}" | cut -f 5 -d :)
         rhelmajor=$(echo $RHEL_VERSION | sed -E 's/([0-9]+)\.{1}[0-9]+(\.[0-9]+)?/\1/')
       ;;
-      rhel) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)
+      rhel|centos) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)
       ;;
       fedora)
         if [ "${VARIANT_ID}" == "coreos" ]; then

--- a/bindata/network/openshift-sdn/sdn.yaml
+++ b/bindata/network/openshift-sdn/sdn.yaml
@@ -187,7 +187,7 @@ spec:
               RHEL_VERSION=$(echo "${CPE_NAME}" | cut -f 5 -d :)
               rhelmajor=$(echo $RHEL_VERSION | sed -E 's/([0-9]+)\.{1}[0-9]+(\.[0-9]+)?/\1/')
             ;;
-            rhel) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)
+            rhel|centos) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)
             ;;
             fedora)
               if [ "${VARIANT_ID}" == "coreos" ]; then

--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -439,7 +439,7 @@ data:
           RHEL_VERSION=$(echo "${CPE_NAME}" | cut -f 5 -d :)
           rhelmajor=$(echo $RHEL_VERSION | sed -E 's/([0-9]+)\.{1}[0-9]+(\.[0-9]+)?/\1/')
         ;;
-        rhel) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)
+        rhel|centos) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)
         ;;
         fedora)
           if [ "${VARIANT_ID}" == "coreos" ]; then


### PR DESCRIPTION
As we move to using pure centos bootimages for OKD, support the "centos" ID as the ID will not be "scos" anymore.