### PR TITLE
OCPBUGS-54238: Update CSR status condition appropriately

### DIFF
--- a/pkg/controller/signer/signer_test.go
+++ b/pkg/controller/signer/signer_test.go
@@ -158,6 +158,13 @@ func TestSigner_reconciler_withInvalidUserName(t *testing.T) {
 	g.Expect(len(csrConditions)).To(Equal(1))
 	g.Expect(csrConditions[0].Reason).To(Equal("CSRInvalidUser"))
 	g.Expect(csrConditions[0].Type).To(Equal(certificatev1.CertificateFailed))
+
+	co, _, err = getStatuses(client, "testing")
+	if err != nil {
+		t.Fatalf("error getting network.operator: %v", err)
+	}
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(len(co.Status.Conditions)).To(BeZero())
 }
 
 func generateCSR() (string, error) {


### PR DESCRIPTION
When CSR signing reattempt happens, signer controller is not updating existing `CertificateFailed` condition type, instead it tries to add another `CertificateFailed` condition and leads to Duplicate value: "Failed" error in the network co status,

```
 % oc get co network
NAME      VERSION                                                   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
network   4.19.0-0.ci.test-2025-03-26-015315-ci-ln-g8dqch2-latest   True        False         True       4h      Unable to update csr: CertificateSigningRequest.certificates.k8s.io "ipsec-csr-test-80237" is invalid: status.conditions[1].type: Duplicate value: "Failed"
```

Fixing it just by updating existing `CertificateFailed` condition so that network status don't get updated unnecessarily for this case.