### PR TITLE
OCPBUGS-86761: Add noOverlay configuration to ClusterUserDefinedNetwork CRD

### DIFF
--- a/bindata/network/ovn-kubernetes/common/001-crd.yaml
+++ b/bindata/network/ovn-kubernetes/common/001-crd.yaml
@@ -4472,6 +4472,31 @@ spec:
                         specified in the subnets field
                       rule: '!has(self.excludeSubnets) || self.excludeSubnets.all(e,
                         self.subnets.exists(s, cidr(s).containsCIDR(cidr(e))))'
+{{- if .OVN_NOOVERLAY_ENABLE }}                        
+                  noOverlay:
+                    description: |-
+                      NoOverlay contains configuration for no-overlay mode.
+                      This is only allowed when Transport is "NoOverlay".
+                    properties:
+                      outboundSNAT:
+                        description: OutboundSNAT defines the SNAT behavior for outbound
+                          traffic from pods.
+                        enum:
+                        - Enabled
+                        - Disabled
+                        type: string
+                      routing:
+                        description: Routing specifies whether the pod network routing
+                          is managed by OVN-Kubernetes or users.
+                        enum:
+                        - Managed
+                        - Unmanaged
+                        type: string
+                    required:
+                    - outboundSNAT
+                    - routing
+                    type: object
+{{- end }}                    
                   topology:
                     description: |-
                       Topology describes network configuration.
@@ -4485,7 +4510,7 @@ spec:
                     - Layer3
                     - Localnet
                     type: string
-{{- if .OVN_EVPN_ENABLE_API }}
+{{- if or .OVN_EVPN_ENABLE_API .OVN_NOOVERLAY_ENABLE }}
                   transport:
                     description: |-
                       Transport describes the transport technology for pod-to-pod traffic.
@@ -4495,8 +4520,12 @@ spec:
                       When omitted, the network uses the default OVN overlay transport (e.g. Geneve, VXLAN)
                       as configured by ovn-encap-type.
                     enum:
+{{- if .OVN_NOOVERLAY_ENABLE }}
                     - NoOverlay
+{{- end }}
+{{- if .OVN_EVPN_ENABLE_API }}
                     - EVPN
+{{- end }}                    
                     type: string
 {{- end }}
                 required:
@@ -4538,6 +4567,18 @@ spec:
                     when transport is 'EVPN'
                   rule: '!has(self.transport) || self.transport != ''EVPN'' || self.topology
                     != ''Layer3'' || !has(self.evpn) || !has(self.evpn.macVRF)'
+{{- end }}
+{{- if .OVN_NOOVERLAY_ENABLE }}
+                - message: transport 'NoOverlay' is only supported for Layer3 primary
+                    networks
+                  rule: '!has(self.transport) || self.transport != ''NoOverlay'' ||
+                    (self.topology == ''Layer3'' && has(self.layer3) && self.layer3.role
+                    == ''Primary'')'
+                - message: spec.noOverlay is required when type transport is 'NoOverlay'
+                  rule: '!has(self.transport) || self.transport != ''NoOverlay'' ||
+                    has(self.noOverlay)'
+                - message: spec.noOverlay is forbidden when transport type is not 'NoOverlay'
+                  rule: self.transport == 'NoOverlay' || !has(self.noOverlay)
 {{- end }}
                 - message: Network spec is immutable
                   rule: self == oldSelf

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -421,6 +421,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	// and controls deployment of EVPN runtime components (VTEP CRD, RBAC, FRR containers).
 	data.Data["OVN_EVPN_ENABLE_API"] = featureGates.Enabled(apifeatures.FeatureGateEVPN)
 	data.Data["OVN_EVPN_ENABLE"] = featureGates.Enabled(apifeatures.FeatureGateEVPN) && c.RouteAdvertisements == operv1.RouteAdvertisementsEnabled
+	data.Data["OVN_NOOVERLAY_ENABLE"] = featureGates.Enabled(apifeatures.FeatureGateNoOverlayMode)
 
 	data.Data["ReachabilityTotalTimeoutSeconds"] = c.EgressIPConfig.ReachabilityTotalTimeoutSeconds
 


### PR DESCRIPTION
Adds the noOverlay field with outboundSNAT and routing properties to the ClusterUserDefinedNetwork CRD, gated by the OVN_NOOVERLAY_ENABLE feature flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a "NoOverlay" networking mode as a transport option with configurable outbound SNAT (Enabled/Disabled) and routing (Managed/Unmanaged).
  * Enabled via a feature flag; schema and validations enforce "NoOverlay" only for Layer3 topology with Primary role and require/forbid the no-overlay settings accordingly.
  * Manifests now reflect the no-overlay mode when the feature flag is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->