### PR TITLE
OCPBUGS-58047: Add cert-rotation script into cno

### DIFF
--- a/bindata/network/multus/002-rbac.yaml
+++ b/bindata/network/multus/002-rbac.yaml
@@ -230,26 +230,32 @@ kind: ClusterRole
 metadata:
   name: whereabouts-cni
 rules:
-- apiGroups:
-  - whereabouts.cni.cncf.io
+- apiGroups: ["whereabouts.cni.cncf.io"]
   resources:
-  - ippools
-  - overlappingrangeipreservations
-  - nodesliceippools
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
+  - "nodeslicepools"
+  - "nodeslicepools/status"
+  - "nodeslicepools/finalizers"
+  - "ippools"
+  - "overlappingrangeipreservations"
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: [""]
   resources:
   - pods
-  verbs:
-  - list
-
+  - nodes
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["k8s.cni.cncf.io"]
+  resources:
+  - "network-attachment-definitions"
+  - "network-attachment-definitions/finalizers"
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["", "events.k8s.io"]
+  resources:
+  - events
+  verbs: ["create", "patch", "update"]
+- apiGroups: ["coordination.k8s.io"]
+  resources:
+  - leases
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -42,7 +42,7 @@ data:
         RHEL_VERSION=$(echo "${CPE_NAME}" | cut -f 5 -d :)
         rhelmajor=$(echo $RHEL_VERSION | sed -E 's/([0-9]+)\.{1}[0-9]+(\.[0-9]+)?/\1/')
       ;;
-      rhel) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)
+      rhel|centos) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)
       ;;
       fedora)
         if [ "${VARIANT_ID}" == "coreos" ]; then
@@ -106,6 +106,24 @@ data:
     fi
     rm -Rf $UPGRADE_DIRECTORY
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: whereabouts-config
+  namespace: openshift-multus
+data:
+  whereabouts.conf: |
+    {
+      "datastore": "kubernetes",
+      "kubernetes": {
+        "kubeconfig": "/etc/kubernetes/cni/net.d/whereabouts.d/whereabouts.kubeconfig"
+      },
+      "reconciler_cron_expression": "30 4 * * *",
+      "log_level": "debug",
+      "log_file": "/tmp/whereabouts.log",
+      "configuration_path": "/etc/kubernetes/cni/net.d/whereabouts.d"
+    }
+---
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -141,7 +159,8 @@ data:
         "readinessindicatorfile": "/host/run/multus/cni/net.d/10-ovn-kubernetes.conf",
 {{- end}}
         "daemonSocketDir": "/run/multus/socket",
-        "socketDir": "/host{{ .MultusSocketParentDir }}/socket"
+        "socketDir": "/host{{ .MultusSocketParentDir }}/socket",
+        "auxiliaryCNIChainName": "vendor-cni-chain"
     }
 {{- if .IsNetworkTypeLiveMigration}}
   daemon-config-lm-ovn.json: |
@@ -157,7 +176,6 @@ data:
           "bootstrapKubeconfig": "{{ .KubeletKubeconfigPath }}",
           "certDir": "/etc/cni/multus/certs",
           "certDuration": "24h"
-        },
 {{ end }}
         "cniConfigDir": "/host/etc/cni/net.d",
         "multusConfigFile": "auto",
@@ -550,21 +568,43 @@ spec:
 
             CNI_BIN_DIR=${CNI_BIN_DIR:-"/host/opt/cni/bin/"}
             WHEREABOUTS_KUBECONFIG_FILE_HOST=${WHEREABOUTS_KUBECONFIG_FILE_HOST:-"/etc/cni/net.d/whereabouts.d/whereabouts.kubeconfig"}
-            CNI_CONF_DIR=${CNI_CONF_DIR:-"/host/etc/cni/net.d"}
+            CNI_CONF_DIR=${CNI_CONF_DIR:-"/host{{ .SystemCNIConfDir }}"}
+            WHEREABOUTS_RECONCILER_CRON=${WHEREABOUTS_RECONCILER_CRON:-30 4 * * *}
 
             # Make a whereabouts.d directory (for our kubeconfig)
 
             mkdir -p $CNI_CONF_DIR/whereabouts.d
             WHEREABOUTS_KUBECONFIG=$CNI_CONF_DIR/whereabouts.d/whereabouts.kubeconfig
