### PR TITLE
CORENET-7116: Fix security job - exclude vendor and upgrade to SHA256

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,6 @@
+# References:
+# https://docs.snyk.io/scan-applications/snyk-code/using-snyk-code-from-the-cli/excluding-directories-and-files-from-the-snyk-code-cli-test
+# https://docs.snyk.io/snyk-cli/commands/ignore
+exclude:
+  global:
+    - 'vendor/**' # Upstream dependencies (not project code)

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"context"
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -483,7 +483,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	// daemonsets need to know when those ConfigMaps change so they can
 	// restart with the new options. Render those ConfigMaps first and
 	// embed a hash of their data into the ovnkube-node daemonsets.
-	h := sha1.New()
+	h := sha256.New()
 	for _, path := range cmPaths {
 		manifests, err := render.RenderTemplate(path, &data)
 		if err != nil {
@@ -505,7 +505,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 
 	// Compute a separate hash for no-overlay node config (outboundSNAT).
 	// This allows ovnkube-node to restart when outboundSNAT changes
-	nodeNoOverlayHash := sha1.New()
+	nodeNoOverlayHash := sha256.New()
 	nodeNoOverlayHashData := fmt.Sprintf("outboundSNAT=%v", data.Data["NoOverlayOutboundSNAT"])
 	if _, err := nodeNoOverlayHash.Write([]byte(nodeNoOverlayHashData)); err != nil {
 		return nil, progressing, errors.Wrap(err, "failed to hash node no-overlay config")
@@ -515,7 +515,7 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	// Compute a separate hash for control-plane config (bgpManagedConfig).
 	// This allows ovnkube-control-plane to restart when bgpManagedConfig changes,
 	// without restarting ovnkube-node pods.
-	cpHash := sha1.New()
+	cpHash := sha256.New()
 	cpHashData := fmt.Sprintf("asNumber=%v,topology=%v",
 		data.Data["NoOverlayManagedASNumber"],
 		data.Data["NoOverlayManagedTopology"])

--- a/pkg/util/k8s/unstructured.go
+++ b/pkg/util/k8s/unstructured.go
@@ -1,7 +1,7 @@
 package k8s
 
 import (
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 
@@ -25,13 +25,13 @@ func ToUnstructured(obj interface{}) (*uns.Unstructured, error) {
 	return u, nil
 }
 
-// CalculateHash computes MD5 sum of the JSONfied object passed as obj.
+// CalculateHash computes SHA256 sum of the JSONfied object passed as obj.
 func CalculateHash(obj interface{}) (string, error) {
 	configStr, err := json.Marshal(obj)
 	if err != nil {
 		return "", err
 	}
-	configSum := md5.Sum(configStr)
+	configSum := sha256.Sum256(configStr)
 	return fmt.Sprintf("%x", configSum), nil
 }
 


### PR DESCRIPTION
Snyk scanner flags SHA1 and MD5 usage as weak hash algorithms even though they're only used for config change detection (not cryptographic purposes). Upgrading to SHA256 eliminates the scanner warnings without changing functionality.

Changes:
- pkg/network/ovn_kubernetes.go: SHA1 → SHA256 for ConfigMap checksums
- pkg/util/k8s/unstructured.go: MD5 → SHA256 for object checksums

Related: [CORENET-7116](https://redhat.atlassian.net/browse/CORENET-7116)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Snyk configuration to exclude the vendor directory from scans.
  * Switched hashing algorithms to SHA-256 across networking and utility components for stronger, consistent digests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->