### PR TITLE
OCPBUGS-84519: Add terminationMessagePolicy to missing ovn-kubernetes containers

### DIFF
--- a/bindata/network/ovn-kubernetes/common/error-cni.yaml
+++ b/bindata/network/ovn-kubernetes/common/error-cni.yaml
@@ -114,6 +114,7 @@ spec:
       containers:
       - name: error-cni-init
         image: {{.OvnImage}}
+        terminationMessagePolicy: FallbackToLogsOnError
         command:
           - /bin/sh
           - -c

--- a/bindata/network/ovn-kubernetes/common/pre-puller.yaml
+++ b/bindata/network/ovn-kubernetes/common/pre-puller.yaml
@@ -29,6 +29,7 @@ spec:
       - name: ovnkube-upgrades-prepuller
         image: "{{.OvnImage}}"
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         command:
         - /bin/bash
         - -c


### PR DESCRIPTION
Sets FallbackToLogsOnError on error-cni-init and ovnkube-upgrades-prepuller containers.

All other containers in openshift-ovn-kubernetes namespace already have this field set.

Fixes: https://issues.redhat.com/browse/OCPBUGS-84519

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error diagnostic capabilities for OVN-Kubernetes network components by updating how container termination messages are handled. These configuration changes ensure that error information is properly captured and available in logs when components terminate unexpectedly or during normal operations and system upgrades, improving visibility for troubleshooting and incident response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->