### PR TITLE
CORENET-6247: Set runAsUser for ovnkube-control-plane

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
@@ -288,9 +288,9 @@ spec:
         "{{$key}}": "{{$value}}"
         {{ end }}
       {{ end }}
-      {{- if .OVNRunAsUser }}
+      {{- if .RunAsUser }}
       securityContext:
-        runAsUser: {{.OVNRunAsUser}}
+        runAsUser: {{.RunAsUser}}
       {{- end }}
       volumes:
       - name: ovnkube-config

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
@@ -291,6 +291,9 @@ spec:
       {{- if .RunAsUser }}
       securityContext:
         runAsUser: {{.RunAsUser}}
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       {{- end }}
       volumes:
       - name: ovnkube-config

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
@@ -288,6 +288,10 @@ spec:
         "{{$key}}": "{{$value}}"
         {{ end }}
       {{ end }}
+      {{- if .OVNRunAsUser }}
+      securityContext:
+        runAsUser: {{.OVNRunAsUser}}
+      {{- end }}
       volumes:
       - name: ovnkube-config
         configMap:

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -11,6 +11,7 @@ type OVNHyperShiftBootstrapResult struct {
 	Enabled              bool
 	ClusterID            string
 	Namespace            string
+	RunAsUser            string
 	HCPNodeSelector      map[string]string
 	HCPLabels            map[string]string
 	HCPTolerations       []string

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -255,16 +255,6 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	} else {
 		data.Data["OVNPlatformAzure"] = false
 	}
-	if bootstrapResult.Infra.PlatformType == configv1.IBMCloudPlatformType { // TODO: Find a way to exclude IPI clusters from this???
-		// OVN is only supported in IBMCloud on Hypershift clusters, so get RunAsUser from HyperShiftConfig
-		if bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.RunAsUser != "" {
-			data.Data["OVNRunAsUser"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.RunAsUser
-		} else {
-			data.Data["OVNRunAsUser"] = "1001" // We do not want to run this as root, so if nothing is specified, use 1001
-		}
-	} else {
-		data.Data["OVNRunAsUser"] = ""
-	}
 
 	var ippools string
 	for _, net := range conf.ClusterNetwork {
@@ -430,6 +420,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 		productFlavor = "managed"
 		data.Data["CAConfigMap"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.CAConfigMap
 		data.Data["CAConfigMapKey"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.CAConfigMapKey
+		data.Data["RunAsUser"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.RunAsUser
 	}
 	manifestSubDir := filepath.Join(manifestDir, "network/ovn-kubernetes", productFlavor)
 	manifestDirs = append(manifestDirs, manifestSubDir)


### PR DESCRIPTION
Now that IBM ROKS is working on OVN support for Hypershift cluster, we need to run the ovnkube-control-plane pods as a non-root user if at all possible.  This change will run the ovnkube-control-plane pods as the RUN_AS_USER from the cluster-network-operator the same way that multus-admission-controller pods currently do.
