### PR TITLE
OCPBUGS-66159: Add `openshift.io/node-selector` annotation to `openshift-network-console` namespace

### DIFF
--- a/bindata/networking-console-plugin/000-namespace.yaml
+++ b/bindata/networking-console-plugin/000-namespace.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     openshift.io/description: "Namespace for running the networking-console-plugin pods that enables the Networking console section"
     workload.openshift.io/allowed: "management"
+    openshift.io/node-selector: ""
 ---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
currently, the `openshift-network-console` namespace is lacking the `openshift.io/node-selector: ""` annotation.
because of this, if `defaultNodeSelector` is being set in the default scheduler, the pods in this namespace are also affected, and therefore in some cases they cannot be scheduled.