### PR TITLE
CORENET-6127: ovn-k: Enable OVN-K feature when PreconfiguredUDNAddresses is enabled

### DIFF
--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -569,6 +569,11 @@ data:
       if [[ "{{.OVN_ROUTE_ADVERTISEMENTS_ENABLE}}" == "true" ]]; then
         route_advertisements_enable_flag="--enable-route-advertisements"
       fi
+  
+      preconfigured_udn_addresses_enable_flag=
+      if [[ "{{.OVN_PRE_CONF_UDN_ADDR_ENABLE}}" == "true" ]]; then
+        preconfigured_udn_addresses_enable_flag="--enable-preconfigured-udn-addresses"
+      fi
 
       network_observability_enabled_flag=
       if [[ "{{.OVN_OBSERVABILITY_ENABLE}}" == "true" ]]; then
@@ -663,6 +668,7 @@ data:
         ${multi_network_enabled_flag} \
         ${network_segmentation_enabled_flag} \
         ${route_advertisements_enable_flag} \
+        ${preconfigured_udn_addresses_enable_flag} \
         ${multi_network_policy_enabled_flag} \
         ${admin_network_policy_enabled_flag} \
         ${dns_name_resolver_enabled_flag} \

--- a/bindata/network/ovn-kubernetes/managed/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/004-config.yaml
@@ -49,6 +49,9 @@ data:
     {{- end }}
     enable-network-segmentation=true
 {{- end }}
+{{- if .OVN_PRE_CONF_UDN_ADDR_ENABLE }}
+    enable-preconfigured-udn-addresses=true
+{{- end }}
 {{- if .OVN_MULTI_NETWORK_POLICY_ENABLE }}
     enable-multi-networkpolicy=true
 {{- end }}
@@ -140,6 +143,9 @@ data:
     enable-multi-network=true
     {{- end }}
     enable-network-segmentation=true
+{{- if .OVN_PRE_CONF_UDN_ADDR_ENABLE }}
+    enable-preconfigured-udn-addresses=true
+{{- end }}
 {{- end }}
 {{- if .OVN_MULTI_NETWORK_POLICY_ENABLE }}
     enable-multi-networkpolicy=true

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
@@ -193,6 +193,11 @@ spec:
           if [[ "{{.OVN_ROUTE_ADVERTISEMENTS_ENABLE}}" == "true" ]]; then
             route_advertisements_enable_flag="--enable-route-advertisements"
           fi
+          
+          preconfigured_udn_addresses_enable_flag=
+          if [[ "{{.OVN_PRE_CONF_UDN_ADDR_ENABLE}}" == "true" ]]; then
+            preconfigured_udn_addresses_enable_flag="--enable-preconfigured-udn-addresses"
+          fi
 
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-control-plane - start ovnkube --init-cluster-manager ${K8S_NODE}"
           exec /usr/bin/ovnkube \
@@ -214,7 +219,8 @@ spec:
             ${persistent_ips_enabled_flag} \
             ${multi_network_enabled_flag} \
             ${network_segmentation_enabled_flag} \
-            ${route_advertisements_enable_flag}
+            ${route_advertisements_enable_flag} \
+            ${preconfigured_udn_addresses_enable_flag}
         volumeMounts:
         - mountPath: /run/ovnkube-config/
           name: ovnkube-config

--- a/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
@@ -55,6 +55,9 @@ data:
     {{- end }}
     enable-network-segmentation=true
 {{- end }}
+{{- if .OVN_PRE_CONF_UDN_ADDR_ENABLE }}
+    enable-preconfigured-udn-addresses=true
+{{- end }}
 {{- if .OVN_MULTI_NETWORK_POLICY_ENABLE }}
     enable-multi-networkpolicy=true
 {{- end }}

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
@@ -144,7 +144,12 @@ spec:
           if [[ "{{.OVN_ROUTE_ADVERTISEMENTS_ENABLE}}" == "true" ]]; then
             route_advertisements_enable_flag="--enable-route-advertisements"
           fi
-
+  
+          preconfigured_udn_addresses_enable_flag=
+          if [[ "{{.OVN_PRE_CONF_UDN_ADDR_ENABLE}}" == "true" ]]; then
+            preconfigured_udn_addresses_enable_flag="--enable-preconfigured-udn-addresses"
+          fi
+          
           if [ "{{.OVN_GATEWAY_MODE}}" == "shared" ]; then
             gateway_mode_flags="--gateway-mode shared"
           elif [ "{{.OVN_GATEWAY_MODE}}" == "local" ]; then
@@ -172,7 +177,8 @@ spec:
             ${multi_network_enabled_flag} \
             ${network_segmentation_enabled_flag} \
             ${gateway_mode_flags} \
-            ${route_advertisements_enable_flag}
+            ${route_advertisements_enable_flag} \
+            ${preconfigured_udn_addresses_enable_flag}
         volumeMounts:
         - mountPath: /run/ovnkube-config/
           name: ovnkube-config

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -324,6 +324,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["OVN_NETWORK_SEGMENTATION_ENABLE"] = featureGates.Enabled(apifeatures.FeatureGateNetworkSegmentation)
 	data.Data["OVN_OBSERVABILITY_ENABLE"] = featureGates.Enabled(apifeatures.FeatureGateOVNObservability)
 	data.Data["OVN_ROUTE_ADVERTISEMENTS_ENABLE"] = c.RouteAdvertisements == operv1.RouteAdvertisementsEnabled
+	data.Data["OVN_PRE_CONF_UDN_ADDR_ENABLE"] = featureGates.Enabled(apifeatures.FeatureGatePreconfiguredUDNAddresses)
 
 	data.Data["ReachabilityTotalTimeoutSeconds"] = c.EgressIPConfig.ReachabilityTotalTimeoutSeconds
 


### PR DESCRIPTION
Following https://github.com/openshift/enhancements/pull/1793, https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5238 and https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5332
This PR makes CNO enable OVN-K feature (EnableCustomNetworkConfig) when PreconfiguredUDNAddresses is enabled