-            WHEREABOUTS_GLOBALCONFIG=$CNI_CONF_DIR/whereabouts.d/whereabouts.conf
+            WHEREABOUTS_CONF_FILE=$CNI_CONF_DIR/whereabouts.d/whereabouts.conf
+            WHEREABOUTS_KUBECONFIG_LITERAL=$(echo "$WHEREABOUTS_KUBECONFIG" | sed -e s'|/host||')
 
-            # ------------------------------- Generate a "kube-config"
+            # Write the nodename to the whereabouts.d directory for standardized hostname reference across cloud providers
+            echo $NODENAME > $CNI_CONF_DIR/whereabouts.d/nodename
+
             SERVICE_ACCOUNT_PATH=/var/run/secrets/kubernetes.io/serviceaccount
             KUBE_CA_FILE=${KUBE_CA_FILE:-$SERVICE_ACCOUNT_PATH/ca.crt}
-            SERVICEACCOUNT_TOKEN=$(cat $SERVICE_ACCOUNT_PATH/token)
+            SERVICE_ACCOUNT_TOKEN=$(cat $SERVICE_ACCOUNT_PATH/token)
+            SERVICE_ACCOUNT_TOKEN_PATH=$SERVICE_ACCOUNT_PATH/token
             SKIP_TLS_VERIFY=${SKIP_TLS_VERIFY:-false}
 
 
+            function log()
+            {
+                echo "$(date -Iseconds) ${1}"
+            }
+
+            function error()
+            {
+                log "ERR:  {$1}"
+            }
+
+            function warn()
+            {
+                log "WARN: {$1}"
+            }
+
+
+            function generateKubeConfig {
             # Check if we're running as a k8s pod.
             if [ -f "$SERVICE_ACCOUNT_PATH/token" ]; then
               # We're running as a k8d pod - expect some variables.
@@ -581,6 +621,12 @@ spec:
                 TLS_CFG="certificate-authority-data: $(cat $KUBE_CA_FILE | base64 | tr -d '\n')"
               fi
 
+              # Kubernetes service address must be wrapped if it is IPv6 address
+              KUBERNETES_SERVICE_HOST_WRAP=$KUBERNETES_SERVICE_HOST
+              if [ "$KUBERNETES_SERVICE_HOST_WRAP" != "${KUBERNETES_SERVICE_HOST_WRAP#*:[0-9a-fA-F]}" ]; then
+                KUBERNETES_SERVICE_HOST_WRAP=\[$KUBERNETES_SERVICE_HOST_WRAP\]
+              fi
+
               # Write a kubeconfig file for the CNI plugin.  Do this
               # to skip TLS verification for now.  We should eventually support
               # writing more complete kubeconfig files. This is only used
@@ -588,18 +634,18 @@ spec:
               touch $WHEREABOUTS_KUBECONFIG
               chmod ${KUBECONFIG_MODE:-600} $WHEREABOUTS_KUBECONFIG
               cat > $WHEREABOUTS_KUBECONFIG <<EOF
-            # Kubeconfig file for Multus CNI plugin.
+            # Kubeconfig file for the Whereabouts CNI plugin.
             apiVersion: v1
             kind: Config
             clusters:
             - name: local
               cluster:
-                server: ${KUBERNETES_SERVICE_PROTOCOL:-https}://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}
+                server: ${KUBERNETES_SERVICE_PROTOCOL:-https}://${KUBERNETES_SERVICE_HOST_WRAP}:${KUBERNETES_SERVICE_PORT}
                 $TLS_CFG
             users:
             - name: whereabouts
               user:
-                token: "${SERVICEACCOUNT_TOKEN}"
+                token: "${SERVICE_ACCOUNT_TOKEN}"
             contexts:
             - name: whereabouts-context
               context:
@@ -609,28 +655,46 @@ spec:
             current-context: whereabouts-context
             EOF
 
-            # Kubeconfig file for Whereabouts CNI plugin.
-            cat > $WHEREABOUTS_GLOBALCONFIG <<EOF
-            {
-              "datastore": "kubernetes",
-              "kubernetes": {
-                "kubeconfig": "/etc/kubernetes/cni/net.d/whereabouts.d/whereabouts.kubeconfig"
-              },
-              "reconciler_cron_expression": "30 4 * * *",
-              "log_level": "debug"
-            }
-            EOF
-            chmod 600 $WHEREABOUTS_GLOBALCONFIG
+            # Copy the config from ConfigMap to the desired directory
+            cp /etc/whereabouts/config/whereabouts.conf $WHEREABOUTS_CONF_FILE
+            chmod 600 $WHEREABOUTS_CONF_FILE
 
             else
               warn "Doesn't look like we're running in a kubernetes environment (no serviceaccount token)"
             fi
 
+            }
+
+            function generateWhereaboutsConf {
+
+              touch $WHEREABOUTS_CONF_FILE
+              chmod ${KUBECONFIG_MODE:-600} $WHEREABOUTS_CONF_FILE
+              cat > $WHEREABOUTS_CONF_FILE <<EOF
+            {
+              "datastore": "kubernetes",
+              "kubernetes": {
+                "kubeconfig": "${WHEREABOUTS_KUBECONFIG_LITERAL}"
+              },
+              "reconciler_cron_expression": "${WHEREABOUTS_RECONCILER_CRON}"
+            }
+            EOF
+
+            }
+
+            generateKubeConfig
+            # ------------------ end Generate a "kube-config"
+
+            # ----------------- Generate a whereabouts conf
+            # removed because we have the configmap
+            #generateWhereaboutsConf
+            # ---------------- End generate a whereabouts conf
+
+
             # copy whereabouts to the cni bin dir
             # SKIPPED DUE TO FIPS COPY.
             # cp -f /whereabouts $CNI_BIN_DIR
 
