### PR TITLE
OCPBUGS-56086: Validate NAD name and spec only in multus admission controller

### DIFF
--- a/bindata/network/multus-admission-controller/003-webhook.yaml
+++ b/bindata/network/multus-admission-controller/003-webhook.yaml
@@ -27,6 +27,10 @@ webhooks:
         apiGroups: ["k8s.cni.cncf.io"]
         apiVersions: ["v1"]
         resources: ["network-attachment-definitions"]
+    matchConditions:
+      # On updates, only validate if the Spec changes
+      - name: CreateDeleteOrUpdatedSpec
+        expression: oldObject == null || object == null || object.spec != oldObject.spec
     sideEffects: NoneOnDryRun
     admissionReviewVersions:
     - v1


### PR DESCRIPTION
This should save up calls to the webhook and reduce latency when a NAD is updated to add labels or annotations.

The root cause of the change is the OVNK BGP feature: when BGP is enabled for the cluster default network, reconfiguration might cause temporary disruptions. As part of this reconfiguration and necessary to complete it, OVNK depends on annotating an internal NAD. We want to avoid having to reach the webhook for this annotation because the temporary disruption might prevent it and in that case the reconfiguration won't complete.

Another possibility would be to filter out from validation the specific internal NAD but this current approach might be more beneficial overall.

/cc @kyrtapz @dougbtv 