### PR TITLE
OCPBUGS-83863: Remove version-specific CNI binary copy logic

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -39,7 +39,7 @@ data:
     UPGRADE_DIRECTORY=${DESTINATION_DIRECTORY}upgrade_$(uuidgen)
     rm -Rf $UPGRADE_DIRECTORY
     mkdir -p $UPGRADE_DIRECTORY
-    cp -r --remove-destination ${sourcedir}* $UPGRADE_DIRECTORY
+    find "${sourcedir}" -maxdepth 1 -mindepth 1 ! -type d -exec cp --remove-destination {} "${UPGRADE_DIRECTORY}/" \;
     if [ $? -eq 0 ]; then
       log "Successfully copied files in ${sourcedir} to $UPGRADE_DIRECTORY"
     else

--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -21,10 +21,8 @@ data:
     DESTINATION_DIRECTORY=/host/opt/cni/bin/
 
     # Perform validation of usage
-    if [ -z "$RHEL8_SOURCE_DIRECTORY" ] ||
-       [ -z "$RHEL9_SOURCE_DIRECTORY" ] ||
-       [ -z "$DEFAULT_SOURCE_DIRECTORY" ]; then
-      log "FATAL ERROR: You must set env variables: RHEL8_SOURCE_DIRECTORY, RHEL9_SOURCE_DIRECTORY, DEFAULT_SOURCE_DIRECTORY"
+    if [ -z "$SOURCE_DIRECTORY" ]; then
+      log "FATAL ERROR: You must set the SOURCE_DIRECTORY env variable"
       exit 1
     fi
 
@@ -33,55 +31,8 @@ data:
       exit 1
     fi
 
-    # Collect host OS information
-    . /host/etc/os-release
-    rhelmajor=
-    # detect which version we're using in order to copy the proper binaries
-    case "${ID}" in
-      rhcos|scos)
-        RHEL_VERSION=$(echo "${CPE_NAME}" | cut -f 5 -d :)
-        rhelmajor=$(echo $RHEL_VERSION | sed -E 's/([0-9]+)\.{1}[0-9]+(\.[0-9]+)?/\1/')
-      ;;
-      rhel|centos) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)
-      ;;
-      fedora)
-        if [ "${VARIANT_ID}" == "coreos" ]; then
-          rhelmajor=8
-        else
-          log "FATAL ERROR: Unsupported Fedora variant=${VARIANT_ID}"
-          exit 1
-        fi
-      ;;
-      *) log "FATAL ERROR: Unsupported OS ID=${ID}"; exit 1
-      ;;
-    esac
-
-    # Set which directory we'll copy from, detect if it exists
-    sourcedir=
-    founddir=false
-    case "${rhelmajor}" in
-      8)
-        if [ -d "${RHEL8_SOURCE_DIRECTORY}" ]; then
-          sourcedir=${RHEL8_SOURCE_DIRECTORY}
-          founddir=true
-        fi
-      ;;
-      9)
-        if [ -d "${RHEL9_SOURCE_DIRECTORY}" ]; then
-          sourcedir=${RHEL9_SOURCE_DIRECTORY}
-          founddir=true
-        fi
-      ;;
-      *)
-        log "ERROR: RHEL Major Version Unsupported, rhelmajor=${rhelmajor}"
-      ;;
-    esac
-
-    # When it doesn't exist, fall back to the original directory.
-    if [ "$founddir" == false ]; then
-      log "Source directory unavailable for OS version: ${rhelmajor}"
-      sourcedir=$DEFAULT_SOURCE_DIRECTORY
-    fi
+    sourcedir="${SOURCE_DIRECTORY}"
+    log "Copying binaries from ${sourcedir}"
 
     # Use a subdirectory called "upgrade" so we can atomically move fully copied files.
     # We now use --remove-destination after running into an issue with -f not working over symlinks
@@ -221,8 +172,6 @@ spec:
         volumeMounts:
         - mountPath: /entrypoint
           name: cni-binary-copy
-        - mountPath: /host/etc/os-release
-          name: os-release
         - name: system-cni-dir
           mountPath: /host/etc/cni/net.d
         - name: multus-cni-dir
@@ -260,11 +209,7 @@ spec:
         - name: etc-kubernetes
           mountPath: /etc/kubernetes
         env:
