### PR TITLE
OCPBUGS-54806: Add recording rules for UDN telemetry

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/alert-rules-control-plane.yaml
@@ -23,6 +23,10 @@ spec:
       expr: max by(direction, action)(ovnkube_controller_admin_network_policies_rules)
     - record: cluster:ovnkube_controller_baseline_admin_network_policies_rules:max
       expr: max by(direction, action)(ovnkube_controller_baseline_admin_network_policies_rules)
+    - record: cluster:ovnkube_clustermanager_user_defined_networks:max
+      expr: max by(role, topology)(ovnkube_clustermanager_user_defined_networks)
+    - record: cluster:ovnkube_clustermanager_cluster_user_defined_networks:max
+      expr: max by(role, topology)(ovnkube_clustermanager_cluster_user_defined_networks)
     # OVN kubernetes cluster manager functional alerts
     - alert: V4SubnetAllocationThresholdExceeded
       annotations:

--- a/bindata/network/ovn-kubernetes/self-hosted/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/alert-rules-control-plane.yaml
@@ -22,6 +22,10 @@ spec:
       expr: max by(direction, action)(ovnkube_controller_admin_network_policies_rules)
     - record: cluster:ovnkube_controller_baseline_admin_network_policies_rules:max
       expr: max by(direction, action)(ovnkube_controller_baseline_admin_network_policies_rules)
+    - record: cluster:ovnkube_clustermanager_user_defined_networks:max
+      expr: max by(role, topology)(ovnkube_clustermanager_user_defined_networks)
+    - record: cluster:ovnkube_clustermanager_cluster_user_defined_networks:max
+      expr: max by(role, topology)(ovnkube_clustermanager_cluster_user_defined_networks)
     # OVN kubernetes cluster manager functional alerts
     - alert: V4SubnetAllocationThresholdExceeded
       annotations:


### PR DESCRIPTION
(The metric is designed to have only the things we want for telemetry anyway, but the rules for telemetry metrics say we need an explicit recording rule anyway, so that if more info gets added to the metric later it doesn't get automatically sucked in to telemetry.)

/cc