### PR TITLE
Use same conf file both host and containerized ipsec deployment

### DIFF
--- a/bindata/network/ovn-kubernetes/common/ipsec-containerized.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-containerized.yaml
@@ -261,6 +261,18 @@ spec:
           # Workaround for https://github.com/libreswan/libreswan/issues/373
           ulimit -n 1024
 
+          # The ovs-monitor-ipsec doesn't set authby, so when it calls ipsec auto --start
+          # the default ones defined at Libreswan's compile time will be used. On restart,
+          # Libreswan will use authby from libreswan.config. If libreswan.config is
+          # incompatible with the Libreswan's compiled-in defaults, then we'll have an
+          # authentication problem. But OTOH, ovs-monitor-ipsec does set ike and esp algorithms,
+          # so those may be incompatible with libreswan.config as well. Hence commenting out the
+          # "include" from libreswan.conf to avoid such conflicts.
+          defaultcpinclude="include \/etc\/crypto-policies\/back-ends\/libreswan.config"
+          if ! grep -q "# ${defaultcpinclude}" /etc/ipsec.conf; then
+            sed -i "/${defaultcpinclude}/s/^/# /" /etc/ipsec.conf
+          fi
+
           /usr/libexec/ipsec/addconn --config /etc/ipsec.conf --checkconfig
           # Check kernel modules
           /usr/libexec/ipsec/_stackmanager start
@@ -275,7 +287,7 @@ spec:
           # We are running this in the foreground so that the container will be restarted when ovs-monitor-ipsec fails.
           /usr/libexec/platform-python /usr/share/openvswitch/scripts/ovs-monitor-ipsec \
             --pidfile=/var/run/openvswitch/ovs-monitor-ipsec.pid --ike-daemon=libreswan --no-restart-ike-daemon \
-            --ipsec-d /var/lib/ipsec/nss \
+            --ipsec-conf /etc/ipsec.d/openshift.conf --ipsec-d /var/lib/ipsec/nss \
             --log-file --monitor unix:/var/run/openvswitch/db.sock
         env:
         - name: K8S_NODE
@@ -294,6 +306,8 @@ spec:
           name: host-var-log-ovs
         - mountPath: /etc/openvswitch
           name: etc-openvswitch
+        - mountPath: /etc
+          name: host-etc
         resources:
           requests:
             cpu: 10m
@@ -345,6 +359,10 @@ spec:
       - name: host-cni-netd
         hostPath:
           path: "{{.CNIConfDir}}"
+      -  name: host-etc
+         hostPath:
+          path: /etc
+          type: Directory
       tolerations:
       - operator: "Exists"
 {{end}}


### PR DESCRIPTION
The host and containerized ipsec deployments are not sharing same conf file containing ipsec connection entries populated by ovs-monitor-ipsec process. when ipsec is moved from containerized to host deployment at the time of ipsec installation, this file won't be present after ipsec machine config installed, node reboot, so ipsec can't be established before crio is started. Hence this PR makes containerized ipsec deployment to use `/etc/ipsec.d/openshift.conf` file from the host so that it can be used later by pluto daemon to establish IKE SAs before kubelet/crio is started.