### PR TITLE
Bump OVN northd probe interval to 20 seconds

### DIFF
--- a/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
@@ -75,7 +75,7 @@ spec:
         - name: OVN_SB_RAFT_ELECTION_TIMER
           value: "16"
         - name: OVN_NORTHD_PROBE_INTERVAL
-          value: "10000"
+          value: "20000"
         - name: OVN_CONTROLLER_INACTIVITY_PROBE
           value: "180000"
         - name: OVN_NB_INACTIVITY_PROBE

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -87,7 +87,7 @@ spec:
         - name: OVN_SB_RAFT_ELECTION_TIMER
           value: "16"
         - name: OVN_NORTHD_PROBE_INTERVAL
-          value: "10000"
+          value: "20000"
         - name: OVN_CONTROLLER_INACTIVITY_PROBE
           value: "180000"
         - name: OVN_NB_INACTIVITY_PROBE


### PR DESCRIPTION
Large OVN NB/SB databases can delay probe responses during initial sync. The 10s interval is not sufficient and can lead to repeated reconnects and failures. So bumping it to 20s to improve startup stability.

```
2026-02-04T16:03:33.603510916Z 2026-02-04T16:03:33.603Z|00554|reconnect|INFO|unix:/var/run/ovn/ovnnb_db.sock: connecting...
2026-02-04T16:03:33.603534674Z 2026-02-04T16:03:33.603Z|00555|reconnect|INFO|unix:/var/run/ovn/ovnnb_db.sock: connected
2026-02-04T16:03:53.611519611Z 2026-02-04T16:03:53.611Z|00556|reconnect|ERR|unix:/var/run/ovn/ovnnb_db.sock: no response to inactivity probe after 10 seconds, disconnecting
2026-02-04T16:03:53.611548880Z 2026-02-04T16:03:53.611Z|00557|reconnect|INFO|unix:/var/run/ovn/ovnnb_db.sock: connection dropped
2026-02-04T16:03:53.611558696Z 2026-02-04T16:03:53.611Z|00558|reconnect|INFO|unix:/var/run/ovn/ovnnb_db.sock: waiting 2 seconds before reconnect
2026-02-04T16:03:55.613540420Z 2026-02-04T16:03:55.613Z|00559|reconnect|INFO|unix:/var/run/ovn/ovnnb_db.sock: connecting...
2026-02-04T16:03:55.613568133Z 2026-02-04T16:03:55.613Z|00560|reconnect|INFO|unix:/var/run/ovn/ovnnb_db.sock: connected
2026-02-04T16:04:09.483100968Z 2026-02-04T16:04:09.483Z|00561|reconnect|ERR|unix:/var/run/ovn/ovnsb_db.sock: no response to inactivity probe after 10 seconds, disconnecting
2026-02-04T16:04:09.483140599Z 2026-02-04T16:04:09.483Z|00562|reconnect|INFO|unix:/var/run/ovn/ovnsb_db.sock: connection dropped
2026-02-04T16:04:09.483158393Z 2026-02-04T16:04:09.483Z|00563|ovn_northd|INFO|ovn-northd lock lost. This ovn-northd instance is now on standby.
```