### PR TITLE
Mount pluto socket file path into ovnkube-node pod

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -507,6 +507,10 @@ spec:
           name: ovnkube-config
         - mountPath: /env
           name: env-overrides
+{{ if .OVNIPsecEnable }}
+        - mountPath: /var/run/pluto
+          name: run-pluto
+{{ end }}
         resources:
           requests:
             cpu: 10m
@@ -713,5 +717,11 @@ spec:
         configMap:
           name: ovnkube-script-lib
           defaultMode: 0744
+{{ if .OVNIPsecEnable }}
+      - name: run-pluto
+        hostPath:
+          path: /var/run/pluto
+          type: DirectoryOrCreate
+{{ end }}
       tolerations:
       - operator: "Exists"

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -639,6 +639,10 @@ spec:
           name: ovnkube-config
         - mountPath: /env
           name: env-overrides
+{{ if .OVNIPsecEnable }}
+        - mountPath: /var/run/pluto
+          name: run-pluto
+{{ end }}
         resources:
           requests:
             cpu: 10m
@@ -841,5 +845,11 @@ spec:
         configMap:
           name: ovnkube-script-lib
           defaultMode: 0744
+{{ if .OVNIPsecEnable }}
+      - name: run-pluto
+        hostPath:
+          path: /var/run/pluto
+          type: DirectoryOrCreate
+{{ end }}
       tolerations:
       - operator: "Exists"


### PR DESCRIPTION
In order to collect ipsec tunnel metrics we need access to pluto daemon socket for running `ipsec showstates` command. So this PR mounts `/var/run/pluto` host directory into `ovnkube-controller` container.