### PR TITLE
CORENET-7330: Allow per-node OVN encap IP override via env-overrides

### DIFF
--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -478,6 +478,21 @@ data:
         echo "$(date --iso-8601=seconds) [{$1}] ${2}"
     }
 
+    # set-encap-ip-flag() sets --encap-ip from the OVN_ENCAP_IP environment
+    # variable when present.
+    set-encap-ip-flag()
+    {
+      local ovn_encap_ip_normalized
+      ovn_encap_ip_flag=
+
+      ovn_encap_ip_normalized="${OVN_ENCAP_IP//[[:space:]]/}"
+
+      if [[ -n "${ovn_encap_ip_normalized}" ]]; then
+        log "encapip" "Using OVN_ENCAP_IP=${OVN_ENCAP_IP}"
+        ovn_encap_ip_flag="--encap-ip=${ovn_encap_ip_normalized}"
+      fi
+    }
+
     # cni-bin-copy() detects the host OS and copies the correct shim binary to
     # the CNI binary directory.
     #
@@ -688,6 +703,8 @@ data:
         enable_interconnect_flag="--enable-interconnect"
       fi
 
+      set-encap-ip-flag
+
       exec /usr/bin/ovnkube \
         ${init_ovnkube_controller} \
         --init-node "${K8S_NODE}" \
@@ -698,6 +715,7 @@ data:
         ${gateway_mode_flags} \
         ${node_mgmt_port_netdev_flags} \
         ${ovnkube_node_mode} \
+        ${ovn_encap_ip_flag} \
         --metrics-bind-address "127.0.0.1:${metrics_port}" \
         --ovn-metrics-bind-address "127.0.0.1:${ovn_metrics_port}" \
         --metrics-enable-pprof \

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -4402,6 +4402,74 @@ func TestRenderOVNKubernetes_OpenFlowProbeOverride(t *testing.T) {
 	})
 }
 
