### PR TITLE
NO-JIRA: remove PersistentIPsForVirt FG

### DIFF
--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -958,7 +958,6 @@ logfile-maxage=0`,
 			enabledFeatureGates: []configv1.FeatureGateName{
 				apifeatures.FeatureGateNetworkSegmentation,
 				apifeatures.FeatureGatePreconfiguredUDNAddresses,
-				apifeatures.FeatureGatePersistentIPsForVirtualization,
 			},
 		},
 	}


### PR DESCRIPTION
This PR is to quickly remove FeatureGatePersistentIPsForVirtualization due to [openshift/cluster-network-operator#2737](https://github.com/openshift/cluster-network-operator/pull/2737)