### PR TITLE
Add enable-dynamic-udn-allocation config override

### DIFF
--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -720,6 +720,10 @@ data:
         allow_icmp_network_policy_flag="--allow-icmp-network-policy={{.AllowICMPNetworkPolicy}}"
       fi
 
+      if [[ "{{.EnableDynamicUDNAllocation}}" != "" ]]; then
+        enable_dynamic_udn_allocation_flag="--enable-dynamic-udn-allocation={{.EnableDynamicUDNAllocation}}"
+      fi
+
       NETWORK_NODE_IDENTITY_ENABLE=
       if [[ "{{.NETWORK_NODE_IDENTITY_ENABLE}}" == "true" ]]; then
         NETWORK_NODE_IDENTITY_ENABLE="
@@ -792,6 +796,7 @@ data:
         ${ovn_advertised_udn_isolation_mode_flag} \
         ${openflow_probe_flag} \
         ${allow_icmp_network_policy_flag} \
+        ${enable_dynamic_udn_allocation_flag} \
         ${NETWORK_NODE_IDENTITY_ENABLE} \
         ${ovn_v4_join_subnet_opt} \
         ${ovn_v6_join_subnet_opt} \

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
@@ -222,6 +222,11 @@ spec:
             network_connect_enabled_flag="--enable-network-connect"
           fi
 
+          enable_dynamic_udn_allocation_flag=
+          if [[ "{{.EnableDynamicUDNAllocation}}" != "" ]]; then
+            enable_dynamic_udn_allocation_flag="--enable-dynamic-udn-allocation={{.EnableDynamicUDNAllocation}}"
+          fi
+
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-control-plane - start ovnkube --init-cluster-manager ${K8S_NODE}"
           exec /usr/bin/ovnkube \
             --enable-interconnect \
@@ -255,7 +260,8 @@ spec:
             --enable-multicast \
             --enable-multi-external-gateway=true \
             ${multi_network_policy_enabled_flag} \
-            ${admin_network_policy_enabled_flag}
+            ${admin_network_policy_enabled_flag} \
+            ${enable_dynamic_udn_allocation_flag}
         volumeMounts:
         - mountPath: /run/ovnkube-config/
           name: ovnkube-config

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
@@ -169,6 +169,11 @@ spec:
             network_connect_enabled_flag="--enable-network-connect"
           fi
 
+          enable_dynamic_udn_allocation_flag=
+          if [[ "{{.EnableDynamicUDNAllocation}}" != "" ]]; then
+            enable_dynamic_udn_allocation_flag="--enable-dynamic-udn-allocation={{.EnableDynamicUDNAllocation}}"
+          fi
+
           if [ "{{.OVN_GATEWAY_MODE}}" == "shared" ]; then
             gateway_mode_flags="--gateway-mode shared"
           elif [ "{{.OVN_GATEWAY_MODE}}" == "local" ]; then
@@ -209,7 +214,8 @@ spec:
             --enable-multicast \
             --enable-multi-external-gateway=true \
             ${multi_network_policy_enabled_flag} \
-            ${admin_network_policy_enabled_flag}
+            ${admin_network_policy_enabled_flag} \
+            ${enable_dynamic_udn_allocation_flag}
         volumeMounts:
         - mountPath: /run/ovnkube-config/
           name: ovnkube-config

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -203,6 +203,17 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 			}
 		}
 	}
+	data.Data["EnableDynamicUDNAllocation"] = ""
+	if raw, ok := bootstrapResult.OVN.OVNKubernetesConfig.ConfigOverrides["enable-dynamic-udn-allocation"]; ok {
+		enableDynamicUDNAllocation := strings.TrimSpace(raw)
+		if enableDynamicUDNAllocation != "" {
+			if _, err := strconv.ParseBool(enableDynamicUDNAllocation); err != nil {
+				klog.Warningf("Ignoring invalid enable-dynamic-udn-allocation override %q: expected boolean", raw)
+			} else {
+				data.Data["EnableDynamicUDNAllocation"] = enableDynamicUDNAllocation
+			}
+		}
+	}
 
 	if conf.Migration != nil {
 		if conf.Migration.MTU != nil {

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -4450,6 +4450,69 @@ func TestRenderOVNKubernetes_AllowICMPNetworkPolicyOverride(t *testing.T) {
 	})
 }
 
