### PR TITLE
NO-JIRA: Added global overrides for OVN-Kubernetes

### DIFF
--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -11,6 +11,13 @@ data:
   ovnkube-lib.sh: |-
     #!/bin/bash
     set -x
+    # Add global overrides if the container has mounted any
+    if [[ -f "/env/_global" ]]; then
+      set -o allexport
+      source "/env/_global"
+      set +o allexport
+    fi
+
     # Add node-specific overrides if the container has mounted any
     K8S_NODE=${K8S_NODE:-}
     if [[ -n "${K8S_NODE}" && -f "/env/${K8S_NODE}" ]]; then


### PR DESCRIPTION
So far, one can override log levels in specific nodes via `env-overrides` configmap. However, only specific nodes could be overridden, there was not a global override. This modifies `ovnkube-lib.sh` to allow specifying a `_global` node whose overrides are sourced in all nodes when present. If `_global` and node-specific keys are present in the configmap, values on the node-specific one should take precedence.

This would be useful for scenarios where there is machine autoscaling, because you cannot know the node names in advance and manually maintain the `env-overrides` configmap if the node machines change automatically.