### PR TITLE
[DNM] [release-4.20] Bump OVN northd probe interval to 20 seconds

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -352,19 +352,6 @@ spec:
                 set -x
                 . /ovnkube-lib/ovnkube-lib.sh || exit 1
                 sbdb-post-start
-        readinessProbe:
-{{ if not .IsSNO }}
-          initialDelaySeconds: 10
-{{ end }}
-          timeoutSeconds: 5
-          exec:
-            command:
-            - /bin/bash
-            - -c
-            - |
-              set -xeo pipefail
-              . /ovnkube-lib/ovnkube-lib.sh || exit 1
-              ovndb-readiness-probe "sb"
         env:
         - name: OVN_LOG_LEVEL
           value: info

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -408,24 +408,6 @@ spec:
 {{- end }}
                 . /ovnkube-lib/ovnkube-lib.sh || exit 1
                 sbdb-post-start
-        readinessProbe:
-{{ if not .IsSNO }}
-          initialDelaySeconds: 10
-{{ end }}
-          timeoutSeconds: 5
-          exec:
-            command:
-            - /bin/bash
-            - -c
-            - |
-              set -xeo pipefail
-{{- if .IsNetworkTypeLiveMigration }}
-              if ! ip link show br-ex; then
-                exit 0
-              fi
-{{- end }}
-              . /ovnkube-lib/ovnkube-lib.sh || exit 1
-              ovndb-readiness-probe "sb"
         env:
         - name: OVN_LOG_LEVEL
           value: info

--- a/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml
@@ -75,7 +75,7 @@ spec:
         - name: OVN_SB_RAFT_ELECTION_TIMER
           value: "16"
         - name: OVN_NORTHD_PROBE_INTERVAL
-          value: "10000"
+          value: "30000"
         - name: OVN_CONTROLLER_INACTIVITY_PROBE
           value: "180000"
         - name: OVN_NB_INACTIVITY_PROBE

--- a/manifests/0000_70_cluster-network-operator_03_deployment.yaml
+++ b/manifests/0000_70_cluster-network-operator_03_deployment.yaml
@@ -87,7 +87,7 @@ spec:
         - name: OVN_SB_RAFT_ELECTION_TIMER
           value: "16"
         - name: OVN_NORTHD_PROBE_INTERVAL
-          value: "10000"
+          value: "30000"
         - name: OVN_CONTROLLER_INACTIVITY_PROBE
           value: "180000"
         - name: OVN_NB_INACTIVITY_PROBE


### PR DESCRIPTION
Large OVN NB/SB databases can delay probe responses during initial sync. The 10s interval is not sufficient and can lead to repeated client reconnects and failures. Bump it to 20s to improve startup stability.


(cherry picked from commit 961f551f5b9386a6f3e59d787a2dd70f6994abe5)