### PR TITLE
NO-JIRA: deprecate exportloopref

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,7 +7,7 @@ linters:
   disable-all: true #so that lint version bumps don't change results
   enable:
     - errcheck
-    - exportloopref
+    - copyloopvar
     - gosimple
     - govet
     - ineffassign


### PR DESCRIPTION
/cc @kyrtapz 
we need to  remove `exportloopref` in .golangci.yaml
```
level=warning msg="The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar."
```