### PR TITLE
CORENET-6306: Set RunAsUser for network-node-identity

### DIFF
--- a/bindata/network/node-identity/managed/node-identity.yaml
+++ b/bindata/network/node-identity/managed/node-identity.yaml
@@ -252,6 +252,13 @@ spec:
         "{{$key}}": "{{$value}}"
         {{ end }}
       {{ end }}
+      {{- if .RunAsUser }}
+      securityContext:
+        runAsUser: {{.RunAsUser}}
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      {{- end }}
       volumes:
         - name: env-overrides
           configMap:

--- a/pkg/network/node_identity.go
+++ b/pkg/network/node_identity.go
@@ -82,6 +82,7 @@ func renderNetworkNodeIdentity(conf *operv1.NetworkSpec, bootstrapResult *bootst
 
 		data.Data["CAConfigMap"] = hcpCfg.CAConfigMap
 		data.Data["CAConfigMapKey"] = hcpCfg.CAConfigMapKey
+		data.Data["RunAsUser"] = hcpCfg.RunAsUser
 
 		webhookCALookup = types.NamespacedName{Name: hcpCfg.CAConfigMap, Namespace: hcpCfg.Namespace}
 		caKey = hcpCfg.CAConfigMapKey


### PR DESCRIPTION
We should be running the network-node-identity pods as the user specified in the cluster-network-operator container's RUN_AS_USER environment variable if it is specified).   We already do this for the multus-admissions-controller:
- https://github.com/openshift/cluster-network-operator/blob/f41e188873b952c6dd0d41d89fdc7c63da51fc7f/pkg/network/multus_admission_controller.go#L96
- https://github.com/openshift/cluster-network-operator/blob/f41e188873b952c6dd0d41d89fdc7c63da51fc7f/bindata/network/multus-admission-controller/admission-controller.yaml#L264-L267

and recently in PR https://github.com/openshift/cluster-network-operator/pull/2757/files I added this for ovnkube-controll-plane. This PR does the same thing for network-node-identity.

I tested this in a ROKS cluster that I had running OVN, by disabling the hypershift reconciliation and updating the network-node-identity deployment manually with this change to run as user 1001.  Then I tested the webhook call by adding a condition to a node in the cluster, and it worked fine running as user 1001.