### PR TITLE
OCPBUGS-82973: align frr-k8s 25/3/2026

### DIFF
--- a/bindata/network/frr-k8s/001-crd.yaml
+++ b/bindata/network/frr-k8s/001-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: frrconfigurations.frrk8s.metallb.io
 spec:
   group: frrk8s.metallb.io
@@ -185,8 +185,10 @@ spec:
                               disableMP:
                                 default: false
                                 description: |-
-                                  To set if we want to disable MP BGP that will separate IPv4 and IPv6 route exchanges into distinct BGP sessions.
-                                  Deprecated: DisableMP is deprecated in favor of dualStackAddressFamily.
+                                  DisableMP is no longer used and has no effect.
+                                  Use DualStackAddressFamily instead to enable the neighbor for both IPv4 and IPv6 address families.
+
+                                  Deprecated: This field is ignored. Use DualStackAddressFamily instead.
                                 type: boolean
                               dualStackAddressFamily:
                                 default: false
@@ -490,7 +492,72 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: frrk8sconfigurations.frrk8s.metallb.io
+spec:
+  group: frrk8s.metallb.io
+  names:
+    kind: FRRK8sConfiguration
+    listKind: FRRK8sConfigurationList
+    plural: frrk8sconfigurations
+    singular: frrk8sconfiguration
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          FRRK8sConfiguration holds the FRR Operator configuration with global
+          settings for the K8s and FRR.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FRRK8sConfigurationSpec defines the desired state of FRRK8sConfiguration.
+            properties:
+              logLevel:
+                description: |-
+                  LogLevel sets the logging verbosity for the FRR-K8s components at runtime.
+                  When configured, this value overrides the defaults established by the --log-level CLI flag.
+                  Valid values are: all, debug, info, warn, error, none.
+                enum:
+                - all
+                - debug
+                - info
+                - warn
+                - error
+                - none
+                type: string
+            type: object
+          status:
+            description: FRRK8sConfigurationStatus defines the observed state of FRRK8sConfiguration.
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: frrnodestates.frrk8s.metallb.io
 spec:
   group: frrk8s.metallb.io
@@ -555,7 +622,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: bgpsessionstates.frrk8s.metallb.io
 spec:
   group: frrk8s.metallb.io

--- a/bindata/network/frr-k8s/002-rbac.yaml
+++ b/bindata/network/frr-k8s/002-rbac.yaml
@@ -125,6 +125,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - frrk8s.metallb.io
+  resources:
+  - frrk8sconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews

--- a/bindata/network/frr-k8s/frr-k8s.yaml
+++ b/bindata/network/frr-k8s/frr-k8s.yaml
@@ -97,7 +97,8 @@ spec:
         args:
         - --node-name=$(NODE_NAME)
         - --namespace=$(NAMESPACE)
-        - --metrics-bind-address=127.0.0.1:7572
+        - --metrics-bind-address=0.0.0.0:9140
+        - --metrics-cert-dir=/etc/metrics
         - $(LOG_LEVEL)
         env:
         - name: FRR_CONFIG_FILE
@@ -119,8 +120,8 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         ports:
-        - containerPort: 7572
-          name: monitoring
+        - containerPort: 9140
+          name: metricshttps
         resources:
           requests:
             cpu: 100m
@@ -128,8 +129,8 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:
-            path: /metrics
-            port: monitoring
+            path: /healthz
+            port: 7572
             host: 127.0.0.1
           initialDelaySeconds: 10
           periodSeconds: 10
@@ -138,8 +139,8 @@ spec:
           failureThreshold: 3
         readinessProbe:
           httpGet:
-            path: /metrics
-            port: monitoring
+            path: /readyz
+            port: 7572
             host: 127.0.0.1
           initialDelaySeconds: 10
           periodSeconds: 10
@@ -157,6 +158,9 @@ spec:
         volumeMounts:
           - name: reloader
             mountPath: /etc/frr_reloader
+          - name: metrics-certs
+            mountPath: /etc/metrics
+            readOnly: true
       - name: frr
         securityContext:
           allowPrivilegeEscalation: false
@@ -192,15 +196,15 @@ spec:
         livenessProbe:
           httpGet:
             path: /livez
-            port: 7573
-            host: 127.0.0.1
+            port: 9141
+            scheme: HTTPS
           periodSeconds: 10
           failureThreshold: 3
         startupProbe:
           httpGet:
             path: /livez
-            port: 7573
-            host: 127.0.0.1
+            port: 9141
+            scheme: HTTPS
           failureThreshold: 30
           periodSeconds: 5
       - name: reloader
@@ -222,11 +226,13 @@ spec:
         image: {{.FRRK8sImage}}
         command: ["/etc/frr_metrics/frr-metrics"]
         args:
