### PR TITLE
CORENET-6276: Use priorityClass from HostedControlPlane for OVN and NNI

### DIFF
--- a/bindata/cloud-network-config-controller/managed/controller.yaml
+++ b/bindata/cloud-network-config-controller/managed/controller.yaml
@@ -66,7 +66,7 @@ spec:
                   matchLabels:
                     hypershift.openshift.io/hosted-control-plane: {{.HostedClusterNamespace}}
                 topologyKey: kubernetes.io/hostname
-      priorityClassName: hypershift-control-plane
+      priorityClassName: {{ .PriorityClass | default "hypershift-control-plane" }}
       securityContext:
 {{- if not (eq .RunAsUser "")}}
         runAsUser: {{.RunAsUser}}

--- a/bindata/network/node-identity/managed/node-identity.yaml
+++ b/bindata/network/node-identity/managed/node-identity.yaml
@@ -79,7 +79,7 @@ spec:
                   matchLabels:
                     hypershift.openshift.io/hosted-control-plane: {{.HostedClusterNamespace}}
                 topologyKey: kubernetes.io/hostname
-      priorityClassName: hypershift-api-critical
+      priorityClassName: {{ .PriorityClass | default "hypershift-api-critical" }}
       initContainers:
         - name: hosted-cluster-kubecfg-setup
           image: "{{.CLIImage}}"

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
@@ -81,7 +81,7 @@ spec:
                   matchLabels:
                     hypershift.openshift.io/hosted-control-plane: {{.HostedClusterNamespace}}
                 topologyKey: kubernetes.io/hostname
