### PR TITLE
NO-JIRA: Update CNO reviewers/approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,19 +2,23 @@ aliases:
   core-approvers:
   - abhat
   - danwinship
-  - dougbtv
   - fepan
   - JacobTanenbaum
   - jcaamano
   - knobunc
   - kyrtapz
-  - trozet
+  - pliurh
+  - tssurya
   core-reviewers:
-  - abhat
+  - arghosh93
+  - arkadeepsen 
+  - bpickard22
   - danwinship
-  - dougbtv
-  - JacobTanenbaum
   - jcaamano
   - kyrtapz
-  - trozet
+  - martinkennelly 
+  - miheer
+  - pliurh
+  - pperiyasamy 
+  - ricky-rav
   - tssurya


### PR DESCRIPTION
Removing trozet as he left the company. Adding tssurya as team lead replacement.

Adding pliurh as approver replacing dougbtv who will be eventually removed after some soak period as he moved on to other unrelated projects. pliurh has demonstrated extensive experience working on this repository througout his work on sdn->ovnk different migration modes.

Added bpickard22 to help as a reviewer for multus related changes as a replacement for dougbtv.