### PR TITLE
OCPBUGS-88306: Remove --enable-interconnect flag from OVN-K manifests

### DIFF
--- a/bindata/network/node-identity/managed/node-identity.yaml
+++ b/bindata/network/node-identity/managed/node-identity.yaml
@@ -135,7 +135,6 @@ spec:
                 --webhook-host="" \
                 --webhook-port={{.NetworkNodeIdentityPort}} \
                 ${ho_enable} \
-                --enable-interconnect \
                 --disable-approver \
                 --extra-allowed-user="system:serviceaccount:openshift-ovn-kubernetes:ovn-kubernetes-control-plane" \
                 --pod-admission-conditions="/var/run/ovnkube-identity-config/additional-pod-admission-cond.json" \

--- a/bindata/network/node-identity/managed/node-identity.yaml
+++ b/bindata/network/node-identity/managed/node-identity.yaml
@@ -126,6 +126,12 @@ spec:
             # OVN-K will try to remove hybrid overlay node annotations even when the hybrid overlay is not enabled.
             # https://github.com/ovn-org/ovn-kubernetes/blob/ac6820df0b338a246f10f412cd5ec903bd234694/go-controller/pkg/ovn/master.go#L791
             ho_enable="--enable-hybrid-overlay"
+            # DROP: remove when older OVN-K images that require --enable-interconnect are no longer supported
+            enable_interconnect_flag=
+            if /usr/bin/ovnkube-identity --help 2>&1 | grep -q -- '--enable-interconnect'; then
+              enable_interconnect_flag="--enable-interconnect"
+            fi
+
             echo "I$(date "+%m%d %H:%M:%S.%N") - network-node-identity - start webhook"
             # extra-allowed-user: service account `ovn-kubernetes-control-plane`
             # sets pod annotations in multi-homing layer3 network controller (cluster-manager)
@@ -135,6 +141,7 @@ spec:
                 --webhook-host="" \
                 --webhook-port={{.NetworkNodeIdentityPort}} \
                 ${ho_enable} \
+                ${enable_interconnect_flag} \
                 --disable-approver \
                 --extra-allowed-user="system:serviceaccount:openshift-ovn-kubernetes:ovn-kubernetes-control-plane" \
                 --pod-admission-conditions="/var/run/ovnkube-identity-config/additional-pod-admission-cond.json" \

--- a/bindata/network/node-identity/self-hosted/node-identity.yaml
+++ b/bindata/network/node-identity/self-hosted/node-identity.yaml
@@ -56,7 +56,6 @@ spec:
                 --webhook-host={{.NetworkNodeIdentityIP}} \
                 --webhook-port={{.NetworkNodeIdentityPort}} \
                 ${ho_enable} \
-                --enable-interconnect \
                 --disable-approver \
                 --extra-allowed-user="system:serviceaccount:openshift-ovn-kubernetes:ovn-kubernetes-control-plane" \
                 --wait-for-kubernetes-api={{.NetworkNodeIdentityTerminationDurationSeconds}}s \

--- a/bindata/network/node-identity/self-hosted/node-identity.yaml
+++ b/bindata/network/node-identity/self-hosted/node-identity.yaml
@@ -48,6 +48,12 @@ spec:
             # OVN-K will try to remove hybrid overlay node annotations even when the hybrid overlay is not enabled.
             # https://github.com/ovn-org/ovn-kubernetes/blob/ac6820df0b338a246f10f412cd5ec903bd234694/go-controller/pkg/ovn/master.go#L791
             ho_enable="--enable-hybrid-overlay"
+            # DROP: remove when older OVN-K images that require --enable-interconnect are no longer supported
+            enable_interconnect_flag=
+            if /usr/bin/ovnkube-identity --help 2>&1 | grep -q -- '--enable-interconnect'; then
+              enable_interconnect_flag="--enable-interconnect"
+            fi
+
             echo "I$(date "+%m%d %H:%M:%S.%N") - network-node-identity - start webhook"
             # extra-allowed-user: service account `ovn-kubernetes-control-plane`
             # sets pod annotations in multi-homing layer3 network controller (cluster-manager)
@@ -56,6 +62,7 @@ spec:
                 --webhook-host={{.NetworkNodeIdentityIP}} \
                 --webhook-port={{.NetworkNodeIdentityPort}} \
                 ${ho_enable} \
+                ${enable_interconnect_flag} \
                 --disable-approver \
                 --extra-allowed-user="system:serviceaccount:openshift-ovn-kubernetes:ovn-kubernetes-control-plane" \
                 --wait-for-kubernetes-api={{.NetworkNodeIdentityTerminationDurationSeconds}}s \

--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -739,7 +739,6 @@ data:
         ${evpn_enable_flag} \
         ${network_observability_enabled_flag} \
         --zone ${K8S_NODE} \
