### PR TITLE
OCPBUGS-88063: Add ovn-k8s-cni-overlay to multus-networkpolicy allowed plugins

### DIFF
--- a/bindata/network/multus-networkpolicy/multus-networkpolicy.yaml
+++ b/bindata/network/multus-networkpolicy/multus-networkpolicy.yaml
@@ -36,7 +36,7 @@ spec:
         args:
         - "--host-prefix=/host"
         - "--container-runtime-endpoint=/run/crio/crio.sock"
-        - "--network-plugins=macvlan,sriov,ipvlan,bond"
+        - "--network-plugins=macvlan,sriov,ipvlan,bond,ovn-k8s-cni-overlay"
         - "--custom-v6-ingress-rule-file=/etc/multi-networkpolicy/rules/custom-v6-rules.txt"
         - "--custom-v6-egress-rule-file=/etc/multi-networkpolicy/rules/custom-v6-rules.txt"
         - "--hostname-override=$(K8S_NODE_NAME)"


### PR DESCRIPTION
## Problem

MultiNetworkPolicy is not enforced on UDN (User Defined Network) secondary interfaces in OCP 5.0.

This is a regression from OCP 4.22 where MultiNetworkPolicy worked natively with UDN.

**Jira:** OCPBUGS-88063

## Root Cause

OCP 5.0 separated MultiNetworkPolicy from ovnkube-controller into a standalone daemonset that validates CNI types against an allowlist.

UDN networks use CNI type `ovn-k8s-cni-overlay` which is missing from the `--network-plugins` list, causing UDN networks to be silently rejected and policies to never be enforced.

## Architectural Change

**OCP 4.22:**
- MultiNetworkPolicy integrated into ovnkube-controller with `--enable-multi-networkpolicy=true`
- Native UDN support without CNI type validation
- No separate multus-networkpolicy daemonset

**OCP 5.0:**
- MultiNetworkPolicy separated into standalone daemonset in openshift-multus namespace
- Validates CNI types against `--network-plugins` allowlist
- Requires `ovn-k8s-cni-overlay` to support UDN networks

## Solution

Add `ovn-k8s-cni-overlay` to the allowed network-plugins list in multus-networkpolicy daemonset configuration.

## Testing

### Test Results - OCP 4.22 (Baseline)
- ✅ **OCP-78259**: UDN Layer3 + Egress ipBlock policy - **PASSED** (6m55s)
  - MultiNetworkPolicy correctly enforced via native ovnkube-controller integration
  - Traffic blocked as expected by policy rules

### Test Results - OCP 5.0 (Before Fix)
- ❌ **OCP-77656**: UDN Layer2 + Ingress ipBlock policy - **FAILED**
- ❌ **OCP-78125**: UDN Layer2 + Egress ipBlock policy - **FAILED**
- ❌ **OCP-78259**: UDN Layer3 + Egress ipBlock policy - **FAILED**
- ❌ **OCP-77657**: UDN Layer3 + Ingress ipBlock policy - **FAILED**

All tests showed traffic allowed when it should be blocked by policy, confirming zero policy enforcement on UDN networks.

**Failure Pattern:**
```
Expected: curl from pod0 to pod2 should FAIL (blocked by policy)
Actual:   curl SUCCESS - "Hello OpenShift!" returned
Result:   Policy created successfully but never enforced
```

### Test Results - OCP 5.0 (After Fix)
Validated on test cluster with this fix applied:
- ✅ **OCP-77656**: UDN Layer2 + Ingress ipBlock policy - **PASSED**
- ✅ **OCP-78125**: UDN Layer2 + Egress ipBlock policy - **PASSED**
- ✅ **OCP-78259**: UDN Layer3 + Egress ipBlock policy - **PASSED**
- ✅ **OCP-77657**: UDN Layer3 + Ingress ipBlock policy - **PASSED**
- ✅ **OCP-75624**: UDN Layer3 basic connectivity - **PASSED**

All tests show proper policy enforcement with traffic blocked as expected.

## Impact

**Severity:** Critical  
**Scope:** All users attempting to use MultiNetworkPolicy on UDN Layer2/Layer3 secondary networks  
**Behavior:** Complete loss of policy enforcement (silent failure - policies appear to be created successfully but have no effect)

**User Impact:**
- Network microsegmentation using MultiNetworkPolicy on UDN networks has zero enforcement
- Security policies intended to block traffic are silently ignored
- No error messages or warnings visible to users

## Files Changed

- `bindata/network/multus-networkpolicy/multus-networkpolicy.yaml` (1 line)

## Related

- **Jira Bug:** OCPBUGS-88063
- **Test Fixes:** openshift/openshift-tests-private#30013
- Follows same pattern as PR #1443 which added `sriov` support

## Verification

After applying this change:

1. The multus-networkpolicy daemonset will accept UDN networks with CNI type `ovn-k8s-cni-overlay`
2. Policies targeting UDN networks will be processed and enforced
3. All five failing tests (77656, 78125, 78259, 77657, 75624) should pass

```bash
# Verify configuration after fix
oc get daemonset multus-networkpolicy -n openshift-multus -o yaml | grep network-plugins
# Expected: --network-plugins=macvlan,sriov,ipvlan,bond,ovn-k8s-cni-overlay
```