### PR TITLE
CNF-18236: FRRK8s webhook: webhook liveness / readiness from metrics to webhook

### DIFF
--- a/bindata/network/frr-k8s/webhook.yaml
+++ b/bindata/network/frr-k8s/webhook.yaml
@@ -72,6 +72,7 @@ spec:
         - --disable-cert-rotation=true
         - --namespace=$(NAMESPACE)
         - --metrics-bind-address=:7572
+        - --webhook-port=9443
         env:
         - name: NAMESPACE
           valueFrom:
@@ -82,6 +83,8 @@ spec:
         ports:
         - containerPort: 7572
           name: monitoring
+        - containerPort: 9443
+          name: webhook          
         securityContext:
          runAsNonRoot: true
         resources:
@@ -91,15 +94,17 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:
-            path: /metrics
-            port: monitoring
+            path: /healthz
+            port: webhook
+            scheme: HTTPS
           initialDelaySeconds: 10
           periodSeconds: 10
           failureThreshold: 3
         readinessProbe:
           httpGet:
-            path: /metrics
-            port: monitoring
+            path: /healthz
+            port: webhook
+            scheme: HTTPS
           initialDelaySeconds: 10
           periodSeconds: 10
           failureThreshold: 3


### PR DESCRIPTION
Instead of relying on the metrics port to understand when the webhook is ready, we try to hit the endpoint of the webhook itself, so the webhook pod is going to be ready only when it is effectively able to serve.

This is aligned with the frr-k8s binary change where we add a new endpoint "healtz" to the webhook server.

This is also required for https://github.com/openshift/frr/pull/93 where we disable the metrics endpoint as part of making the webhook hostnetworked.