### PR TITLE
MON-4505: Migrate Prometheus targets discovering from Endpoints to EndpointSlices

### DIFF
--- a/bindata/kube-proxy/monitor.yaml
+++ b/bindata/kube-proxy/monitor.yaml
@@ -24,6 +24,7 @@ spec:
   selector:
     matchLabels:
       app: kube-proxy
+  serviceDiscoveryRole: EndpointSlice
 ---
 apiVersion: v1
 kind: Service
@@ -59,6 +60,14 @@ rules:
   - services
   - endpoints
   - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
   verbs:
   - get
   - list

--- a/bindata/network-diagnostics/network-check-source.yaml
+++ b/bindata/network-diagnostics/network-check-source.yaml
@@ -138,6 +138,7 @@ spec:
   selector:
     matchLabels:
       app: network-check-source
+  serviceDiscoveryRole: EndpointSlice
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -152,6 +153,14 @@ rules:
   - services
   - endpoints
   - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
   verbs:
   - get
   - list

--- a/bindata/network/frr-k8s/monitor.yaml
+++ b/bindata/network/frr-k8s/monitor.yaml
@@ -57,6 +57,7 @@ spec:
   selector:
     matchLabels:
       name: frr-k8s-monitor-service
+  serviceDiscoveryRole: EndpointSlice
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -70,6 +71,14 @@ rules:
       - services
       - endpoints
       - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
     verbs:
       - get
       - list

--- a/bindata/network/multus-admission-controller/monitor.yaml
+++ b/bindata/network/multus-admission-controller/monitor.yaml
@@ -58,6 +58,7 @@ spec:
   selector:
     matchLabels:
       app: multus-admission-controller
+  serviceDiscoveryRole: EndpointSlice
 {{- if not .HyperShiftEnabled}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -72,6 +73,14 @@ rules:
   - services
   - endpoints
   - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
   verbs:
   - get
   - list

--- a/bindata/network/network-metrics/002-prometheus.yaml
+++ b/bindata/network/network-metrics/002-prometheus.yaml
@@ -24,6 +24,7 @@ spec:
   namespaceSelector:
     matchNames:
       - openshift-multus
+  serviceDiscoveryRole: EndpointSlice
 ---
 apiVersion: v1
 kind: Service
@@ -57,6 +58,14 @@ rules:
       - services
       - endpoints
       - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
     verbs:
       - get
       - list

--- a/bindata/network/ovn-kubernetes/common/monitor-node.yaml
+++ b/bindata/network/ovn-kubernetes/common/monitor-node.yaml
@@ -31,6 +31,7 @@ spec:
   selector:
     matchLabels:
       app: ovnkube-node
+  serviceDiscoveryRole: EndpointSlice
 ---
 apiVersion: v1
 kind: Service
@@ -70,6 +71,14 @@ rules:
   - services
   - endpoints
   - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
   verbs:
   - get
   - list

--- a/bindata/network/ovn-kubernetes/managed/monitor-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/monitor-control-plane.yaml
@@ -48,6 +48,7 @@ spec:
   selector:
     matchLabels:
       app: ovnkube-control-plane
+  serviceDiscoveryRole: EndpointSlice
 ---
 apiVersion: v1
 kind: Service

--- a/bindata/network/ovn-kubernetes/self-hosted/monitor-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/monitor-control-plane.yaml
@@ -24,6 +24,7 @@ spec:
   selector:
     matchLabels:
       app: ovnkube-control-plane
+  serviceDiscoveryRole: EndpointSlice
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/04-monitoring-role.yaml
+++ b/manifests/04-monitoring-role.yaml
@@ -18,3 +18,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/06-servicemonitor.yaml
+++ b/manifests/06-servicemonitor.yaml
@@ -20,3 +20,4 @@ spec:
   selector:
     matchLabels:
       name: network-operator
+  serviceDiscoveryRole: EndpointSlice


### PR DESCRIPTION
This PR migrates Prometheus service discovery from the deprecated Endpoints API to the EndpointSlices API, by:

- Setting `serviceDiscoveryRole: EndpointSlice` on ServiceMonitors.
- Granting Prometheus `endpointslices` permissions.

We're taking a conservative approach by keeping the existing `endpoints` permissions alongside the new `endpointslices` ones. This provides a safety net in case any ServiceMonitors, whether deployed from this repo or from another source, still rely on the same Role and were missed during the migration.

That said, since both resources provide essentially the same data, keeping both isn't meaningfully more permissive from a security standpoint.

**These changes target OpenShift 4.22+ and should not be backported to earlier releases.**

Due to the scope of changes across multiple repositories, these modifications were generated with Claude assistance.