-        --enable-interconnect \
         --enable-multicast \
         --acl-logging-rate-limit "{{.OVNPolicyAuditRateLimit}}" \
         ${gw_interface_flag} \

--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -718,6 +718,12 @@ data:
         ovn_v6_transit_switch_subnet_opt="--cluster-manager-v6-transit-subnet {{.V6TransitSwitchSubnet}}"
       fi
 
+      # DROP: remove when older OVN-K images that require --enable-interconnect are no longer supported
+      enable_interconnect_flag=
+      if /usr/bin/ovnkube --help 2>&1 | grep -q -- '--enable-interconnect'; then
+        enable_interconnect_flag="--enable-interconnect"
+      fi
+
       exec /usr/bin/ovnkube \
         ${init_ovnkube_controller} \
         --init-node "${K8S_NODE}" \
@@ -739,6 +745,7 @@ data:
         ${evpn_enable_flag} \
         ${network_observability_enabled_flag} \
         --zone ${K8S_NODE} \
+        ${enable_interconnect_flag} \
         --enable-multicast \
         --acl-logging-rate-limit "{{.OVNPolicyAuditRateLimit}}" \
         ${gw_interface_flag} \

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
@@ -195,8 +195,15 @@ spec:
             evpn_enable_flag="--enable-evpn"
           fi
 
+          # DROP: remove when older OVN-K images that require --enable-interconnect are no longer supported
+          enable_interconnect_flag=
+          if /usr/bin/ovnkube --help 2>&1 | grep -q -- '--enable-interconnect'; then
+            enable_interconnect_flag="--enable-interconnect"
+          fi
+
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-control-plane - start ovnkube --init-cluster-manager ${K8S_NODE}"
           exec /usr/bin/ovnkube \
+            ${enable_interconnect_flag} \
             --enable-multicast \
             --init-cluster-manager "${K8S_NODE}" \
             --config-file=/run/ovnkube-config/ovnkube.conf \

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
@@ -197,7 +197,6 @@ spec:
 
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-control-plane - start ovnkube --init-cluster-manager ${K8S_NODE}"
           exec /usr/bin/ovnkube \
-            --enable-interconnect \
             --enable-multicast \
             --init-cluster-manager "${K8S_NODE}" \
             --config-file=/run/ovnkube-config/ovnkube.conf \

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
@@ -151,8 +151,15 @@ spec:
             exit 1
           fi
 
+          # DROP: remove when older OVN-K images that require --enable-interconnect are no longer supported
+          enable_interconnect_flag=
+          if /usr/bin/ovnkube --help 2>&1 | grep -q -- '--enable-interconnect'; then
+            enable_interconnect_flag="--enable-interconnect"
+          fi
+
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-control-plane - start ovnkube --init-cluster-manager ${K8S_NODE}"
           exec /usr/bin/ovnkube \
+            ${enable_interconnect_flag} \
             --enable-multicast \
             --init-cluster-manager "${K8S_NODE}" \
             --config-file=/run/ovnkube-config/ovnkube.conf \

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
@@ -153,7 +153,6 @@ spec:
 
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-control-plane - start ovnkube --init-cluster-manager ${K8S_NODE}"
           exec /usr/bin/ovnkube \
-            --enable-interconnect \
             --enable-multicast \
             --init-cluster-manager "${K8S_NODE}" \
             --config-file=/run/ovnkube-config/ovnkube.conf \

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -6,15 +6,12 @@ import (
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 )
 
-const OVN_INTERCONNECT_CONFIGMAP_NAME = "ovn-interconnect-configuration"
 const OVN_NAMESPACE = "openshift-ovn-kubernetes"
 const OVN_CONTROL_PLANE = "ovnkube-control-plane"
 const OVN_NODE = "ovnkube-node"
@@ -22,10 +19,6 @@ const OVN_CONTROLLER = "ovnkube-controller"
 const MTU_CM_NAMESPACE = "openshift-network-operator"
 const MTU_CM_NAME = "mtu"
 const OVN_NBDB = "nbdb"
-
-func GetInterConnectConfigMap(kubeClient kubernetes.Interface) (*corev1.ConfigMap, error) {
-	return kubeClient.CoreV1().ConfigMaps(OVN_NAMESPACE).Get(context.TODO(), OVN_INTERCONNECT_CONFIGMAP_NAME, metav1.GetOptions{})
-}
 
 func ReadMTUConfigMap(ctx context.Context, client cnoclient.Client) (int, error) {
 	klog.V(4).Infof("Looking for ConfigMap %s/%s", MTU_CM_NAMESPACE, MTU_CM_NAME)


### PR DESCRIPTION
We should drop the second commit once we sync the upstream changes into `openshift/ovn-kubernetes`.
It is required today so ovn-k works in both scenarios. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with different OVN-Kubernetes image versions by making the interconnect feature conditional on runtime support detection. The system now probes for feature availability before enabling interconnect functionality, preventing startup failures when the feature is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->