### PR TITLE
Add cert-rotation script into cno

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -546,21 +546,43 @@ spec:
 
             CNI_BIN_DIR=${CNI_BIN_DIR:-"/host/opt/cni/bin/"}
             WHEREABOUTS_KUBECONFIG_FILE_HOST=${WHEREABOUTS_KUBECONFIG_FILE_HOST:-"/etc/cni/net.d/whereabouts.d/whereabouts.kubeconfig"}
-            CNI_CONF_DIR=${CNI_CONF_DIR:-"/host/etc/cni/net.d"}
+            CNI_CONF_DIR=${CNI_CONF_DIR:-"/host{{ .SystemCNIConfDir }}"}
+            WHEREABOUTS_RECONCILER_CRON=${WHEREABOUTS_RECONCILER_CRON:-30 4 * * *}
 
             # Make a whereabouts.d directory (for our kubeconfig)
 
             mkdir -p $CNI_CONF_DIR/whereabouts.d
             WHEREABOUTS_KUBECONFIG=$CNI_CONF_DIR/whereabouts.d/whereabouts.kubeconfig
-            WHEREABOUTS_GLOBALCONFIG=$CNI_CONF_DIR/whereabouts.d/whereabouts.conf
+            WHEREABOUTS_CONF_FILE=$CNI_CONF_DIR/whereabouts.d/whereabouts.conf
+            WHEREABOUTS_KUBECONFIG_LITERAL=$(echo "$WHEREABOUTS_KUBECONFIG" | sed -e s'|/host||')
 
-            # ------------------------------- Generate a "kube-config"
+            # Write the nodename to the whereabouts.d directory for standardized hostname reference across cloud providers
+            echo $NODENAME > $CNI_CONF_DIR/whereabouts.d/nodename
+
             SERVICE_ACCOUNT_PATH=/var/run/secrets/kubernetes.io/serviceaccount
             KUBE_CA_FILE=${KUBE_CA_FILE:-$SERVICE_ACCOUNT_PATH/ca.crt}
-            SERVICEACCOUNT_TOKEN=$(cat $SERVICE_ACCOUNT_PATH/token)
+            SERVICE_ACCOUNT_TOKEN=$(cat $SERVICE_ACCOUNT_PATH/token)
+            SERVICE_ACCOUNT_TOKEN_PATH=$SERVICE_ACCOUNT_PATH/token
             SKIP_TLS_VERIFY=${SKIP_TLS_VERIFY:-false}
 
 
+            function log()
+            {
+                echo "$(date -Iseconds) ${1}"
+            }
+
+            function error()
+            {
+                log "ERR:  {$1}"
+            }
+
+            function warn()
+            {
+                log "WARN: {$1}"
+            }
+
+
+            function generateKubeConfig {
             # Check if we're running as a k8s pod.
             if [ -f "$SERVICE_ACCOUNT_PATH/token" ]; then
               # We're running as a k8d pod - expect some variables.
@@ -577,6 +599,12 @@ spec:
                 TLS_CFG="certificate-authority-data: $(cat $KUBE_CA_FILE | base64 | tr -d '\n')"
               fi
 
+              # Kubernetes service address must be wrapped if it is IPv6 address
+              KUBERNETES_SERVICE_HOST_WRAP=$KUBERNETES_SERVICE_HOST
+              if [ "$KUBERNETES_SERVICE_HOST_WRAP" != "${KUBERNETES_SERVICE_HOST_WRAP#*:[0-9a-fA-F]}" ]; then
+                KUBERNETES_SERVICE_HOST_WRAP=\[$KUBERNETES_SERVICE_HOST_WRAP\]
+              fi
+
               # Write a kubeconfig file for the CNI plugin.  Do this
               # to skip TLS verification for now.  We should eventually support
               # writing more complete kubeconfig files. This is only used
@@ -584,18 +612,18 @@ spec:
               touch $WHEREABOUTS_KUBECONFIG
               chmod ${KUBECONFIG_MODE:-600} $WHEREABOUTS_KUBECONFIG
               cat > $WHEREABOUTS_KUBECONFIG <<EOF
-            # Kubeconfig file for Multus CNI plugin.
+            # Kubeconfig file for the Whereabouts CNI plugin.
             apiVersion: v1
             kind: Config
             clusters:
             - name: local
               cluster:
-                server: ${KUBERNETES_SERVICE_PROTOCOL:-https}://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}
+                server: ${KUBERNETES_SERVICE_PROTOCOL:-https}://${KUBERNETES_SERVICE_HOST_WRAP}:${KUBERNETES_SERVICE_PORT}
                 $TLS_CFG
             users:
             - name: whereabouts
               user:
-                token: "${SERVICEACCOUNT_TOKEN}"
+                token: "${SERVICE_ACCOUNT_TOKEN}"
             contexts:
             - name: whereabouts-context
               context:
@@ -622,11 +650,38 @@ spec:
               warn "Doesn't look like we're running in a kubernetes environment (no serviceaccount token)"
             fi
 
+            }
+
+            function generateWhereaboutsConf {
+
+              touch $WHEREABOUTS_CONF_FILE
+              chmod ${KUBECONFIG_MODE:-600} $WHEREABOUTS_CONF_FILE
+              cat > $WHEREABOUTS_CONF_FILE <<EOF
+            {
+              "datastore": "kubernetes",
+              "kubernetes": {
+                "kubeconfig": "${WHEREABOUTS_KUBECONFIG_LITERAL}"
+              },
+              "reconciler_cron_expression": "${WHEREABOUTS_RECONCILER_CRON}"
+            }
+            EOF
+
+            }
+
+            generateKubeConfig
+            # ------------------ end Generate a "kube-config"
+
+            # ----------------- Generate a whereabouts conf
+            # removed because we have the configmap
+            #generateWhereaboutsConf
+            # ---------------- End generate a whereabouts conf
+
+
             # copy whereabouts to the cni bin dir
             # SKIPPED DUE TO FIPS COPY.
             # cp -f /whereabouts $CNI_BIN_DIR
 
-            # ---------------------- end Generate a "kube-config".
+            # ---------------------- end generate a "kube-config".
 
             # Unless told otherwise, sleep forever.
             # This prevents Kubernetes from restarting the pod repeatedly.


### PR DESCRIPTION
update install-cni script to match whereabouts bin so that we get cert rotatation in openshift

we have to break the tokenwatcher section of the whereabouts script out because it was running in an init container, so it would never "complete", hanging the rollout

to accomplish this I created a new whereabouts watcher ds to house this section of the script

IMPORTANT: to enable the token watcher to run you must have the the whereabouts shim in your network object
https://docs.openshift.com/container-platform/4.12/networking/multiple_networks/configuring-additional-network.html#nw-multus-creating-whereabouts-reconciler-daemon-set_configuring-additional-network

(cherry picked from commit 6e82842306a2722188b7af48d3a73b4bdd36c0e4) (cherry picked from commit 89d7afc3b2b80608de39eb1b67644136d13173c5)