### PR TITLE
OCPBUGS-55285: bindata,ovn-k,cudn: Validate loclanet topology's excludeSubnet match specified subnets

### DIFF
--- a/bindata/network/ovn-kubernetes/common/001-crd.yaml
+++ b/bindata/network/ovn-kubernetes/common/001-crd.yaml
@@ -4032,6 +4032,11 @@ spec:
                         IPv6 subnet is used
                       rule: '!has(self.subnets) || !has(self.mtu) || !self.subnets.exists_one(i,
                         isCIDR(i) && cidr(i).ip().family() == 6) || self.mtu >= 1280'
+                    - fieldPath: .excludeSubnets
+                      message: excludeSubnets must be subnetworks of the networks
+                        specified in the subnets field
+                      rule: '!has(self.excludeSubnets) || self.excludeSubnets.all(e,
+                        self.subnets.exists(s, cidr(s).containsCIDR(cidr(e))))'
                   topology:
                     description: |-
                       Topology describes network configuration.


### PR DESCRIPTION
Add CEL validation on OVN-K CUDN CRD for localnet to topology,  to ensure the specified `excludeSubnetes` match the specified `subnets`.

**Note to reviewer:**
This change make the CRD diverge from the CRD on U/S due to a bug [[1]](https://issues.redhat.com/browse/OCPBUGS-54426) that its fix is available on D/S [[2]](https://github.com/openshift/kubernetes/pull/2263) [[3]](https://github.com/openshift/kubernetes/pull/2267) but not available on U/S yet.

Once the fix is available on U/S, the CRD definition in OVN-Kubentes repo should have the same CEL validation this PR adds, tracked by [[4]](https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5195).

[1] https://issues.redhat.com/browse/OCPBUGS-54426
[2] https://github.com/openshift/kubernetes/pull/2263
[3] https://github.com/openshift/kubernetes/pull/2267
[4] https://github.com/ovn-kubernetes/ovn-kubernetes/issues/5195