### PR TITLE
[release-4.22] OCPBUGS-90721: NVIDIA-596: Enable dpu healthcheck

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -134,7 +134,7 @@ metadata:
 data:
   daemon-config.json: |
     {
-        "cniVersion": "0.3.1",
+        "cniVersion": "1.1.0",
         "chrootDir": "/hostroot",
         "logToStderr": true,
         "logLevel": "verbose",

--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -540,6 +540,9 @@ data:
       # Ensure allow_icmp_network_policy_flag is always defined
       allow_icmp_network_policy_flag=
 
+      # Ensure dpu_lease_flags is always defined
+      dpu_lease_flags=
+
       if [[ $# -ne 3 ]]; then
         echo "Expected three arguments but got $#"
         exit 1
@@ -583,6 +586,13 @@ data:
         # disable init-ovnkube-controller for dpu-host mode as it is not supported
         init_ovnkube_controller=""
 
+      fi
+
+      if [[ -n "${OVNKUBE_NODE_LEASE_RENEW_INTERVAL}" ]]; then
+        dpu_lease_flags="--dpu-node-lease-renew-interval ${OVNKUBE_NODE_LEASE_RENEW_INTERVAL}"
+      fi
+      if [[ -n "${OVNKUBE_NODE_LEASE_DURATION}" ]]; then
+        dpu_lease_flags="${dpu_lease_flags} --dpu-node-lease-duration ${OVNKUBE_NODE_LEASE_DURATION}"
       fi
 
       if [ "{{.OVN_GATEWAY_MODE}}" == "shared" ]; then
@@ -746,5 +756,6 @@ data:
         ${ovn_v4_masquerade_subnet_opt} \
         ${ovn_v6_masquerade_subnet_opt} \
         ${ovn_v4_transit_switch_subnet_opt} \
-        ${ovn_v6_transit_switch_subnet_opt}
+        ${ovn_v6_transit_switch_subnet_opt} \
+        ${dpu_lease_flags}
     }

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -437,6 +437,12 @@ spec:
         - name: OVNKUBE_NODE_MGMT_PORT_DP_RESOURCE_NAME
           value: {{ .MgmtPortResourceName }}
         {{ end }}
+        {{ if or (eq .OVN_NODE_MODE "dpu-host") (eq .OVN_NODE_MODE "dpu") }}
+        - name: OVNKUBE_NODE_LEASE_RENEW_INTERVAL
+          value: "{{.DpuNodeLeaseRenewInterval}}"
+        - name: OVNKUBE_NODE_LEASE_DURATION
+          value: "{{.DpuNodeLeaseDuration}}"
+        {{ end }}
 {{ if .HTTP_PROXY }}
         - name: "HTTP_PROXY"
           value: "{{ .HTTP_PROXY}}"

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -473,6 +473,12 @@ spec:
         - name: OVNKUBE_NODE_MGMT_PORT_DP_RESOURCE_NAME
           value: {{ .MgmtPortResourceName }}
         {{ end }}
+        {{ if or (eq .OVN_NODE_MODE "dpu-host") (eq .OVN_NODE_MODE "dpu") }}
+        - name: OVNKUBE_NODE_LEASE_RENEW_INTERVAL
+          value: "{{.DpuNodeLeaseRenewInterval}}"
+        - name: OVNKUBE_NODE_LEASE_DURATION
+          value: "{{.DpuNodeLeaseDuration}}"
+        {{ end }}
         - name: K8S_NODE
           valueFrom:
             fieldRef:

--- a/hack/hardware-offload-config.yaml
+++ b/hack/hardware-offload-config.yaml
@@ -12,3 +12,5 @@ data:
     dpu-mode-label: "network.operator.openshift.io/dpu="
     smart-nic-mode-label: "network.operator.openshift.io/smart-nic="
     mgmt-port-resource-name: "openshift.io/mgmtvf"
+    dpu-node-lease-renew-interval: "10"
+    dpu-node-lease-duration: "40"

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -30,18 +30,20 @@ type OVNHyperShiftBootstrapResult struct {
 }
 
 type OVNConfigBoostrapResult struct {
-	GatewayMode           string
-	HyperShiftConfig      *OVNHyperShiftBootstrapResult
-	DisableUDPAggregation bool
-	DpuHostModeLabel      string
-	DpuHostModeNodes      []string
-	DpuHostModeValue      string
-	DpuModeLabel          string
-	DpuModeNodes          []string
-	SmartNicModeLabel     string
-	SmartNicModeNodes     []string
-	SmartNicModeValue     string
-	MgmtPortResourceName  string
+	GatewayMode               string
+	HyperShiftConfig          *OVNHyperShiftBootstrapResult
+	DisableUDPAggregation     bool
+	DpuHostModeLabel          string
+	DpuHostModeNodes          []string
+	DpuHostModeValue          string
+	DpuModeLabel              string
+	DpuModeNodes              []string
+	SmartNicModeLabel         string
+	SmartNicModeNodes         []string
+	SmartNicModeValue         string
+	MgmtPortResourceName      string
+	DpuNodeLeaseRenewInterval int
+	DpuNodeLeaseDuration      int
 	// ConfigOverrides contains the overrides for the OVN Kubernetes configuration
 	// This is used to set the hidden OVN Kubernetes configuration in the cluster
 	// It is a map of key-value pairs where the key is the configuration option and the

--- a/pkg/network/kube_proxy_test.go
+++ b/pkg/network/kube_proxy_test.go
@@ -374,10 +374,12 @@ func TestFillKubeProxyDefaults(t *testing.T) {
 var FakeKubeProxyBootstrapResult = bootstrap.BootstrapResult{
 	OVN: bootstrap.OVNBootstrapResult{
 		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-			DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
-			DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
-			SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
-			MgmtPortResourceName: "",
+			DpuHostModeLabel:          OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+			DpuModeLabel:              OVN_NODE_SELECTOR_DEFAULT_DPU,
+			SmartNicModeLabel:         OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+			MgmtPortResourceName:      "",
+			DpuNodeLeaseRenewInterval: DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT,
+			DpuNodeLeaseDuration:      DPU_NODE_LEASE_DURATION_DEFAULT,
 		},
 	},
 }

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -65,6 +65,11 @@ const OVN_NODE_SELECTOR_DEFAULT_DPU = "network.operator.openshift.io/dpu="
 const OVN_NODE_SELECTOR_DEFAULT_SMART_NIC = "network.operator.openshift.io/smart-nic="
 const OVN_NODE_IDENTITY_CERT_DURATION = "24h"
 
+// Default DPU health check lease configuration.
+// Setting renew-interval to 0 disables the health check.
+const DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT = 10
+const DPU_NODE_LEASE_DURATION_DEFAULT = 40
+
 // gRPC healthcheck port. See: https://github.com/openshift/enhancements/pull/1209
 const OVN_EGRESSIP_HEALTHCHECK_PORT = "9107"
 
@@ -232,6 +237,8 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	data.Data["SmartNicModeLabel"] = bootstrapResult.OVN.OVNKubernetesConfig.SmartNicModeLabel
 	data.Data["SmartNicModeValue"] = bootstrapResult.OVN.OVNKubernetesConfig.SmartNicModeValue
 	data.Data["MgmtPortResourceName"] = bootstrapResult.OVN.OVNKubernetesConfig.MgmtPortResourceName
+	data.Data["DpuNodeLeaseRenewInterval"] = strconv.Itoa(bootstrapResult.OVN.OVNKubernetesConfig.DpuNodeLeaseRenewInterval)
+	data.Data["DpuNodeLeaseDuration"] = strconv.Itoa(bootstrapResult.OVN.OVNKubernetesConfig.DpuNodeLeaseDuration)
 	data.Data["OVN_CONTROLLER_INACTIVITY_PROBE"] = os.Getenv("OVN_CONTROLLER_INACTIVITY_PROBE")
 	controller_inactivity_probe := os.Getenv("OVN_CONTROLLER_INACTIVITY_PROBE")
 	if len(controller_inactivity_probe) == 0 {
@@ -1010,10 +1017,12 @@ func findCommonNode(nodeLists ...[]string) (bool, string) {
 // if it exists, otherwise returns default configuration for OCP clusters using OVN-Kubernetes
 func bootstrapOVNConfig(conf *operv1.Network, kubeClient cnoclient.Client, hc *hypershift.HyperShiftConfig, infraStatus *bootstrap.InfraStatus) (*bootstrap.OVNConfigBoostrapResult, error) {
 	ovnConfigResult := &bootstrap.OVNConfigBoostrapResult{
-		DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
-		DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
-		SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
-		MgmtPortResourceName: "",
+		DpuHostModeLabel:          OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+		DpuModeLabel:              OVN_NODE_SELECTOR_DEFAULT_DPU,
+		SmartNicModeLabel:         OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+		MgmtPortResourceName:      "",
+		DpuNodeLeaseRenewInterval: DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT,
+		DpuNodeLeaseDuration:      DPU_NODE_LEASE_DURATION_DEFAULT,
 	}
 	if conf.Spec.DefaultNetwork.OVNKubernetesConfig.GatewayConfig == nil {
 		bootstrapOVNGatewayConfig(conf, kubeClient.ClientFor("").CRClient())
@@ -1058,6 +1067,34 @@ func bootstrapOVNConfig(conf *operv1.Network, kubeClient cnoclient.Client, hc *h
 		mgmtPortresourceName, exists := cm.Data["mgmt-port-resource-name"]
 		if exists {
 			ovnConfigResult.MgmtPortResourceName = mgmtPortresourceName
+		}
+
+		if val, exists := cm.Data["dpu-node-lease-renew-interval"]; exists {
+			parsed, err := strconv.Atoi(val)
+			if err == nil && parsed >= 0 {
+				ovnConfigResult.DpuNodeLeaseRenewInterval = parsed
+			} else {
+				klog.Warningf("Invalid dpu-node-lease-renew-interval %q, using default %d", val, DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT)
+			}
+		}
+		if val, exists := cm.Data["dpu-node-lease-duration"]; exists {
+			parsed, err := strconv.Atoi(val)
+			if err == nil && parsed > 0 {
+				ovnConfigResult.DpuNodeLeaseDuration = parsed
+			} else {
+				klog.Warningf("Invalid dpu-node-lease-duration %q (must be > 0), using default %d", val, DPU_NODE_LEASE_DURATION_DEFAULT)
+			}
+		}
+
+		// Setting renew-interval to 0 disables the DPU health check.
+		// Duration must always be > 0 (required by ovn-kubernetes).
+		if ovnConfigResult.DpuNodeLeaseRenewInterval == 0 {
+			ovnConfigResult.DpuNodeLeaseDuration = DPU_NODE_LEASE_DURATION_DEFAULT
+		} else if ovnConfigResult.DpuNodeLeaseDuration <= ovnConfigResult.DpuNodeLeaseRenewInterval {
+			klog.Warningf("dpu-node-lease-duration (%d) must be greater than dpu-node-lease-renew-interval (%d), using defaults",
+				ovnConfigResult.DpuNodeLeaseDuration, ovnConfigResult.DpuNodeLeaseRenewInterval)
+			ovnConfigResult.DpuNodeLeaseRenewInterval = DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT
+			ovnConfigResult.DpuNodeLeaseDuration = DPU_NODE_LEASE_DURATION_DEFAULT
 		}
 	}
 

--- a/pkg/network/ovn_kubernetes_dpu_host_test.go
+++ b/pkg/network/ovn_kubernetes_dpu_host_test.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -160,6 +161,8 @@ func createTestRenderData(ovnNodeMode string) render.RenderData {
 	data.Data["SmartNicModeValue"] = ""
 	data.Data["DpuModeLabel"] = ""
 	data.Data["MgmtPortResourceName"] = ""
+	data.Data["DpuNodeLeaseRenewInterval"] = strconv.Itoa(DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT)
+	data.Data["DpuNodeLeaseDuration"] = strconv.Itoa(DPU_NODE_LEASE_DURATION_DEFAULT)
 	data.Data["HTTP_PROXY"] = ""
 	data.Data["HTTPS_PROXY"] = ""
 	data.Data["NO_PROXY"] = ""
@@ -209,6 +212,94 @@ func getMatchExpression(g *WithT, ds *appsv1.DaemonSet, label string) (corev1.No
 	}
 
 	return corev1.NodeSelectorOpDoesNotExist, ""
+}
+
+// TestOVNKubernetesLeaseEnvVars tests that DPU lease env vars are set
+// for DPU and DPU-host modes but not for full mode
+func TestOVNKubernetesLeaseEnvVars(t *testing.T) {
+	templates := []struct {
+		name         string
+		templatePath string
+	}{
+		{
+			name:         "managed",
+			templatePath: "../../bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml",
+		},
+		{
+			name:         "self-hosted",
+			templatePath: "../../bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml",
+		},
+	}
+
+	testCases := []struct {
+		name        string
+		ovnNodeMode string
+		expectSet   bool
+	}{
+		{
+			name:        "full mode should not have lease env vars",
+			ovnNodeMode: "full",
+			expectSet:   false,
+		},
+		{
+			name:        "dpu-host mode should have lease env vars",
+			ovnNodeMode: "dpu-host",
+			expectSet:   true,
+		},
+		{
+			name:        "dpu mode should have lease env vars",
+			ovnNodeMode: "dpu",
+			expectSet:   true,
+		},
+	}
+
+	// Env vars with literal values
+	leaseEnvVars := map[string]string{
+		"OVNKUBE_NODE_LEASE_RENEW_INTERVAL": strconv.Itoa(DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT),
+		"OVNKUBE_NODE_LEASE_DURATION":       strconv.Itoa(DPU_NODE_LEASE_DURATION_DEFAULT),
+	}
+	for _, template := range templates {
+		for _, tc := range testCases {
+			testName := template.name + "_" + tc.name
+			t.Run(testName, func(t *testing.T) {
+				g := NewGomegaWithT(t)
+
+				data := createTestRenderData(tc.ovnNodeMode)
+
+				objs, err := render.RenderTemplate(template.templatePath, &data)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(objs).To(HaveLen(1))
+
+				yamlBytes, err := yaml.Marshal(objs[0])
+				g.Expect(err).NotTo(HaveOccurred())
+
+				ds := &appsv1.DaemonSet{}
+				err = yaml.Unmarshal(yamlBytes, ds)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				for envName, expectedValue := range leaseEnvVars {
+					found := false
+					for _, container := range ds.Spec.Template.Spec.Containers {
+						for _, env := range container.Env {
+							if env.Name == envName {
+								found = true
+								g.Expect(env.Value).To(Equal(expectedValue),
+									"%s should be set to %s", envName, expectedValue)
+							}
+						}
+					}
+
+					if tc.expectSet {
+						g.Expect(found).To(BeTrue(),
+							"%s should be set for %s mode", envName, tc.ovnNodeMode)
+					} else {
+						g.Expect(found).To(BeFalse(),
+							"%s should not be set for %s mode", envName, tc.ovnNodeMode)
+					}
+				}
+			})
+		}
+	}
 }
 
 // TestOVNKubernetesNodeSelectorOperator tests that the node selector operator works correctly with label values of different Full/SmartNIC/DPU modes

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -97,10 +97,12 @@ func TestRenderOVNKubernetes(t *testing.T) {
 	bootstrapResult.OVN = bootstrap.OVNBootstrapResult{
 		ControlPlaneReplicaCount: 3,
 		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-			DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
-			DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
-			SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
-			MgmtPortResourceName: "",
+			DpuHostModeLabel:          OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+			DpuModeLabel:              OVN_NODE_SELECTOR_DEFAULT_DPU,
+			SmartNicModeLabel:         OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+			MgmtPortResourceName:      "",
+			DpuNodeLeaseRenewInterval: DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT,
+			DpuNodeLeaseDuration:      DPU_NODE_LEASE_DURATION_DEFAULT,
 			HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
 				Enabled: false,
 			},
@@ -221,10 +223,12 @@ func TestRenderOVNKubernetesIPv6(t *testing.T) {
 	bootstrapResult.OVN = bootstrap.OVNBootstrapResult{
 		ControlPlaneReplicaCount: 3,
 		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-			DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
-			DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
-			SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
-			MgmtPortResourceName: "",
+			DpuHostModeLabel:          OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+			DpuModeLabel:              OVN_NODE_SELECTOR_DEFAULT_DPU,
+			SmartNicModeLabel:         OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+			MgmtPortResourceName:      "",
+			DpuNodeLeaseRenewInterval: DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT,
+			DpuNodeLeaseDuration:      DPU_NODE_LEASE_DURATION_DEFAULT,
 			HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
 				Enabled: false,
 			},
@@ -242,10 +246,12 @@ func TestRenderOVNKubernetesIPv6(t *testing.T) {
 	bootstrapResult.OVN = bootstrap.OVNBootstrapResult{
 		ControlPlaneReplicaCount: 3,
 		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-			DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
-			DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
-			SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
-			MgmtPortResourceName: "",
+			DpuHostModeLabel:          OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+			DpuModeLabel:              OVN_NODE_SELECTOR_DEFAULT_DPU,
+			SmartNicModeLabel:         OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+			MgmtPortResourceName:      "",
+			DpuNodeLeaseRenewInterval: DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT,
+			DpuNodeLeaseDuration:      DPU_NODE_LEASE_DURATION_DEFAULT,
 			HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
 				Enabled: false,
 			},
@@ -1036,10 +1042,12 @@ logfile-maxage=0`,
 			bootstrapResult.OVN = bootstrap.OVNBootstrapResult{
 				ControlPlaneReplicaCount: tc.controlPlaneReplicaCount,
 				OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-					DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
-					DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
-					SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
-					MgmtPortResourceName: "",
+					DpuHostModeLabel:          OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+					DpuModeLabel:              OVN_NODE_SELECTOR_DEFAULT_DPU,
+					SmartNicModeLabel:         OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+					MgmtPortResourceName:      "",
+					DpuNodeLeaseRenewInterval: DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT,
+					DpuNodeLeaseDuration:      DPU_NODE_LEASE_DURATION_DEFAULT,
 					HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
 						Enabled: false,
 					},
@@ -2238,10 +2246,12 @@ status:
 				ControlPlaneUpdateStatus: controlPlaneStatus,
 				NodeUpdateStatus:         nodeStatus,
 				OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-					DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
-					DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
-					SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
-					MgmtPortResourceName: "",
+					DpuHostModeLabel:          OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+					DpuModeLabel:              OVN_NODE_SELECTOR_DEFAULT_DPU,
+					SmartNicModeLabel:         OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+					MgmtPortResourceName:      "",
+					DpuNodeLeaseRenewInterval: DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT,
+					DpuNodeLeaseDuration:      DPU_NODE_LEASE_DURATION_DEFAULT,
 					HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
 						Enabled: false,
 					},
@@ -2543,10 +2553,12 @@ func TestRenderOVNKubernetesEnableIPsec(t *testing.T) {
 			IPFamilyMode: names.IPFamilySingleStack,
 		},
 		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-			DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
-			DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
-			SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
-			MgmtPortResourceName: "",
+			DpuHostModeLabel:          OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+			DpuModeLabel:              OVN_NODE_SELECTOR_DEFAULT_DPU,
+			SmartNicModeLabel:         OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+			MgmtPortResourceName:      "",
+			DpuNodeLeaseRenewInterval: DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT,
+			DpuNodeLeaseDuration:      DPU_NODE_LEASE_DURATION_DEFAULT,
 			HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
 				Enabled: false,
 			},
@@ -2770,10 +2782,12 @@ func TestRenderOVNKubernetesEnableIPsecForHostedControlPlane(t *testing.T) {
 			IPFamilyMode: names.IPFamilySingleStack,
 		},
 		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-			DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
-			DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
-			SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
-			MgmtPortResourceName: "",
+			DpuHostModeLabel:          OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+			DpuModeLabel:              OVN_NODE_SELECTOR_DEFAULT_DPU,
+			SmartNicModeLabel:         OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+			MgmtPortResourceName:      "",
+			DpuNodeLeaseRenewInterval: DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT,
+			DpuNodeLeaseDuration:      DPU_NODE_LEASE_DURATION_DEFAULT,
 			HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
 				Enabled: false,
 			},
@@ -2871,10 +2885,12 @@ func TestRenderOVNKubernetesIPsecUpgradeWithMachineConfig(t *testing.T) {
 			IsOVNIPsecActiveOrRollingOut: true,
 		},
 		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-			DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
-			DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
-			SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
-			MgmtPortResourceName: "",
+			DpuHostModeLabel:          OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+			DpuModeLabel:              OVN_NODE_SELECTOR_DEFAULT_DPU,
+			SmartNicModeLabel:         OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+			MgmtPortResourceName:      "",
+			DpuNodeLeaseRenewInterval: DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT,
+			DpuNodeLeaseDuration:      DPU_NODE_LEASE_DURATION_DEFAULT,
 			HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
 				Enabled: false,
 			},
@@ -2983,10 +2999,12 @@ func TestRenderOVNKubernetesIPsecUpgradeWithNoMachineConfig(t *testing.T) {
 			IsOVNIPsecActiveOrRollingOut: true,
 		},
 		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-			DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
-			DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
-			SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
-			MgmtPortResourceName: "",
+			DpuHostModeLabel:          OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+			DpuModeLabel:              OVN_NODE_SELECTOR_DEFAULT_DPU,
+			SmartNicModeLabel:         OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+			MgmtPortResourceName:      "",
+			DpuNodeLeaseRenewInterval: DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT,
+			DpuNodeLeaseDuration:      DPU_NODE_LEASE_DURATION_DEFAULT,
 			HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
 				Enabled: false,
 			},
@@ -3131,10 +3149,12 @@ func TestRenderOVNKubernetesIPsecUpgradeWithHypershiftHostedCluster(t *testing.T
 			IsOVNIPsecActiveOrRollingOut: true,
 		},
 		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-			DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
-			DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
-			SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
-			MgmtPortResourceName: "",
+			DpuHostModeLabel:          OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+			DpuModeLabel:              OVN_NODE_SELECTOR_DEFAULT_DPU,
+			SmartNicModeLabel:         OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+			MgmtPortResourceName:      "",
+			DpuNodeLeaseRenewInterval: DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT,
+			DpuNodeLeaseDuration:      DPU_NODE_LEASE_DURATION_DEFAULT,
 			HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
 				Enabled: false,
 			},
@@ -3234,10 +3254,12 @@ func TestRenderOVNKubernetesDisableIPsec(t *testing.T) {
 			IsOVNIPsecActiveOrRollingOut: true,
 		},
 		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-			DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
-			DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
-			SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
-			MgmtPortResourceName: "",
+			DpuHostModeLabel:          OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+			DpuModeLabel:              OVN_NODE_SELECTOR_DEFAULT_DPU,
+			SmartNicModeLabel:         OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+			MgmtPortResourceName:      "",
+			DpuNodeLeaseRenewInterval: DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT,
+			DpuNodeLeaseDuration:      DPU_NODE_LEASE_DURATION_DEFAULT,
 			HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
 				Enabled: false,
 			},
@@ -3444,10 +3466,12 @@ func TestRenderOVNKubernetesEnableIPsecWithUserInstalledIPsecMachineConfigs(t *t
 			IPFamilyMode: names.IPFamilySingleStack,
 		},
 		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-			DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
-			DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
-			SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
-			MgmtPortResourceName: "",
+			DpuHostModeLabel:          OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+			DpuModeLabel:              OVN_NODE_SELECTOR_DEFAULT_DPU,
+			SmartNicModeLabel:         OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+			MgmtPortResourceName:      "",
+			DpuNodeLeaseRenewInterval: DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT,
+			DpuNodeLeaseDuration:      DPU_NODE_LEASE_DURATION_DEFAULT,
 			HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
 				Enabled: false,
 			},
@@ -3590,10 +3614,12 @@ func TestRenderOVNKubernetesDisableIPsecWithUserInstalledIPsecMachineConfigs(t *
 			IsOVNIPsecActiveOrRollingOut: true,
 		},
 		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-			DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
-			DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
-			SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
-			MgmtPortResourceName: "",
+			DpuHostModeLabel:          OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+			DpuModeLabel:              OVN_NODE_SELECTOR_DEFAULT_DPU,
+			SmartNicModeLabel:         OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+			MgmtPortResourceName:      "",
+			DpuNodeLeaseRenewInterval: DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT,
+			DpuNodeLeaseDuration:      DPU_NODE_LEASE_DURATION_DEFAULT,
 			HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
 				Enabled: false,
 			},
@@ -3729,10 +3755,12 @@ func TestRenderOVNKubernetesDualStackPrecedenceOverUpgrade(t *testing.T) {
 			IPFamilyMode: names.IPFamilySingleStack,
 		},
 		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-			DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
-			DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
-			SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
-			MgmtPortResourceName: "",
+			DpuHostModeLabel:          OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+			DpuModeLabel:              OVN_NODE_SELECTOR_DEFAULT_DPU,
+			SmartNicModeLabel:         OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+			MgmtPortResourceName:      "",
+			DpuNodeLeaseRenewInterval: DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT,
+			DpuNodeLeaseDuration:      DPU_NODE_LEASE_DURATION_DEFAULT,
 			HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
 				Enabled: false,
 			},
@@ -3972,10 +4000,12 @@ func TestRenderOVNKubernetesEnablePersistentIPs(t *testing.T) {
 	bootstrapResult.OVN = bootstrap.OVNBootstrapResult{
 		ControlPlaneReplicaCount: 3,
 		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-			DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
-			DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
-			SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
-			MgmtPortResourceName: "",
+			DpuHostModeLabel:          OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+			DpuModeLabel:              OVN_NODE_SELECTOR_DEFAULT_DPU,
+			SmartNicModeLabel:         OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+			MgmtPortResourceName:      "",
+			DpuNodeLeaseRenewInterval: DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT,
+			DpuNodeLeaseDuration:      DPU_NODE_LEASE_DURATION_DEFAULT,
 			HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
 				Enabled: false,
 			},
@@ -4150,10 +4180,12 @@ func Test_renderOVNKubernetes(t *testing.T) {
 		bootstrapResult.OVN = bootstrap.OVNBootstrapResult{
 			ControlPlaneReplicaCount: 3,
 			OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-				DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
-				DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
-				SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
-				MgmtPortResourceName: "",
+				DpuHostModeLabel:          OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+				DpuModeLabel:              OVN_NODE_SELECTOR_DEFAULT_DPU,
+				SmartNicModeLabel:         OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+				MgmtPortResourceName:      "",
+				DpuNodeLeaseRenewInterval: DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT,
+				DpuNodeLeaseDuration:      DPU_NODE_LEASE_DURATION_DEFAULT,
 				HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
 					Enabled: false,
 				},
@@ -4291,10 +4323,12 @@ func TestRenderOVNKubernetes_AdvertisedUDNIsolationModeOverride(t *testing.T) {
 		bootstrapResult.OVN = bootstrap.OVNBootstrapResult{
 			ControlPlaneReplicaCount: 3,
 			OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-				DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
-				DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
-				SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
-				MgmtPortResourceName: "",
+				DpuHostModeLabel:          OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+				DpuModeLabel:              OVN_NODE_SELECTOR_DEFAULT_DPU,
+				SmartNicModeLabel:         OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+				MgmtPortResourceName:      "",
+				DpuNodeLeaseRenewInterval: DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT,
+				DpuNodeLeaseDuration:      DPU_NODE_LEASE_DURATION_DEFAULT,
 				HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
 					Enabled: false,
 				},
@@ -4332,10 +4366,12 @@ func TestRenderOVNKubernetes_OpenFlowProbeOverride(t *testing.T) {
 		bootstrapResult.OVN = bootstrap.OVNBootstrapResult{
 			ControlPlaneReplicaCount: 3,
 			OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
-				DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
-				DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
-				SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
-				MgmtPortResourceName: "",
+				DpuHostModeLabel:          OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+				DpuModeLabel:              OVN_NODE_SELECTOR_DEFAULT_DPU,
+				SmartNicModeLabel:         OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+				MgmtPortResourceName:      "",
+				DpuNodeLeaseRenewInterval: DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT,
+				DpuNodeLeaseDuration:      DPU_NODE_LEASE_DURATION_DEFAULT,
 				HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
 					Enabled: false,
 				},
@@ -4744,6 +4780,85 @@ func TestRenderOVNKubernetesNoOverlay(t *testing.T) {
 	}
 }
 
+func TestDpuLeaseConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name                  string
+		leaseRenewInterval    int
+		leaseDuration         int
+		expectedRenewInterval string
+		expectedDuration      string
+		expectPresent         bool
+	}{
+		{
+			name:                  "custom values are rendered",
+			leaseRenewInterval:    15,
+			leaseDuration:         60,
+			expectedRenewInterval: "15",
+			expectedDuration:      "60",
+			expectPresent:         true,
+		},
+		{
+			name:                  "defaults are rendered",
+			leaseRenewInterval:    DPU_NODE_LEASE_RENEW_INTERVAL_DEFAULT,
+			leaseDuration:         DPU_NODE_LEASE_DURATION_DEFAULT,
+			expectedRenewInterval: "10",
+			expectedDuration:      "40",
+			expectPresent:         true,
+		},
+		{
+			name:                  "zero renew interval disables health check",
+			leaseRenewInterval:    0,
+			leaseDuration:         DPU_NODE_LEASE_DURATION_DEFAULT,
+			expectedRenewInterval: "0",
+			expectedDuration:      strconv.Itoa(DPU_NODE_LEASE_DURATION_DEFAULT),
+			expectPresent:         true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			crd := OVNKubernetesConfig.DeepCopy()
+			config := &crd.Spec
+			errs := validateOVNKubernetes(config)
+			g.Expect(errs).To(HaveLen(0))
+			fillDefaults(config, nil)
+
+			bootstrapResult := fakeBootstrapResult()
+			bootstrapResult.OVN = bootstrap.OVNBootstrapResult{
+				ControlPlaneReplicaCount: 3,
+				OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
+					DpuHostModeLabel:          OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+					DpuModeLabel:              OVN_NODE_SELECTOR_DEFAULT_DPU,
+					SmartNicModeLabel:         OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+					MgmtPortResourceName:      "",
+					DpuNodeLeaseRenewInterval: tc.leaseRenewInterval,
+					DpuNodeLeaseDuration:      tc.leaseDuration,
+					DpuHostModeNodes:          []string{"dpu-host-node-1"},
+					HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
+						Enabled: false,
+					},
+				},
+			}
+
+			featureGatesCNO := getDefaultFeatureGates()
+			fakeClient := cnofake.NewFakeClient()
+			objs, _, err := renderOVNKubernetes(config, bootstrapResult, manifestDirOvn, fakeClient, featureGatesCNO)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			envVars := extractDaemonSetEnvVars(g, objs, "ovnkube-node-dpu-host", "ovnkube-controller")
+			if tc.expectPresent {
+				g.Expect(envVars["OVNKUBE_NODE_LEASE_RENEW_INTERVAL"]).To(Equal(tc.expectedRenewInterval))
+				g.Expect(envVars["OVNKUBE_NODE_LEASE_DURATION"]).To(Equal(tc.expectedDuration))
+			} else {
+				_, hasInterval := envVars["OVNKUBE_NODE_LEASE_RENEW_INTERVAL"]
+				_, hasDuration := envVars["OVNKUBE_NODE_LEASE_DURATION"]
+				g.Expect(hasInterval).To(BeFalse(), "OVNKUBE_NODE_LEASE_RENEW_INTERVAL should not be set when disabled")
+				g.Expect(hasDuration).To(BeFalse(), "OVNKUBE_NODE_LEASE_DURATION should not be set when disabled")
+			}
+		})
+	}
+}
+
 // TestFillOVNKubernetesDefaultsMTUNoOverlay tests that MTU is set correctly for no-overlay mode
 func TestFillOVNKubernetesDefaultsMTUNoOverlay(t *testing.T) {
 	g := NewGomegaWithT(t)
@@ -4855,4 +4970,39 @@ func TestValidateMTUForNoOverlay(t *testing.T) {
 		err := ValidateMTUForNoOverlay(conf, 0)
 		g.Expect(err).To(BeNil())
 	})
+}
+
+// extractDaemonSetEnvVars finds a DaemonSet by name in the rendered objects and returns
+// env vars for the specified container as a map.
+func extractDaemonSetEnvVars(g *WithT, objs []*uns.Unstructured, dsName, containerName string) map[string]string {
+	envVars := map[string]string{}
+	for _, obj := range objs {
+		if obj.GetKind() != "DaemonSet" || obj.GetName() != dsName {
+			continue
+		}
+		containers, found, err := uns.NestedSlice(obj.Object, "spec", "template", "spec", "containers")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(found).To(BeTrue())
+		for _, c := range containers {
+			cmap := c.(map[string]interface{})
+			name, _, _ := uns.NestedString(cmap, "name")
+			if name != containerName {
+				continue
+			}
+			envList, found, err := uns.NestedSlice(cmap, "env")
+			g.Expect(err).NotTo(HaveOccurred())
+			if !found {
+				return envVars
+			}
+			for _, e := range envList {
+				emap := e.(map[string]interface{})
+				eName, _, _ := uns.NestedString(emap, "name")
+				eVal, _, _ := uns.NestedString(emap, "value")
+				envVars[eName] = eVal
+			}
+			return envVars
+		}
+	}
+	g.Expect(true).To(BeFalse(), "could not find DaemonSet %s with container %s", dsName, containerName)
+	return envVars
 }


### PR DESCRIPTION
This is a manual cherry-pick of #2941 to release-4.22.


## Changes

Cherry-picks both commits from #2941:

1. **[NVIDIA-596](https://redhat.atlassian.net/browse/NVIDIA-596): Enable DPU healthcheck** — Adds configurable DPU node lease health monitoring (`dpu-node-lease-renew-interval`, `dpu-node-lease-duration`) read from the `hardware-offload-config` ConfigMap. Env vars `OVNKUBE_NODE_LEASE_RENEW_INTERVAL` / `OVNKUBE_NODE_LEASE_DURATION` are injected into ovnkube-node for dpu-host/dpu modes. Script-lib translates them into `--dpu-node-lease-renew-interval` / `--dpu-node-lease-duration` CLI flags. Setting renew-interval to 0 disables the health check.

2. **[NVIDIA-616](https://redhat.atlassian.net/browse/NVIDIA-616): Bump Multus CNI API version to 1.1.0** — Required for CNI STATUS and GC verbs used by the DPU health check. Backward compatible with 0.3.1.

## Conflict Resolution

One conflict in `bindata/network/ovn-kubernetes/common/008-script-lib.yaml` at the end of the `start-ovnkube-node()` function: release-4.22 still has `${egress_features_enable_flag}` and `${multi_external_gateway_enable_flag}` (which were removed on master by #2944). Resolution keeps these existing lines and appends the new `${dpu_lease_flags}`.

This is compatible with #2997 (cherry-pick of #2944) which is pending on release-4.22 — when #2997 merges, it will cleanly remove the egress/gateway lines while `${dpu_lease_flags}` remains.