### PR TITLE
OCPBUGS-83800: add remaining CNO NetworkPolicies [take 2]

### DIFF
--- a/bindata/cloud-network-config-controller/self-hosted/networkpolicies.yaml
+++ b/bindata/cloud-network-config-controller/self-hosted/networkpolicies.yaml
@@ -1,0 +1,32 @@
+# The openshift-cloud-network-config-controller namespace is created
+# via the CNO manifests, but we can't create a default-deny policy
+# there and an allow policy here, because the two policies won't be
+# applied at the same time. So we create both of them here.
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: default-deny
+  namespace: openshift-cloud-network-config-controller
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress: []
+  egress: []
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: cloud-network-config-controller
+  namespace: openshift-cloud-network-config-controller
+spec:
+  podSelector:
+    matchLabels:
+      app: cloud-network-config-controller
+  policyTypes:
+    - Egress
+  egress:
+    # CNCC needs access to apiserver and cloud APIs, possibly via a proxy... for now we
+    # just allow all egress.
+    - {}

--- a/manifests/0000_70_cluster-network-operator_00_namespace.yaml
+++ b/manifests/0000_70_cluster-network-operator_00_namespace.yaml
@@ -21,6 +21,10 @@ apiVersion: networking.k8s.io/v1
 metadata:
   name: default-deny
   namespace: openshift-network-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   podSelector: {}
   policyTypes:


### PR DESCRIPTION
#2959 was [reverted](https://github.com/openshift/cluster-network-operator/pull/2999) because it broke upgrades; we can't have CVO create the CNCC "deny" policy and then have CNO create the "allow" policy, because that creates a gap where everything is denied. This just moves the default-deny policy from manifests to bindata so they're both applied at the same time.

/assign @jcaamano 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added network security policies to control ingress and egress traffic for the cloud network configuration controller
  * Updated cluster network operator policies with release management annotations for improved deployment consistency across environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->