-      priorityClassName: hypershift-api-critical
+      priorityClassName: {{ .PriorityClass | default "hypershift-api-critical" }}
       initContainers:
       # Remove once https://github.com/kubernetes/kubernetes/issues/85966 is addressed
       - name: init-ip

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -20,6 +20,7 @@ type OVNHyperShiftBootstrapResult struct {
 	ControlPlaneImage    string
 	CAConfigMap          string
 	CAConfigMapKey       string
+	PriorityClass        string
 }
 
 type OVNConfigBoostrapResult struct {

--- a/pkg/network/cloud_network.go
+++ b/pkg/network/cloud_network.go
@@ -98,6 +98,7 @@ func renderCloudNetworkConfigController(conf *operv1.NetworkSpec, bootstrapResul
 		data.Data["HCPLabels"] = cloudBootstrapResult.HostedControlPlane.Labels
 		data.Data["HCPTolerations"] = cloudBootstrapResult.HostedControlPlane.Tolerations
 		data.Data["RunAsUser"] = hcpCfg.RunAsUser
+		data.Data["PriorityClass"] = cloudBootstrapResult.HostedControlPlane.PriorityClass
 		// In HyperShift CloudNetworkConfigController is deployed as a part of the hosted cluster controlplane
 		// which means that it is created in the management cluster.
 		// CloudNetworkConfigController should use the proxy settings configured by hypershift controlplane operator

--- a/pkg/network/node_identity.go
+++ b/pkg/network/node_identity.go
@@ -102,6 +102,7 @@ func renderNetworkNodeIdentity(conf *operv1.NetworkSpec, bootstrapResult *bootst
 		data.Data["HCPNodeSelector"] = bootstrapResult.Infra.HostedControlPlane.NodeSelector
 		data.Data["HCPLabels"] = bootstrapResult.Infra.HostedControlPlane.Labels
 		data.Data["HCPTolerations"] = bootstrapResult.Infra.HostedControlPlane.Tolerations
+		data.Data["PriorityClass"] = bootstrapResult.Infra.HostedControlPlane.PriorityClass
 
 		data.Data["NetworkNodeIdentityImage"] = hcpCfg.ControlPlaneImage // OVN_CONTROL_PLANE_IMAGE
 		localAPIServer := bootstrapResult.Infra.APIServers[bootstrap.APIServerDefaultLocal]

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -234,7 +234,6 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["HCPNodeSelector"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.HCPNodeSelector
 	data.Data["HCPLabels"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.HCPLabels
 	data.Data["HCPTolerations"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.HCPTolerations
-	data.Data["PriorityClass"] = bootstrapResult.Infra.HostedControlPlane.PriorityClass
 	data.Data["OVN_NB_INACTIVITY_PROBE"] = nb_inactivity_probe
 	data.Data["OVN_CERT_CN"] = OVN_CERT_CN
 	data.Data["OVN_NORTHD_PROBE_INTERVAL"] = os.Getenv("OVN_NORTHD_PROBE_INTERVAL")
@@ -422,6 +421,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 		data.Data["CAConfigMap"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.CAConfigMap
 		data.Data["CAConfigMapKey"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.CAConfigMapKey
 		data.Data["RunAsUser"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.RunAsUser
+		data.Data["PriorityClass"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.PriorityClass
 	}
 	manifestSubDir := filepath.Join(manifestDir, "network/ovn-kubernetes", productFlavor)
 	manifestDirs = append(manifestDirs, manifestSubDir)
@@ -735,6 +735,7 @@ func bootstrapOVNHyperShiftConfig(hc *hypershift.HyperShiftConfig, kubeClient cn
 	ovnHypershiftResult.HCPNodeSelector = hcp.NodeSelector
 	ovnHypershiftResult.HCPLabels = hcp.Labels
 	ovnHypershiftResult.HCPTolerations = hcp.Tolerations
+	ovnHypershiftResult.PriorityClass = hcp.PriorityClass
 
 	switch hcp.ControllerAvailabilityPolicy {
 	case hypershift.HighlyAvailable:

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -234,6 +234,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["HCPNodeSelector"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.HCPNodeSelector
 	data.Data["HCPLabels"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.HCPLabels
 	data.Data["HCPTolerations"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.HCPTolerations
+	data.Data["PriorityClass"] = bootstrapResult.Infra.HostedControlPlane.PriorityClass
 	data.Data["OVN_NB_INACTIVITY_PROBE"] = nb_inactivity_probe
 	data.Data["OVN_CERT_CN"] = OVN_CERT_CN
 	data.Data["OVN_NORTHD_PROBE_INTERVAL"] = os.Getenv("OVN_NORTHD_PROBE_INTERVAL")

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -234,6 +234,10 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["HCPNodeSelector"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.HCPNodeSelector
 	data.Data["HCPLabels"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.HCPLabels
 	data.Data["HCPTolerations"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.HCPTolerations
+	data.Data["CAConfigMap"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.CAConfigMap
+	data.Data["CAConfigMapKey"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.CAConfigMapKey
+	data.Data["RunAsUser"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.RunAsUser
+	data.Data["PriorityClass"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.PriorityClass
 	data.Data["OVN_NB_INACTIVITY_PROBE"] = nb_inactivity_probe
 	data.Data["OVN_CERT_CN"] = OVN_CERT_CN
 	data.Data["OVN_NORTHD_PROBE_INTERVAL"] = os.Getenv("OVN_NORTHD_PROBE_INTERVAL")
@@ -418,10 +422,6 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	productFlavor := "self-hosted"
 	if bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.Enabled {
 		productFlavor = "managed"
-		data.Data["CAConfigMap"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.CAConfigMap
-		data.Data["CAConfigMapKey"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.CAConfigMapKey
-		data.Data["RunAsUser"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.RunAsUser
-		data.Data["PriorityClass"] = bootstrapResult.OVN.OVNKubernetesConfig.HyperShiftConfig.PriorityClass
 	}
 	manifestSubDir := filepath.Join(manifestDir, "network/ovn-kubernetes", productFlavor)
 	manifestDirs = append(manifestDirs, manifestSubDir)


### PR DESCRIPTION
priorityClass can be specified in the HostedControlPlane for hypershift managed clusters.  When it is specified, it should be used by the control plane components.  Currently the cluster-network-operator deployment and the multus-admission-controller deployment do use the priority class that is specified, but the ovnkube-control-plane and network-node-identity deployments do not, they use a hardcoded value.

This change updates the ovnkube-control-plane and network-node-identity deployments to use teh priorityClass from the HostedControlPlane if it is specified