### PR TITLE
OCPBUGS-58448: fg, virt: remove FeatureGatePersistentIPsForVirtualization

### DIFF
--- a/bindata/network/ovn-kubernetes/common/001-crd.yaml
+++ b/bindata/network/ovn-kubernetes/common/001-crd.yaml
@@ -3101,7 +3101,6 @@ status:
   conditions: null
   storedVersions: null
 {{- end }}
-{{- if .OVN_PERSISTENT_IPS_ENABLE }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -3165,7 +3164,6 @@ spec:
       storage: true
       subresources:
         status: {}
-{{- end }}
 {{- if .OVN_NETWORK_SEGMENTATION_ENABLE }}
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/bindata/network/ovn-kubernetes/common/004-rbac-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/common/004-rbac-control-plane.yaml
@@ -150,7 +150,6 @@ rules:
   - network-attachment-definitions
   verbs:
   - patch
-{{- if .OVN_PERSISTENT_IPS_ENABLE }}
 - apiGroups:
     - k8s.cni.cncf.io
   resources:
@@ -161,7 +160,6 @@ rules:
   resources:
     - ipamclaims/status
   verbs: [ "patch", "update" ]
-{{- end}}
 {{- if .OVN_NETWORK_SEGMENTATION_ENABLE }}
 - apiGroups:
     - discovery.k8s.io

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
@@ -178,10 +178,7 @@ spec:
             dns_name_resolver_enabled_flag="--enable-dns-name-resolver"
           fi
 
-          persistent_ips_enabled_flag=
-          if [[ "{{.OVN_PERSISTENT_IPS_ENABLE}}" == "true" ]]; then
-            persistent_ips_enabled_flag="--enable-persistent-ips"
-          fi
+          persistent_ips_enabled_flag="--enable-persistent-ips"
 
           # This is needed so that converting clusters from GA to TP
           # will rollout control plane pods as well

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
@@ -129,10 +129,7 @@ spec:
             dns_name_resolver_enabled_flag="--enable-dns-name-resolver"
           fi
 
-          persistent_ips_enabled_flag=
-          if [[ "{{.OVN_PERSISTENT_IPS_ENABLE}}" == "true" ]]; then
-            persistent_ips_enabled_flag="--enable-persistent-ips"
-          fi
+          persistent_ips_enabled_flag="--enable-persistent-ips"
 
           # This is needed so that converting clusters from GA to TP
           # will rollout control plane pods as well

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -374,8 +374,6 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 		data.Data["OVN_MULTI_NETWORK_POLICY_ENABLE"] = true
 	}
 
-	data.Data["OVN_PERSISTENT_IPS_ENABLE"] = featureGates.Enabled(apifeatures.FeatureGatePersistentIPsForVirtualization)
-
 	//there only needs to be two cluster managers
 	clusterManagerReplicas := 2
 	if bootstrapResult.OVN.ControlPlaneReplicaCount < 2 {

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -77,7 +77,7 @@ func getDefaultFeatureGates() featuregates.FeatureGate {
 	return featuregates.NewFeatureGate(
 		[]configv1.FeatureGateName{apifeatures.FeatureGateAdminNetworkPolicy, apifeatures.FeatureGateDNSNameResolver,
 			apifeatures.FeatureGateNetworkSegmentation, apifeatures.FeatureGateOVNObservability},
-		[]configv1.FeatureGateName{apifeatures.FeatureGatePersistentIPsForVirtualization},
+		[]configv1.FeatureGateName{},
 	)
 }
 
@@ -963,7 +963,6 @@ logfile-maxage=0`,
 			knownFeatureGates := []configv1.FeatureGateName{
 				apifeatures.FeatureGateAdminNetworkPolicy,
 				apifeatures.FeatureGateDNSNameResolver,
-				apifeatures.FeatureGatePersistentIPsForVirtualization,
 				apifeatures.FeatureGateNetworkSegmentation,
 				apifeatures.FeatureGateOVNObservability,
 			}
@@ -3859,7 +3858,6 @@ func TestRenderOVNKubernetesEnablePersistentIPs(t *testing.T) {
 		[]configv1.FeatureGateName{
 			apifeatures.FeatureGateAdminNetworkPolicy,
 			apifeatures.FeatureGateDNSNameResolver,
-			apifeatures.FeatureGatePersistentIPsForVirtualization,
 			apifeatures.FeatureGateNetworkSegmentation,
 			apifeatures.FeatureGateOVNObservability,
 		},
@@ -4035,7 +4033,6 @@ func Test_renderOVNKubernetes(t *testing.T) {
 				apifeatures.FeatureGateAdminNetworkPolicy,
 				apifeatures.FeatureGateDNSNameResolver,
 				apifeatures.FeatureGateNetworkSegmentation,
-				apifeatures.FeatureGatePersistentIPsForVirtualization,
 				apifeatures.FeatureGateOVNObservability,
 			},
 		)
@@ -4048,7 +4045,6 @@ func Test_renderOVNKubernetes(t *testing.T) {
 			[]configv1.FeatureGateName{
 				apifeatures.FeatureGateAdminNetworkPolicy,
 				apifeatures.FeatureGateDNSNameResolver,
-				apifeatures.FeatureGatePersistentIPsForVirtualization,
 				apifeatures.FeatureGateOVNObservability,
 			},
 		)
@@ -4075,7 +4071,7 @@ func Test_renderOVNKubernetes(t *testing.T) {
 				client:          cnofake.NewFakeClient(),
 				featureGates:    noFeatureGates,
 			},
-			expectNumObjs: 37,
+			expectNumObjs: 38,
 		},
 		{
 			name: "render routeadvertisements",
@@ -4090,7 +4086,7 @@ func Test_renderOVNKubernetes(t *testing.T) {
 				client:          cnofake.NewFakeClient(),
 				featureGates:    noFeatureGates,
 			},
-			expectNumObjs: 38,
+			expectNumObjs: 39,
 		},
 		{
 			name: "render with UDN",
@@ -4101,7 +4097,7 @@ func Test_renderOVNKubernetes(t *testing.T) {
 				client:          cnofake.NewFakeClient(),
 				featureGates:    udnFeatureGate,
 			},
-			expectNumObjs: 43,
+			expectNumObjs: 44,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This feature was GA'ed in 4.18 - let's remove it from the codebase.

Removing it from the API will be done in a follow-up PR.