### PR TITLE
[release-4.13] use net.JoinHostPort for URL construction

### DIFF
--- a/bindata/cloud-network-config-controller/managed/controller.yaml
+++ b/bindata/cloud-network-config-controller/managed/controller.yaml
@@ -68,7 +68,7 @@ spec:
           - -c
           - |
             kc=/var/run/secrets/hosted_cluster/kubeconfig
-            kubectl --kubeconfig $kc config set clusters.default.server "https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}"
+            kubectl --kubeconfig $kc config set clusters.default.server "{{.KubernetesServiceURL}}"
             kubectl --kubeconfig $kc config set clusters.default.certificate-authority /hosted-ca/ca.crt
             kubectl --kubeconfig $kc config set users.admin.tokenFile /var/run/secrets/hosted_cluster/token
             kubectl --kubeconfig $kc config set contexts.default.cluster default
@@ -78,11 +78,6 @@ spec:
         volumeMounts:
           - mountPath: /var/run/secrets/hosted_cluster
             name: hosted-cluster-api-access
-        env:
-          - name: KUBERNETES_SERVICE_PORT
-            value: "{{.KubernetesServicePort}}"
-          - name: KUBERNETES_SERVICE_HOST
-            value: "{{.KubernetesServiceHost}}"
       containers:
       # hosted-cluster-token creates a token with a custom path(/var/run/secrets/hosted_cluster/token)
       # The token path is included in the kubeconfig used by cncc containers to talk to the hosted clusters API server

--- a/bindata/network/multus-admission-controller/admission-controller.yaml
+++ b/bindata/network/multus-admission-controller/admission-controller.yaml
@@ -79,7 +79,7 @@ spec:
             - -c
             - |
               kc=/var/run/secrets/hosted_cluster/kubeconfig
-              kubectl --kubeconfig $kc config set clusters.default.server "https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}"
+              kubectl --kubeconfig $kc config set clusters.default.server "{{.KubernetesServiceURL}}"
               kubectl --kubeconfig $kc config set clusters.default.certificate-authority /hosted-ca/ca.crt
               kubectl --kubeconfig $kc config set users.admin.tokenFile /var/run/secrets/hosted_cluster/token
               kubectl --kubeconfig $kc config set contexts.default.cluster default
@@ -89,11 +89,6 @@ spec:
           volumeMounts:
             - mountPath: /var/run/secrets/hosted_cluster
               name: hosted-cluster-api-access
-          env:
-            - name: KUBERNETES_SERVICE_PORT
-              value: "{{.KubernetesServicePort}}"
-            - name: KUBERNETES_SERVICE_HOST
-              value: "{{.KubernetesServiceHost}}"
       automountServiceAccountToken: false
 {{- end }}
       containers:

--- a/pkg/network/cloud_network.go
+++ b/pkg/network/cloud_network.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 
@@ -42,8 +43,8 @@ func renderCloudNetworkConfigController(conf *operv1.NetworkSpec, bootstrapResul
 	data.Data["PlatformTypeAzure"] = v1.AzurePlatformType
 	data.Data["PlatformTypeGCP"] = v1.GCPPlatformType
 	data.Data["CloudNetworkConfigControllerImage"] = os.Getenv("CLOUD_NETWORK_CONFIG_CONTROLLER_IMAGE")
-	data.Data["KubernetesServiceHost"] = cloudBootstrapResult.APIServers[bootstrap.APIServerDefaultLocal].Host
-	data.Data["KubernetesServicePort"] = cloudBootstrapResult.APIServers[bootstrap.APIServerDefaultLocal].Port
+	localAPIServer := cloudBootstrapResult.APIServers[bootstrap.APIServerDefaultLocal]
+	data.Data["KubernetesServiceURL"] = "https://" + net.JoinHostPort(localAPIServer.Host, localAPIServer.Port)
 	data.Data["ExternalControlPlane"] = cloudBootstrapResult.ControlPlaneTopology == configv1.ExternalTopologyMode
 	data.Data["PlatformAzureEnvironment"] = ""
 	data.Data["PlatformAWSCAPath"] = ""

--- a/pkg/network/multus_admission_controller.go
+++ b/pkg/network/multus_admission_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -75,8 +76,8 @@ func renderMultusAdmissonControllerConfig(manifestDir string, externalControlPla
 	data.Data["RHOBSMonitoring"] = os.Getenv("RHOBS_MONITORING")
 	if hsc.Enabled {
 		data.Data["AdmissionControllerNamespace"] = hsc.Namespace
-		data.Data["KubernetesServiceHost"] = bootstrapResult.Infra.APIServers[bootstrap.APIServerDefaultLocal].Host
-		data.Data["KubernetesServicePort"] = bootstrapResult.Infra.APIServers[bootstrap.APIServerDefaultLocal].Port
+		localAPIServer := bootstrapResult.Infra.APIServers[bootstrap.APIServerDefaultLocal]
+		data.Data["KubernetesServiceURL"] = "https://" + net.JoinHostPort(localAPIServer.Host, localAPIServer.Port)
 		data.Data["CLIImage"] = os.Getenv("CLI_IMAGE")
 		data.Data["TokenMinterImage"] = os.Getenv("TOKEN_MINTER_IMAGE")
 		data.Data["TokenAudience"] = os.Getenv("TOKEN_AUDIENCE")


### PR DESCRIPTION
## Summary

Cherry-pick of commit a8f745d1b74a from release-4.14 (part of PR #2996, originally from PR #2969).

- Replaces shell-based `https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}` with a Go-rendered `{{.KubernetesServiceURL}}` template value using `net.JoinHostPort()` in:
  - Multus admission controller YAML (`bindata/network/multus-admission-controller/admission-controller.yaml`)
  - Cloud network config controller YAML (`bindata/cloud-network-config-controller/managed/controller.yaml`)
- The corresponding Go code (`pkg/network/cloud_network.go`, `pkg/network/multus_admission_controller.go`) now constructs the URL properly using `net.JoinHostPort()`, which only adds brackets for IPv6 addresses
- The env var block that injected `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` into the init container is removed since the URL is now rendered directly into the template

## Root cause

The previous code unconditionally wrapped `KUBERNETES_SERVICE_HOST` in square brackets when constructing the Kubernetes API server URL. Go 1.24.8+ (CVE-2025-47912) rejects brackets around non-IPv6 addresses, causing URL parsing failures.

## Why this is needed

The 4.14 nightly `gcp-ovn-rt-upgrade` job upgrades from 4.13 to 4.14. The 4.13 source cluster hits this bug before the upgrade delivers the fixed 4.14 code.

## Test plan
- [ ] Verify the Go code compiles: `go build ./cmd/...`
- [ ] Verify the YAML templates render correctly with hostname-based API server addresses
- [ ] Verify the YAML templates still work correctly with IPv6 API server addresses
- [ ] Verify 4.13 -> 4.14 upgrade succeeds