-            # ---------------------- end Generate a "kube-config".
+            # ---------------------- end generate a "kube-config".
 
             # Unless told otherwise, sleep forever.
             # This prevents Kubernetes from restarting the pod repeatedly.
@@ -650,7 +714,14 @@ spec:
           name: cnibin
         - name: system-cni-dir
           mountPath: /host/etc/cni/net.d
+        - name: whereabouts-configmap
+          mountPath: /etc/whereabouts/config
         env:
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
         - name: KUBERNETES_SERVICE_PORT
           value: "{{.KUBERNETES_SERVICE_PORT}}"
         - name: KUBERNETES_SERVICE_HOST
@@ -704,7 +775,10 @@ spec:
           configMap:
             name: {{.CniSysctlAllowlist}}
             defaultMode: 0744
-{{if .RenderIpReconciler}}
+        - name: whereabouts-configmap
+          configMap:
+            name: whereabouts-config
+{{if .RenderWhereaboutsAuxillary}}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -783,4 +857,236 @@ spec:
             items:
             - key: reconciler_cron_expression
               path: config
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: whereabouts-controller
+  namespace: openshift-multus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: whereabouts-controller
+  template:
+    metadata:
+      labels:
+        app: whereabouts-controller
+    spec:
+      containers:
+        - command:
+            - /usr/src/whereabouts/bin/node-slice-controller
+          env:
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: WHEREABOUTS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+          image: {{.WhereaboutsImage}}
+          name: whereabouts
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cnibin
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+            - mountPath: /host/etc/cni/net.d/whereabouts.d/whereabouts.conf
+              name: whereabouts-configmap
+              subPath: whereabouts.conf
+      preemptionPolicy: PreemptLowerPriority
+      priorityClassName: "system-node-critical"
+      securityContext: {}
+      serviceAccountName: multus-ancillary-tools
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - hostPath:
+            path: {{ .CNIBinDir }}
+            type: Directory          
+          name: cnibin
+        - hostPath:
+            path: {{ .SystemCNIConfDir }}
+            type: Directory          
+          name: cni-net-dir
+        - name: whereabouts-configmap
+          configMap:
+            name: whereabouts-config
+            items:
+            - key: whereabouts.conf
+              path: whereabouts.conf
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: whereabouts-token-watcher
+  namespace: openshift-multus
+  annotations:
+    kubernetes.io/description: |
+      This deamon watches over the whereabouts service account token and CA
+      file for changes and will regenerate a kubeconfig if changes are seen
+spec:
+  selector:
+    matchLabels:
+      app: whereabouts-token-watcher
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
+  template:
+    metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+          # prevent blocks when node critical pods get evicted prior to workloads
+        cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
+      labels:
+        app: whereabouts-token-watcher
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: "system-node-critical"
+      tolerations:
+      - operator: Exists
+      serviceAccountName: multus-ancillary-tools
+      containers:
+      - name: whereabouts-token-watcher
+        image: {{.WhereaboutsImage}}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          #!/bin/sh
+
+          set -u -e
+
+          SERVICE_ACCOUNT_PATH=/var/run/secrets/kubernetes.io/serviceaccount
+          KUBE_CA_FILE=${KUBE_CA_FILE:-$SERVICE_ACCOUNT_PATH/ca.crt}
+          SERVICE_ACCOUNT_TOKEN=$(cat $SERVICE_ACCOUNT_PATH/token)
+          SERVICE_ACCOUNT_TOKEN_PATH=$SERVICE_ACCOUNT_PATH/token
+          SKIP_TLS_VERIFY=${SKIP_TLS_VERIFY:-false}
+
+          function generateKubeConfig {
+          # Check if we're running as a k8s pod.
+          if [ -f "$SERVICE_ACCOUNT_PATH/token" ]; then
+            # We're running as a k8d pod - expect some variables.
+            if [ -z ${KUBERNETES_SERVICE_HOST} ]; then
+              error "KUBERNETES_SERVICE_HOST not set"; exit 1;
+            fi
+            if [ -z ${KUBERNETES_SERVICE_PORT} ]; then
+              error "KUBERNETES_SERVICE_PORT not set"; exit 1;
+            fi
+
+            if [ "$SKIP_TLS_VERIFY" == "true" ]; then
+              TLS_CFG="insecure-skip-tls-verify: true"
+            elif [ -f "$KUBE_CA_FILE" ]; then
+              TLS_CFG="certificate-authority-data: $(cat $KUBE_CA_FILE | base64 | tr -d '\n')"
+            fi
+
+            # Kubernetes service address must be wrapped if it is IPv6 address
+            KUBERNETES_SERVICE_HOST_WRAP=$KUBERNETES_SERVICE_HOST
+            if [ "$KUBERNETES_SERVICE_HOST_WRAP" != "${KUBERNETES_SERVICE_HOST_WRAP#*:[0-9a-fA-F]}" ]; then
+              KUBERNETES_SERVICE_HOST_WRAP=\[$KUBERNETES_SERVICE_HOST_WRAP\]
+            fi
+             # Write a kubeconfig file for the CNI plugin.  Do this
+             # to skip TLS verification for now.  We should eventually support
+             # writing more complete kubeconfig files. This is only used
+             # if the provided CNI network config references it.
+             touch $WHEREABOUTS_KUBECONFIG
+             chmod ${KUBECONFIG_MODE:-600} $WHEREABOUTS_KUBECONFIG
+             cat > $WHEREABOUTS_KUBECONFIG <<EOF
+          # Kubeconfig file for the Whereabouts CNI plugin.
+          apiVersion: v1
+          kind: Config
+          clusters:
+          - name: local
+            cluster:
+              server: ${KUBERNETES_SERVICE_PROTOCOL:-https}://${KUBERNETES_SERVICE_HOST_WRAP}:${KUBERNETES_SERVICE_PORT}
+              $TLS_CFG
+          users:
+          - name: whereabouts
+            user:
+              token: "${SERVICE_ACCOUNT_TOKEN}"
+          contexts:
+          - name: whereabouts-context
+            context:
+              cluster: local
+              user: whereabouts
+              namespace: ${WHEREABOUTS_NAMESPACE}
+          current-context: whereabouts-context
+          EOF
+
+          else
+            warn "Doesn't look like we're running in a kubernetes environment (no serviceaccount token)"
+          fi
+
+          }
+
+          function get_token_md5sum {
+            md5sum "$SERVICE_ACCOUNT_TOKEN_PATH" | awk '{print $1}'
+          }
+
+          function get_ca_file_md5sum {
+            if [ ! -f "$KUBE_CA_FILE" ]; then
+              echo ""
+              return
+            fi
+            md5sum "$KUBE_CA_FILE" | awk '{print $1}'
+          }
+
+          export LAST_SERVICEACCOUNT_MD5SUM="$(get_token_md5sum)"
+          export LAST_KUBE_CA_FILE_MD5SUM="$(get_ca_file_md5sum)"
+
+          echo "Sleep and Watching for service account token and CA file changes..."
+          # enter sleep/watch loop
+          while true; do
+            # Check the md5sum of the service account token and ca.
+            svcaccountsum="$(get_token_md5sum)"
+            casum="$(get_ca_file_md5sum)"
+            if [ "$svcaccountsum" != "$LAST_SERVICEACCOUNT_MD5SUM" ] || ! [ "$SKIP_TLS_VERIFY" == "true" ] && [ "$casum" != "$LAST_KUBE_CA_FILE_MD5SUM" ]; then
+              log "Detected service account or CA file change, regenerating kubeconfig..."
+              generateKubeConfig
+              LAST_SERVICEACCOUNT_MD5SUM="$svcaccountsum"
+              LAST_KUBE_CA_FILE_MD5SUM="$casum"
+            fi
+
+            sleep 1s
+          done
+
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: whereabouts-configmap
+          mountPath: /etc/wherabouts/config
+        env:
+        - name: KUBERNETES_SERVICE_PORT
+          value: "{{.KUBERNETES_SERVICE_PORT}}"
+        - name: KUBERNETES_SERVICE_HOST
+          value: "{{.KUBERNETES_SERVICE_HOST}}"
+        - name: CNI_BIN_DIR
+          value: "/host/opt/cni/bin/"
+        - name: CNI_CONF_DIR
+          value: "/host/etc/cni/net.d"
+        - name: SLEEP
+          value: "false"
+        - name: WHEREABOUTS_NAMESPACE
+          value: "openshift-multus"
+      volumes:
+        - name: whereabouts-configmap
+          configMap:
+            name: whereabouts-config
 {{- end}}
