### PR TITLE
OCPBUGS-52837: frr-k8s: rename validatingwebhook name

### DIFF
--- a/bindata/network/frr-k8s/webhook.yaml
+++ b/bindata/network/frr-k8s/webhook.yaml
@@ -16,7 +16,7 @@ spec:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: frr-k8s-validating-webhook-configuration
+  name: frr-k8s-validating-webhook-configuration-ocp
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"
 webhooks:


### PR DESCRIPTION
clean cherry-pick from https://github.com/openshift/cluster-network-operator/pull/2659