+func TestRenderOVNKubernetes_EnableDynamicUDNAllocationOverride(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	crd := OVNKubernetesConfig.DeepCopy()
+	config := &crd.Spec
+	fillDefaults(config, nil)
+
+	renderWithOverrides := func(overrides map[string]string) string {
+		bootstrapResult := fakeBootstrapResult()
+		bootstrapResult.OVN = bootstrap.OVNBootstrapResult{
+			ControlPlaneReplicaCount: 3,
+			OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
+				DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+				DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
+				SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+				MgmtPortResourceName: "",
+				HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
+					Enabled: false,
+				},
+				ConfigOverrides: overrides,
+			},
+		}
+		featureGatesCNO := getDefaultFeatureGates()
+		fakeClient := cnofake.NewFakeClient()
+
+		objs, _, err := renderOVNKubernetes(config, bootstrapResult, manifestDirOvn, fakeClient, featureGatesCNO)
+		g.Expect(err).NotTo(HaveOccurred())
+		return extractOVNScriptLib(g, objs)
+	}
+
+	t.Run("with enable-dynamic-udn-allocation override set to true", func(t *testing.T) {
+		ovnkubeScriptLib := renderWithOverrides(map[string]string{"enable-dynamic-udn-allocation": "true"})
+		g.Expect(ovnkubeScriptLib).To(ContainSubstring(`
+  if [[ "true" != "" ]]; then
+    enable_dynamic_udn_allocation_flag="--enable-dynamic-udn-allocation=true"
+  fi`))
+	})
+
+	t.Run("with enable-dynamic-udn-allocation override set to false", func(t *testing.T) {
+		ovnkubeScriptLib := renderWithOverrides(map[string]string{"enable-dynamic-udn-allocation": "false"})
+		g.Expect(ovnkubeScriptLib).To(ContainSubstring(`
+  if [[ "false" != "" ]]; then
+    enable_dynamic_udn_allocation_flag="--enable-dynamic-udn-allocation=false"
+  fi`))
+	})
+
+	t.Run("without enable-dynamic-udn-allocation override", func(t *testing.T) {
+		ovnkubeScriptLib := renderWithOverrides(nil)
+		g.Expect(ovnkubeScriptLib).To(ContainSubstring(`
+  if [[ "" != "" ]]; then
+    enable_dynamic_udn_allocation_flag="--enable-dynamic-udn-allocation="
+  fi`))
+	})
+
+	t.Run("with invalid enable-dynamic-udn-allocation override", func(t *testing.T) {
+		ovnkubeScriptLib := renderWithOverrides(map[string]string{"enable-dynamic-udn-allocation": "notabool"})
+		g.Expect(ovnkubeScriptLib).To(ContainSubstring(`
+  if [[ "" != "" ]]; then
+    enable_dynamic_udn_allocation_flag="--enable-dynamic-udn-allocation="
+  fi`))
+	})
+}
+
 func TestOVNKubernetesControlPlaneFlags(t *testing.T) {
 	g := NewGomegaWithT(t)
 


### PR DESCRIPTION
Support --enable-dynamic-udn-allocation flag for both ovnkube-cluster-manager and ovnkube-controller via the ovn-kubernetes-config-overrides configmap.

Example: 
```
oc create configmap ovn-kubernetes-config-overrides -n openshift-network-operator --from-literal=enable-dynamic-udn-allocation=true 
```

should automatically re-deploy ovn-k. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configurable dynamic User-Defined Network (UDN) allocation in OVN-Kubernetes deployments, allowing users to enable or disable the feature via configuration.

* **Tests**
  * Added test coverage for dynamic UDN allocation configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->