### PR TITLE
OCPBUGS-60126: HCP: fix handling of tolerations with no key/value

### DIFF
--- a/pkg/hypershift/hypershift.go
+++ b/pkg/hypershift/hypershift.go
@@ -331,19 +331,52 @@ func tolerationsToStringSliceYaml(tolerations []corev1.Toleration) ([]string, er
 		return nil, nil
 	}
 
-	yamlBytes, err := yaml.Marshal(tolerations)
-	if err != nil {
-		return nil, err
-	}
+	var result []string
 
-	yamlStrs := []string{}
-	for _, arg := range strings.Split(string(yamlBytes), "\n") {
-
-		// filter out null and empty strings
-		if strings.Contains(arg, ": null") || strings.Contains(arg, ": \"\"") {
-			continue
+	for _, toleration := range tolerations {
+		// Marshal single toleration
+		yamlBytes, err := yaml.Marshal(toleration)
+		if err != nil {
+			return nil, err
 		}
-		yamlStrs = append(yamlStrs, arg)
+
+		// Process the single toleration's YAML lines
+		lines := strings.Split(string(yamlBytes), "\n")
+		var tolerationLines []string
+
+		for _, line := range lines {
+			// Skip empty lines
+			if strings.TrimSpace(line) == "" {
+				continue
+			}
+
+			// filter out empty strings but keep null values as they are valid for tolerations
+			if strings.Contains(line, ": \"\"") {
+				continue
+			}
+
+			// filter out null values including tolerationseconds: null
+			if strings.Contains(line, ": null") {
+				continue
+			}
+
+			tolerationLines = append(tolerationLines, line)
+		}
+
+		// Add array marker to the first line and proper indentation to all lines
+		for i := range tolerationLines {
+			if i == 0 {
+				// First line gets the array marker
+				tolerationLines[i] = "- " + strings.TrimSpace(tolerationLines[i])
+			} else {
+				// Subsequent lines get proper indentation (2 spaces)
+				tolerationLines[i] = "  " + strings.TrimSpace(tolerationLines[i])
+			}
+		}
+
+		// Add all lines from this toleration to the result
+		result = append(result, tolerationLines...)
 	}
-	return yamlStrs, nil
+
+	return result, nil
 }

--- a/pkg/hypershift/hypershift_test.go
+++ b/pkg/hypershift/hypershift_test.go
@@ -1,11 +1,13 @@
 package hypershift
 
 import (
+	"testing"
+
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"testing"
 )
 
 func TestParseHostedControlPlane(t *testing.T) {
@@ -101,5 +103,112 @@ spec:
 		actualOutput, err := ParseHostedControlPlane(hcpUnstructured)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(actualOutput).To(Equal(tc.expectedOutput))
+	}
+}
+
+func TestTolerationsToStringSliceYaml(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	testCases := []struct {
+		name        string
+		tolerations []corev1.Toleration
+		expected    []string
+	}{
+		{
+			name: "operator Exists with no key or value should generate valid YAML",
+			tolerations: []corev1.Toleration{
+				{
+					Operator: corev1.TolerationOpExists,
+				},
+			},
+			expected: []string{
+				"- operator: Exists",
+			},
+		},
+		{
+			name: "operator Equal with key and value should include all fields",
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "true",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			expected: []string{
+				"- key: node-role.kubernetes.io/master",
+				"  operator: Equal",
+				"  value: \"true\"",
+				"  effect: NoSchedule",
+			},
+		},
+		{
+			name: "empty string values should be filtered out",
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "test-key",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			expected: []string{
+				"- key: test-key",
+				"  operator: Equal",
+				"  effect: NoSchedule",
+			},
+		},
+		{
+			name: "operator Exists with key should not include null value",
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node.kubernetes.io/unreachable",
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoExecute,
+				},
+			},
+			expected: []string{
+				"- key: node.kubernetes.io/unreachable",
+				"  operator: Exists",
+				"  effect: NoExecute",
+			},
+		},
+		{
+			name: "multiple tolerations should generate proper YAML array",
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "true",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				{
+					Operator: corev1.TolerationOpExists,
+				},
+				{
+					Key:      "node.kubernetes.io/unreachable",
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoExecute,
+				},
+			},
+			expected: []string{
+				"- key: node-role.kubernetes.io/master",
+				"  operator: Equal",
+				"  value: \"true\"",
+				"  effect: NoSchedule",
+				"- operator: Exists",
+				"- key: node.kubernetes.io/unreachable",
+				"  operator: Exists",
+				"  effect: NoExecute",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := tolerationsToStringSliceYaml(tc.tolerations)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(result).To(Equal(tc.expected), "Expected exact YAML format match")
+		})
 	}
 }


### PR DESCRIPTION
Fixes rendering of tolerations that do not include a key/value.
Ref: [OCPBUGS-60126](https://issues.redhat.com/browse/OCPBUGS-60126)