### PR TITLE
OCPBUGS-57643: Add release version annotation to whereabouts-controller/whereabouts-token-watcher

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -862,6 +862,8 @@ kind: Deployment
 metadata:
   name: whereabouts-controller
   namespace: openshift-multus
+  annotations:
+    release.openshift.io/version: "{{.ReleaseVersion}}"
 spec:
   replicas: 1
   selector:
@@ -935,6 +937,7 @@ metadata:
     kubernetes.io/description: |
       This deamon watches over the whereabouts service account token and CA
       file for changes and will regenerate a kubeconfig if changes are seen
+    release.openshift.io/version: "{{.ReleaseVersion}}"
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Include a `release.openshift.io/version` annotation on both `whereabouts-controller` deployment and `whereabouts-token-watcher` daemonset. The CNO [compares this against the target version](https://github.com/openshift/cluster-network-operator/blob/2a1d6159a44bf8aa26bba9981f144006a1d99990/pkg/controller/statusmanager/pod_status.go#L114-L116) during an upgrade and never updates its version if the check fails.