### PR TITLE
CORENET-7154: Fix debounce timer for OperatorConfig level being incorrectly cleared

### DIFF
--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -473,13 +473,6 @@ func (status *StatusManager) set(reachedAvailableLevel bool, conditions ...operv
 		}
 
 		if operStatus == nil {
-			if _, exists := status.failureFirstSeen[OperatorConfig]; !exists {
-				status.failureFirstSeen[OperatorConfig] = status.clock.Now()
-				return nil
-			}
-			if status.clock.Since(status.failureFirstSeen[OperatorConfig]) < degradedFailureDurationThreshold {
-				return nil
-			}
 			cohelpers.SetStatusCondition(&co.Status.Conditions, configv1.ClusterOperatorStatusCondition{
 				Type:    configv1.OperatorDegraded,
 				Status:  configv1.ConditionTrue,
@@ -487,7 +480,6 @@ func (status *StatusManager) set(reachedAvailableLevel bool, conditions ...operv
 				Message: "Failed to get networks.operator.openshift.io cluster",
 			}, clock.RealClock{})
 		} else {
-			delete(status.failureFirstSeen, OperatorConfig)
 			if reachedAvailableLevel {
 				co.Status.Versions = []configv1.OperandVersion{
 					{Name: "operator", Version: operStatus.Version},

--- a/pkg/controller/statusmanager/status_manager_test.go
+++ b/pkg/controller/statusmanager/status_manager_test.go
@@ -147,16 +147,6 @@ func TestStatusManager_set(t *testing.T) {
 	// No operator config yet; should reflect this in the cluster operator
 	status.set(false)
 
-	// NoOperConfig doesn't get set degraded yet (debounced for 2 min)
-	_, err := getCO(client, "testing")
-	if err == nil {
-		t.Fatalf("ClusterOperator should not exist yet (NoOperConfig debounced)")
-	}
-
-	// Advance clock past the debounce threshold
-	status.clock.(*testingclock.FakeClock).Step(3 * time.Minute)
-	status.set(false)
-
 	co, err := getCO(client, "testing")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
The debounce timer for the `OperatorConfig` status level was being incorrectly cleared when the operator config exists. The code was using the `OperatorConfig` status level internally to track the debounce timer for when the operator config is missing. However it also blindly cleared the timer when the operator config exists, which is the normal case, potentially interfering with a caller's usage of the `OperatorConfig` status level.

This commit removes the debouncing for this case as the operconfig should never actually be missing so it was likely some other error that occurred that facilitated adding the debounce. Since it is unknown what caused the original scenario, we shouldn't assume that delaying the degraded status is the correct solution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cluster operator is now marked degraded immediately when required operator configuration is missing, ensuring prompt and consistent degraded-state reporting.

* **Tests**
  * Tests updated to verify the immediate degraded behavior and to ensure debounce/timer state does not delay or hide missing-configuration reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->