### PR TITLE
OCPBUGS-60421: Set maxUnavailable 10% on MultiNetworkPolicy DS

### DIFF
--- a/bindata/network/multus-networkpolicy/multus-networkpolicy.yaml
+++ b/bindata/network/multus-networkpolicy/multus-networkpolicy.yaml
@@ -16,6 +16,8 @@ spec:
       app: multus-networkpolicy
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       annotations:


### PR DESCRIPTION
The MultiNetworkPolicy DaemonSet was using the default maxUnavailable value of 1, which caused a long delay during the upgrade. We resolved this by setting the value to 10%, aligning with our other DaemonSets.