### PR TITLE
OCPBUGS-55090: Configures subdirectory based CNI chain loading

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -159,7 +159,8 @@ data:
         "readinessindicatorfile": "/host/run/multus/cni/net.d/10-ovn-kubernetes.conf",
 {{- end}}
         "daemonSocketDir": "/run/multus/socket",
-        "socketDir": "/host{{ .MultusSocketParentDir }}/socket"
+        "socketDir": "/host{{ .MultusSocketParentDir }}/socket",
+        "auxiliaryCNIChainName": "vendor-cni-chain"
     }
 {{- if .IsNetworkTypeLiveMigration}}
   daemon-config-lm-ovn.json: |


### PR DESCRIPTION
Using the `auxiliaryCNIChainName` feature which isolates executions to an independent CNI chain.

See also [this gist](https://gist.github.com/dougbtv/52ecdc17a7601d26312f7fd3fa49dc5d) with a demo about how to operate it.