### PR TITLE
NO-JIRA: remove unused clusterrolebinding default-account-cluster-network-operator

### DIFF
--- a/manifests/0000_70_cluster-network-operator_02_rbac.yaml
+++ b/manifests/0000_70_cluster-network-operator_02_rbac.yaml
@@ -24,21 +24,3 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
   apiGroup: rbac.authorization.k8s.io
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: default-account-cluster-network-operator
-  annotations:
-    release.openshift.io/delete: "true"
-    include.release.openshift.io/self-managed-high-availability: "false"
-    include.release.openshift.io/ibm-cloud-managed: "false"
-    include.release.openshift.io/single-node-developer: "false"
-subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: openshift-network-operator
-roleRef: 
-  kind: ClusterRole
-  name: cluster-admin
-  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
1. The default-account-cluster-network-operator ClusterRoleBinding only worke when upgrade from 4.15
2. cleanup the unused yaml in newest(4.20) version
3. kind of subsequent optimization measures of https://github.com/openshift/cluster-network-operator/pull/2084

address https://github.com/openshift/cluster-version-operator/issues/1207