### PR TITLE
MON-4432: Add EndpointSlice support to DaemonSet ServiceMonitors

### DIFF
--- a/bindata/kube-proxy/monitor.yaml
+++ b/bindata/kube-proxy/monitor.yaml
@@ -24,6 +24,7 @@ spec:
   selector:
     matchLabels:
       app: kube-proxy
+  serviceDiscoveryRole: EndpointSlice
 ---
 apiVersion: v1
 kind: Service
@@ -59,6 +60,14 @@ rules:
   - services
   - endpoints
   - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
   verbs:
   - get
   - list

--- a/bindata/network/frr-k8s/monitor.yaml
+++ b/bindata/network/frr-k8s/monitor.yaml
@@ -57,6 +57,7 @@ spec:
   selector:
     matchLabels:
       name: frr-k8s-monitor-service
+  serviceDiscoveryRole: EndpointSlice
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -74,6 +75,14 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+    - discovery.k8s.io
+    resources:
+    - endpointslices
+    verbs:
+    - get
+    - list
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/bindata/network/network-metrics/002-prometheus.yaml
+++ b/bindata/network/network-metrics/002-prometheus.yaml
@@ -24,6 +24,7 @@ spec:
   namespaceSelector:
     matchNames:
       - openshift-multus
+  serviceDiscoveryRole: EndpointSlice
 ---
 apiVersion: v1
 kind: Service
@@ -61,6 +62,14 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+    - discovery.k8s.io
+    resources:
+    - endpointslices
+    verbs:
+    - get
+    - list
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/bindata/network/openshift-sdn/monitor.yaml
+++ b/bindata/network/openshift-sdn/monitor.yaml
@@ -24,6 +24,7 @@ spec:
   selector:
     matchLabels:
       app: sdn
+  serviceDiscoveryRole: EndpointSlice
 ---
 apiVersion: v1
 kind: Service
@@ -72,6 +73,7 @@ spec:
   selector:
     matchLabels:
       app: sdn-controller
+  serviceDiscoveryRole: EndpointSlice
 ---
 apiVersion: v1
 kind: Service
@@ -107,6 +109,14 @@ rules:
   - services
   - endpoints
   - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
   verbs:
   - get
   - list

--- a/bindata/network/ovn-kubernetes/common/monitor-node.yaml
+++ b/bindata/network/ovn-kubernetes/common/monitor-node.yaml
@@ -31,6 +31,7 @@ spec:
   selector:
     matchLabels:
       app: ovnkube-node
+  serviceDiscoveryRole: EndpointSlice
 ---
 apiVersion: v1
 kind: Service
@@ -70,6 +71,14 @@ rules:
   - services
   - endpoints
   - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
   verbs:
   - get
   - list


### PR DESCRIPTION
Configure all ServiceMonitor objects for DaemonSet workloads to use EndpointSlice for service discovery instead of the default Endpoints API, improving scalability and performance for monitoring DaemonSet pods.

Changes:
- Add serviceDiscoveryRole: EndpointSlice to ServiceMonitor specs
- Add discovery.k8s.io/endpointslices RBAC permissions to prometheus-k8s Roles


Related Epic: https://issues.redhat.com/browse/MON-4216

cc @simonpasquier 

/hold to test changes