### PR TITLE
OCPBUGS-77015: wait for patch port to apply drop garp flows

### DIFF
--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -247,9 +247,38 @@ data:
           local of_port
           of_port=$(ovs-vsctl get interface "$port_name" ofport)
           ovs-ofctl add-flow "$bridge" "cookie=$cookie,table=0,priority=$priority,in_port=$of_port,arp,arp_op=1,actions=drop" > /dev/null
-          break
+          echo "$(date -Iseconds) - INFO - Added GARP drop flow on $bridge port $port_name (ofport=$of_port)"
+          return 0
         fi
       done
+
+      # Port not found
+      return 1
+    }
+
+    # Wait for patch port to exist and add GARP drop flow.
+    wait-and-add-garp-drop-flow() {
+      local bridge="$1"
+      local max_retries=90
+      local retries=0
+
+      while [[ "${retries}" -lt "${max_retries}" ]]; do
+        if add_garp_drop_flow "${bridge}"; then
+          return 0
+        fi
+
+        (( retries += 1 ))
+
+        # Log once after 30 seconds to indicate we're still waiting
+        if [[ "${retries}" -eq 15 ]]; then
+          echo "$(date -Iseconds) - INFO - Waiting for patch port on ${bridge} to be ready..."
+        fi
+
+        sleep 2
+      done
+
+      echo "$(date -Iseconds) - WARN - Failed to add GARP drop flow on ${bridge} after ${max_retries} attempts (best-effort workaround)"
+      return 1
     }
 
     # quit-nbdb() will cleanly shut down the northbound dbserver. It is intended
@@ -512,7 +541,7 @@ data:
       # start temp work around
       # remove when https://issues.redhat.com/browse/FDP-1537 is available
       if ovs-vsctl br-exists "br-ex"; then
-          add_garp_drop_flow br-ex
+          (wait-and-add-garp-drop-flow br-ex &)
       fi
       # end temp work around
 


### PR DESCRIPTION
There is currently a race in the ovnkube-lib script where we try to add some drop flows to prevent duplicate garps to the patch port, but if the patch port isnt ready, the ovn-controller can connect to the db and create the patch port without the flow.

We need to wait for the patch port to exist before we try to add the GARP drop flow

also added some logs for better visibility

Assisted-By: Claude Sonnet 4.5

cc @pperiyasamy 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic retry-and-wait for bridge integration setup with extended retry limit and 2s delays.
  * Starts the retry process in the background so initialization remains non-blocking.
  * Improved INFO logs when waiting and when a drop-flow is added; emits a WARN if retries exhaust without success and clearly reports failure when the required port never appears.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->