### PR TITLE
OCPBUGS-53180: Add IPv6 NGINX configuration

### DIFF
--- a/bindata/networking-console-plugin/001-config-map.yaml
+++ b/bindata/networking-console-plugin/001-config-map.yaml
@@ -9,6 +9,7 @@ data:
       keepalive_timeout  65;
       server {
         listen              9443 ssl;
+        listen              [::]:9443 ssl;
         ssl_certificate     /var/cert/tls.crt;
         ssl_certificate_key /var/cert/tls.key;
         root                /opt/app-root/src;


### PR DESCRIPTION
Add an additional listen directive that will catch IPv6-originated requests towards the nginx server that serves the networking-console-plugin manifests.