### PR TITLE
OCPBUGS-83406 OCPBUGS-83407:  fix issue for managed mode of no-overlay

### DIFF
--- a/bindata/network/frr-k8s/config.yaml
+++ b/bindata/network/frr-k8s/config.yaml
@@ -46,7 +46,7 @@ data:
     #
     vtysh_enable=yes
     zebra_options="  -A 127.0.0.1 -s 90000000 --limit-fds 100000"
-    bgpd_options="   -A 127.0.0.1 -p 0 --limit-fds 100000"
+    bgpd_options="   -A 127.0.0.1 -p {{ if .NoOverlayManagedEnabled }}179{{ else }}0{{ end }} --limit-fds 100000"
     ospfd_options="  -A 127.0.0.1"
     ospf6d_options=" -A ::1"
     ripd_options="   -A 127.0.0.1"

--- a/bindata/network/ovn-kubernetes/common/004-rbac-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/common/004-rbac-control-plane.yaml
@@ -243,7 +243,7 @@ rules:
   verbs:
   - patch
   - update
-- apiGroups: 
+- apiGroups:
   - frrk8s.metallb.io
   resources:
   - frrconfigurations
@@ -255,6 +255,17 @@ rules:
   - delete
   - update
   - patch
+{{- end}}
+{{- if .NoOverlayManagedEnabled }}
+- apiGroups:
+  - k8s.ovn.org
+  resources:
+  - routeadvertisements
+  verbs:
+  - create
+  - delete
+  - patch
+  - update
 {{- end}}
 {{- if .OVN_EVPN_ENABLE }}
 - apiGroups:

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -861,6 +861,8 @@ func renderAdditionalRoutingCapabilities(conf *operv1.NetworkSpec, manifestDir s
 			data.Data["FRRK8sImage"] = os.Getenv("FRR_K8S_IMAGE")
 			data.Data["KubeRBACProxyImage"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
 			data.Data["ReleaseVersion"] = os.Getenv("RELEASE_VERSION")
+			data.Data["NoOverlayManagedEnabled"] = conf.DefaultNetwork.OVNKubernetesConfig != nil &&
+				conf.DefaultNetwork.OVNKubernetesConfig.BGPManagedConfig.BGPTopology != ""
 			objs, err := render.RenderDir(filepath.Join(manifestDir, "network/frr-k8s"), &data)
 			if err != nil {
 				return nil, fmt.Errorf("failed to render frr-k8s manifests: %w", err)

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -860,6 +860,8 @@ func renderAdditionalRoutingCapabilities(conf *operv1.NetworkSpec, manifestDir s
 			data := render.MakeRenderData()
 			data.Data["FRRK8sImage"] = os.Getenv("FRR_K8S_IMAGE")
 			data.Data["ReleaseVersion"] = os.Getenv("RELEASE_VERSION")
+			data.Data["NoOverlayManagedEnabled"] = conf.DefaultNetwork.OVNKubernetesConfig != nil &&
+				conf.DefaultNetwork.OVNKubernetesConfig.BGPManagedConfig.BGPTopology != ""
 			objs, err := render.RenderDir(filepath.Join(manifestDir, "network/frr-k8s"), &data)
 			if err != nil {
 				return nil, fmt.Errorf("failed to render frr-k8s manifests: %w", err)


### PR DESCRIPTION
there are two issues for no-overlay managed routing mode:

With -p 0, the BGP daemon does not listen for incoming connections, which breaks the full-mesh iBGP topology used in managed routing mode. Each node must be able to accept BGP sessions from all other nodes, requiring the standard port 179 to be active.

When no-overlay transport is configured with managed routing (NoOverlayManagedEnabled),
the ovn-kubernetes-control-plane service account runs the managed BGP controller which
needs to create, delete, patch and update RouteAdvertisements CRs. The existing
OVN_ROUTE_ADVERTISEMENTS_ENABLE block only grants list/get/watch, causing the cluster
manager to fail on startup with a forbidden error.

cherry-picked from https://github.com/openshift/cluster-network-operator/pull/2954

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * BGP daemon will accept incoming BGP sessions on port 179 when managed overlay routing is enabled (otherwise listens on the default isolated port).
  * Control-plane permissions now optionally allow creating/updating route advertisement resources when managed overlay routing is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->