### PR TITLE
[release-4.22] OCPBUGS-88307: Remove --enable-interconnect flag from OVN-K manifests

### DIFF
--- a/bindata/network/node-identity/managed/node-identity.yaml
+++ b/bindata/network/node-identity/managed/node-identity.yaml
@@ -135,7 +135,6 @@ spec:
                 --webhook-host="" \
                 --webhook-port={{.NetworkNodeIdentityPort}} \
                 ${ho_enable} \
-                --enable-interconnect \
                 --disable-approver \
                 --extra-allowed-user="system:serviceaccount:openshift-ovn-kubernetes:ovn-kubernetes-control-plane" \
                 --pod-admission-conditions="/var/run/ovnkube-identity-config/additional-pod-admission-cond.json" \

--- a/bindata/network/node-identity/managed/node-identity.yaml
+++ b/bindata/network/node-identity/managed/node-identity.yaml
@@ -126,6 +126,12 @@ spec:
             # OVN-K will try to remove hybrid overlay node annotations even when the hybrid overlay is not enabled.
             # https://github.com/ovn-org/ovn-kubernetes/blob/ac6820df0b338a246f10f412cd5ec903bd234694/go-controller/pkg/ovn/master.go#L791
             ho_enable="--enable-hybrid-overlay"
+            # DROP: remove when older OVN-K images that require --enable-interconnect are no longer supported
+            enable_interconnect_flag=
+            if /usr/bin/ovnkube-identity --help 2>&1 | grep -q -- '--enable-interconnect'; then
+              enable_interconnect_flag="--enable-interconnect"
+            fi
+
             echo "I$(date "+%m%d %H:%M:%S.%N") - network-node-identity - start webhook"
             # extra-allowed-user: service account `ovn-kubernetes-control-plane`
             # sets pod annotations in multi-homing layer3 network controller (cluster-manager)
@@ -135,6 +141,7 @@ spec:
                 --webhook-host="" \
                 --webhook-port={{.NetworkNodeIdentityPort}} \
                 ${ho_enable} \
+                ${enable_interconnect_flag} \
                 --disable-approver \
                 --extra-allowed-user="system:serviceaccount:openshift-ovn-kubernetes:ovn-kubernetes-control-plane" \
                 --pod-admission-conditions="/var/run/ovnkube-identity-config/additional-pod-admission-cond.json" \

--- a/bindata/network/node-identity/self-hosted/node-identity.yaml
+++ b/bindata/network/node-identity/self-hosted/node-identity.yaml
@@ -56,7 +56,6 @@ spec:
                 --webhook-host={{.NetworkNodeIdentityIP}} \
                 --webhook-port={{.NetworkNodeIdentityPort}} \
                 ${ho_enable} \
-                --enable-interconnect \
                 --disable-approver \
                 --extra-allowed-user="system:serviceaccount:openshift-ovn-kubernetes:ovn-kubernetes-control-plane" \
                 --wait-for-kubernetes-api={{.NetworkNodeIdentityTerminationDurationSeconds}}s \

--- a/bindata/network/node-identity/self-hosted/node-identity.yaml
+++ b/bindata/network/node-identity/self-hosted/node-identity.yaml
@@ -48,6 +48,12 @@ spec:
             # OVN-K will try to remove hybrid overlay node annotations even when the hybrid overlay is not enabled.
             # https://github.com/ovn-org/ovn-kubernetes/blob/ac6820df0b338a246f10f412cd5ec903bd234694/go-controller/pkg/ovn/master.go#L791
             ho_enable="--enable-hybrid-overlay"
+            # DROP: remove when older OVN-K images that require --enable-interconnect are no longer supported
+            enable_interconnect_flag=
+            if /usr/bin/ovnkube-identity --help 2>&1 | grep -q -- '--enable-interconnect'; then
+              enable_interconnect_flag="--enable-interconnect"
+            fi
+
             echo "I$(date "+%m%d %H:%M:%S.%N") - network-node-identity - start webhook"
             # extra-allowed-user: service account `ovn-kubernetes-control-plane`
             # sets pod annotations in multi-homing layer3 network controller (cluster-manager)
@@ -56,6 +62,7 @@ spec:
                 --webhook-host={{.NetworkNodeIdentityIP}} \
                 --webhook-port={{.NetworkNodeIdentityPort}} \
                 ${ho_enable} \
+                ${enable_interconnect_flag} \
                 --disable-approver \
                 --extra-allowed-user="system:serviceaccount:openshift-ovn-kubernetes:ovn-kubernetes-control-plane" \
                 --wait-for-kubernetes-api={{.NetworkNodeIdentityTerminationDurationSeconds}}s \

--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -753,6 +753,12 @@ data:
         ovn_v6_transit_switch_subnet_opt="--cluster-manager-v6-transit-subnet {{.V6TransitSwitchSubnet}}"
       fi
 
