### PR TITLE
Bug 87818: Prevent spurious ovnkube-node DaemonSet rollout during install

### DIFF
--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -481,25 +481,81 @@ func renderOVNKubernetes(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.Bo
 	// daemonsets need to know when those ConfigMaps change so they can
 	// restart with the new options. Render those ConfigMaps first and
 	// embed a hash of their data into the ovnkube-node daemonsets.
+	//
+	// To avoid spurious DaemonSet rollouts during install (when the CNO
+	// reconciles multiple times in quick succession and template inputs
+	// may resolve differently), we compare the rendered ConfigMap .data
+	// against the deployed ConfigMap .data. If they match, we preserve
+	// the existing hash from the DaemonSet annotation rather than
+	// recomputing it. This prevents a DaemonSet generation bump (and
+	// thus a rolling update) when the ConfigMap content hasn't actually
+	// changed. See OCPBUGS-87818 for details.
 	h := sha1.New()
+	var renderedCMData map[string]interface{}
 	for _, path := range cmPaths {
 		manifests, err := render.RenderTemplate(path, &data)
 		if err != nil {
 			return nil, progressing, errors.Wrapf(err, "failed to render ConfigMap template %q", path)
 		}
 
-		// Hash each rendered ConfigMap object's data
+		// Hash only the .data section of each rendered ConfigMap to avoid
+		// instability from metadata differences across reconciliation passes.
 		for _, m := range manifests {
-			bytes, err := json.Marshal(m)
+			cmData, _, _ := uns.NestedMap(m.Object, "data")
+			if cmData == nil {
+				cmData = map[string]interface{}{}
+			}
+			// Remember the rendered .data for comparison with the deployed ConfigMap.
+			if renderedCMData == nil {
+				renderedCMData = cmData
+			}
+			bytes, err := json.Marshal(cmData)
 			if err != nil {
-				return nil, progressing, errors.Wrapf(err, "failed to marshal ConfigMap %q manifest", path)
+				return nil, progressing, errors.Wrapf(err, "failed to marshal ConfigMap %q data", path)
 			}
 			if _, err := h.Write(bytes); err != nil {
 				return nil, progressing, errors.Wrapf(err, "failed to hash ConfigMap %q data", path)
 			}
 		}
 	}
-	data.Data["OVNKubeConfigHash"] = hex.EncodeToString(h.Sum(nil))
+	newHash := hex.EncodeToString(h.Sum(nil))
+
+	// Preserve the existing DaemonSet hash annotation if the deployed ConfigMap
+	// content matches the rendered content. This avoids unnecessary rolling
+	// updates caused by template rendering instability during bootstrap.
+	configHash := newHash
+	existingCM := &corev1.ConfigMap{}
+	if err := client.Default().CRClient().Get(context.TODO(),
+		types.NamespacedName{Name: "ovnkube-script-lib", Namespace: util.OVN_NAMESPACE}, existingCM); err == nil {
+		// ConfigMap exists — compare .data with the rendered content.
+		existingDataMatch := true
+		if renderedCMData != nil {
+			for key, renderedVal := range renderedCMData {
+				if existingCM.Data[key] != fmt.Sprintf("%v", renderedVal) {
+					existingDataMatch = false
+					break
+				}
+			}
+			if len(existingCM.Data) != len(renderedCMData) {
+				existingDataMatch = false
+			}
+		}
+		if existingDataMatch {
+			// The deployed ConfigMap already has the same content.
+			// Look up the existing DaemonSet annotation to preserve the hash.
+			existingDS := &appsv1.DaemonSet{}
+			if err := client.Default().CRClient().Get(context.TODO(),
+				types.NamespacedName{Name: "ovnkube-node", Namespace: util.OVN_NAMESPACE}, existingDS); err == nil {
+				if ann := existingDS.Spec.Template.Annotations; ann != nil {
+					if existingHash, ok := ann["network.operator.openshift.io/ovnkube-script-lib-hash"]; ok && existingHash != "" {
+						klog.V(4).Infof("Preserving existing ovnkube-script-lib-hash %q (deployed ConfigMap data matches rendered data)", existingHash)
+						configHash = existingHash
+					}
+				}
+			}
+		}
+	}
+	data.Data["OVNKubeConfigHash"] = configHash
 
 	// Compute a separate hash for no-overlay node config (outboundSNAT).
 	// This allows ovnkube-node to restart when outboundSNAT changes


### PR DESCRIPTION
## Problem

During cluster install, the CNO reconciles multiple times in quick succession (~33s apart). The `008-script-lib.yaml` ConfigMap template renders with slightly different content across passes because template variables populated from live cluster state (`bootstrapResult`) may not have fully settled. This causes the `ovnkube-script-lib-hash` annotation on the `ovnkube-node` DaemonSet pod template to change, triggering an unnecessary rolling update.

On nodes where the gen-1 pod init container (`kubecfg-setup`) is still pulling the ~1.4 GB OVN image when the rolling update begins, the pod becomes a zombie — it has a `deletionTimestamp` but cannot be terminated because the init container is blocked on the CRI-level image pull. The DaemonSet controller sees the zombie pod on that node and refuses to create a gen-2 replacement (because `maxUnavailable: 10%` rounds to 0 for small clusters). This permanently blocks CNI initialization on that node, causing cascading install failure.

## Root Cause

The `OVNKubeConfigHash` is computed by rendering `008-script-lib.yaml` as a Go template and SHA1-hashing the entire JSON-marshaled manifest (including metadata). Some template variables resolve differently between the first and second CNO reconciliation pass during bootstrap, producing different hashes even though the actual ConfigMap `.data` content is the same. The different hash updates the DaemonSet pod template annotation → DaemonSet generation bump → rolling update → zombie pod deadlock.

## Fix

1. **Hash only the `.data` section** of the rendered ConfigMap instead of the full manifest including metadata — eliminates hash instability from metadata differences.
2. **Compare the rendered ConfigMap `.data` with the deployed ConfigMap** in the cluster. If they match, preserve the existing DaemonSet hash annotation rather than writing the newly computed one.

This ensures the DaemonSet annotation only changes when the ConfigMap content has actually been updated, preventing spurious rolling updates during install.

## Impact

- **6 Component Readiness regressions** in 4.22-main (41655, 41656, 41681, 41700, 41701, 41702)
- 100% reproducible across AWS amd64/arm64, both Default and TechPreview FeatureSets
- Sippy Triage: [576](https://sippy-auth.dptools.openshift.org/sippy-ng/component_readiness/triages/576)
- Jira: [OCPBUGS-87818](https://redhat.atlassian.net/browse/OCPBUGS-87818)

---
🤖 *This PR was generated by AI on behalf of @mkowalski, who has reviewed it.*