### PR TITLE
Fix multus kubeconfig brackets before binary upgrade

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -181,6 +181,22 @@ spec:
       priorityClassName: "system-node-critical"
       tolerations:
       - operator: Exists
+      initContainers:
+      - name: fix-cni-kubeconfig
+        image: {{.MultusImage}}
+        command: ["/bin/bash", "-c"]
+        args:
+        - |
+          KC="/host/etc/cni/net.d/multus.d/multus.kubeconfig"
+          [ -f "$KC" ] || exit 0
+          if grep -q 'server:.*://\[' "$KC"; then
+            sed -i -E 's|(server: https?://)(\[)([^]]+[^0-9:.])(\])|\1\3|g' "$KC"
+          fi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: system-cni-dir
+          mountPath: /host/etc/cni/net.d
       containers:
       - name: kube-multus
         image: {{.MultusImage}}


### PR DESCRIPTION
## Summary

- Adds an init container to the multus DaemonSet that strips brackets from non-IPv6 hostnames in the existing multus kubeconfig before the main container copies the new binary
- Fixes upgrade failures caused by the Go bump for CVE-2025-47912 where `net/url` now rejects `https://[hostname]:6443` format URLs
- The init container is a no-op on fresh installs and already-fixed nodes; IPv6 addresses in brackets are preserved

## Problem

During 4.13→4.14 upgrades, the old multus kubeconfig on nodes (written by the 4.13 shell entrypoint which unconditionally wraps `KUBERNETES_SERVICE_HOST` in brackets) contains server URLs like `https://[hostname]:6443`. When the 4.14 multus DaemonSet rolls out, `cnibincopy.sh` copies the new binary **before** `multus-daemon` rewrites the kubeconfig. CRI-O immediately uses the new binary for pod sandbox teardowns (`DEL`), reads the old bracketed kubeconfig, and fails:

```
Multus: error getting k8s client: host must be a URL or a host:port pair:
"https://[api-int.ci-op-...]:6443"
```

This blocks all pod termination (500+ FailedKillPod events), stalls the dns-default DaemonSet rollout, causes DNS operator degradation, and fails the upgrade. The `gcp-ovn-rt-upgrade-4.14-minor` blocking job has been failing for 5+ consecutive payloads due to this issue.

## Fix

Add a `fix-cni-kubeconfig` init container that runs before `kube-multus`:
1. Checks if the kubeconfig exists (exits on fresh install)
2. If the server URL has brackets around a non-IPv6 hostname, strips them with `sed`
3. Main container then safely copies the new binary — CRI-O uses new binary + fixed kubeconfig

## Test plan

- [ ] Verify `gcp-ovn-rt-upgrade-4.14-minor` (4.13→4.14 upgrade) passes with this change
- [ ] Verify fresh 4.14 install succeeds (init container should exit cleanly with no kubeconfig to fix)
- [ ] Verify IPv6 dual-stack clusters preserve bracketed IPv6 addresses in kubeconfigs

🤖 Generated with [Claude Code](https://claude.com/claude-code)