### PR TITLE
CORENET-6290: Restrict access to mounted secrets in ovnkube-control-plane

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
@@ -312,14 +312,17 @@ spec:
           optional: true
       - name: ovn-control-plane-metrics-cert
         secret:
+          defaultMode: 0640
           secretName: ovn-control-plane-metrics-cert
       - name: admin-kubeconfig
         secret:
+          defaultMode: 0640
           secretName: service-network-admin-kubeconfig
       - name: hosted-cluster-api-access
         emptyDir: {}
       - name: hosted-ca-cert
         secret:
+          defaultMode: 0640
           secretName: root-ca
           items:
             - key: ca.crt


### PR DESCRIPTION
Improve security of ovnkube-control-plane by removing read-all access to the mounted secrets.  I tested this change manually, updating the ovnkube-control-plane deployment to use non-root 1001 user id and to set all the mounted secrets to 0640, and it worked fine because that 1001 user is still in the root group, and the mounted secret files are all owned by user root and group root.