### PR TITLE
OCPBUGS-53187: Update self-referencing URLs from master to main

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,7 +124,7 @@ it is also consumed by third-party network operators that replace the Network Co
 
 **Output:** Most core networking components.
 
-For more detailed documentation, see [operands.md](https://github.com/openshift/cluster-network-operator/blob/master/docs/operands.md).
+For more detailed documentation, see [operands.md](operands.md).
 
 This is the "main" controller, in that it is responsible for rendering the core networking components (OVN-Kubernetes, Multus, etc). It is broken down into stages:
 
@@ -214,7 +214,7 @@ All controllers should report a status back. The controllers in the CNO are no d
 The CNO derives status in two ways:
 
 - Controllers can report a Degraded / non-Degraded state
-- A special Status Controller watches Pods, Deployments, and Daemonsets and derives status from them. This is only used for pods created by the Network controller. It is from this that we determine the "Available" and "Progressing" statuses. There is [more detailed documentation](https://github.com/openshift/cluster-network-operator/blob/master/docs/operands.md).
+- A special Status Controller watches Pods, Deployments, and Daemonsets and derives status from them. This is only used for pods created by the Network controller. It is from this that we determine the "Available" and "Progressing" statuses. There is [more detailed documentation](operands.md).
 
 Status is posted to both the `Network.operator.openshift.io` object, as well as the network `ClusterOperator.config.openshift.io` object, and the two statuses are currently identical.
 

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -151,7 +151,7 @@ func InfraStatus(client cnoclient.Client) (*bootstrap.InfraStatus, error) {
 	}
 
 	// As per instructions given in the following links:
-	// https://github.com/openshift/cluster-network-operator/blob/master/docs/enabling_ns_ipsec.md#prerequsits
+	// docs/enabling_ns_ipsec.md#prerequsits
 	// https://docs.openshift.com/container-platform/4.14/networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.html#nw-ovn-ipsec-north-south-enable_configuring-ipsec-ovn
 	// The IPsecMachineConfig in 4.14 is created by user and can be created with any name and also is not managed by network operator, so find it by using the label
 	// and looking for the extension.


### PR DESCRIPTION
Update GitHub URLs pointing to openshift/cluster-network-operator's own master branch to use main, in preparation for the default branch rename.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links from external repository URLs to relative links within the documentation site.
  * Adjusted inline documentation references to point to local docs for prerequisites and operands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->