### PR TITLE
OCPBUGS-55488: Remove environment variables related to ARO HCP MIv2 for CNO

### DIFF
--- a/bindata/cloud-network-config-controller/managed/controller.yaml
+++ b/bindata/cloud-network-config-controller/managed/controller.yaml
@@ -189,12 +189,6 @@ spec:
           value: "{{ .NO_PROXY}}"
 {{ end }}
 {{- if not (eq .AzureManagedSecretProviderClass "")}}
-        - name: "ARO_HCP_MI_CLIENT_ID"
-          value: "{{ .AzureManagedClientID }}"
-        - name: "ARO_HCP_TENANT_ID"
-          value: "{{ .AzureManagedTenantID }}"
-        - name: "ARO_HCP_CLIENT_CERTIFICATE_PATH"
-          value: "{{ .AzureManagedCertPath}}"
         - name: "ARO_HCP_CLIENT_CREDENTIALS_PATH"
           value: "{{ .AzureManagedCredsPath}}"
 {{ end }}

--- a/pkg/network/cloud_network.go
+++ b/pkg/network/cloud_network.go
@@ -105,10 +105,7 @@ func renderCloudNetworkConfigController(conf *operv1.NetworkSpec, bootstrapResul
 		data.Data["HTTP_PROXY"] = os.Getenv("MGMT_HTTP_PROXY")
 		data.Data["HTTPS_PROXY"] = os.Getenv("MGMT_HTTPS_PROXY")
 		data.Data["NO_PROXY"] = os.Getenv("MGMT_NO_PROXY")
-		data.Data["AzureManagedClientID"] = os.Getenv("ARO_HCP_MI_CLIENT_ID")
-		data.Data["AzureManagedTenantID"] = os.Getenv("ARO_HCP_TENANT_ID")
 		data.Data["AzureManagedCertDirectory"] = azureCertPath
-		data.Data["AzureManagedCertPath"] = filepath.Join(azureCertPath, os.Getenv("ARO_HCP_CLIENT_CERTIFICATE_NAME"))
 		data.Data["AzureManagedCredsPath"] = filepath.Join(azureCertPath, os.Getenv("MANAGED_AZURE_HCP_CREDENTIALS_FILE_PATH"))
 		data.Data["AzureManagedSecretProviderClass"] = os.Getenv("ARO_HCP_SECRET_PROVIDER_CLASS")
 		caOverride.ObjectMeta = metav1.ObjectMeta{


### PR DESCRIPTION
This commit removes the environment variables related to ARO HCP managed identity version 2. These environment variables are no longer needed for ARO HCP managed identity version 3.