-        - --metrics-port=7573
-        - --metrics-bind-address=127.0.0.1
+        - --metrics-port=9141
+        - --metrics-bind-address=0.0.0.0
+        - --tls-cert-file=/etc/metrics/tls.crt
+        - --tls-private-key-file=/etc/metrics/tls.key
         ports:
-        - containerPort: 7573
-          name: monitoring
+        - containerPort: 9141
+          name: frrmetricshttps
         resources:
           requests:
             cpu: 10m
@@ -239,6 +245,9 @@ spec:
           mountPath: /etc/frr
         - name: metrics
           mountPath: /etc/frr_metrics
+        - name: metrics-certs
+          mountPath: /etc/metrics
+          readOnly: true
       - name: frr-status
         image: {{.FRRK8sImage}}
         args:
@@ -272,48 +281,6 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
-      - name: kube-rbac-proxy
-        image: {{.KubeRBACProxyImage}}
-        args:
-        - --logtostderr
-        - --secure-listen-address=:9140
-        - --upstream=http://127.0.0.1:7572/
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-        - --tls-private-key-file=/etc/metrics/tls.key
-        - --tls-cert-file=/etc/metrics/tls.crt
-        ports:
-        - containerPort: 9140
-          name: metricshttps
-        resources:
-          requests:
-            cpu: 10m
-            memory: 20Mi
-        terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts:
-        - name: metrics-certs
-          mountPath: /etc/metrics
-          readOnly: true
-      - name: kube-rbac-proxy-frr
-        image: {{.KubeRBACProxyImage}}
-        args:
-        - --logtostderr
-        - --secure-listen-address=:9141
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-        - --upstream=http://127.0.0.1:7573/
-        - --tls-private-key-file=/etc/metrics/tls.key
-        - --tls-cert-file=/etc/metrics/tls.crt
-        ports:
-        - containerPort: 9141
-          name: frrmetricshttps
-        resources:
-          requests:
-            cpu: 10m
-            memory: 20Mi
-        terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts:
-        - name: metrics-certs
-          mountPath: /etc/metrics
-          readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:

--- a/bindata/network/frr-k8s/frr-k8s.yaml
+++ b/bindata/network/frr-k8s/frr-k8s.yaml
@@ -254,7 +254,7 @@ spec:
         - --node-name=$(NODE_NAME)
         - --namespace=$(NAMESPACE)
         - --pod-name=$(POD_NAME)
-        - --poll-interval=2m
+        - $(POLL_INTERVAL)
         command:
         - /etc/frr_status/frr-status
         env:
@@ -270,6 +270,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: POLL_INTERVAL
+          valueFrom:
+            configMapKeyRef:
+              name: env-overrides
+              key: frrk8s-poll-interval
+              optional: true
         volumeMounts:
         - mountPath: /var/run/frr
           name: frr-sockets

--- a/bindata/network/frr-k8s/frr-k8s.yaml
+++ b/bindata/network/frr-k8s/frr-k8s.yaml
@@ -254,6 +254,7 @@ spec:
         - --node-name=$(NODE_NAME)
         - --namespace=$(NAMESPACE)
         - --pod-name=$(POD_NAME)
+        - $(LOG_LEVEL)
         - $(POLL_INTERVAL)
         command:
         - /etc/frr_status/frr-status
@@ -270,6 +271,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: LOG_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              name: env-overrides
+              key: frrk8s-loglevel
+              optional: true
         - name: POLL_INTERVAL
           valueFrom:
             configMapKeyRef:

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -859,7 +859,6 @@ func renderAdditionalRoutingCapabilities(conf *operv1.NetworkSpec, manifestDir s
 		case operv1.RoutingCapabilitiesProviderFRR:
 			data := render.MakeRenderData()
 			data.Data["FRRK8sImage"] = os.Getenv("FRR_K8S_IMAGE")
-			data.Data["KubeRBACProxyImage"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
 			data.Data["ReleaseVersion"] = os.Getenv("RELEASE_VERSION")
 			objs, err := render.RenderDir(filepath.Join(manifestDir, "network/frr-k8s"), &data)
 			if err != nil {

--- a/pkg/network/render_test.go
+++ b/pkg/network/render_test.go
@@ -568,7 +568,7 @@ func Test_renderAdditionalRoutingCapabilities(t *testing.T) {
 					},
 				},
 			},
-			want:        19,
+			want:        20,
 			expectedErr: nil,
 		},
 	}


### PR DESCRIPTION
Aligning the frr-k8s manifests with https://github.com/openshift/frr/pull/128, the 2 major changes are:
* frr-k8s no longer uses kube-rbac-proxy but rather exposes the https endpoints directly, aligning the bits with upstream
* new crd introduced
the 2 other commits are for e2e passing downstream, as upstream has these assumptions already baked in