### PR TITLE
CNF-18237: Align frrk8s manifests to upstream

### DIFF
--- a/bindata/network/frr-k8s/001-crd.yaml
+++ b/bindata/network/frr-k8s/001-crd.yaml
@@ -184,9 +184,15 @@ spec:
                                     0
                               disableMP:
                                 default: false
-                                description: To set if we want to disable MP BGP that
-                                  will separate IPv4 and IPv6 route exchanges into
-                                  distinct BGP sessions.
+                                description: |-
+                                  To set if we want to disable MP BGP that will separate IPv4 and IPv6 route exchanges into distinct BGP sessions.
+                                  Deprecated: DisableMP is deprecated in favor of dualStackAddressFamily.
+                                type: boolean
+                              dualStackAddressFamily:
+                                default: false
+                                description: |-
+                                  To set if we want to enable the neighbor not only for the ipfamily related to its session,
+                                  but also the other one. This allows to advertise/receive IPv4 prefixes over IPv6 sessions and vice versa.
                                 type: boolean
                               dynamicASN:
                                 description: |-
@@ -222,6 +228,8 @@ spec:
                                   represents an interface name on the host and if user provides an invalid
                                   value, only the actual BGP session will not be established.
                                   Address and Interface are mutually exclusive and one of them must be specified.
+                                  Note: when enabling unnumbered, the neighbor will be enabled for both
+                                  IPv4 and IPv6 address families.
                                 type: string
                               keepaliveTime:
                                 description: |-

--- a/bindata/network/frr-k8s/webhook.yaml
+++ b/bindata/network/frr-k8s/webhook.yaml
@@ -61,7 +61,7 @@ spec:
         component: frr-k8s-webhook-server
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        openshift.io/required-scc: restricted-v2
+        openshift.io/required-scc: privileged
     spec:
       containers:
       - command:
@@ -81,9 +81,7 @@ spec:
         name: frr-k8s-webhook-server
         ports:
         - containerPort: 9123
-          name: webhook          
-        securityContext:
-         runAsNonRoot: true
+          name: webhook
         resources:
           requests:
             cpu: 10m

--- a/bindata/network/frr-k8s/webhook.yaml
+++ b/bindata/network/frr-k8s/webhook.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ports:
   - port: 443
-    targetPort: 9443
+    targetPort: webhook
   selector:
     component: frr-k8s-webhook-server
 ---
@@ -71,8 +71,7 @@ spec:
         - --webhook-mode=onlywebhook
         - --disable-cert-rotation=true
         - --namespace=$(NAMESPACE)
-        - --metrics-bind-address=:7572
-        - --webhook-port=9443
+        - --webhook-port=9123
         env:
         - name: NAMESPACE
           valueFrom:
@@ -81,9 +80,7 @@ spec:
         image: {{.FRRK8sImage}}
         name: frr-k8s-webhook-server
         ports:
-        - containerPort: 7572
-          name: monitoring
-        - containerPort: 9443
+        - containerPort: 9123
           name: webhook          
         securityContext:
          runAsNonRoot: true
@@ -127,3 +124,4 @@ spec:
       serviceAccountName: frr-k8s-daemon
       priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 10
+      hostNetwork: true


### PR DESCRIPTION
Align to upstream:

- FRRK8s webhook becomes hostnetworked and we change the port to one in the allowed range in https://github.com/openshift/enhancements/blob/master/dev-guide/host-port-registry.md (still need to be registered)
- The DisableMP is deprecated, the default behavior is single stack ipfamily, a dualstackIPFamily flag is added for backward compatibility. 