+// TestRenderOVNKubernetes_NodeDaemonSetEnvOverridesVolume verifies the
+// ovnkube-node DaemonSet keeps the optional env-overrides ConfigMap mounted so
+// node-specific OVN encapsulation overrides can be sourced at startup.
+func TestRenderOVNKubernetes_NodeDaemonSetEnvOverridesVolume(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	crd := OVNKubernetesConfig.DeepCopy()
+	config := &crd.Spec
+	fillDefaults(config, nil)
+
+	bootstrapResult := fakeBootstrapResult()
+	bootstrapResult.OVN = bootstrap.OVNBootstrapResult{
+		ControlPlaneReplicaCount: 3,
+		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
+			DpuHostModeLabel:          OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+			DpuModeLabel:              OVN_NODE_SELECTOR_DEFAULT_DPU,
+			SmartNicModeLabel:         OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+			MgmtPortResourceName:      "",
+			DpuNodeLeaseRenewInterval: DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT,
+			DpuNodeLeaseDuration:      DPU_NODE_LEASE_DURATION_DEFAULT,
+			HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
+				Enabled: false,
+			},
+		},
+	}
+	featureGatesCNO := getDefaultFeatureGates()
+	fakeClient := cnofake.NewFakeClient()
+
+	objs, _, err := renderOVNKubernetes(config, bootstrapResult, manifestDirOvn, fakeClient, featureGatesCNO)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	nodeDS := findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
+	g.Expect(nodeDS).NotTo(BeNil())
+
+	ds := appsv1.DaemonSet{}
+	g.Expect(convert(nodeDS, &ds)).To(Succeed())
+
+	var envOverridesVolume *v1.Volume
+	for i := range ds.Spec.Template.Spec.Volumes {
+		volume := &ds.Spec.Template.Spec.Volumes[i]
+		if volume.Name == "env-overrides" {
+			envOverridesVolume = volume
+			break
+		}
+	}
+
+	g.Expect(envOverridesVolume).NotTo(BeNil())
+	g.Expect(envOverridesVolume.ConfigMap).NotTo(BeNil())
+	g.Expect(envOverridesVolume.ConfigMap.Name).To(Equal("env-overrides"))
+	g.Expect(envOverridesVolume.ConfigMap.Optional).NotTo(BeNil())
+	g.Expect(*envOverridesVolume.ConfigMap.Optional).To(BeTrue())
+
+	nodeContainer, ok := findContainer(ds.Spec.Template.Spec.Containers, "ovnkube-node")
+	if !ok {
+		nodeContainer, ok = findContainer(ds.Spec.Template.Spec.Containers, "ovnkube-controller")
+	}
+	g.Expect(ok).To(BeTrue(), "expecting container named ovnkube-node or ovnkube-controller in the DaemonSet")
+
+	hasEnvOverridesMount := false
+	for _, mount := range nodeContainer.VolumeMounts {
+		if mount.Name == "env-overrides" && mount.MountPath == "/env" {
+			hasEnvOverridesMount = true
+			break
+		}
+	}
+	g.Expect(hasEnvOverridesMount).To(BeTrue())
+}
+
 func TestRenderOVNKubernetes_AllowICMPNetworkPolicyOverride(t *testing.T) {
 	g := NewGomegaWithT(t)
 


### PR DESCRIPTION
Teach the ovnkube node startup wrapper to source OVN_ENCAP_IP from the
per-node env-overrides ConfigMap and pass it to ovnkube as --encap-ip.

## How to test / verify
This change is intended for configuration through the per-node `env-overrides` ConfigMap. It does not introduce a new API.

### Manual verification
#### Day0

### Day0 example
Day0 can be exercised by providing the per-node `env-overrides` ConfigMap as an installer manifest and configuring the target secondary interface during installation.
Example `install-config.yaml`:

```yaml
apiVersion: v1
baseDomain: example.com
metadata:
  name: ocp
compute:
- name: worker
  replicas: 0
controlPlane:
  name: master
  replicas: 1
networking:
  networkType: OVNKubernetes
  machineNetwork:
  - cidr: 192.168.122.0/24
platform:
  baremetal:
    provisioningNetwork: Disabled
    apiVIPs:
    - 192.168.122.10
    ingressVIPs:
    - 192.168.122.11
    hosts:
    - name: master-0
      role: master
      bmc:
        address: redfish-virtualmedia://192.0.2.10/redfish/v1/Systems/System.Embedded.1
        username: root
        password: password
      bootMACAddress: 52:54:00:aa:bb:cc
      bootMode: UEFI
      networkConfig:
        interfaces:
        - name: eno1
          type: ethernet
          state: up
          ipv4:
            enabled: true
            address:
            - ip: 192.168.122.20
              prefix-length: 24
        - name: eno2
          type: ethernet
          state: up
          ipv4:
            enabled: true
            address:
            - ip: 10.10.20.10
              prefix-length: 24
        dns-resolver:
          config:
            server:
            - 192.168.122.1
        routes:
          config:
          - destination: 0.0.0.0/0
            next-hop-address: 192.168.122.1
            next-hop-interface: eno1
pullSecret: 'REDACTED'
sshKey: 'ssh-ed25519 AAAA...'
```

Example installer manifest:

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: env-overrides
  namespace: openshift-ovn-kubernetes
data:
  master-0: |
    OVN_ENCAP_IP=10.10.20.10
```

#### Day2
1. Create or update the `env-overrides` ConfigMap in `openshift-ovn-kubernetes` with a per-node `OVN_ENCAP_IP` entry, for example:
```yaml
   apiVersion: v1
   kind: ConfigMap
   metadata:
     name: env-overrides
     namespace: openshift-ovn-kubernetes
   data:
     <node-name>: |
       OVN_ENCAP_IP=10.0.0.10
```

3. Restart the `ovnkube-node` DaemonSet so the startup wrapper re-sources the override:


```bash
   oc -n openshift-ovn-kubernetes rollout restart ds/ovnkube-node
```


Wait for the rollout to complete:


```bash
oc -n openshift-ovn-kubernetes rollout status ds/ovnkube-node
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved network encapsulation configuration by automatically wiring `OVN_ENCAP_IP` into the `ovnkube` startup as `--encap-ip=${OVN_ENCAP_IP}`.
  * Updated node startup to incorporate this encapsulation IP flag during startup.
  * Ensured per-node environment overrides are supported via an optional ConfigMap volume mounted at `/env`.

* **Tests**
  * Added rendering tests covering `OVN_ENCAP_IP` wiring and the `env-overrides` volume/ConfigMap behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->