### PR TITLE
OCPBUGS-61561: Relax label req. of DPU/DPU Host/Smart NIC

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -62,7 +62,13 @@ spec:
               {{ if .DpuHostModeLabel }}
               - key: {{ .DpuHostModeLabel }}
                 {{ if eq .OVN_NODE_MODE "dpu-host" }}
+                {{ if .DpuHostModeValue }}
+                operator: In
+                values:
+                - "{{ .DpuHostModeValue }}"
+                {{ else }}
                 operator: Exists
+                {{ end }}
                 {{ else if eq .OVN_NODE_MODE "smart-nic" }}
                 operator: DoesNotExist
                 {{ else }}
@@ -74,7 +80,13 @@ spec:
                 {{ if eq .OVN_NODE_MODE "dpu-host" }}
                 operator: DoesNotExist
                 {{ else if eq .OVN_NODE_MODE "smart-nic" }}
+                {{ if .SmartNicModeValue }}
+                operator: In
+                values:
+                - "{{ .SmartNicModeValue }}"
+                {{ else }}
                 operator: Exists
+                {{ end }}
                 {{ else }}
                 operator: DoesNotExist
                 {{ end }}

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -62,7 +62,13 @@ spec:
               {{ if .DpuHostModeLabel }}
               - key: {{ .DpuHostModeLabel }}
                 {{ if eq .OVN_NODE_MODE "dpu-host" }}
+                {{ if .DpuHostModeValue }}
+                operator: In
+                values:
+                - "{{ .DpuHostModeValue }}"
+                {{ else }}
                 operator: Exists
+                {{ end }}
                 {{ else if eq .OVN_NODE_MODE "smart-nic" }}
                 operator: DoesNotExist
                 {{ else }}
@@ -74,7 +80,13 @@ spec:
                 {{ if eq .OVN_NODE_MODE "dpu-host" }}
                 operator: DoesNotExist
                 {{ else if eq .OVN_NODE_MODE "smart-nic" }}
+                {{ if .SmartNicModeValue }}
+                operator: In
+                values:
+                - "{{ .SmartNicModeValue }}"
+                {{ else }}
                 operator: Exists
+                {{ end }}
                 {{ else }}
                 operator: DoesNotExist
                 {{ end }}

--- a/hack/hardware-offload-config.yaml
+++ b/hack/hardware-offload-config.yaml
@@ -5,7 +5,10 @@ metadata:
     name: hardware-offload-config
     namespace: openshift-network-operator
 data:
-    dpu-host-mode-label: "network.operator.openshift.io/dpu-host"
-    dpu-mode-label: "network.operator.openshift.io/dpu"
-    smart-nic-mode-label: "network.operator.openshift.io/smart-nic"
+    # Label format options:
+    # "key=" → operator: Exists (matches any node with this label, regardless of value)
+    # "key=value" → operator: In with values: ["value"] (matches only nodes with this specific value)
+    dpu-host-mode-label: "network.operator.openshift.io/dpu-host="
+    dpu-mode-label: "network.operator.openshift.io/dpu="
+    smart-nic-mode-label: "network.operator.openshift.io/smart-nic="
     mgmt-port-resource-name: "openshift.io/mgmtvf"

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -29,10 +29,12 @@ type OVNConfigBoostrapResult struct {
 	DisableUDPAggregation bool
 	DpuHostModeLabel      string
 	DpuHostModeNodes      []string
+	DpuHostModeValue      string
 	DpuModeLabel          string
 	DpuModeNodes          []string
 	SmartNicModeLabel     string
 	SmartNicModeNodes     []string
+	SmartNicModeValue     string
 	MgmtPortResourceName  string
 	// ConfigOverrides contains the overrides for the OVN Kubernetes configuration
 	// This is used to set the hidden OVN Kubernetes configuration in the cluster

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -869,7 +869,14 @@ func bootstrapOVNConfig(conf *operv1.Network, kubeClient cnoclient.Client, hc *h
 		}
 	}
 
