### PR TITLE
Update linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,13 +1,13 @@
-run:
-  skip-dirs:
+issues:
+  exclude-dirs:
     - vendor
   modules-download-mode: vendor
 
 linters:
   disable-all: true #so that lint version bumps don't change results
   enable:
-    - errcheck
     - copyloopvar
+    - errcheck
     - gosimple
     - govet
     - ineffassign
@@ -15,8 +15,8 @@ linters:
     - nolintlint
     - nosprintfhostport
     - staticcheck
-    - tenv
     - typecheck
     - unconvert
     - unused
+    - usetesting
     - wastedassign

--- a/pkg/apply/merge_test.go
+++ b/pkg/apply/merge_test.go
@@ -1,7 +1,6 @@
 package apply
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -73,7 +72,7 @@ func Test_Merge(t *testing.T) {
 			tt.expected.GetObjectKind().SetGroupVersionKind(tt.kind)
 			merge := getMergeForUpdate(tt.input)
 			g.Expect(merge).NotTo(BeNil())
-			uns, err := merge(context.Background(), client.Default())
+			uns, err := merge(t.Context(), client.Default())
 			g.Expect(err).NotTo(HaveOccurred())
 			output := reflect.New(reflect.ValueOf(tt.expected).Elem().Type()).Interface()
 			err = runtime.DefaultUnstructuredConverter.FromUnstructured(uns.Object, output)

--- a/pkg/controller/clusterconfig/migration_test.go
+++ b/pkg/controller/clusterconfig/migration_test.go
@@ -1,8 +1,6 @@
 package clusterconfig
 
 import (
-	"context"
-
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -438,7 +436,7 @@ func TestPrepareOperatorConfigForNetworkTypeMigration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			ctx := t.Context()
 			r := &ReconcileClusterConfig{
 				client: fake.NewFakeClient(),
 			}

--- a/pkg/controller/operconfig/migration_test.go
+++ b/pkg/controller/operconfig/migration_test.go
@@ -1,7 +1,6 @@
 package operconfig
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -182,7 +181,7 @@ func TestEgressIpMigration(t *testing.T) {
 			g := NewWithT(t)
 			client := fake.NewFakeClient(tc.objects...)
 
-			egressIpList, _, err := convertSdnEgressIpToOvnEgressIp(context.Background(), client)
+			egressIpList, _, err := convertSdnEgressIpToOvnEgressIp(t.Context(), client)
 			if err != nil {
 				t.Fatalf("convertSdnEgressIpToOvnEgressIp: %v", err)
 			}
@@ -202,7 +201,7 @@ func TestEgressIpMigration(t *testing.T) {
 			g.Expect(egressIpValueList).To(ConsistOf(expectedEgressIpList...), "expected applied OVN egressIPs to have egressIP list matching input SDN config")
 
 			// Check that node annotation has been added
-			nodeObj, err := client.Default().Kubernetes().CoreV1().Nodes().Get(context.Background(), testMigrationHost, metav1.GetOptions{})
+			nodeObj, err := client.Default().Kubernetes().CoreV1().Nodes().Get(t.Context(), testMigrationHost, metav1.GetOptions{})
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -452,17 +451,17 @@ func TestEgressIpRollbackMigration(t *testing.T) {
 			g := NewWithT(t)
 			client := fake.NewFakeClient(tc.objects...)
 
-			err := convertOvnEgressIpToSdnEgressIp(context.Background(), client)
+			err := convertOvnEgressIpToSdnEgressIp(t.Context(), client)
 			if err != nil {
 				t.Fatalf("convertOvnEgressIpToSdnEgressIp: %v", err)
 			}
 
 			// Get the Hostsubnet and Netnamespace that should be updated
-			hsn, err := client.Default().Dynamic().Resource(gvrHostSubnet).Get(context.Background(), testMigrationHost, metav1.GetOptions{})
+			hsn, err := client.Default().Dynamic().Resource(gvrHostSubnet).Get(t.Context(), testMigrationHost, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("failed to get hostsubnet: %v", err)
 			}
-			nns, err := client.Default().Dynamic().Resource(gvrNetnamespace).Get(context.Background(), testMigrationNamespace, metav1.GetOptions{})
+			nns, err := client.Default().Dynamic().Resource(gvrNetnamespace).Get(t.Context(), testMigrationNamespace, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("failed to get netnamespace: %v", err)
 			}
@@ -521,12 +520,12 @@ func TestMulticastMigration(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			client := fake.NewFakeClient(tc.objects...)
 
-			err := enableMulticastOVN(context.Background(), client)
+			err := enableMulticastOVN(t.Context(), client)
 			if err != nil {
 				t.Fatalf("enableMulticastOVN: %v", err)
 			}
 
-			ns, err := client.Default().Kubernetes().CoreV1().Namespaces().Get(context.Background(), testMigrationNamespace, metav1.GetOptions{})
+			ns, err := client.Default().Kubernetes().CoreV1().Namespaces().Get(t.Context(), testMigrationNamespace, metav1.GetOptions{})
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -576,12 +575,12 @@ func TestMulticastMigrationRollback(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			client := fake.NewFakeClient(tc.objects...)
 
-			err := enableMulticastSDN(context.Background(), client)
+			err := enableMulticastSDN(t.Context(), client)
 			if err != nil {
 				t.Fatalf("enableMulticastOVN: %v", err)
 			}
 
-			nns, err := client.Default().Dynamic().Resource(gvrNetnamespace).Get(context.Background(), testMigrationNamespace, metav1.GetOptions{})
+			nns, err := client.Default().Dynamic().Resource(gvrNetnamespace).Get(t.Context(), testMigrationNamespace, metav1.GetOptions{})
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -697,7 +696,7 @@ func TestEnsureMachineConfigPools(t *testing.T) {
 			condType := "sampleConditionType"
 			nowTimestamp := metav1.Now()
 			// call the ensureMachineConfigPools method
-			isDesired, isStable, err := r.ensureMachineConfigPools(context.Background(), clusterConfig, condType, tc.isMatch, nowTimestamp)
+			isDesired, isStable, err := r.ensureMachineConfigPools(t.Context(), clusterConfig, condType, tc.isMatch, nowTimestamp)
 
 			g.Expect(err).To(BeNil())
 			g.Expect(isDesired).To(Equal(tc.result.isDesired))

--- a/pkg/controller/operconfig/mtu_probe_test.go
+++ b/pkg/controller/operconfig/mtu_probe_test.go
@@ -1,7 +1,6 @@
 package operconfig
 
 import (
-	"context"
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -88,7 +87,7 @@ func TestProbeMTU(t *testing.T) {
 					},
 				},
 			}
-			actual, err := r.probeMTU(context.Background(), &operv1.Network{}, tc.infra)
+			actual, err := r.probeMTU(t.Context(), &operv1.Network{}, tc.infra)
 			if err != nil {
 				t.Fatalf("probeMTU: %v", err)
 			}

--- a/pkg/controller/signer/signer_test.go
+++ b/pkg/controller/signer/signer_test.go
@@ -65,14 +65,14 @@ func TestSigner_reconciler(t *testing.T) {
 		Reason:  "AutoApproved",
 		Message: "Automatically approved by " + signerName})
 
-	err = client.Default().CRClient().Create(context.TODO(), csrObj)
+	err = client.Default().CRClient().Create(t.Context(), csrObj)
 	g.Expect(err).NotTo(HaveOccurred())
-	_, err = client.Default().Kubernetes().CertificatesV1().CertificateSigningRequests().Create(context.TODO(), csrObj, metav1.CreateOptions{})
+	_, err = client.Default().Kubernetes().CertificatesV1().CertificateSigningRequests().Create(t.Context(), csrObj, metav1.CreateOptions{})
 	g.Expect(err).NotTo(HaveOccurred())
 
 	node := &corev1.Node{}
 	node.Name = nodeName
-	_, err = client.Default().Kubernetes().CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
+	_, err = client.Default().Kubernetes().CoreV1().Nodes().Create(t.Context(), node, metav1.CreateOptions{})
 	g.Expect(err).NotTo(HaveOccurred())
 
 	ca, err := crypto.MakeSelfSignedCAConfigForDuration(signerName, 10*time.Minute)
@@ -87,14 +87,14 @@ func TestSigner_reconciler(t *testing.T) {
 	caSecret.Data = make(map[string][]byte)
 	caSecret.Data["tls.crt"] = certBytes.Bytes()
 	caSecret.Data["tls.key"] = keyBytes.Bytes()
-	err = client.Default().CRClient().Create(context.TODO(), caSecret)
+	err = client.Default().CRClient().Create(t.Context(), caSecret)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	_, err = signer.Reconcile(context.TODO(),
+	_, err = signer.Reconcile(t.Context(),
 		reconcile.Request{NamespacedName: types.NamespacedName{Name: csrName}})
 	g.Expect(err).NotTo(HaveOccurred())
 
-	err = client.Default().CRClient().Get(context.TODO(), types.NamespacedName{Name: csrName}, csrObj)
+	err = client.Default().CRClient().Get(t.Context(), types.NamespacedName{Name: csrName}, csrObj)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(csrObj.Status.Certificate).ShouldNot(BeEmpty())
 
@@ -137,21 +137,21 @@ func TestSigner_reconciler_withInvalidUserName(t *testing.T) {
 	csrObj.Spec.Usages = []certificatev1.KeyUsage{"ipsec tunnel"}
 	csrObj.Spec.Username = fmt.Sprintf("system:ovn-node:%s", "suspicious-node")
 
-	err = client.Default().CRClient().Create(context.TODO(), csrObj)
+	err = client.Default().CRClient().Create(t.Context(), csrObj)
 	g.Expect(err).NotTo(HaveOccurred())
-	_, err = client.Default().Kubernetes().CertificatesV1().CertificateSigningRequests().Create(context.TODO(), csrObj, metav1.CreateOptions{})
+	_, err = client.Default().Kubernetes().CertificatesV1().CertificateSigningRequests().Create(t.Context(), csrObj, metav1.CreateOptions{})
 	g.Expect(err).NotTo(HaveOccurred())
 
 	node := &corev1.Node{}
 	node.Name = nodeName
-	_, err = client.Default().Kubernetes().CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
+	_, err = client.Default().Kubernetes().CoreV1().Nodes().Create(t.Context(), node, metav1.CreateOptions{})
 	g.Expect(err).NotTo(HaveOccurred())
 
-	_, err = signer.Reconcile(context.TODO(),
+	_, err = signer.Reconcile(t.Context(),
 		reconcile.Request{NamespacedName: types.NamespacedName{Name: csrName}})
 	g.Expect(err).NotTo(HaveOccurred())
 
-	err = client.Default().CRClient().Get(context.TODO(), types.NamespacedName{Name: csrName}, csrObj)
+	err = client.Default().CRClient().Get(t.Context(), types.NamespacedName{Name: csrName}, csrObj)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(csrObj.Status.Certificate).Should(BeEmpty())
 	csrConditions := csrObj.Status.Conditions
@@ -189,9 +189,9 @@ func generateCSR() (string, error) {
 func setOC(t *testing.T, client cnoclient.Client, oc *operv1.Network) {
 	t.Helper()
 	g := NewGomegaWithT(t)
-	_, err := client.Default().OpenshiftOperatorClient().OperatorV1().Networks().Update(context.TODO(), oc, metav1.UpdateOptions{})
+	_, err := client.Default().OpenshiftOperatorClient().OperatorV1().Networks().Update(t.Context(), oc, metav1.UpdateOptions{})
 	if apierrors.IsNotFound(err) {
-		_, err = client.Default().OpenshiftOperatorClient().OperatorV1().Networks().Create(context.TODO(), oc, metav1.CreateOptions{})
+		_, err = client.Default().OpenshiftOperatorClient().OperatorV1().Networks().Create(t.Context(), oc, metav1.CreateOptions{})
 	}
 	g.Expect(err).NotTo(HaveOccurred())
 }
@@ -199,9 +199,9 @@ func setOC(t *testing.T, client cnoclient.Client, oc *operv1.Network) {
 func setCO(t *testing.T, client cnoclient.Client, co *configv1.ClusterOperator) {
 	t.Helper()
 	g := NewGomegaWithT(t)
-	err := client.Default().CRClient().Update(context.TODO(), co)
+	err := client.Default().CRClient().Update(t.Context(), co)
 	if apierrors.IsNotFound(err) {
-		err = client.Default().CRClient().Create(context.TODO(), co)
+		err = client.Default().CRClient().Create(t.Context(), co)
 	}
 	g.Expect(err).NotTo(HaveOccurred())
 }

--- a/pkg/controller/statusmanager/status_manager_test.go
+++ b/pkg/controller/statusmanager/status_manager_test.go
@@ -50,9 +50,9 @@ func getCO(client cnoclient.Client, name string) (*configv1.ClusterOperator, err
 
 func setCO(t *testing.T, client cnoclient.Client, name string) {
 	co := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: name}}
-	err := client.ClientFor("").CRClient().Update(context.TODO(), co)
+	err := client.ClientFor("").CRClient().Update(t.Context(), co)
 	if apierrors.IsNotFound(err) {
-		err = client.ClientFor("").CRClient().Create(context.TODO(), co)
+		err = client.ClientFor("").CRClient().Create(t.Context(), co)
 	}
 	if err != nil {
 		t.Fatalf("Failed to set: %v", err)
@@ -75,9 +75,9 @@ func getStatuses(client cnoclient.Client, name string) (*configv1.ClusterOperato
 
 func setOC(t *testing.T, client cnoclient.Client, oc *operv1.Network) {
 	t.Helper()
-	_, err := client.Default().OpenshiftOperatorClient().OperatorV1().Networks().Update(context.TODO(), oc, metav1.UpdateOptions{})
+	_, err := client.Default().OpenshiftOperatorClient().OperatorV1().Networks().Update(t.Context(), oc, metav1.UpdateOptions{})
 	if apierrors.IsNotFound(err) {
-		_, err = client.Default().OpenshiftOperatorClient().OperatorV1().Networks().Create(context.TODO(), oc, metav1.CreateOptions{})
+		_, err = client.Default().OpenshiftOperatorClient().OperatorV1().Networks().Create(t.Context(), oc, metav1.CreateOptions{})
 	}
 	if err != nil {
 		t.Fatalf("Failed to set: %v", err)
@@ -86,9 +86,9 @@ func setOC(t *testing.T, client cnoclient.Client, oc *operv1.Network) {
 
 func set(t *testing.T, client cnoclient.Client, obj crclient.Object) {
 	t.Helper()
-	err := client.ClientFor("").CRClient().Update(context.TODO(), obj)
+	err := client.ClientFor("").CRClient().Update(t.Context(), obj)
 	if apierrors.IsNotFound(err) {
-		err = client.ClientFor("").CRClient().Create(context.TODO(), obj)
+		err = client.ClientFor("").CRClient().Create(t.Context(), obj)
 
 	}
 	if err != nil {
@@ -98,7 +98,7 @@ func set(t *testing.T, client cnoclient.Client, obj crclient.Object) {
 
 func setStatus(t *testing.T, client cnoclient.Client, obj crclient.Object) {
 	t.Helper()
-	err := client.ClientFor("").CRClient().Status().Update(context.TODO(), obj)
+	err := client.ClientFor("").CRClient().Status().Update(t.Context(), obj)
 	if err != nil {
 		t.Fatalf("Failed to set status: %v", err)
 	}
@@ -273,7 +273,7 @@ func TestStatusManager_set(t *testing.T) {
 		},
 	}
 	status.deleteRelatedObjectsNotRendered(co)
-	err = status.client.ClientFor("").CRClient().Get(context.TODO(), types.NamespacedName{Name: "current"}, obj)
+	err = status.client.ClientFor("").CRClient().Get(t.Context(), types.NamespacedName{Name: "current"}, obj)
 	if err == nil {
 		t.Fatalf("unexpected related object in ClusterOperator object was not deleted")
 	}
@@ -455,7 +455,7 @@ func TestStatusManagerSetFromIPsecConfigs(t *testing.T) {
 		Labels:          names.MasterRoleMachineConfigLabel(),
 		OwnerReferences: networkOwnerRef()},
 		Spec: mcfgv1.MachineConfigSpec{Extensions: []string{"ipsec"}}}
-	err = status.SetMachineConfigs(context.TODO(), []mcfgv1.MachineConfig{masterIPsecMachineConfig})
+	err = status.SetMachineConfigs(t.Context(), []mcfgv1.MachineConfig{masterIPsecMachineConfig})
 	if err != nil {
 		t.Fatalf("error setting machine configs: %v", err)
 	}
@@ -499,7 +499,7 @@ func TestStatusManagerSetFromIPsecConfigs(t *testing.T) {
 		Labels:          names.WorkerRoleMachineConfigLabel(),
 		OwnerReferences: networkOwnerRef()},
 		Spec: mcfgv1.MachineConfigSpec{Extensions: []string{"ipsec"}}}
-	err = status.SetMachineConfigs(context.TODO(), []mcfgv1.MachineConfig{masterIPsecMachineConfig, workerIPsecMachineConfig})
+	err = status.SetMachineConfigs(t.Context(), []mcfgv1.MachineConfig{masterIPsecMachineConfig, workerIPsecMachineConfig})
 	if err != nil {
 		t.Fatalf("error setting machine configs: %v", err)
 	}
@@ -588,7 +588,7 @@ func TestStatusManagerSetFromIPsecConfigs(t *testing.T) {
 
 	// Remove worker machine configs and check network operator status condition is updated
 	// accordingly.
-	err = status.SetMachineConfigs(context.TODO(), []mcfgv1.MachineConfig{masterIPsecMachineConfig})
+	err = status.SetMachineConfigs(t.Context(), []mcfgv1.MachineConfig{masterIPsecMachineConfig})
 	if err != nil {
 		t.Fatalf("error setting machine configs: %v", err)
 	}
@@ -647,7 +647,7 @@ func TestStatusManagerSetFromIPsecConfigs(t *testing.T) {
 	}
 	// Remove master machine config, set master mcp into degraded state, check network operator
 	// status condition is updated accordingly.
-	err = status.SetMachineConfigs(context.TODO(), []mcfgv1.MachineConfig{})
+	err = status.SetMachineConfigs(t.Context(), []mcfgv1.MachineConfig{})
 	if err != nil {
 		t.Fatalf("error processing machine config pools: %v", err)
 	}
@@ -1189,7 +1189,7 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 	}
 
 	// check hung annotation is set (also, need to refresh objects since they were updated)
-	err = client.ClientFor("").CRClient().Get(context.TODO(), types.NamespacedName{Namespace: "one", Name: "alpha"}, dsA)
+	err = client.ClientFor("").CRClient().Get(t.Context(), types.NamespacedName{Namespace: "one", Name: "alpha"}, dsA)
 	if err != nil {
 		t.Fatalf("error getting DaemonSet: %v", err)
 	}
@@ -1240,7 +1240,7 @@ func TestStatusManagerSetFromDaemonSets(t *testing.T) {
 		t.Fatalf("unexpected Status.Versions: %#v", co.Status.Versions)
 	}
 
-	err = client.ClientFor("").CRClient().Get(context.TODO(), types.NamespacedName{Namespace: "one", Name: "alpha"}, dsA)
+	err = client.ClientFor("").CRClient().Get(t.Context(), types.NamespacedName{Namespace: "one", Name: "alpha"}, dsA)
 	if err != nil {
 		t.Fatalf("error getting DaemonSet: %v", err)
 	}
@@ -1552,7 +1552,7 @@ func TestStatusManagerSetFromDeployments(t *testing.T) {
 		t.Fatalf("Didn't find %s in pod state", nsn)
 	}
 
-	err = client.ClientFor("").CRClient().Get(context.TODO(), types.NamespacedName{Namespace: depB.Namespace, Name: depB.Name}, depB)
+	err = client.ClientFor("").CRClient().Get(t.Context(), types.NamespacedName{Namespace: depB.Namespace, Name: depB.Name}, depB)
 	if err != nil {
 		t.Fatalf("error getting Deployment: %v", err)
 	}
@@ -1637,7 +1637,7 @@ func TestStatusManagerSetFromDeployments(t *testing.T) {
 		t.Fatalf("unexpected Status.Versions: %#v", co.Status.Versions)
 	}
 
-	err = client.ClientFor("").CRClient().Get(context.TODO(), types.NamespacedName{Namespace: depB.Namespace, Name: depB.Name}, depB)
+	err = client.ClientFor("").CRClient().Get(t.Context(), types.NamespacedName{Namespace: depB.Namespace, Name: depB.Name}, depB)
 	if err != nil {
 		t.Fatalf("error getting Deployment: %v", err)
 	}
@@ -1707,7 +1707,7 @@ func setLastPodState(t *testing.T, client cnoclient.Client, name string, ps podS
 		t.Fatal(err)
 	}
 	co.Annotations[lastSeenAnnotation] = string(lsBytes)
-	err = client.ClientFor("").CRClient().Update(context.Background(), co)
+	err = client.ClientFor("").CRClient().Update(t.Context(), co)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
update golang-cli linter to use non-deprecated linters
update test context refs to t.Context() to satisfy usetesting linter

we need this in order to run make check as it will error out in its current state due to fully deprecated linters