### PR TITLE
OCPBUGS-58306: Disable network segmentation when multus is disabled

### DIFF
--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -368,6 +368,8 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["OVN_MULTI_NETWORK_POLICY_ENABLE"] = false
 	if conf.DisableMultiNetwork != nil && *conf.DisableMultiNetwork {
 		data.Data["OVN_MULTI_NETWORK_ENABLE"] = false
+		data.Data["OVN_NETWORK_SEGMENTATION_ENABLE"] = false
+		klog.Warningf("Forcing OVN_NETWORK_SEGMENTATION_ENABLE=false because DisableMultiNetwork=true in the operator config")
 	} else if conf.UseMultiNetworkPolicy != nil && *conf.UseMultiNetworkPolicy {
 		// Multi-network policy support requires multi-network support to be
 		// enabled

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -822,6 +822,49 @@ logfile-maxage=0`,
 			enabledFeatureGates:      []configv1.FeatureGateName{apifeatures.FeatureGateNetworkSegmentation},
 		},
 		{
+			desc: "disable network segmentation when multi-network is disabled",
+			expected: `
+[default]
+mtu="1500"
+cluster-subnets="10.128.0.0/15/23,10.0.0.0/14/24"
+encap-port="8061"
+enable-lflow-cache=true
+lflow-cache-limit-kb=1048576
+enable-udp-aggregation=true
+udn-allowed-default-services="default/kubernetes,openshift-dns/dns-default"
+
+[kubernetes]
+service-cidrs="172.30.0.0/16"
+ovn-config-namespace="openshift-ovn-kubernetes"
+apiserver="https://testing.test:8443"
+host-network-namespace="openshift-host-network"
+platform-type="GCP"
+healthz-bind-address="0.0.0.0:10256"
+dns-service-namespace="openshift-dns"
+dns-service-name="dns-default"
+
+[ovnkubernetesfeature]
+enable-egress-ip=true
+enable-egress-firewall=true
+enable-egress-qos=true
+enable-egress-service=true
+egressip-node-healthcheck-port=9107
+enable-multi-external-gateway=true
+
+[gateway]
+mode=shared
+nodeport=true
+
+[logging]
+libovsdblogfile=/var/log/ovnkube/libovsdb.log
+logfile-maxsize=100
+logfile-maxbackups=5
+logfile-maxage=0`,
+			controlPlaneReplicaCount: 2,
+			disableMultiNet:          true,
+			enabledFeatureGates:      []configv1.FeatureGateName{apifeatures.FeatureGateNetworkSegmentation},
+		},
+		{
 			desc: "enable multi-network policies without multi-network support",
 			expected: `
 [default]


### PR DESCRIPTION
Network segmentation requires multus to be enabled. If the user disables multus (multi networks), we should also disable network segmentation. 
Since network segmentation is on by default, we have to disable it explicitly if we find `disableMultiNetwork=true`