### PR TITLE
OCPBUGS-54837: Add missing backendAddressPools read permission on azure

### DIFF
--- a/manifests/02-cncc-credentials.yaml
+++ b/manifests/02-cncc-credentials.yaml
@@ -87,6 +87,7 @@ spec:
     - Microsoft.Compute/virtualMachines/read
     - Microsoft.Network/virtualNetworks/read
     - Microsoft.Network/virtualNetworks/subnets/join/action
+    - Microsoft.Network/loadBalancers/backendAddressPools/read
     - Microsoft.Network/loadBalancers/backendAddressPools/join/action
 ---
 apiVersion: cloudcredential.openshift.io/v1


### PR DESCRIPTION
Although the issue was found while testing on AKS it is not specific to it.
This also affects standalone Azure deployments. 