### PR TITLE
[release-4.15] OCPBUGS-84183: fix(hypershift): use net.JoinHostPort for URL construction

### DIFF
--- a/bindata/cloud-network-config-controller/managed/controller.yaml
+++ b/bindata/cloud-network-config-controller/managed/controller.yaml
@@ -72,7 +72,7 @@ spec:
           - -c
           - |
             kc=/var/run/secrets/hosted_cluster/kubeconfig
-            kubectl --kubeconfig $kc config set clusters.default.server "https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}"
+            kubectl --kubeconfig $kc config set clusters.default.server "{{.KubernetesServiceURL}}"
             kubectl --kubeconfig $kc config set clusters.default.certificate-authority /hosted-ca/ca.crt
             kubectl --kubeconfig $kc config set users.admin.tokenFile /var/run/secrets/hosted_cluster/token
             kubectl --kubeconfig $kc config set contexts.default.cluster default
@@ -82,11 +82,6 @@ spec:
         volumeMounts:
           - mountPath: /var/run/secrets/hosted_cluster
             name: hosted-cluster-api-access
-        env:
-          - name: KUBERNETES_SERVICE_PORT
-            value: "{{.KubernetesServicePort}}"
-          - name: KUBERNETES_SERVICE_HOST
-            value: "{{.KubernetesServiceHost}}"
       containers:
       # hosted-cluster-token creates a token with a custom path(/var/run/secrets/hosted_cluster/token)
       # The token path is included in the kubeconfig used by cncc containers to talk to the hosted clusters API server

--- a/bindata/cloud-network-config-controller/managed/controller.yaml
+++ b/bindata/cloud-network-config-controller/managed/controller.yaml
@@ -164,10 +164,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: KUBERNETES_SERVICE_PORT
-          value: "{{.KubernetesServicePort}}"
-        - name: KUBERNETES_SERVICE_HOST
-          value: "{{.KubernetesServiceHost}}"
         - name: RELEASE_VERSION
           value: "{{.ReleaseVersion}}"
 {{ if .HTTP_PROXY }}

--- a/bindata/cloud-network-config-controller/self-hosted/controller.yaml
+++ b/bindata/cloud-network-config-controller/self-hosted/controller.yaml
@@ -56,10 +56,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: KUBERNETES_SERVICE_PORT
-          value: "{{.KubernetesServicePort}}"
-        - name: KUBERNETES_SERVICE_HOST
-          value: "{{.KubernetesServiceHost}}"
         - name: RELEASE_VERSION
           value: "{{.ReleaseVersion}}"
 {{ if .HTTP_PROXY }}

--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -96,7 +96,7 @@ spec:
             - -c
             - |
               kc=/var/run/secrets/hosted_cluster/kubeconfig
-              kubectl --kubeconfig $kc config set clusters.default.server "https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}"
+              kubectl --kubeconfig $kc config set clusters.default.server "{{.KubernetesServiceURL}}"
               kubectl --kubeconfig $kc config set clusters.default.certificate-authority /hosted-ca/ca.crt
               kubectl --kubeconfig $kc config set users.admin.tokenFile /var/run/secrets/hosted_cluster/token
               kubectl --kubeconfig $kc config set contexts.default.cluster default
@@ -106,11 +106,6 @@ spec:
           volumeMounts:
             - mountPath: /var/run/secrets/hosted_cluster
               name: hosted-cluster-api-access
-          env:
-            - name: KUBERNETES_SERVICE_PORT
-              value: "{{.KubernetesServicePort}}"
-            - name: KUBERNETES_SERVICE_HOST
-              value: "{{.KubernetesServiceHost}}"
       automountServiceAccountToken: false
 {{- end }}
       containers:

--- a/pkg/network/cloud_network.go
+++ b/pkg/network/cloud_network.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 
@@ -41,8 +42,8 @@ func renderCloudNetworkConfigController(conf *operv1.NetworkSpec, bootstrapResul
 	data.Data["PlatformTypeAzure"] = v1.AzurePlatformType
 	data.Data["PlatformTypeGCP"] = v1.GCPPlatformType
 	data.Data["CloudNetworkConfigControllerImage"] = os.Getenv("CLOUD_NETWORK_CONFIG_CONTROLLER_IMAGE")
-	data.Data["KubernetesServiceHost"] = cloudBootstrapResult.APIServers[bootstrap.APIServerDefaultLocal].Host
-	data.Data["KubernetesServicePort"] = cloudBootstrapResult.APIServers[bootstrap.APIServerDefaultLocal].Port
+	localAPIServer := cloudBootstrapResult.APIServers[bootstrap.APIServerDefaultLocal]
+	data.Data["KubernetesServiceURL"] = "https://" + net.JoinHostPort(localAPIServer.Host, localAPIServer.Port)
 	data.Data["ExternalControlPlane"] = cloudBootstrapResult.ControlPlaneTopology == configv1.ExternalTopologyMode
 	data.Data["PlatformAzureEnvironment"] = ""
 	data.Data["PlatformAWSCAPath"] = ""

--- a/pkg/network/multus_admission_controller.go
+++ b/pkg/network/multus_admission_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -86,8 +87,8 @@ func renderMultusAdmissonControllerConfig(manifestDir string, externalControlPla
 	data.Data["PriorityClass"] = nil
 	if hsc.Enabled {
 		data.Data["AdmissionControllerNamespace"] = hsc.Namespace
-		data.Data["KubernetesServiceHost"] = bootstrapResult.Infra.APIServers[bootstrap.APIServerDefaultLocal].Host
-		data.Data["KubernetesServicePort"] = bootstrapResult.Infra.APIServers[bootstrap.APIServerDefaultLocal].Port
+		localAPIServer := bootstrapResult.Infra.APIServers[bootstrap.APIServerDefaultLocal]
+		data.Data["KubernetesServiceURL"] = "https://" + net.JoinHostPort(localAPIServer.Host, localAPIServer.Port)
 		data.Data["CLIImage"] = os.Getenv("CLI_IMAGE")
 		data.Data["TokenMinterImage"] = os.Getenv("TOKEN_MINTER_IMAGE")
 		data.Data["TokenAudience"] = os.Getenv("TOKEN_AUDIENCE")


### PR DESCRIPTION
This is a cherry-pick of https://github.com/openshift/cluster-network-operator/pull/2969 together with https://github.com/openshift/cluster-network-operator/pull/2182.