### PR TITLE
OCPBUGS-60264: Fix multus webhook match condition for spec changes

### DIFF
--- a/bindata/network/multus-admission-controller/003-webhook.yaml
+++ b/bindata/network/multus-admission-controller/003-webhook.yaml
@@ -30,7 +30,7 @@ webhooks:
     matchConditions:
       # On updates, only validate if the Spec changes
       - name: CreateDeleteOrUpdatedSpec
-        expression: oldObject == null || object == null || object.spec != oldObject.spec
+        expression: oldObject == null || object == null || has(object.spec) != has(oldObject.spec) || (has(object.spec) && object.spec != oldObject.spec)
     sideEffects: NoneOnDryRun
     admissionReviewVersions:
     - v1


### PR DESCRIPTION
Update the CreateDeleteOrUpdatedSpec match condition to properly handle cases where spec field is removed or added.
Fixes #2771
cc: @jcaamano 