### PR TITLE
OCPBUGS-54159: frr-k8s: tolerate all taints

### DIFF
--- a/bindata/network/frr-k8s/frr-k8s.yaml
+++ b/bindata/network/frr-k8s/frr-k8s.yaml
@@ -276,9 +276,4 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
-        operator: Exists
-      - key: node-role.kubernetes.io/control-plane
-        effect: NoSchedule
-        operator: Exists
+      - operator: "Exists"


### PR DESCRIPTION
Just as ovnkube-node, frr-k8s daemon set is an infrastructure component and should be deployed regardless of taints. This solves frr-k8s pods not being deployed on nodes labeled with node-role.kubernetes.io/infra and tainted with NoSchedule.