### PR TITLE
OCPBUGS-48305: frr-k8s: align manifests with operator

### DIFF
--- a/bindata/network/frr-k8s/frr-k8s.yaml
+++ b/bindata/network/frr-k8s/frr-k8s.yaml
@@ -87,7 +87,6 @@ spec:
         - --namespace=$(NAMESPACE)
         - --metrics-bind-address=127.0.0.1:7572
         - $(LOG_LEVEL)
-        - --health-probe-bind-address=127.0.0.1:8081
         env:
         - name: FRR_CONFIG_FILE
           value: /etc/frr_reloader/frr.conf
@@ -117,8 +116,8 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:
-            path: /healthz
-            port: 8081
+            path: /metrics
+            port: monitoring
             host: 127.0.0.1
           initialDelaySeconds: 10
           periodSeconds: 10
@@ -127,8 +126,8 @@ spec:
           failureThreshold: 3
         readinessProbe:
           httpGet:
-            path: /healthz
-            port: 8081
+            path: /metrics
+            port: monitoring
             host: 127.0.0.1
           initialDelaySeconds: 10
           periodSeconds: 10

--- a/bindata/network/frr-k8s/webhook.yaml
+++ b/bindata/network/frr-k8s/webhook.yaml
@@ -71,7 +71,7 @@ spec:
         - --webhook-mode=onlywebhook
         - --disable-cert-rotation=true
         - --namespace=$(NAMESPACE)
-        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=:7572
         env:
         - name: NAMESPACE
           valueFrom:
@@ -79,6 +79,9 @@ spec:
               fieldPath: metadata.namespace
         image: {{.FRRK8sImage}}
         name: frr-k8s-webhook-server
+        ports:
+        - containerPort: 7572
+          name: monitoring
         securityContext:
          runAsNonRoot: true
         resources:
@@ -88,15 +91,15 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:
-            path: /healthz
-            port: 8081
+            path: /metrics
+            port: monitoring
           initialDelaySeconds: 10
           periodSeconds: 10
           failureThreshold: 3
         readinessProbe:
           httpGet:
-            path: /readyz
-            port: 8081
+            path: /metrics
+            port: monitoring
           initialDelaySeconds: 10
           periodSeconds: 10
           failureThreshold: 3


### PR DESCRIPTION
cherry-pick from 4.19 https://github.com/openshift/cluster-network-operator/pull/2615, without the unnumbered api changes that are not supported in 4.18
