### PR TITLE
 [release-4.19] BGP related backports

### DIFF
--- a/bindata/network/frr-k8s/001-crd.yaml
+++ b/bindata/network/frr-k8s/001-crd.yaml
@@ -184,9 +184,15 @@ spec:
                                     0
                               disableMP:
                                 default: false
-                                description: To set if we want to disable MP BGP that
-                                  will separate IPv4 and IPv6 route exchanges into
-                                  distinct BGP sessions.
+                                description: |-
+                                  To set if we want to disable MP BGP that will separate IPv4 and IPv6 route exchanges into distinct BGP sessions.
+                                  Deprecated: DisableMP is deprecated in favor of dualStackAddressFamily.
+                                type: boolean
+                              dualStackAddressFamily:
+                                default: false
+                                description: |-
+                                  To set if we want to enable the neighbor not only for the ipfamily related to its session,
+                                  but also the other one. This allows to advertise/receive IPv4 prefixes over IPv6 sessions and vice versa.
                                 type: boolean
                               dynamicASN:
                                 description: |-
@@ -222,6 +228,8 @@ spec:
                                   represents an interface name on the host and if user provides an invalid
                                   value, only the actual BGP session will not be established.
                                   Address and Interface are mutually exclusive and one of them must be specified.
+                                  Note: when enabling unnumbered, the neighbor will be enabled for both
+                                  IPv4 and IPv6 address families.
                                 type: string
                               keepaliveTime:
                                 description: |-

--- a/bindata/network/frr-k8s/config.yaml
+++ b/bindata/network/frr-k8s/config.yaml
@@ -46,7 +46,7 @@ data:
     #
     vtysh_enable=yes
     zebra_options="  -A 127.0.0.1 -s 90000000 --limit-fds 100000"
-    bgpd_options="   -A 127.0.0.1 --limit-fds 100000"
+    bgpd_options="   -A 127.0.0.1 -p 0 --limit-fds 100000"
     ospfd_options="  -A 127.0.0.1"
     ospf6d_options=" -A ::1"
     ripd_options="   -A 127.0.0.1"

--- a/bindata/network/frr-k8s/webhook.yaml
+++ b/bindata/network/frr-k8s/webhook.yaml
@@ -61,7 +61,7 @@ spec:
         component: frr-k8s-webhook-server
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        openshift.io/required-scc: restricted-v2
+        openshift.io/required-scc: privileged
     spec:
       containers:
       - command:
@@ -78,8 +78,6 @@ spec:
               fieldPath: metadata.namespace
         image: {{.FRRK8sImage}}
         name: frr-k8s-webhook-server        
-        securityContext:
-         runAsNonRoot: true
         resources:
           requests:
             cpu: 10m

--- a/bindata/network/frr-k8s/webhook.yaml
+++ b/bindata/network/frr-k8s/webhook.yaml
@@ -71,17 +71,13 @@ spec:
         - --webhook-mode=onlywebhook
         - --disable-cert-rotation=true
         - --namespace=$(NAMESPACE)
-        - --metrics-bind-address=:7572
         env:
         - name: NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
         image: {{.FRRK8sImage}}
-        name: frr-k8s-webhook-server
-        ports:
-        - containerPort: 7572
-          name: monitoring
+        name: frr-k8s-webhook-server        
         securityContext:
          runAsNonRoot: true
         resources:
@@ -122,3 +118,4 @@ spec:
       serviceAccountName: frr-k8s-daemon
       priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 10
+      hostNetwork: true

--- a/bindata/network/multus-admission-controller/003-webhook.yaml
+++ b/bindata/network/multus-admission-controller/003-webhook.yaml
@@ -27,6 +27,10 @@ webhooks:
         apiGroups: ["k8s.cni.cncf.io"]
         apiVersions: ["v1"]
         resources: ["network-attachment-definitions"]
+    matchConditions:
+      # On updates, only validate if the Spec changes
+      - name: CreateDeleteOrUpdatedSpec
+        expression: oldObject == null || object == null || object.spec != oldObject.spec
     sideEffects: NoneOnDryRun
     admissionReviewVersions:
     - v1

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
@@ -148,6 +148,15 @@ spec:
             route_advertisements_enable_flag="--enable-route-advertisements"
           fi
 
+          if [ "{{.OVN_GATEWAY_MODE}}" == "shared" ]; then
+            gateway_mode_flags="--gateway-mode shared"
+          elif [ "{{.OVN_GATEWAY_MODE}}" == "local" ]; then
+            gateway_mode_flags="--gateway-mode local"
+          else
+            echo "Invalid OVN_GATEWAY_MODE: \"{{.OVN_GATEWAY_MODE}}\". Must be \"local\" or \"shared\"."
+            exit 1
+          fi
+
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-control-plane - start ovnkube --init-cluster-manager ${K8S_NODE}"
           exec /usr/bin/ovnkube \
             --enable-interconnect \
@@ -165,6 +174,7 @@ spec:
             ${persistent_ips_enabled_flag} \
             ${multi_network_enabled_flag} \
             ${network_segmentation_enabled_flag} \
+            ${gateway_mode_flags} \
             ${route_advertisements_enable_flag}
         volumeMounts:
         - mountPath: /run/ovnkube-config/


### PR DESCRIPTION
cherry-picked
```
5cc28c623 FRR-K8s webhook: promote to priviledged
7056e67b7 FRRK8s CRDs: align to upstream
0b29885cc FRRK8s webhook: align to upstream
acdd04316 FRRK8s webhook: webhook liveness / readiness from metrics to webhook
0dae0a03e (origin/nad-validation-nameOrSpec, nad-validation-nameOrSpec) Validate NAD name and spec only in multus admission controller
401f7b46b frr-k8s: stop listening for incoming connection in the bgp daemon
bc5f08ed5 Pass '--gateway-mode' flag for ovnkube-cluster-manager
```
did not cherry-pick
```
acdd04316 FRRK8s webhook: webhook liveness / readiness from metrics to webhook
```
as that requires FRR-k8s to be backported as well which is pending.

conflict: https://github.com/openshift/cluster-network-operator/commit/acdd04316930ec1abb30e0e198f118766cc920eb added webhook arg/port, later on https://github.com/openshift/cluster-network-operator/commit/0b29885cc06a36c8c4a23deb47acb551e73dc774 removed the monitoring arg/port. The resolution of the conflict is, logically, neither webhook arg/port nor monitoring arg/port defined.

/cc @fedepaol 
to croscheck the resolution of the conflict

/hold
waiting for https://github.com/openshift/cluster-network-operator/pull/2714 unless we decide otherwise