### PR TITLE
OCPBUGS-55962: Provide config map to force loose isolation for UDN networks

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -430,6 +430,10 @@ spec:
         - name: "NO_PROXY"
           value: "{{ .NO_PROXY}}"
 {{ end }}
+        {{ if .IsLooseUDNIsolationEnabled }}
+        - name: UDN_ISOLATION_MODE
+          value: "loose"
+        {{ end }}
         - name: K8S_NODE
           valueFrom:
             fieldRef:

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -562,6 +562,10 @@ spec:
         - name: OVNKUBE_NODE_MGMT_PORT_DP_RESOURCE_NAME
           value: {{ .MgmtPortResourceName }}
         {{ end }}
+        {{ if .IsLooseUDNIsolationEnabled }}
+        - name: UDN_ISOLATION_MODE
+          value: "loose"
+        {{ end }}
         - name: K8S_NODE
           valueFrom:
             fieldRef:

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -126,6 +126,11 @@ type InfraStatus struct {
 
 	// ConsolePluginCRDExists set to true when the consoleplugins.console.openshift.io has been deployed.
 	ConsolePluginCRDExists bool
+
+	// LooseUDNIsolationModeEnabled set to true when loose isolation mode is enabled between two BGP advertised
+	// UDN networks. In loose isolation mode, those network pods can communicate with each other accoding to
+	// provider network configuration.
+	LooseUDNIsolationModeEnabled bool
 }
 
 // APIServer is the hostname & port of a given APIServer. (This is the

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -180,6 +180,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["NETWORK_NODE_IDENTITY_ENABLE"] = bootstrapResult.Infra.NetworkNodeIdentityEnabled
 	data.Data["NodeIdentityCertDuration"] = OVN_NODE_IDENTITY_CERT_DURATION
 	data.Data["IsNetworkTypeLiveMigration"] = false
+	data.Data["IsLooseUDNIsolationEnabled"] = bootstrapResult.Infra.LooseUDNIsolationModeEnabled
 
 	if conf.Migration != nil {
 		if conf.Migration.MTU != nil && conf.Migration.Mode != operv1.LiveNetworkMigrationMode {


### PR DESCRIPTION
This PR adds support for configuring loose isolation mode for the BGP advertised UDN networks. The config map with name `openshift-network-operator/udn-config-overrides` must be created with `force-loose-isolation` key set to `true` which rolls out the loose mode by recreating `ovnkube-node` daemonset pods.

Steps to roll out loose isolation mode:

1. Create a below config map.
```
kind: ConfigMap
apiVersion: v1
metadata:
  name: udn-config-overrides
  namespace: openshift-network-operator
data:
  force-loose-isolation: "true"
```
2. Wait for ovnkube-node DS rollout to complete.
3. Create BGP advertised UDN networks.