### PR TITLE
CORENET-6581: Add transport label to CUDN telemetry recording rule

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/alert-rules-control-plane.yaml
@@ -26,7 +26,7 @@ spec:
     - record: cluster:ovnkube_clustermanager_user_defined_networks:max
       expr: max by(role, topology)(ovnkube_clustermanager_user_defined_networks)
     - record: cluster:ovnkube_clustermanager_cluster_user_defined_networks:max
-      expr: max by(role, topology)(ovnkube_clustermanager_cluster_user_defined_networks)
+      expr: max by(role, topology, transport)(ovnkube_clustermanager_cluster_user_defined_networks)
     # OVN kubernetes cluster manager functional alerts
     - alert: V4SubnetAllocationThresholdExceeded
       annotations:

--- a/bindata/network/ovn-kubernetes/self-hosted/alert-rules-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/alert-rules-control-plane.yaml
@@ -25,7 +25,7 @@ spec:
     - record: cluster:ovnkube_clustermanager_user_defined_networks:max
       expr: max by(role, topology)(ovnkube_clustermanager_user_defined_networks)
     - record: cluster:ovnkube_clustermanager_cluster_user_defined_networks:max
-      expr: max by(role, topology)(ovnkube_clustermanager_cluster_user_defined_networks)
+      expr: max by(role, topology, transport)(ovnkube_clustermanager_cluster_user_defined_networks)
     # OVN kubernetes cluster manager functional alerts
     - alert: V4SubnetAllocationThresholdExceeded
       annotations:


### PR DESCRIPTION
Add the `transport` dimension to the CUDN recording rule:

```
max by(role, topology) → max by(role, topology, transport)
```

This preserves the Geneve / EVPN / NoOverlay / Localnet breakdown in the aggregated telemetry metric.

Depends on (upstream ovn-kubernetes):
- https://github.com/ovn-kubernetes/ovn-kubernetes/pull/6265

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced cluster monitoring metrics aggregation by adding transport-level dimensionality to control plane metric recording rules in both managed and self-hosted deployments for improved monitoring granularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->