### PR TITLE
OCPBUGS-65631: Use dedicated service accounts for multus pods

### DIFF
--- a/bindata/allowlist/daemonset/daemonset.yaml
+++ b/bindata/allowlist/daemonset/daemonset.yaml
@@ -18,6 +18,7 @@ spec:
         cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
     spec:
       hostNetwork: true
+      serviceAccountName: multus-ancillary-tools
       containers:
         - name: kube-multus-additional-cni-plugins
           image:  {{.MultusImage}}

--- a/bindata/network/multus/002-rbac.yaml
+++ b/bindata/network/multus/002-rbac.yaml
@@ -133,6 +133,13 @@ subjects:
 
 {{ if .NETWORK_NODE_IDENTITY_ENABLE }}
 ---
+# This SA has no permissions since the pod uses node identity for API access
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: multus-node-identity
+  namespace: openshift-multus
+---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -193,7 +193,9 @@ spec:
       hostPID: true
       nodeSelector:
         kubernetes.io/os: linux
-{{ if not .NETWORK_NODE_IDENTITY_ENABLE }}
+{{ if .NETWORK_NODE_IDENTITY_ENABLE }}
+      serviceAccountName: multus-node-identity
+{{ else }}
       serviceAccountName: multus
 {{ end }}
       priorityClassName: "system-node-critical"

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -193,7 +193,10 @@ spec:
       hostPID: true
       nodeSelector:
         kubernetes.io/os: linux
-{{ if not .NETWORK_NODE_IDENTITY_ENABLE }}
+{{ if .NETWORK_NODE_IDENTITY_ENABLE }}
+      serviceAccountName: multus-node-identity
+{{ else }}
+      # Network node identity disabled, use service account with permissions
       serviceAccountName: multus
 {{ end }}
       priorityClassName: "system-node-critical"

--- a/pkg/network/multus_test.go
+++ b/pkg/network/multus_test.go
@@ -1,11 +1,14 @@
 package network
 
 import (
+	"path/filepath"
 	"testing"
 
 	operv1 "github.com/openshift/api/operator/v1"
 
 	. "github.com/onsi/gomega"
+	"github.com/openshift/cluster-network-operator/pkg/render"
+	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 var MultusConfig = operv1.Network{
@@ -55,4 +58,85 @@ func TestRenderMultus(t *testing.T) {
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("ClusterRole", "", "multus")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("DaemonSet", "openshift-multus", "multus")))
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("NetworkPolicy", "openshift-multus", "default-deny")))
+}
+
+// TestMultusServiceAccountWithoutNodeIdentity tests service account is set when node identity is disabled
+func TestMultusServiceAccountWithoutNodeIdentity(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	crd := MultusConfig.DeepCopy()
+	config := &crd.Spec
+	enabled := false
+	config.DisableMultiNetwork = &enabled
+	fillDefaults(config, nil)
+
+	// Test without node identity - should have service account
+	bootstrapWithoutNodeIdentity := fakeBootstrapResult()
+	bootstrapWithoutNodeIdentity.Infra.NetworkNodeIdentityEnabled = false
+
+	objs, err := renderMultus(config, bootstrapWithoutNodeIdentity, manifestDir)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	daemonSet := findDaemonSet(objs, "openshift-multus", "multus")
+	g.Expect(daemonSet).NotTo(BeNil())
+
+	serviceAccount, found, err := uns.NestedString(daemonSet.Object, "spec", "template", "spec", "serviceAccountName")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(found).To(BeTrue())
+	g.Expect(serviceAccount).To(Equal("multus"))
+
+	// Verify that multus-node-identity service account is NOT created when node identity is disabled
+	g.Expect(objs).NotTo(ContainElement(HaveKubernetesID("ServiceAccount", "openshift-multus", "multus-node-identity")))
+
+	// Test with node identity - should use multus-node-identity service account
+	bootstrapWithNodeIdentity := fakeBootstrapResult()
+	bootstrapWithNodeIdentity.Infra.NetworkNodeIdentityEnabled = true
+
+	objs, err = renderMultus(config, bootstrapWithNodeIdentity, manifestDir)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	daemonSet = findDaemonSet(objs, "openshift-multus", "multus")
+	g.Expect(daemonSet).NotTo(BeNil())
+
+	serviceAccount, found, err = uns.NestedString(daemonSet.Object, "spec", "template", "spec", "serviceAccountName")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(found).To(BeTrue(), "serviceAccountName should be set when NETWORK_NODE_IDENTITY_ENABLE=true")
+	g.Expect(serviceAccount).To(Equal("multus-node-identity"), "daemonset should use multus-node-identity service account when node identity is enabled")
+
+	// Verify that multus-node-identity service account is created when node identity is enabled
+	g.Expect(objs).To(ContainElement(HaveKubernetesID("ServiceAccount", "openshift-multus", "multus-node-identity")))
+}
+
+func findDaemonSet(objs []*uns.Unstructured, namespace, name string) *uns.Unstructured {
+	for _, obj := range objs {
+		if obj.GetKind() == "DaemonSet" && obj.GetNamespace() == namespace && obj.GetName() == name {
+			return obj
+		}
+	}
+	return nil
+}
+
+// TestAllowlistDaemonSetServiceAccount verifies that cni-sysctl-allowlist-ds is using its bespoke service account
+func TestAllowlistDaemonSetServiceAccount(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// Render the allowlist daemonset manifests
+	data := render.MakeRenderData()
+	data.Data["MultusImage"] = "test-multus-image:latest"
+	data.Data["CniSysctlAllowlist"] = "cni-sysctl-allowlist"
+	data.Data["ReleaseVersion"] = "test-version"
+
+	objs, err := render.RenderDir(filepath.Join(manifestDir, "allowlist/daemonset"), &data)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(objs).NotTo(BeEmpty())
+
+	// Find the cni-sysctl-allowlist-ds daemonset
+	daemonSet := findDaemonSet(objs, "openshift-multus", "cni-sysctl-allowlist-ds")
+	g.Expect(daemonSet).NotTo(BeNil(), "cni-sysctl-allowlist-ds daemonset should be rendered")
+
+	// Verify that the serviceAccountName is set to multus-ancillary-tools
+	serviceAccount, found, err := uns.NestedString(daemonSet.Object, "spec", "template", "spec", "serviceAccountName")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(found).To(BeTrue(), "serviceAccountName should be set in the daemonset")
+	g.Expect(serviceAccount).To(Equal("multus-ancillary-tools"), "daemonset should use multus-ancillary-tools service account")
 }


### PR DESCRIPTION
This work was taken/adapted from yboaron's PR in #2845. yboaron has given me permission to take over his work on this.

Service accounts have been added to multus related pods.

+ `openshift-multus/cni-sysctl-allowlist-ds` pod now uses `multus-ancillary-tools` ServiceAccount. 
+ `openshift-multus/multus` now uses newly created `multus-node-identity` ServiceAccount when `NETWORK_NODE_IDENTITY_ENABLE == true` instead of `default`. The service account has no bindings attached.

The commit message has been kept the same, and the logic has been kept the same from the mentioned PR. Though, line placement does differ for `multus.yaml`. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added tests to verify Multus DaemonSet uses the correct service account with node identity enabled/disabled and that the ancillary allowlist DaemonSet uses the expected service account.

* **Chores**
  * Multus DaemonSet service account assignment now switches based on network node identity feature.
  * Added a service account for node identity when that feature is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->