### PR TITLE
CORS-4200: Accept the GCP service endpoints

### DIFF
--- a/pkg/network/cloud_network.go
+++ b/pkg/network/cloud_network.go
@@ -80,6 +80,14 @@ func renderCloudNetworkConfigController(conf *operv1.NetworkSpec, bootstrapResul
 		data.Data["PlatformAzureEnvironment"] = cloudBootstrapResult.PlatformStatus.Azure.CloudName
 	}
 
+	if cloudBootstrapResult.PlatformType == v1.GCPPlatformType {
+		for _, ep := range cloudBootstrapResult.PlatformStatus.GCP.ServiceEndpoints {
+			if ep.Name == configv1.GCPServiceEndpointNameCompute {
+				apiurl = ep.URL
+			}
+		}
+	}
+
 	data.Data["PlatformAPIURL"] = apiurl
 
 	manifestDirs := make([]string, 0, 2)


### PR DESCRIPTION
pkg/network/cloud_network.go:
** Accept the GCP service endpoints. Use the compute endpoint override (if it exists) to set the API URL. This value is passed to cloud-network-config-controller to be used when the GCP compute service is created, so that all requests to the api are sent via this url rather than the default.