### PR TITLE
CORENET-6311: Skip running _stackmanager for libreswan 5.3+

### DIFF
--- a/bindata/network/ovn-kubernetes/common/ipsec-containerized.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-containerized.yaml
@@ -262,8 +262,11 @@ spec:
           ulimit -n 1024
 
           /usr/libexec/ipsec/addconn --config /etc/ipsec.conf --checkconfig
-          # Check kernel modules
-          /usr/libexec/ipsec/_stackmanager start
+          # Check kernel modules only for libreswan version <= 5.2. The _stackmanager binary is
+          # removed from 5.3 onwards, so this check is not needed on later versions.
+          if [ -e /usr/libexec/ipsec/_stackmanager ]; then
+            /usr/libexec/ipsec/_stackmanager start
+          fi
           # Check nss database status
           /usr/sbin/ipsec --checknss
           # Start the pluto IKE daemon

--- a/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
@@ -273,8 +273,11 @@ spec:
           ulimit -n 1024
 
           /usr/libexec/ipsec/addconn --config /etc/ipsec.conf --checkconfig
-          # Check kernel modules
-          /usr/libexec/ipsec/_stackmanager start
+          # Check kernel modules only for libreswan version <= 5.2. The _stackmanager binary is
+          # removed from 5.3 onwards, so this check is not needed on later versions.
+          if [ -e /usr/libexec/ipsec/_stackmanager ]; then
+            /usr/libexec/ipsec/_stackmanager start
+          fi
           # Check nss database status
           /usr/sbin/ipsec --checknss
 


### PR DESCRIPTION
The `_stackmanager` binary was removed in libreswan 5.3 and is no longer required for prerequisite checks. This commit conditionally runs `_stackmanager` only when the binary is present on the system.

cc @huiran0826 