### PR TITLE
[release-4.17] OCPBUGS-84181: fix(hypershift): use net.JoinHostPort for URL construction

### DIFF
--- a/bindata/cloud-network-config-controller/managed/controller.yaml
+++ b/bindata/cloud-network-config-controller/managed/controller.yaml
@@ -77,7 +77,7 @@ spec:
           - -c
           - |
             kc=/var/run/secrets/hosted_cluster/kubeconfig
-            kubectl --kubeconfig $kc config set clusters.default.server "https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}"
+            kubectl --kubeconfig $kc config set clusters.default.server "{{.KubernetesServiceURL}}"
             kubectl --kubeconfig $kc config set clusters.default.certificate-authority /hosted-ca/ca.crt
             kubectl --kubeconfig $kc config set users.admin.tokenFile /var/run/secrets/hosted_cluster/token
             kubectl --kubeconfig $kc config set contexts.default.cluster default
@@ -88,10 +88,6 @@ spec:
           - mountPath: /var/run/secrets/hosted_cluster
             name: hosted-cluster-api-access
         env:
-          - name: KUBERNETES_SERVICE_PORT
-            value: "{{.KubernetesServicePort}}"
-          - name: KUBERNETES_SERVICE_HOST
-            value: "{{.KubernetesServiceHost}}"
           - name: AZURE_MSI_AUTHENTICATION
             value: "{{.AzureMSIAuthentication}}"
       containers:

--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -96,7 +96,7 @@ spec:
             - -c
             - |
               kc=/var/run/secrets/hosted_cluster/kubeconfig
-              kubectl --kubeconfig $kc config set clusters.default.server "https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}"
+              kubectl --kubeconfig $kc config set clusters.default.server "{{.KubernetesServiceURL}}"
               kubectl --kubeconfig $kc config set clusters.default.certificate-authority /hosted-ca/ca.crt
               kubectl --kubeconfig $kc config set users.admin.tokenFile /var/run/secrets/hosted_cluster/token
               kubectl --kubeconfig $kc config set contexts.default.cluster default
@@ -107,11 +107,6 @@ spec:
           volumeMounts:
             - mountPath: /var/run/secrets/hosted_cluster
               name: hosted-cluster-api-access
-          env:
-            - name: KUBERNETES_SERVICE_PORT
-              value: "{{.KubernetesServicePort}}"
-            - name: KUBERNETES_SERVICE_HOST
-              value: "{{.KubernetesServiceHost}}"
       automountServiceAccountToken: false
 {{- end }}
       containers:

--- a/pkg/network/cloud_network.go
+++ b/pkg/network/cloud_network.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 
@@ -41,8 +42,8 @@ func renderCloudNetworkConfigController(conf *operv1.NetworkSpec, bootstrapResul
 	data.Data["PlatformTypeAzure"] = v1.AzurePlatformType
 	data.Data["PlatformTypeGCP"] = v1.GCPPlatformType
 	data.Data["CloudNetworkConfigControllerImage"] = os.Getenv("CLOUD_NETWORK_CONFIG_CONTROLLER_IMAGE")
-	data.Data["KubernetesServiceHost"] = cloudBootstrapResult.APIServers[bootstrap.APIServerDefaultLocal].Host
-	data.Data["KubernetesServicePort"] = cloudBootstrapResult.APIServers[bootstrap.APIServerDefaultLocal].Port
+	localAPIServer := cloudBootstrapResult.APIServers[bootstrap.APIServerDefaultLocal]
+	data.Data["KubernetesServiceURL"] = "https://" + net.JoinHostPort(localAPIServer.Host, localAPIServer.Port)
 	data.Data["ExternalControlPlane"] = cloudBootstrapResult.ControlPlaneTopology == configv1.ExternalTopologyMode
 	data.Data["PlatformAzureEnvironment"] = ""
 	data.Data["PlatformAWSCAPath"] = ""

--- a/pkg/network/multus_admission_controller.go
+++ b/pkg/network/multus_admission_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -85,8 +86,8 @@ func renderMultusAdmissonControllerConfig(manifestDir string, externalControlPla
 	data.Data["PriorityClass"] = nil
 	if hsc.Enabled {
 		data.Data["AdmissionControllerNamespace"] = hsc.Namespace
-		data.Data["KubernetesServiceHost"] = bootstrapResult.Infra.APIServers[bootstrap.APIServerDefaultLocal].Host
-		data.Data["KubernetesServicePort"] = bootstrapResult.Infra.APIServers[bootstrap.APIServerDefaultLocal].Port
+		localAPIServer := bootstrapResult.Infra.APIServers[bootstrap.APIServerDefaultLocal]
+		data.Data["KubernetesServiceURL"] = "https://" + net.JoinHostPort(localAPIServer.Host, localAPIServer.Port)
 		data.Data["CLIImage"] = os.Getenv("CLI_IMAGE")
 		if os.Getenv("CLI_CONTROL_PLANE_IMAGE") != "" {
 			data.Data["CLIImage"] = os.Getenv("CLI_CONTROL_PLANE_IMAGE")


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry-pick of #2969 to release-4.17. The init containers were unconditionally wrapping KUBERNETES_SERVICE_HOST in brackets, creating URLs like `https://[172.29.0.1]:443`. Go 1.24.8+ (CVE-2025-47912) now rejects IPv4 addresses in brackets per RFC 3986.

Uses `net.JoinHostPort` server-side to construct the URL correctly for both IPv4 and IPv6 addresses, removing the need for shell-level env vars.

**Which issue(s) this PR fixes**:
Fixes https://issues.redhat.com/browse/OCPBUGS-84143

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.