### PR TITLE
OCPBUGS-65488: Add cluster-scoped RBAC and CRDs to network ClusterOperator relatedObjects

### DIFF
--- a/pkg/controller/operconfig/operconfig_controller.go
+++ b/pkg/controller/operconfig/operconfig_controller.go
@@ -453,6 +453,21 @@ func (r *ReconcileOperConfig) Reconcile(ctx context.Context, request reconcile.R
 		Name:     "openshift-cloud-network-config-controller",
 	})
 
+	// Add cluster-scoped RBAC resources deployed by CVO from static manifests.
+	// Per OCPBUGS-65488: ClusterRoleBindings must be explicitly listed in relatedObjects
+	// for 'oc adm inspect clusteroperator/network' to collect them for debugging.
+	relatedObjects = append(relatedObjects, configv1.ObjectReference{
+		Group:    "rbac.authorization.k8s.io",
+		Resource: "clusterrolebindings",
+		Name:     "cluster-network-operator",
+	})
+
+	relatedObjects = append(relatedObjects, configv1.ObjectReference{
+		Group:    "rbac.authorization.k8s.io",
+		Resource: "clusterrolebindings",
+		Name:     "default-account-cluster-network-operator",
+	})
+
 	r.status.SetRelatedObjects(relatedObjects)
 	r.status.SetRelatedClusterObjects(relatedClusterObjects)
 	err = r.status.SetMachineConfigs(ctx, renderedMachineConfigs)


### PR DESCRIPTION
## Summary
Adds missing cluster-scoped resources to the network ClusterOperator's `relatedObjects` field to enable `oc adm inspect clusteroperator/network` to collect all relevant resources for debugging.

## Associated Bug:

https://redhat.atlassian.net/browse/OCPBUGS-65488

## Problem
While checking `oc adm inspect clusteroperator` output in CI, several cluster-scoped resources deployed via static manifests were missing from the network ClusterOperator's `relatedObjects`:
- ClusterRoleBinding: `cluster-network-operator` 
- ClusterRoleBinding: `default-account-cluster-network-operator`
- CRDs: `egressrouters.network.operator.openshift.io`, `operatorpkis.network.operator.openshift.io`, `networks.operator.openshift.io`

This caused `oc adm inspect` to fail collecting these resources, making debugging more difficult.

## Solution
Updated `manifests/0000_70_cluster-network-operator_05_clusteroperator.yaml` to include these cluster-scoped resources in the `status.relatedObjects` field.

## Testing
### Manual Verification
1. Deploy cluster with updated manifest
2. Run `oc adm inspect clusteroperator/network`
3. Verify the following files are collected:
  

## Before Fix:

```
clusterroles % ls
metrics-daemon-role.yaml				net-attach-def-project.yaml				openshift-ovn-kubernetes-cluster-reader.yaml		openshift-ovn-kubernetes-udn-editor.yaml
multus-admission-controller-webhook.yaml		network-diagnostics.yaml				openshift-ovn-kubernetes-control-plane-limited.yaml	openshift-ovn-kubernetes-udn-viewer.yaml
multus-ancillary-tools.yaml				network-node-identity.yaml				openshift-ovn-kubernetes-kube-rbac-proxy.yaml		whereabouts-cni.yaml
multus.yaml						openshift-iptables-alerter.yaml				openshift-ovn-kubernetes-node-limited.yaml
 clusterrolebindings % ls
metrics-daemon-sa-rolebinding.yaml			multus-group.yaml					network-node-identity.yaml				openshift-ovn-kubernetes-node-kube-rbac-proxy.yaml
multus-admission-controller-webhook.yaml		multus-transient.yaml					openshift-iptables-alerter.yaml
multus-ancillary-tools.yaml				multus-whereabouts.yaml					openshift-ovn-kubernetes-control-plane-limited.yaml
multus-cluster-readers.yaml				network-diagnostics.yaml				openshift-ovn-kubernetes-node-identity-limited.yaml
```

## After Fix:

 ```
 inspect.local.1906073230607695611/cluster-scoped-resources/rbac.authorization.k8s.io/clusterroles
clusterroles % ls
metrics-daemon-role.yaml				net-attach-def-project.yaml				openshift-ovn-kubernetes-cluster-reader.yaml		openshift-ovn-kubernetes-udn-editor.yaml
multus-admission-controller-webhook.yaml		network-diagnostics.yaml				openshift-ovn-kubernetes-control-plane-limited.yaml	openshift-ovn-kubernetes-udn-viewer.yaml
multus-ancillary-tools.yaml				network-node-identity.yaml				openshift-ovn-kubernetes-kube-rbac-proxy.yaml		whereabouts-cni.yaml
multus.yaml						openshift-iptables-alerter.yaml				openshift-ovn-kubernetes-node-limited.yaml

 clusterrolebindings % ls 
cluster-network-operator.yaml				multus-cluster-readers.yaml				network-diagnostics.yaml				openshift-ovn-kubernetes-node-identity-limited.yaml
metrics-daemon-sa-rolebinding.yaml			multus-group.yaml					network-node-identity.yaml				openshift-ovn-kubernetes-node-kube-rbac-proxy.yaml
multus-admission-controller-webhook.yaml		multus-transient.yaml					openshift-iptables-alerter.yaml
multus-ancillary-tools.yaml				multus-whereabouts.yaml					openshift-ovn-kubernetes-control-plane-limited.yaml
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced cluster resource tracking by including additional cluster-scoped RBAC bindings in the system’s recorded related-object status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->