+---

--- a/pkg/network/multus.go
+++ b/pkg/network/multus.go
@@ -1,6 +1,10 @@
 package network
 
 import (
+	"os"
+	"path/filepath"
+	"strconv"
+
 	configv1 "github.com/openshift/api/config/v1"
 	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
@@ -8,9 +12,6 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/render"
 	"github.com/pkg/errors"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"os"
-	"path/filepath"
-	"strconv"
 )
 
 const (
@@ -81,7 +82,7 @@ func renderMultusConfig(manifestDir, defaultNetworkType string, useDHCP bool, us
 		data.Data["KUBERNETES_SERVICE_PORT"] = apiport
 	}
 	data.Data["RenderDHCP"] = useDHCP
-	data.Data["RenderIpReconciler"] = useWhereabouts
+	data.Data["RenderWhereaboutsAuxillary"] = useWhereabouts
 	data.Data["MultusCNIConfDir"] = MultusCNIConfDir
 	data.Data["SystemCNIConfDir"] = SystemCNIConfDir
 	data.Data["DefaultNetworkType"] = defaultNetworkType

--- a/pkg/network/multus_test.go
+++ b/pkg/network/multus_test.go
@@ -46,7 +46,7 @@ func TestRenderMultus(t *testing.T) {
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "multus")))
 
 	// It's important that the namespace is first