+      # DROP: remove when older OVN-K images that require --enable-interconnect are no longer supported
+      enable_interconnect_flag=
+      if /usr/bin/ovnkube --help 2>&1 | grep -q -- '--enable-interconnect'; then
+        enable_interconnect_flag="--enable-interconnect"
+      fi
+
       exec /usr/bin/ovnkube \
         ${init_ovnkube_controller} \
         --init-node "${K8S_NODE}" \
@@ -782,6 +788,7 @@ data:
         ${network_observability_enabled_flag} \
         ${enable_multicast_flag} \
         --zone ${K8S_NODE} \
+        ${enable_interconnect_flag} \
         --acl-logging-rate-limit "{{.OVNPolicyAuditRateLimit}}" \
         ${gw_interface_flag} \
         ${ip_forwarding_flag} \

--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -782,7 +782,6 @@ data:
         ${network_observability_enabled_flag} \
         ${enable_multicast_flag} \
         --zone ${K8S_NODE} \
-        --enable-interconnect \
         --acl-logging-rate-limit "{{.OVNPolicyAuditRateLimit}}" \
         ${gw_interface_flag} \
         ${ip_forwarding_flag} \

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
@@ -222,8 +222,15 @@ spec:
             network_connect_enabled_flag="--enable-network-connect"
           fi
 
+          # DROP: remove when older OVN-K images that require --enable-interconnect are no longer supported
+          enable_interconnect_flag=
+          if /usr/bin/ovnkube --help 2>&1 | grep -q -- '--enable-interconnect'; then
+            enable_interconnect_flag="--enable-interconnect"
+          fi
+
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-control-plane - start ovnkube --init-cluster-manager ${K8S_NODE}"
           exec /usr/bin/ovnkube \
+            ${enable_interconnect_flag} \
             --init-cluster-manager "${K8S_NODE}" \
             --config-file=/run/ovnkube-config/ovnkube.conf \
             --k8s-token-file=/var/run/secrets/hosted_cluster/token \

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
@@ -224,7 +224,6 @@ spec:
 
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-control-plane - start ovnkube --init-cluster-manager ${K8S_NODE}"
           exec /usr/bin/ovnkube \
-            --enable-interconnect \
             --init-cluster-manager "${K8S_NODE}" \
             --config-file=/run/ovnkube-config/ovnkube.conf \
             --k8s-token-file=/var/run/secrets/hosted_cluster/token \

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
@@ -178,8 +178,15 @@ spec:
             exit 1
           fi
 
+          # DROP: remove when older OVN-K images that require --enable-interconnect are no longer supported
+          enable_interconnect_flag=
+          if /usr/bin/ovnkube --help 2>&1 | grep -q -- '--enable-interconnect'; then
+            enable_interconnect_flag="--enable-interconnect"
+          fi
+
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-control-plane - start ovnkube --init-cluster-manager ${K8S_NODE}"
           exec /usr/bin/ovnkube \
+            ${enable_interconnect_flag} \
             --init-cluster-manager "${K8S_NODE}" \
             --config-file=/run/ovnkube-config/ovnkube.conf \
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
@@ -180,7 +180,6 @@ spec:
 
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-control-plane - start ovnkube --init-cluster-manager ${K8S_NODE}"
           exec /usr/bin/ovnkube \
-            --enable-interconnect \
             --init-cluster-manager "${K8S_NODE}" \
             --config-file=/run/ovnkube-config/ovnkube.conf \
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -6,15 +6,12 @@ import (
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 )
 
-const OVN_INTERCONNECT_CONFIGMAP_NAME = "ovn-interconnect-configuration"
 const OVN_NAMESPACE = "openshift-ovn-kubernetes"
 const OVN_CONTROL_PLANE = "ovnkube-control-plane"
 const OVN_NODE = "ovnkube-node"
@@ -22,10 +19,6 @@ const OVN_CONTROLLER = "ovnkube-controller"
 const MTU_CM_NAMESPACE = "openshift-network-operator"
 const MTU_CM_NAME = "mtu"
 const OVN_NBDB = "nbdb"
-
-func GetInterConnectConfigMap(kubeClient kubernetes.Interface) (*corev1.ConfigMap, error) {
-	return kubeClient.CoreV1().ConfigMaps(OVN_NAMESPACE).Get(context.TODO(), OVN_INTERCONNECT_CONFIGMAP_NAME, metav1.GetOptions{})
-}
 
 func ReadMTUConfigMap(ctx context.Context, client cnoclient.Client) (int, error) {
 	klog.V(4).Infof("Looking for ConfigMap %s/%s", MTU_CM_NAMESPACE, MTU_CM_NAME)


### PR DESCRIPTION
Manual cherry-pick of #3008 

Resolved conflicts in:
- bindata/network/ovn-kubernetes/common/008-script-lib.yaml
- bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
- bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml