### PR TITLE
OCPBUGS-58231: Revert #2730 "CNF-18237: Align frrk8s manifests to upstream"

### DIFF
--- a/bindata/network/frr-k8s/001-crd.yaml
+++ b/bindata/network/frr-k8s/001-crd.yaml
@@ -184,15 +184,9 @@ spec:
                                     0
                               disableMP:
                                 default: false
-                                description: |-
-                                  To set if we want to disable MP BGP that will separate IPv4 and IPv6 route exchanges into distinct BGP sessions.
-                                  Deprecated: DisableMP is deprecated in favor of dualStackAddressFamily.
-                                type: boolean
-                              dualStackAddressFamily:
-                                default: false
-                                description: |-
-                                  To set if we want to enable the neighbor not only for the ipfamily related to its session,
-                                  but also the other one. This allows to advertise/receive IPv4 prefixes over IPv6 sessions and vice versa.
+                                description: To set if we want to disable MP BGP that
+                                  will separate IPv4 and IPv6 route exchanges into
+                                  distinct BGP sessions.
                                 type: boolean
                               dynamicASN:
                                 description: |-
@@ -228,8 +222,6 @@ spec:
                                   represents an interface name on the host and if user provides an invalid
                                   value, only the actual BGP session will not be established.
                                   Address and Interface are mutually exclusive and one of them must be specified.
-                                  Note: when enabling unnumbered, the neighbor will be enabled for both
-                                  IPv4 and IPv6 address families.
                                 type: string
                               keepaliveTime:
                                 description: |-

--- a/bindata/network/frr-k8s/webhook.yaml
+++ b/bindata/network/frr-k8s/webhook.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ports:
   - port: 443
-    targetPort: webhook
+    targetPort: 9443
   selector:
     component: frr-k8s-webhook-server
 ---
@@ -61,7 +61,7 @@ spec:
         component: frr-k8s-webhook-server
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        openshift.io/required-scc: privileged
+        openshift.io/required-scc: restricted-v2
     spec:
       containers:
       - command:
@@ -71,7 +71,8 @@ spec:
         - --webhook-mode=onlywebhook
         - --disable-cert-rotation=true
         - --namespace=$(NAMESPACE)
-        - --webhook-port=9123
+        - --metrics-bind-address=:7572
+        - --webhook-port=9443
         env:
         - name: NAMESPACE
           valueFrom:
@@ -80,8 +81,12 @@ spec:
         image: {{.FRRK8sImage}}
         name: frr-k8s-webhook-server
         ports:
-        - containerPort: 9123
-          name: webhook
+        - containerPort: 7572
+          name: monitoring
+        - containerPort: 9443
+          name: webhook          
+        securityContext:
+         runAsNonRoot: true
         resources:
           requests:
             cpu: 10m
@@ -122,4 +127,3 @@ spec:
       serviceAccountName: frr-k8s-daemon
       priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 10
-      hostNetwork: true


### PR DESCRIPTION
Reverts #2730 ; tracked by OCPBUGS-58231

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are *_exploring_* reverting this change to get CI and/or nightly payloads flowing again.

> Suspect this may be related to '[Feature:SCC][Early] should not have pod creation failures during install' test failures which failed 3 recent 4.20 nightlies

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
run nightly aggregated e.g. /payload-aggregate periodic-ci-openshift-release-master-ci-4.20-e2e-aws-ovn-upgrade-out-of-change 10
```

CC: @fedepaol

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
