### PR TITLE
[release-4.18] OCPBUGS-77151: Add config override for openflow-probe

### DIFF
--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -502,6 +502,9 @@ data:
       local metrics_port=$2
       local ovn_metrics_port=$3
 
+      # Ensure openflow_probe_flag is always defined
+      openflow_probe_flag=
+
       if [[ $# -ne 3 ]]; then
         echo "Expected three arguments but got $#"
         exit 1
@@ -624,6 +627,10 @@ data:
         sysctl -w net.ipv6.conf.all.forwarding=0
       fi
 
+      if [[ "{{.OpenFlowProbe}}" != "" ]]; then
+        openflow_probe_flag="--openflow-probe={{.OpenFlowProbe}}"
+      fi
+
       NETWORK_NODE_IDENTITY_ENABLE=
       if [[ "{{.NETWORK_NODE_IDENTITY_ENABLE}}" == "true" ]]; then
         NETWORK_NODE_IDENTITY_ENABLE="
@@ -692,6 +699,7 @@ data:
         --acl-logging-rate-limit "{{.OVNPolicyAuditRateLimit}}" \
         ${gw_interface_flag} \
         ${ip_forwarding_flag} \
+        ${openflow_probe_flag} \
         ${NETWORK_NODE_IDENTITY_ENABLE} \
         ${ovn_v4_join_subnet_opt} \
         ${ovn_v6_join_subnet_opt} \

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -32,6 +32,11 @@ type OVNConfigBoostrapResult struct {
 	SmartNicModeLabel     string
 	SmartNicModeNodes     []string
 	MgmtPortResourceName  string
+	// ConfigOverrides contains the overrides for the OVN Kubernetes configuration
+	// This is used to set the hidden OVN Kubernetes configuration in the cluster
+	// It is a map of key-value pairs where the key is the configuration option and the
+	// value is the configuration value.
+	ConfigOverrides map[string]string
 }
 
 // OVNUpdateStatus contains the status of existing daemonset

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -68,7 +68,9 @@ const OVN_NODE_IDENTITY_CERT_DURATION = "24h"
 const OVN_EGRESSIP_HEALTHCHECK_PORT = "9107"
 
 const (
-	OVSFlowsConfigMapName        = "ovs-flows-config"
+	OVSFlowsConfigMapName              = "ovs-flows-config"
+	OVNKubernetesConfigOverridesCMName = "ovn-kubernetes-config-overrides"
+
 	OVSFlowsConfigNamespace      = names.APPLIED_NAMESPACE
 	defaultV4InternalSubnet      = "100.64.0.0/16"
 	defaultV6InternalSubnet      = "fd98::/64"
@@ -866,6 +868,11 @@ func bootstrapOVNConfig(conf *operv1.Network, kubeClient cnoclient.Client, hc *h
 	found, nodeName := findCommonNode(ovnConfigResult.DpuHostModeNodes, ovnConfigResult.DpuModeNodes, ovnConfigResult.SmartNicModeNodes)
 	if found {
 		return nil, fmt.Errorf("Node %s has multiple hardware offload labels.", nodeName)
+	}
+
+	ovnConfigResult.ConfigOverrides, err = getOVNKubernetesConfigOverrides(kubeClient)
+	if err != nil {
+		return nil, fmt.Errorf("Could not get OVN Kubernetes config overrides: %w", err)
 	}
 
 	klog.Infof("OVN configuration is now %+v", ovnConfigResult)
@@ -1973,4 +1980,22 @@ func GetMasqueradeSubnet(conf *operv1.OVNKubernetesConfig) (v4Subnet, v6Subnet s
 		}
 	}
 	return
+}
+
+// getOVNKubernetesConfigOverrides retrieves OVN Kubernetes configuration overrides from the
+// openshift-network-operator/ovn-kubernetes-config-overrides configmap.
+// If the configmap exists, it returns the data as a map.
+// If the configmap does not exist, it returns nil, indicating that no overrides are set
+// and no error.
+// If there is an error retrieving the configmap, it returns an error.
+func getOVNKubernetesConfigOverrides(client cnoclient.Client) (map[string]string, error) {
+	configMap := &corev1.ConfigMap{}
+	if err := client.Default().CRClient().Get(context.TODO(),
+		types.NamespacedName{Name: OVNKubernetesConfigOverridesCMName, Namespace: names.APPLIED_NAMESPACE}, configMap); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("unable to retrieve config from configmap %v: %s", OVNKubernetesConfigOverridesCMName, err)
+	}
+	return configMap.Data, nil
 }

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -182,6 +182,17 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["NETWORK_NODE_IDENTITY_ENABLE"] = bootstrapResult.Infra.NetworkNodeIdentityEnabled
 	data.Data["NodeIdentityCertDuration"] = OVN_NODE_IDENTITY_CERT_DURATION
 	data.Data["IsNetworkTypeLiveMigration"] = false
+	data.Data["OpenFlowProbe"] = ""
+	if raw, ok := bootstrapResult.OVN.OVNKubernetesConfig.ConfigOverrides["openflow-probe"]; ok {
+		probe := strings.TrimSpace(raw)
+		if probe != "" {
+			if _, err := strconv.ParseUint(probe, 10, 32); err != nil {
+				klog.Warningf("Ignoring invalid openflow-probe override %q: expected non-negative integer", raw)
+			} else {
+				data.Data["OpenFlowProbe"] = probe
+			}
+		}
+	}
 
 	if conf.Migration != nil {
 		if conf.Migration.MTU != nil && conf.Migration.Mode != operv1.LiveNetworkMigrationMode {

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -3926,6 +3926,18 @@ func extractOVNKubeConfig(g *WithT, objs []*uns.Unstructured) string {
 	return ""
 }
 
+func extractOVNScriptLib(g *WithT, objs []*uns.Unstructured) string {
+	for _, obj := range objs {
+		if obj.GetKind() == "ConfigMap" && obj.GetName() == "ovnkube-script-lib" {
+			val, ok, err := uns.NestedString(obj.Object, "data", "ovnkube-lib.sh")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(ok).To(BeTrue())
+			return val
+		}
+	}
+	return ""
+}
+
 // checkDaemonsetAnnotation check that all the daemonset have the annotation with the
 // same key and value
 func checkDaemonsetAnnotation(g *WithT, objs []*uns.Unstructured, key, value string) bool {

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -4126,3 +4126,49 @@ func Test_renderOVNKubernetes(t *testing.T) {
 		})
 	}
 }
+
+func TestRenderOVNKubernetes_OpenFlowProbeOverride(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	crd := OVNKubernetesConfig.DeepCopy()
+	config := &crd.Spec
+	fillDefaults(config, nil)
+
+	renderWithOverrides := func(overrides map[string]string) string {
+		bootstrapResult := fakeBootstrapResult()
+		bootstrapResult.OVN = bootstrap.OVNBootstrapResult{
+			ControlPlaneReplicaCount: 3,
+			OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
+				DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+				DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
+				SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+				MgmtPortResourceName: "",
+				HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
+					Enabled: false,
+				},
+				ConfigOverrides: overrides,
+			},
+		}
+		featureGatesCNO := getDefaultFeatureGates()
+		fakeClient := cnofake.NewFakeClient()
+
+		objs, _, err := renderOVNKubernetes(config, bootstrapResult, manifestDirOvn, fakeClient, featureGatesCNO)
+		g.Expect(err).NotTo(HaveOccurred())
+		return extractOVNScriptLib(g, objs)
+	}
+
+	t.Run("with openflow-probe override", func(t *testing.T) {
+		ovnkubeScriptLib := renderWithOverrides(map[string]string{"openflow-probe": "60"})
+		g.Expect(ovnkubeScriptLib).To(ContainSubstring(`--openflow-probe=60"`))
+	})
+
+	t.Run("without openflow-probe override", func(t *testing.T) {
+		ovnkubeScriptLib := renderWithOverrides(nil)
+		g.Expect(ovnkubeScriptLib).To(ContainSubstring(`--openflow-probe="`))
+	})
+
+	t.Run("with invalid openflow-probe override", func(t *testing.T) {
+		ovnkubeScriptLib := renderWithOverrides(map[string]string{"openflow-probe": "-60"})
+		g.Expect(ovnkubeScriptLib).To(ContainSubstring(`--openflow-probe="`))
+	})
+}


### PR DESCRIPTION
Manual cherry-pick of 4.19 commits to release-4.18:
- e2ba945: Allow overriding OVN-Kubernetes configuration (ConfigOverrides infrastructure)
- 003d471: Add config override for openflow-probe (OpenFlowProbe feature)

This backport adds ConfigOverrides infrastructure and openflow-probe feature support to release-4.18.

## Conflict Resolution
During cherry-picking, merge conflicts were resolved:
- Removed advertised-udn-isolation-mode code (not needed for this backport)
- Kept ConfigOverrides infrastructure (required by openflow-probe feature)
- Kept openflow-probe feature code and tests only

## Files Changed 
- bindata/network/ovn-kubernetes/common/008-script-lib.yaml
- pkg/network/ovn_kubernetes.go
- pkg/network/ovn_kubernetes_test.go