-        - name: RHEL8_SOURCE_DIRECTORY
-          value: "/usr/src/multus-cni/rhel8/bin/"
-        - name: RHEL9_SOURCE_DIRECTORY
-          value: "/usr/src/multus-cni/rhel9/bin/"
-        - name: DEFAULT_SOURCE_DIRECTORY
+        - name: SOURCE_DIRECTORY
           value: "/usr/src/multus-cni/bin/"
         - name: KUBERNETES_SERVICE_PORT
           value: "{{.KUBERNETES_SERVICE_PORT}}"
@@ -304,10 +249,6 @@ spec:
           hostPath:
             path: {{ .CNIBinDir }}
             type: Directory
-        - name: os-release
-          hostPath:
-            path: /etc/os-release
-            type: File
         - name: cni-binary-copy
           configMap:
             name: cni-copy-resources
@@ -399,15 +340,8 @@ spec:
           name: cni-binary-copy
         - mountPath: /host/opt/cni/bin
           name: cnibin
-        - mountPath: /host/etc/os-release
-          name: os-release
-          readOnly: true
         env:
-        - name: RHEL8_SOURCE_DIRECTORY
-          value: "/usr/src/egress-router-cni/rhel8/bin/"
-        - name: RHEL9_SOURCE_DIRECTORY
-          value: "/usr/src/egress-router-cni/rhel9/bin/"
-        - name: DEFAULT_SOURCE_DIRECTORY
+        - name: SOURCE_DIRECTORY
           value: "/usr/src/egress-router-cni/bin/"
       - name: cni-plugins
         image: {{.CNIPluginsImage}}
@@ -418,20 +352,13 @@ spec:
           name: cni-binary-copy
         - mountPath: /host/opt/cni/bin
           name: cnibin
-        - mountPath: /host/etc/os-release
-          name: os-release
-          readOnly: true
         - mountPath: /host/etc/cni/tuning/
           name: tuning-conf-dir
           readOnly: false
         - mountPath: /sysctls
           name: cni-sysctl-allowlist
         env:
-        - name: RHEL8_SOURCE_DIRECTORY
-          value: "/usr/src/plugins/rhel8/bin/"
-        - name: RHEL9_SOURCE_DIRECTORY
-          value: "/usr/src/plugins/rhel9/bin/"
-        - name: DEFAULT_SOURCE_DIRECTORY
+        - name: SOURCE_DIRECTORY
           value: "/usr/src/plugins/bin/"
       - name: bond-cni-plugin
         image: {{.BondCNIPluginImage}}
@@ -442,16 +369,9 @@ spec:
           name: cni-binary-copy
         - mountPath: /host/opt/cni/bin
           name: cnibin
-        - mountPath: /host/etc/os-release
-          name: os-release
-          readOnly: true
         env:
-        - name: RHEL8_SOURCE_DIRECTORY
-          value: "/bondcni/rhel8/"
-        - name: RHEL9_SOURCE_DIRECTORY
-          value: "/bondcni/rhel9/"
-        - name: DEFAULT_SOURCE_DIRECTORY
-          value: "/bondcni/rhel9/"
+        - name: SOURCE_DIRECTORY
+          value: "/bondcni/"
       - name: routeoverride-cni
         image: {{.RouteOverrideImage}}
         command: ["/entrypoint/cnibincopy.sh"]
@@ -461,15 +381,8 @@ spec:
           name: cni-binary-copy
         - mountPath: /host/opt/cni/bin
           name: cnibin
-        - mountPath: /host/etc/os-release
-          name: os-release
-          readOnly: true
         env:
-        - name: RHEL8_SOURCE_DIRECTORY
-          value: "/usr/src/route-override/rhel8/bin/"
-        - name: RHEL9_SOURCE_DIRECTORY
-          value: "/usr/src/route-override/rhel9/bin/"
-        - name: DEFAULT_SOURCE_DIRECTORY
+        - name: SOURCE_DIRECTORY
           value: "/usr/src/route-override/bin/"
       - name: whereabouts-cni-bincopy
         image: {{.WhereaboutsImage}}
@@ -484,15 +397,8 @@ spec:
           name: cni-binary-copy
         - mountPath: /host/opt/cni/bin
           name: cnibin
