### PR TITLE
OCPBUGS-42303: QE;DNM; Gate ovn-controller starting post reboot until ovnkube controller syncs

### DIFF
--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -59,6 +59,17 @@ data:
         exit 1
       fi
 
+      echo "$(date -Iseconds) - waiting for 10 minutes for ovnkube-controller to sync and SB DB hot..."
+      local retries=0
+      # ten minutes timeout
+      while [[ 3000 -gt "${retries}" ]]; do
+        (( retries += 1 ))
+        if [[ -f /run/ovn-kubernetes/ovnkube-controller-sb-db-hot ]]; then
+          break
+        fi
+        sleep .2
+      done
+
       echo "$(date -Iseconds) - starting ovn-controller"
       exec ovn-controller \
         unix:${vswitch_dbsock} \

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -134,6 +134,9 @@ spec:
           name: node-log
         - mountPath: /dev/log
           name: log-socket
+        - mountPath: /run/ovn-kubernetes
+          name: host-run-ovn-kubernetes
+          readOnly: True
         terminationMessagePolicy: FallbackToLogsOnError
         resources:
           requests:

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -169,6 +169,9 @@ spec:
           name: node-log
         - mountPath: /dev/log
           name: log-socket
+        - mountPath: /run/ovn-kubernetes
+          name: host-run-ovn-kubernetes
+          readOnly: True
         terminationMessagePolicy: FallbackToLogsOnError
         resources:
           requests:


### PR DESCRIPTION
TODO; Must investigate if this is the right approach for all deployments. We need IC enabled.

This commit fixes OCPBUGS-42303.
If ovn-controller starts before ovnkube-controller syncs and the changes propagated to SB DB, then ovn-controller will consume stale SB DB data. This PR gates starting ovn-controller until ovnkube controller syncs. ovnkube-controller emits a file to non-persistent storage and we predicate the start on this.

/hold
/cc

cc @huiran0826 