### PR TITLE
SPLAT-2503: Fixed "null" value for vSphere api and ingress VIP in UPI scenario

### DIFF
--- a/pkg/controller/infrastructureconfig/sync_specstatus.go
+++ b/pkg/controller/infrastructureconfig/sync_specstatus.go
@@ -182,6 +182,12 @@ func syncVips(spec *[]configv1.IP, status *[]string) error {
 	if spec == nil || status == nil {
 		return fmt.Errorf("passed nil value as spec or status vip")
 	}
+
+	// If status is not initialized, it will cause issues when committing "null" value to update
+	if *status == nil {
+		*status = []string{}
+	}
+
 	// `spec` is empty, `status` with value: copy status to spec
 	if len(*spec) == 0 {
 		*spec = ip.StringsToIPs(*status)

--- a/pkg/controller/infrastructureconfig/sync_specstatus_test.go
+++ b/pkg/controller/infrastructureconfig/sync_specstatus_test.go
@@ -911,6 +911,53 @@ func Test_SpecStatusSynchronizer(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "should handle vSphere UPI: empty unset apiServerInternalIPs and ingressIPs",
+			givenInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						VSphere: &configv1.VSpherePlatformSpec{
+							APIServerInternalIPs: []configv1.IP{},
+							IngressIPs:           []configv1.IP{},
+							MachineNetworks:      []configv1.CIDR{"224.0.0.1/24", "224.0.1.1/24"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.VSpherePlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "VSphere",
+						VSphere: &configv1.VSpherePlatformStatus{
+							MachineNetworks: []configv1.CIDR{"224.0.0.1/24", "224.0.1.1/24"},
+						},
+					},
+				},
+			},
+			wantedInfra: configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.InfrastructureSpec{
+					PlatformSpec: configv1.PlatformSpec{
+						VSphere: &configv1.VSpherePlatformSpec{
+							APIServerInternalIPs: []configv1.IP{},
+							IngressIPs:           []configv1.IP{},
+							MachineNetworks:      []configv1.CIDR{"224.0.0.1/24", "224.0.1.1/24"},
+						},
+					},
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: configv1.VSpherePlatformType,
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "VSphere",
+						VSphere: &configv1.VSpherePlatformStatus{
+							APIServerInternalIPs: []string{},
+							IngressIPs:           []string{},
+							MachineNetworks:      []configv1.CIDR{"224.0.0.1/24", "224.0.1.1/24"},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
[SPLAT-2503](https://issues.redhat.com//browse/SPLAT-2503)

### Changes
- Fixed scenario for vSphere UPI when an update to machineCIDR is causing the status field update to fail due to "null" in the ingress and api VIP fields instead of empty string[]

### Notes
This fix is needed for vSphere hybrid support.  During CI e2e testing for the feature, we have hit the issue this PR is attempting to address.  Not sure how this is not hit in the field if someone attempts to adjust infrastructure/cluster at Day 2, but it is very recreateable for this feature.

CI Job with the error: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/69114/rehearse-69114-periodic-ci-openshift-release-master-nightly-4.21-e2e-vsphere-ovn-upi-hybrid-env/1965813825533906944

Error in question:
```
2025-09-10T17:32:09.424252252Z I0910 17:32:09.424176       1 log.go:245] Reconciling Infrastructure.config.openshift.io cluster
2025-09-10T17:32:09.429111595Z I0910 17:32:09.429073       1 log.go:245] reconciling (config.openshift.io/v1, Kind=Infrastructure) /cluster
2025-09-10T17:32:09.436011516Z I0910 17:32:09.435947       1 log.go:245] Error while updating status of infrastructures.config.openshift.io/cluster: failed to apply / update (config.openshift.io/v1, Kind=Infrastructure) /cluster: Infrastructure.config.openshift.io "cluster" is invalid: [status.platformStatus.vsphere.apiServerInternalIPs: Invalid value: "null": platformStatus.vsphere.apiServerInternalIPs in body must be of type array: "null", status.platformStatus.vsphere.ingressIPs: Invalid value: "null": platformStatus.vsphere.ingressIPs in body must be of type array: "null", <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]
2025-09-10T17:32:09.453184214Z I0910 17:32:09.453136       1 log.go:245] Network operator config updated with conditions:
2025-09-10T17:32:09.453184214Z - lastTransitionTime: "2025-09-10T17:21:09Z"
2025-09-10T17:32:09.453184214Z   message: 'Error while updating status of infrastructures.config.openshift.io/cluster:
2025-09-10T17:32:09.453184214Z     failed to apply / update (config.openshift.io/v1, Kind=Infrastructure) /cluster:
2025-09-10T17:32:09.453184214Z     Infrastructure.config.openshift.io "cluster" is invalid: [status.platformStatus.vsphere.apiServerInternalIPs:
2025-09-10T17:32:09.453184214Z     Invalid value: "null": platformStatus.vsphere.apiServerInternalIPs in body must
2025-09-10T17:32:09.453184214Z     be of type array: "null", status.platformStatus.vsphere.ingressIPs: Invalid value:
2025-09-10T17:32:09.453184214Z     "null": platformStatus.vsphere.ingressIPs in body must be of type array: "null",
2025-09-10T17:32:09.453184214Z     <nil>: Invalid value: "null": some validation rules were not checked because the
2025-09-10T17:32:09.453184214Z     object was invalid; correct the existing errors to complete validation]'
2025-09-10T17:32:09.453184214Z   reason: UpdateInfrastructureStatus
2025-09-10T17:32:09.453184214Z   status: "True"
2025-09-10T17:32:09.453184214Z   type: Degraded
2025-09-10T17:32:09.453184214Z - lastTransitionTime: "2025-09-10T16:36:49Z"
2025-09-10T17:32:09.453184214Z   status: "True"
2025-09-10T17:32:09.453184214Z   type: Upgradeable
2025-09-10T17:32:09.453184214Z - lastTransitionTime: "2025-09-10T16:36:49Z"
2025-09-10T17:32:09.453184214Z   status: "False"
2025-09-10T17:32:09.453184214Z   type: ManagementStateDegraded
2025-09-10T17:32:09.453184214Z - lastTransitionTime: "2025-09-10T17:26:28Z"
2025-09-10T17:32:09.453184214Z   status: "False"
2025-09-10T17:32:09.453184214Z   type: Progressing
2025-09-10T17:32:09.453184214Z - lastTransitionTime: "2025-09-10T16:38:33Z"
2025-09-10T17:32:09.453184214Z   status: "True"
2025-09-10T17:32:09.453184214Z   type: Available
```