-        - mountPath: /host/etc/os-release
-          name: os-release
-          readOnly: true
         env:
-        - name: RHEL8_SOURCE_DIRECTORY
-          value: "/usr/src/whereabouts/rhel8/bin/"
-        - name: RHEL9_SOURCE_DIRECTORY
-          value: "/usr/src/whereabouts/rhel9/bin/"
-        - name: DEFAULT_SOURCE_DIRECTORY
+        - name: SOURCE_DIRECTORY
           value: "/usr/src/whereabouts/bin/"
       - name: whereabouts-cni
         image: {{.WhereaboutsImage}}
@@ -697,10 +603,6 @@ spec:
         - name: cnibin
           hostPath:
             path: {{ .CNIBinDir }}
-        - name: os-release
-          hostPath:
-            path: /etc/os-release
-            type: File
         - name: cni-binary-copy
           configMap:
             name: cni-copy-resources

--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -486,44 +486,8 @@ data:
     #   /cni-bin-dir
     cni-bin-copy()
     {
-      # collect host os information
-      . /host/etc/os-release
-      rhelmajor=
-      # detect which version we're using in order to copy the proper binaries
-      case "${ID}" in
-        rhcos|scos)
-          RHEL_VERSION=$(echo "${CPE_NAME}" | cut -f 5 -d :)
-          rhelmajor=$(echo $RHEL_VERSION | sed -E 's/([0-9]+)\.{1}[0-9]+(\.[0-9]+)?/\1/')
-        ;;
-        rhel|centos) rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)
-        ;;
-        fedora)
-          if [ "${VARIANT_ID}" == "coreos" ]; then
-            rhelmajor=8
-          else
-            log "cnibincopy" "FATAL ERROR: Unsupported Fedora variant=${VARIANT_ID}"
-            exit 1
-          fi
-        ;;
-        *) log "cnibincopy" "FATAL ERROR: Unsupported OS ID=${ID}"; exit 1
-        ;;
-      esac
-
-      # Set which directory we'll copy from, detect if it exists
-      sourcedir=/usr/libexec/cni/
-      case "${rhelmajor}" in
-        8)
-          sourcedir=/usr/libexec/cni/rhel8
-        ;;
-        9)
-          sourcedir=/usr/libexec/cni/rhel9
-        ;;
-        *)
-          log "cnibincopy" "ERROR: RHEL Major Version Unsupported, rhelmajor=${rhelmajor}"
-        ;;
-      esac
-
-      cp -f "$sourcedir/ovn-k8s-cni-overlay" /cni-bin-dir/
+      log "cnibincopy" "Copying /usr/libexec/cni/ovn-k8s-cni-overlay to /cni-bin-dir/"
+      cp -f "/usr/libexec/cni/ovn-k8s-cni-overlay" /cni-bin-dir/
     }
 
     # start-ovnkube-node starts the ovnkube-node process. This function does not


### PR DESCRIPTION
## Summary
- Remove all OS detection (`/host/etc/os-release` sourcing, RHEL version case statements) from both cnibincopy scripts
- Consolidate `RHEL8_SOURCE_DIRECTORY`, `RHEL9_SOURCE_DIRECTORY`, and `DEFAULT_SOURCE_DIRECTORY` env vars into a single `SOURCE_DIRECTORY` in multus.yaml
- Copy `ovn-k8s-cni-overlay` directly from `/usr/libexec/cni/` instead of probing version-specific subdirectories
- Remove the `os-release` host volume mount from all cnibincopy init containers and the multus DaemonSet

By the time version-specific paths would be needed again (RHEL 11+), all in-cluster components will use native FIPS, making this logic permanently unnecessary.

This unblocks removing rhel8 build stages from upstream images (openshift/ovn-kubernetes#3149, openshift/multus-cni#285).

## Test plan
- [ ] Verify OVN CNI shim binary is correctly copied on RHEL 9 CoreOS nodes
- [ ] Verify multus and ancillary CNI plugin binaries are correctly copied on RHEL 9 nodes
- [ ] Verify no regression on clusters with current images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified network plugin configuration by removing OS-specific detection logic from multus and OVN-Kubernetes setup scripts, streamlining the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->