### PR TITLE
CNF-16707: frr-k8s: wire the frr-status sidecar container

### DIFF
--- a/bindata/network/frr-k8s/frr-k8s.yaml
+++ b/bindata/network/frr-k8s/frr-k8s.yaml
@@ -43,6 +43,8 @@ spec:
         emptyDir: {}
       - name: metrics
         emptyDir: {}
+      - name: frr-status
+        emptyDir: {}
       - name: metrics-certs
         secret:
           secretName: frr-k8s-certs-secret
@@ -76,6 +78,12 @@ spec:
         volumeMounts:
         - name: metrics
           mountPath: /etc/frr_metrics
+      - name: cp-frr-status
+        image: {{.FRRK8sImage}}
+        command: ["/bin/sh", "-c", "cp -f /frr-status /etc/frr_status/"]
+        volumeMounts:
+        - name: frr-status
+          mountPath: /etc/frr_status
       shareProcessNamespace: true
       containers:
       - name: controller
@@ -231,6 +239,39 @@ spec:
           mountPath: /etc/frr
         - name: metrics
           mountPath: /etc/frr_metrics
+      - name: frr-status
+        image: {{.FRRK8sImage}}
+        args:
+        - --node-name=$(NODE_NAME)
+        - --namespace=$(NAMESPACE)
+        - --pod-name=$(POD_NAME)
+        - --poll-interval=2m
+        command:
+        - /etc/frr_status/frr-status
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        volumeMounts:
+        - mountPath: /var/run/frr
+          name: frr-sockets
+        - mountPath: /etc/frr
+          name: frr-conf
+        - mountPath: /etc/frr_status
+          name: frr-status
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
       - name: kube-rbac-proxy
         image: {{.KubeRBACProxyImage}}
         args:


### PR DESCRIPTION
Now that the changes are merged in the code, we
can update the manifests to include the frr-status exporter in charge of creating the actual resources.