### PR TITLE
OCPBUGS-59135,OCPBUGS-59134: Annotate whereabouts-controller

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -871,6 +871,8 @@ spec:
       app: whereabouts-controller
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: whereabouts-controller
     spec:
@@ -891,9 +893,6 @@ spec:
           image: {{.WhereaboutsImage}}
           name: whereabouts
           resources:
-            limits:
-              cpu: 100m
-              memory: 200Mi
             requests:
               cpu: 100m
               memory: 100Mi


### PR DESCRIPTION
Add target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}' annotation to whereabouts-controller deployment to satisfy
_sig-node__apigroup_config.openshift.io__CPU_Partitioning_cluster_platform_workloads_should_be_annotated_correctly_for_Deployments__Suite_openshift/conformance/parallel_ job

Remove resource limits on whereabouts controller to satisfy ShiftOnStack
conformence test `Pods in platform namespaces are not following resource
request/limit rules or do not have an exception granted`