-	// We want to see if there are any nodes that are labeled for specific modes.
+	// We want to see if there are any nodes that are labeled for specific modes such as Full/SmartNIC/DPU Host/DPU
+	// Currently dpu-host and smart-nic are modes that allow CNO to render the corresponding daemonset pods.
+	// For DPU-Host mode, CNO will set the DPU Host mode environment variable to render the OVN-Kubernetes pods in DPU Host mode.
+	//   Additionally the management port interface is set from a SR-IOV interface.
+	// For Smart NIC mode, CNO will set the mode to be Full mode and render the OVN-Kubernetes daemonset pods.
+	//   The difference is that the management port is set from a SR-IOV interface.
+	// For DPU mode, currently CNO does not render any OVN-Kubernetes daemonset pods (preventing any OVN-Kubernetes
+	//   daemonset pods in DPU mode from running), it is done by an external operator.
 	ovnConfigResult.DpuHostModeNodes, err = getNodeListByLabel(kubeClient, ovnConfigResult.DpuHostModeLabel)
 	if err != nil {
 		return nil, fmt.Errorf("Could not get node list with label %s : %w", ovnConfigResult.DpuHostModeLabel, err)

--- a/pkg/network/ovn_kubernetes_dpu_host_test.go
+++ b/pkg/network/ovn_kubernetes_dpu_host_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ghodss/yaml"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/openshift/cluster-network-operator/pkg/render"
@@ -155,7 +156,9 @@ func createTestRenderData(ovnNodeMode string) render.RenderData {
 	data.Data["DefaultMasqueradeNetworkCIDRs"] = ""
 	data.Data["OVNIPsecEnable"] = false
 	data.Data["DpuHostModeLabel"] = ""
+	data.Data["DpuHostModeValue"] = ""
 	data.Data["SmartNicModeLabel"] = ""
+	data.Data["SmartNicModeValue"] = ""
 	data.Data["DpuModeLabel"] = ""
 	data.Data["MgmtPortResourceName"] = ""
 	data.Data["HTTP_PROXY"] = ""
@@ -181,4 +184,173 @@ func createTestRenderData(ovnNodeMode string) render.RenderData {
 	data.Data["NodeIdentityCertDuration"] = "24h"
 
 	return data
+}
+
+func getMatchExpression(g *WithT, ds *appsv1.DaemonSet, label string) (corev1.NodeSelectorOperator, string) {
+	g.Expect(ds.Spec.Template.Spec.Affinity).NotTo(BeNil(), "Should have affinity")
+	g.Expect(ds.Spec.Template.Spec.Affinity.NodeAffinity).NotTo(BeNil(), "Should have node affinity")
+	g.Expect(ds.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution).NotTo(BeNil(), "Should have required node affinity")
+
+	terms := ds.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	g.Expect(terms).NotTo(BeEmpty(), "Should have node selector terms")
+
+	matchExpressions := terms[0].MatchExpressions
+	g.Expect(matchExpressions).NotTo(BeEmpty(), "Should have match expressions")
+
+	for _, expr := range matchExpressions {
+		if expr.Key == label {
+			if expr.Operator == corev1.NodeSelectorOpIn {
+				g.Expect(len(expr.Values)).To(Equal(1), "In operator should have exactly one value")
+				return expr.Operator, expr.Values[0]
+			} else {
+				return expr.Operator, ""
+			}
+		}
+	}
+
+	return corev1.NodeSelectorOpDoesNotExist, ""
+}
+
+// TestOVNKubernetesNodeSelectorOperator tests that the node selector operator works correctly with label values of different Full/SmartNIC/DPU modes
+func TestOVNKubernetesNodeSelectorOperator(t *testing.T) {
+	templates := []struct {
+		name         string
+		templatePath string
+	}{
+		{
+			name:         "managed",
+			templatePath: "../../bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml",
+		},
+		{
+			name:         "self-hosted",
+			templatePath: "../../bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml",
+		},
+	}
+
+	testCases := []struct {
+		name                 string
+		ovnNodeMode          string
+		dpuHostModeLabel     string
+		smartNicModeLabel    string
+		dpuModeLabel         string
+		expectedOperatorType corev1.NodeSelectorOperator
+		expectedValue        string // Expected value for In operator
+	}{
+		{
+			name:                 "dpu-host mode with key+value labels",
+			ovnNodeMode:          "dpu-host",
+			dpuHostModeLabel:     "network.operator.openshift.io/dpu-host=true",
+			smartNicModeLabel:    "network.operator.openshift.io/smart-nic=true",
+			dpuModeLabel:         "network.operator.openshift.io/dpu=true",
+			expectedOperatorType: corev1.NodeSelectorOpIn,
+			expectedValue:        "true",
+		},
+		{
+			name:                 "smart-nic mode with key+value labels",
+			ovnNodeMode:          "smart-nic",
+			dpuHostModeLabel:     "network.operator.openshift.io/dpu-host=true",
+			smartNicModeLabel:    "network.operator.openshift.io/smart-nic=true",
+			dpuModeLabel:         "network.operator.openshift.io/dpu=true",
+			expectedOperatorType: corev1.NodeSelectorOpIn,
+			expectedValue:        "true",
+		},
+		{
+			name:                 "dpu mode with key+value labels",
+			ovnNodeMode:          "dpu",
+			dpuHostModeLabel:     "network.operator.openshift.io/dpu-host=true",
+			smartNicModeLabel:    "network.operator.openshift.io/smart-nic=true",
+			dpuModeLabel:         "network.operator.openshift.io/dpu=true",
+			expectedOperatorType: corev1.NodeSelectorOpDoesNotExist,
+			expectedValue:        "",
+		},
+		{
+			name:                 "dpu-host mode with key only labels",
+			ovnNodeMode:          "dpu-host",
+			dpuHostModeLabel:     "network.operator.openshift.io/dpu-host=",
+			smartNicModeLabel:    "network.operator.openshift.io/smart-nic=",
+			dpuModeLabel:         "network.operator.openshift.io/dpu=",
+			expectedOperatorType: corev1.NodeSelectorOpExists,
+			expectedValue:        "",
+		},
+		{
+			name:                 "smart-nic mode with key only labels",
+			ovnNodeMode:          "smart-nic",
+			dpuHostModeLabel:     "network.operator.openshift.io/dpu-host=",
+			smartNicModeLabel:    "network.operator.openshift.io/smart-nic=",
+			dpuModeLabel:         "network.operator.openshift.io/dpu=",
+			expectedOperatorType: corev1.NodeSelectorOpExists,
+			expectedValue:        "",
+		},
+		{
+			name:                 "dpu mode with key labels",
+			ovnNodeMode:          "dpu",
+			dpuHostModeLabel:     "network.operator.openshift.io/dpu-host=",
+			smartNicModeLabel:    "network.operator.openshift.io/smart-nic=",
+			dpuModeLabel:         "network.operator.openshift.io/dpu=",
+			expectedOperatorType: corev1.NodeSelectorOpDoesNotExist,
+			expectedValue:        "",
+		},
+	}
+
+	for _, template := range templates {
+		for _, tc := range testCases {
+			testName := template.name + "_" + tc.name
+			t.Run(testName, func(t *testing.T) {
+				g := NewGomegaWithT(t)
+
+				// Create render data
+				data := createTestRenderData(tc.ovnNodeMode)
+				var err error
+				data.Data["DpuHostModeLabel"], data.Data["DpuHostModeValue"], err = getKeyValueFromLabel(tc.dpuHostModeLabel)
+				g.Expect(err).NotTo(HaveOccurred(), "Should be able to get key value from label for %s", tc.dpuHostModeLabel)
+				data.Data["SmartNicModeLabel"], data.Data["SmartNicModeValue"], err = getKeyValueFromLabel(tc.smartNicModeLabel)
+				g.Expect(err).NotTo(HaveOccurred(), "Should be able to get key value from label for %s", tc.smartNicModeLabel)
+				data.Data["DpuModeLabel"], _, err = getKeyValueFromLabel(tc.dpuModeLabel)
+				g.Expect(err).NotTo(HaveOccurred(), "Should be able to get key value from label for %s", tc.dpuModeLabel)
+
+				// Render the template
+				objs, err := render.RenderTemplate(template.templatePath, &data)
+				g.Expect(err).NotTo(HaveOccurred(), "Template rendering should succeed")
+				g.Expect(objs).To(HaveLen(1), "Should render exactly one object")
+
+				// Verify it's a DaemonSet
+				obj := objs[0]
+				g.Expect(obj.GetKind()).To(Equal("DaemonSet"))
+
+				// Verify YAML validity
+				yamlBytes, err := yaml.Marshal(obj)
+				g.Expect(err).NotTo(HaveOccurred(), "Object should be valid YAML")
+				g.Expect(yamlBytes).NotTo(BeEmpty(), "YAML should not be empty")
+
+				// Verify it can be unmarshaled back to a DaemonSet
+				ds := &appsv1.DaemonSet{}
+				err = yaml.Unmarshal(yamlBytes, ds)
+				g.Expect(err).NotTo(HaveOccurred(), "Should be able to unmarshal to DaemonSet")
+				g.Expect(ds.Kind).To(Equal("DaemonSet"))
+
+				operator, value := getMatchExpression(g, ds, data.Data["DpuHostModeLabel"].(string))
+				if tc.ovnNodeMode == "dpu-host" {
+					g.Expect(operator).To(Equal(tc.expectedOperatorType), "Should have expected operator")
+					g.Expect(value).To(Equal(tc.expectedValue), "Should have expected value")
+				} else if tc.ovnNodeMode == "smart-nic" {
+					g.Expect(operator).To(Equal(corev1.NodeSelectorOpDoesNotExist), "Should have expected DoesNotExist operator")
+				} else if tc.ovnNodeMode == "dpu" {
+					g.Expect(operator).To(Equal(corev1.NodeSelectorOpDoesNotExist), "Should have expected DoesNotExist operator")
+				}
+
+				operator, value = getMatchExpression(g, ds, data.Data["SmartNicModeLabel"].(string))
+				if tc.ovnNodeMode == "dpu-host" {
+					g.Expect(operator).To(Equal(corev1.NodeSelectorOpDoesNotExist), "Should have expected DoesNotExist operator")
+				} else if tc.ovnNodeMode == "smart-nic" {
+					g.Expect(operator).To(Equal(tc.expectedOperatorType), "Should have expected operator")
+					g.Expect(value).To(Equal(tc.expectedValue), "Should have expected value")
+				} else if tc.ovnNodeMode == "dpu" {
+					g.Expect(operator).To(Equal(corev1.NodeSelectorOpDoesNotExist), "Should have expected DoesNotExist operator")
+				}
+
+				operator, _ = getMatchExpression(g, ds, data.Data["DpuModeLabel"].(string))
+				g.Expect(operator).To(Equal(corev1.NodeSelectorOpDoesNotExist), "Should have expected DoesNotExist operator")
+			})
+		}
+	}
 }

--- a/pkg/network/ovn_kubernetes_label_validation_test.go
+++ b/pkg/network/ovn_kubernetes_label_validation_test.go
@@ -1,0 +1,166 @@
+package network
+
+import (
+	"testing"
+)
+
+func TestValidateLabel(t *testing.T) {
+	tests := []struct {
+		name  string
+		label string
+		valid bool
+	}{
+		{
+			name:  "valid label with empty value",
+			label: "network.operator.openshift.io/dpu-host=",
+			valid: true,
+		},
+		{
+			name:  "valid label with value",
+			label: "network.operator.openshift.io/dpu-host=true",
+			valid: true,
+		},
+		{
+			name:  "valid label with simple key",
+			label: "dpu-host=enabled",
+			valid: true,
+		},
+		{
+			name:  "valid label with underscore in value",
+			label: "my-label=test_value",
+			valid: true,
+		},
+		{
+			name:  "valid label with dots in value",
+			label: "my-label=test.value",
+			valid: true,
+		},
+		{
+			name:  "valid label with hyphens in value",
+			label: "my-label=test-value",
+			valid: true,
+		},
+		{
+			name:  "valid label with numbers in value",
+			label: "my-label=123test",
+			valid: true,
+		},
+		{
+			name:  "key starting with number",
+			label: "123key=value",
+			valid: true,
+		},
+		{
+			name:  "empty label",
+			label: "",
+			valid: false,
+		},
+		{
+			name:  "missing equals sign",
+			label: "invalid-label-no-equals",
+			valid: false,
+		},
+		{
+			name:  "empty key",
+			label: "=value",
+			valid: false,
+		},
+		{
+			name:  "key with spaces",
+			label: "key with spaces=value",
+			valid: false,
+		},
+		{
+			name:  "value with spaces",
+			label: "key=value with spaces",
+			valid: false,
+		},
+		{
+			name:  "key too long",
+			label: "very-long-key-that-exceeds-kubernetes-limits-and-should-fail-validation-because-it-is-too-long=value",
+			valid: false,
+		},
+		{
+			name:  "value too long",
+			label: "key=very-long-value-that-exceeds-kubernetes-limits-and-should-fail-validation-because-it-is-too-long-to-be-valid",
+			valid: false,
+		},
+		{
+			name:  "key with invalid characters",
+			label: "key@invalid=value",
+			valid: false,
+		},
+		{
+			name:  "value with invalid characters",
+			label: "key=value@invalid",
+			valid: false,
+		},
+		{
+			name:  "key ending with hyphen",
+			label: "key-=value",
+			valid: false,
+		},
+		{
+			name:  "value starting with hyphen",
+			label: "key=-value",
+			valid: false,
+		},
+		{
+			name:  "value ending with hyphen",
+			label: "key=value-",
+			valid: false,
+		},
+		{
+			name:  "multiple equals signs",
+			label: "key=value1=value2",
+			valid: false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := validateLabel(testCase.label)
+			if result != testCase.valid {
+				t.Errorf("validateLabel(%q) = %v, expected %v", testCase.label, result, testCase.valid)
+			}
+		})
+	}
+}
+
+func TestValidateLabelUsage(t *testing.T) {
+	// Test some specific scenarios that would be used in the hardware-offload-config ConfigMap
+	validLabels := []string{
+		"network.operator.openshift.io/dpu-host=",
+		"network.operator.openshift.io/dpu=",
+		"network.operator.openshift.io/smart-nic=",
+		"network.operator.openshift.io/dpu-host=true",
+		"network.operator.openshift.io/smart-nic=enabled",
+		"network.operator.openshift.io/hardware-type=dpu",
+		"hardware-offload=true",
+	}
+
+	invalidLabels := []string{
+		"invalid label without equals",
+		"=no-key",
+		"key with spaces=value",
+		"key=value with spaces",
+		"key@invalid=value",
+		"key=value@invalid",
+	}
+
+	for _, label := range validLabels {
+		t.Run("valid_"+label, func(t *testing.T) {
+			if !validateLabel(label) {
+				t.Errorf("Expected label %q to be valid, but validation failed", label)
+			}
+		})
+	}
+
+	for _, label := range invalidLabels {
+		t.Run("invalid_"+label, func(t *testing.T) {
+			if validateLabel(label) {
+				t.Errorf("Expected label %q to be invalid, but validation passed", label)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- The code prior to this commit only allowed an label with  an empty value.
- However some labels could come from Node Feature Discovery operator which can assign labels with values (not empty).

We need to allow labels that could equal to empty or equal to a specific value. This will allow NFD operator labels to be used to find matching nodes.
Meaning we need the following label="specific value" for ovn-k daemonset to deploy on that node.
label="invalid value" for ovn-k daemonset to NOT deploy on that node.
