### PR TITLE
[release-4.16]: NO-JIRA: Update CNO reviewers/approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,24 +1,7 @@
 reviewers:
-  - abhat
-  - danwinship
-  - dcbw
-  - dougbtv
-  - JacobTanenbaum
-  - jcaamano
-  - kyrtapz
-  - trozet
-  - tssurya
+  - core-reviewers
 approvers:
-  - abhat
-  - danwinship
-  - dcbw
-  - dougbtv
-  - fepan
-  - JacobTanenbaum
-  - jcaamano
-  - knobunc
-  - kyrtapz
-  - trozet
+  - core-approvers
 
 component: Networking
 subcomponent: cluster-network-operator

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,23 @@
+aliases:
+  core-approvers:
+  - abhat
+  - danwinship
+  - JacobTanenbaum
+  - jcaamano
+  - knobunc
+  - kyrtapz
+  - pliurh
+  - tssurya
+  core-reviewers:
+  - arghosh93
+  - arkadeepsen 
+  - bpickard22
+  - danwinship
+  - jcaamano
+  - kyrtapz
+  - martinkennelly 
+  - miheer
+  - pliurh
+  - pperiyasamy 
+  - ricky-rav
+  - tssurya


### PR DESCRIPTION
Removing trozet as he left the company. Adding tssurya as team lead replacement.

Adding pliurh as approver replacing dougbtv who will be eventually removed after some soak period as he moved on to other unrelated projects. pliurh has demonstrated extensive experience working on this repository througout his work on sdn->ovnk different migration modes.

Added bpickard22 to help as a reviewer for multus related changes as a replacement for dougbtv.

Adding the overall core network team as responsible to perform reviews.


(cherry picked from commit 17044384d2dd768d50e2eabdb68aaea5c01f50db) (cherry picked from commit d90db9657e56fcdafeba1a3c4d24edc2114ee91d)