### PR TITLE
OCPBUGS-56051: Configure the terminationMessagePolicy for all containers deployed in HyperShift

### DIFF
--- a/bindata/cloud-network-config-controller/managed/controller.yaml
+++ b/bindata/cloud-network-config-controller/managed/controller.yaml
@@ -97,6 +97,7 @@ spec:
             value: "{{.KubernetesServicePort}}"
           - name: KUBERNETES_SERVICE_HOST
             value: "{{.KubernetesServiceHost}}"
+        terminationMessagePolicy: FallbackToLogsOnError
       containers:
       # hosted-cluster-token creates a token with a custom path(/var/run/secrets/hosted_cluster/token)
       # The token path is included in the kubeconfig used by cncc containers to talk to the hosted clusters API server
@@ -118,6 +119,7 @@ spec:
             name: admin-kubeconfig
           - mountPath: /var/run/secrets/hosted_cluster
             name: hosted-cluster-api-access
+        terminationMessagePolicy: FallbackToLogsOnError
         # cloud-token creates a token with the default service account path
         # The token is read by cncc containers to authenticate against the cloud services
       - name: cloud-token
@@ -137,6 +139,7 @@ spec:
             name: admin-kubeconfig
           - mountPath: /var/run/secrets/openshift/serviceaccount
             name: cloud-token
+        terminationMessagePolicy: FallbackToLogsOnError
       - name: controller
         securityContext:
           allowPrivilegeEscalation: false

--- a/bindata/network/node-identity/managed/node-identity.yaml
+++ b/bindata/network/node-identity/managed/node-identity.yaml
@@ -98,6 +98,7 @@ spec:
           volumeMounts:
             - mountPath: /var/run/secrets/hosted_cluster
               name: hosted-cluster-api-access
+          terminationMessagePolicy: FallbackToLogsOnError
       automountServiceAccountToken: false
       containers:
       - name: webhook
@@ -244,6 +245,7 @@ spec:
             name: admin-kubeconfig
           - mountPath: /var/run/secrets/hosted_cluster
             name: hosted-cluster-api-access
+        terminationMessagePolicy: FallbackToLogsOnError
       {{ if .HCPNodeSelector }}
       nodeSelector:
         {{ range $key, $value := .HCPNodeSelector }}

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
@@ -103,6 +103,7 @@ spec:
             This allows for pod-pod connectivity in postStart hooks the first time they run.
             EOF
         image: "{{.OvnControlPlaneImage}}"
+        terminationMessagePolicy: FallbackToLogsOnError
       automountServiceAccountToken: false
       containers:
       # token-minter creates a token with the default service account path
@@ -125,6 +126,7 @@ spec:
           name: admin-kubeconfig
         - mountPath: /var/run/secrets/hosted_cluster
           name: hosted-cluster-api-access
+        terminationMessagePolicy: FallbackToLogsOnError
       # ovnkube-control-plane: central component that allocates IPAM for each node in the cluster
       - name: ovnkube-control-plane
         image: "{{.OvnControlPlaneImage}}"


### PR DESCRIPTION
Not all containers deployed in HyperShift had the terminationMessagePolicy set.

@martinkennelly ptal