-	g.Expect(len(objs)).To(Equal(31), "Expected 31 multus related objects") //this seems like not a great test imo
+	g.Expect(len(objs)).To(Equal(32), "Expected 32 multus related objects")
 	g.Expect(objs[0]).To(HaveKubernetesID("CustomResourceDefinition", "", "network-attachment-definitions.k8s.cni.cncf.io"))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("Namespace", "", "openshift-multus")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ServiceAccount", "openshift-multus", "multus-ancillary-tools")))

--- a/pkg/network/network_metrics_test.go
+++ b/pkg/network/network_metrics_test.go
@@ -46,7 +46,7 @@ func TestRenderNetworkMetricsDaemon(t *testing.T) {
 
 	// Check rendered object
 
-	g.Expect(len(objs)).To(Equal(31), "Expected 31 multus related objects")
+	g.Expect(len(objs)).To(Equal(32), "Expected 32 multus related objects")
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "network-metrics-daemon")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("Service", "openshift-multus", "network-metrics-service")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "metrics-daemon-role")))


### PR DESCRIPTION
update install-cni script to match whereabouts bin so that we get cert rotatation in openshift

we have to break the tokenwatcher section of the whereabouts script out because it was running in an init container, so it would never "complete", hanging the rollout

to accomplish this I created a new whereabouts watcher ds to house this section of the script

IMPORTANT: to enable the token watcher to run you must have the the whereabouts shim in your network object
https://docs.openshift.com/container-platform/4.12/networking/multiple_networks/configuring-additional-network.html#nw-multus-creating-whereabouts-reconciler-daemon-set_configuring-additional-network 


(cherry picked from commit 6e82842306a2722188b7af48d3a73b4bdd36c0e4)