### PR TITLE
OCPBUGS-98548: Bump github.com/containernetworking/cni v0.8.0 -> v1.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.4
 require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/Masterminds/sprig/v3 v3.2.3
-	github.com/containernetworking/cni v0.8.0
+	github.com/containernetworking/cni v1.3.0
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/onsi/gomega v1.38.1
@@ -18,7 +18,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	github.com/vishvananda/netlink v1.1.0
-	github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae // indirect
+	github.com/vishvananda/netns v0.0.4 // indirect
 	golang.org/x/net v0.46.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.34.1

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38
 github.com/clarketm/json v1.17.1 h1:U1IxjqJkJ7bRK4L6dyphmoO840P6bdhPdbbLySourqI=
 github.com/clarketm/json v1.17.1/go.mod h1:ynr2LRfb0fQU34l07csRNBTcivjySLLiY1YzQqKVfdo=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/containernetworking/cni v0.8.0 h1:BT9lpgGoH4jw3lFC7Odz2prU5ruiYKcgAjMCbgybcKI=
-github.com/containernetworking/cni v0.8.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
+github.com/containernetworking/cni v1.3.0 h1:v6EpN8RznAZj9765HhXQrtXgX+ECGebEYEmnuFjskwo=
+github.com/containernetworking/cni v1.3.0/go.mod h1:Bs8glZjjFfGPHMw6hQu82RUgEPNGEaBb9KS5KtNMnJ4=
 github.com/containers/image/v5 v5.34.1 h1:/m2bkFnuedTyNkzma8s7cFLjeefPIb4trjyafWhIlwM=
 github.com/containers/image/v5 v5.34.1/go.mod h1:/WnvUSEfdqC/ahMRd4YJDBLrpYWkGl018rB77iB3FDo=
 github.com/containers/storage v1.57.1 h1:hKPoFsuBcB3qTzBxa4IFpZMRzUuL5Xhv/BE44W0XHx8=
@@ -385,8 +385,8 @@ github.com/vincent-petithory/dataurl v1.0.0/go.mod h1:FHafX5vmDzyP+1CQATJn7WFKc9
 github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
-github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae h1:4hwBBUfQCFe3Cym0ZtKyq7L16eZUtYKs+BaHDN6mAns=
-github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
+github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
+github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/vmware/vmw-ovflib v0.0.0-20170608004843-1f217b9dc714/go.mod h1:jiPk45kn7klhByRvUq5i2vo1RtHKBHj+iWGFpxbXuuI=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
@@ -544,7 +544,6 @@ golang.org/x/sys v0.0.0-20191110163157-d32e6e3b99c4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/vendor/github.com/containernetworking/cni/pkg/types/args.go
+++ b/vendor/github.com/containernetworking/cni/pkg/types/args.go
@@ -26,8 +26,8 @@ import (
 type UnmarshallableBool bool
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
-// Returns boolean true if the string is "1" or "[Tt]rue"
-// Returns boolean false if the string is "0" or "[Ff]alse"
+// Returns boolean true if the string is "1" or "true" or "True"
+// Returns boolean false if the string is "0" or "false" or "False”
 func (b *UnmarshallableBool) UnmarshalText(data []byte) error {
 	s := strings.ToLower(string(data))
 	switch s {
@@ -91,16 +91,26 @@ func LoadArgs(args string, container interface{}) error {
 			unknownArgs = append(unknownArgs, pair)
 			continue
 		}
-		keyFieldIface := keyField.Addr().Interface()
-		u, ok := keyFieldIface.(encoding.TextUnmarshaler)
+
+		var keyFieldInterface interface{}
+		switch {
+		case keyField.Kind() == reflect.Ptr:
+			keyField.Set(reflect.New(keyField.Type().Elem()))
+			keyFieldInterface = keyField.Interface()
+		case keyField.CanAddr() && keyField.Addr().CanInterface():
+			keyFieldInterface = keyField.Addr().Interface()
+		default:
+			return UnmarshalableArgsError{fmt.Errorf("field '%s' has no valid interface", keyString)}
+		}
+		u, ok := keyFieldInterface.(encoding.TextUnmarshaler)
 		if !ok {
 			return UnmarshalableArgsError{fmt.Errorf(
 				"ARGS: cannot unmarshal into field '%s' - type '%s' does not implement encoding.TextUnmarshaler",
-				keyString, reflect.TypeOf(keyFieldIface))}
+				keyString, reflect.TypeOf(keyFieldInterface))}
 		}
 		err := u.UnmarshalText([]byte(valueString))
 		if err != nil {
-			return fmt.Errorf("ARGS: error parsing value of pair %q: %v)", pair, err)
+			return fmt.Errorf("ARGS: error parsing value of pair %q: %w", pair, err)
 		}
 	}
 

--- a/vendor/github.com/containernetworking/cni/pkg/types/types.go
+++ b/vendor/github.com/containernetworking/cni/pkg/types/types.go
@@ -56,34 +56,73 @@ func (n *IPNet) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// NetConf describes a network.
-type NetConf struct {
+// Use PluginConf instead of NetConf, the NetConf
+// backwards-compat alias will be removed in a future release.
+type NetConf = PluginConf
+
+// PluginConf describes a plugin configuration for a specific network.
+type PluginConf struct {
 	CNIVersion string `json:"cniVersion,omitempty"`
 
 	Name         string          `json:"name,omitempty"`
 	Type         string          `json:"type,omitempty"`
 	Capabilities map[string]bool `json:"capabilities,omitempty"`
 	IPAM         IPAM            `json:"ipam,omitempty"`
-	DNS          DNS             `json:"dns"`
+	DNS          DNS             `json:"dns,omitempty"`
 
 	RawPrevResult map[string]interface{} `json:"prevResult,omitempty"`
 	PrevResult    Result                 `json:"-"`
+
+	// ValidAttachments is only supplied when executing a GC operation
+	ValidAttachments []GCAttachment `json:"cni.dev/valid-attachments,omitempty"`
+}
+
+// GCAttachment is the parameters to a GC call -- namely,
+// the container ID and ifname pair that represents a
+// still-valid attachment.
+type GCAttachment struct {
+	ContainerID string `json:"containerID"`
+	IfName      string `json:"ifname"`
+}
+
+// Note: DNS should be omit if DNS is empty but default Marshal function
+// will output empty structure hence need to write a Marshal function
+func (n *PluginConf) MarshalJSON() ([]byte, error) {
+	bytes, err := json.Marshal(*n)
+	if err != nil {
+		return nil, err
+	}
+
+	fixupObj := make(map[string]interface{})
+	if err := json.Unmarshal(bytes, &fixupObj); err != nil {
+		return nil, err
+	}
+
+	if n.DNS.IsEmpty() {
+		delete(fixupObj, "dns")
+	}
+
+	return json.Marshal(fixupObj)
 }
 
 type IPAM struct {
 	Type string `json:"type,omitempty"`
 }
 
+// IsEmpty returns true if IPAM structure has no value, otherwise return false
+func (i *IPAM) IsEmpty() bool {
+	return i.Type == ""
+}
+
 // NetConfList describes an ordered list of networks.
 type NetConfList struct {
 	CNIVersion string `json:"cniVersion,omitempty"`
 
-	Name         string     `json:"name,omitempty"`
-	DisableCheck bool       `json:"disableCheck,omitempty"`
-	Plugins      []*NetConf `json:"plugins,omitempty"`
+	Name         string        `json:"name,omitempty"`
+	DisableCheck bool          `json:"disableCheck,omitempty"`
+	DisableGC    bool          `json:"disableGC,omitempty"`
+	Plugins      []*PluginConf `json:"plugins,omitempty"`
 }
-
-type ResultFactoryFunc func([]byte) (Result, error)
 
 // Result is an interface that provides the result of plugin execution
 type Result interface {
@@ -118,17 +157,79 @@ type DNS struct {
 	Options     []string `json:"options,omitempty"`
 }
 
+// IsEmpty returns true if DNS structure has no value, otherwise return false
+func (d *DNS) IsEmpty() bool {
+	if len(d.Nameservers) == 0 && d.Domain == "" && len(d.Search) == 0 && len(d.Options) == 0 {
+		return true
+	}
+	return false
+}
+
+func (d *DNS) Copy() *DNS {
+	if d == nil {
+		return nil
+	}
+
+	to := &DNS{Domain: d.Domain}
+	to.Nameservers = append(to.Nameservers, d.Nameservers...)
+	to.Search = append(to.Search, d.Search...)
+	to.Options = append(to.Options, d.Options...)
+	return to
+}
+
 type Route struct {
-	Dst net.IPNet
-	GW  net.IP
+	Dst      net.IPNet
+	GW       net.IP
+	MTU      int
+	AdvMSS   int
+	Priority int
+	Table    *int
+	Scope    *int
 }
 
 func (r *Route) String() string {
-	return fmt.Sprintf("%+v", *r)
+	table := "<nil>"
+	if r.Table != nil {
+		table = fmt.Sprintf("%d", *r.Table)
+	}
+
+	scope := "<nil>"
+	if r.Scope != nil {
+		scope = fmt.Sprintf("%d", *r.Scope)
+	}
+
+	return fmt.Sprintf("{Dst:%+v GW:%v MTU:%d AdvMSS:%d Priority:%d Table:%s Scope:%s}", r.Dst, r.GW, r.MTU, r.AdvMSS, r.Priority, table, scope)
+}
+
+func (r *Route) Copy() *Route {
+	if r == nil {
+		return nil
+	}
+
+	route := &Route{
+		Dst:      r.Dst,
+		GW:       r.GW,
+		MTU:      r.MTU,
+		AdvMSS:   r.AdvMSS,
+		Priority: r.Priority,
+		Scope:    r.Scope,
+	}
+
+	if r.Table != nil {
+		table := *r.Table
+		route.Table = &table
+	}
+
+	if r.Scope != nil {
+		scope := *r.Scope
+		route.Scope = &scope
+	}
+
+	return route
 }
 
 // Well known error codes
-// see https://github.com/containernetworking/cni/blob/master/SPEC.md#well-known-error-codes
+// see https://github.com/containernetworking/cni/blob/main/SPEC.md#well-known-error-codes
 const (
 	ErrUnknown                     uint = iota // 0
 	ErrIncompatibleCNIVersion                  // 1
@@ -138,6 +239,7 @@ const (
 	ErrIOFailure                               // 5
 	ErrDecodingFailure                         // 6
 	ErrInvalidNetworkConfig                    // 7
+	ErrInvalidNetNS                            // 8
 	ErrTryAgainLater               uint = 11
 	ErrInternal                    uint = 999
 )
@@ -173,8 +275,13 @@ func (e *Error) Print() error {
 
 // JSON (un)marshallable types
 type route struct {
-	Dst IPNet  `json:"dst"`
-	GW  net.IP `json:"gw,omitempty"`
+	Dst      IPNet  `json:"dst"`
+	GW       net.IP `json:"gw,omitempty"`
+	MTU      int    `json:"mtu,omitempty"`
+	AdvMSS   int    `json:"advmss,omitempty"`
+	Priority int    `json:"priority,omitempty"`
+	Table    *int   `json:"table,omitempty"`
+	Scope    *int   `json:"scope,omitempty"`
 }
 
 func (r *Route) UnmarshalJSON(data []byte) error {
@@ -185,13 +292,24 @@ func (r *Route) UnmarshalJSON(data []byte) error {
 
 	r.Dst = net.IPNet(rt.Dst)
 	r.GW = rt.GW
+	r.MTU = rt.MTU
+	r.AdvMSS = rt.AdvMSS
+	r.Priority = rt.Priority
+	r.Table = rt.Table
+	r.Scope = rt.Scope
+
 	return nil
 }
 
 func (r Route) MarshalJSON() ([]byte, error) {
 	rt := route{
-		Dst: IPNet(r.Dst),
-		GW:  r.GW,
+		Dst:      IPNet(r.Dst),
+		GW:       r.GW,
+		MTU:      r.MTU,
+		AdvMSS:   r.AdvMSS,
+		Priority: r.Priority,
+		Table:    r.Table,
+		Scope:    r.Scope,
 	}
 
 	return json.Marshal(rt)

--- a/vendor/github.com/vishvananda/netns/.golangci.yml
+++ b/vendor/github.com/vishvananda/netns/.golangci.yml
@@ -1,0 +1,2 @@
+run:
+  timeout: 5m

--- a/vendor/github.com/vishvananda/netns/README.md
+++ b/vendor/github.com/vishvananda/netns/README.md
@@ -23,6 +23,7 @@ import (
     "fmt"
     "net"
     "runtime"
+
     "github.com/vishvananda/netns"
 )
 

--- a/vendor/github.com/vishvananda/netns/doc.go
+++ b/vendor/github.com/vishvananda/netns/doc.go
@@ -1,0 +1,9 @@
+// Package netns allows ultra-simple network namespace handling. NsHandles
+// can be retrieved and set. Note that the current namespace is thread
+// local so actions that set and reset namespaces should use LockOSThread
+// to make sure the namespace doesn't change due to a goroutine switch.
+// It is best to close NsHandles when you are done with them. This can be
+// accomplished via a `defer ns.Close()` on the handle. Changing namespaces
+// requires elevated privileges, so in most cases this code needs to be run
+// as root.
+package netns

--- a/vendor/github.com/vishvananda/netns/netns_linux.go
+++ b/vendor/github.com/vishvananda/netns/netns_linux.go
@@ -1,33 +1,31 @@
-// +build linux
-
 package netns
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"golang.org/x/sys/unix"
 )
 
-// Deprecated: use syscall pkg instead (go >= 1.5 needed).
+// Deprecated: use golang.org/x/sys/unix pkg instead.
 const (
-	CLONE_NEWUTS  = 0x04000000   /* New utsname group? */
-	CLONE_NEWIPC  = 0x08000000   /* New ipcs */
-	CLONE_NEWUSER = 0x10000000   /* New user namespace */
-	CLONE_NEWPID  = 0x20000000   /* New pid namespace */
-	CLONE_NEWNET  = 0x40000000   /* New network namespace */
-	CLONE_IO      = 0x80000000   /* Get io context */
-	bindMountPath = "/run/netns" /* Bind mount path for named netns */
+	CLONE_NEWUTS  = unix.CLONE_NEWUTS  /* New utsname group? */
+	CLONE_NEWIPC  = unix.CLONE_NEWIPC  /* New ipcs */
+	CLONE_NEWUSER = unix.CLONE_NEWUSER /* New user namespace */
+	CLONE_NEWPID  = unix.CLONE_NEWPID  /* New pid namespace */
+	CLONE_NEWNET  = unix.CLONE_NEWNET  /* New network namespace */
+	CLONE_IO      = unix.CLONE_IO      /* Get io context */
 )
 
-// Setns sets namespace using syscall. Note that this should be a method
-// in syscall but it has not been added.
+const bindMountPath = "/run/netns" /* Bind mount path for named netns */
+
+// Setns sets namespace using golang.org/x/sys/unix.Setns.
+//
+// Deprecated: Use golang.org/x/sys/unix.Setns instead.
 func Setns(ns NsHandle, nstype int) (err error) {
 	return unix.Setns(int(ns), nstype)
 }
@@ -35,19 +33,20 @@ func Setns(ns NsHandle, nstype int) (err error) {
 // Set sets the current network namespace to the namespace represented
 // by NsHandle.
 func Set(ns NsHandle) (err error) {
-	return Setns(ns, CLONE_NEWNET)
+	return unix.Setns(int(ns), unix.CLONE_NEWNET)
 }
 
 // New creates a new network namespace, sets it as current and returns
 // a handle to it.
 func New() (ns NsHandle, err error) {
-	if err := unix.Unshare(CLONE_NEWNET); err != nil {
+	if err := unix.Unshare(unix.CLONE_NEWNET); err != nil {
 		return -1, err
 	}
 	return Get()
 }
 
-// NewNamed creates a new named network namespace and returns a handle to it
+// NewNamed creates a new named network namespace, sets it as current,
+// and returns a handle to it
 func NewNamed(name string) (NsHandle, error) {
 	if _, err := os.Stat(bindMountPath); os.IsNotExist(err) {
 		err = os.MkdirAll(bindMountPath, 0755)
@@ -65,13 +64,15 @@ func NewNamed(name string) (NsHandle, error) {
 
 	f, err := os.OpenFile(namedPath, os.O_CREATE|os.O_EXCL, 0444)
 	if err != nil {
+		newNs.Close()
 		return None(), err
 	}
 	f.Close()
 
-	nsPath := fmt.Sprintf("/proc/%d/task/%d/ns/net", os.Getpid(), syscall.Gettid())
-	err = syscall.Mount(nsPath, namedPath, "bind", syscall.MS_BIND, "")
+	nsPath := fmt.Sprintf("/proc/%d/task/%d/ns/net", os.Getpid(), unix.Gettid())
+	err = unix.Mount(nsPath, namedPath, "bind", unix.MS_BIND, "")
 	if err != nil {
+		newNs.Close()
 		return None(), err
 	}
 
@@ -82,7 +83,7 @@ func NewNamed(name string) (NsHandle, error) {
 func DeleteNamed(name string) error {
 	namedPath := path.Join(bindMountPath, name)
 
-	err := syscall.Unmount(namedPath, syscall.MNT_DETACH)
+	err := unix.Unmount(namedPath, unix.MNT_DETACH)
 	if err != nil {
 		return err
 	}
@@ -108,7 +109,7 @@ func GetFromPath(path string) (NsHandle, error) {
 // GetFromName gets a handle to a named network namespace such as one
 // created by `ip netns add`.
 func GetFromName(name string) (NsHandle, error) {
-	return GetFromPath(fmt.Sprintf("/var/run/netns/%s", name))
+	return GetFromPath(filepath.Join(bindMountPath, name))
 }
 
 // GetFromPid gets a handle to the network namespace of a given pid.
@@ -133,33 +134,38 @@ func GetFromDocker(id string) (NsHandle, error) {
 }
 
 // borrowed from docker/utils/utils.go
-func findCgroupMountpoint(cgroupType string) (string, error) {
-	output, err := ioutil.ReadFile("/proc/mounts")
+func findCgroupMountpoint(cgroupType string) (int, string, error) {
+	output, err := os.ReadFile("/proc/mounts")
 	if err != nil {
-		return "", err
+		return -1, "", err
 	}
 
 	// /proc/mounts has 6 fields per line, one mount per line, e.g.
 	// cgroup /sys/fs/cgroup/devices cgroup rw,relatime,devices 0 0
 	for _, line := range strings.Split(string(output), "\n") {
 		parts := strings.Split(line, " ")
-		if len(parts) == 6 && parts[2] == "cgroup" {
-			for _, opt := range strings.Split(parts[3], ",") {
-				if opt == cgroupType {
-					return parts[1], nil
+		if len(parts) == 6 {
+			switch parts[2] {
+			case "cgroup2":
+				return 2, parts[1], nil
+			case "cgroup":
+				for _, opt := range strings.Split(parts[3], ",") {
+					if opt == cgroupType {
+						return 1, parts[1], nil
+					}
 				}
 			}
 		}
 	}
 
-	return "", fmt.Errorf("cgroup mountpoint not found for %s", cgroupType)
+	return -1, "", fmt.Errorf("cgroup mountpoint not found for %s", cgroupType)
 }
 
 // Returns the relative path to the cgroup docker is running in.
 // borrowed from docker/utils/utils.go
 // modified to get the docker pid instead of using /proc/self
-func getThisCgroup(cgroupType string) (string, error) {
-	dockerpid, err := ioutil.ReadFile("/var/run/docker.pid")
+func getDockerCgroup(cgroupVer int, cgroupType string) (string, error) {
+	dockerpid, err := os.ReadFile("/var/run/docker.pid")
 	if err != nil {
 		return "", err
 	}
@@ -171,14 +177,15 @@ func getThisCgroup(cgroupType string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	output, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
+	output, err := os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
 	if err != nil {
 		return "", err
 	}
 	for _, line := range strings.Split(string(output), "\n") {
 		parts := strings.Split(line, ":")
 		// any type used by docker should work
-		if parts[1] == cgroupType {
+		if (cgroupVer == 1 && parts[1] == cgroupType) ||
+			(cgroupVer == 2 && parts[1] == "") {
 			return parts[2], nil
 		}
 	}
@@ -190,40 +197,56 @@ func getThisCgroup(cgroupType string) (string, error) {
 // modified to only return the first pid
 // modified to glob with id
 // modified to search for newer docker containers
+// modified to look for cgroups v2
 func getPidForContainer(id string) (int, error) {
 	pid := 0
 
 	// memory is chosen randomly, any cgroup used by docker works
 	cgroupType := "memory"
 
-	cgroupRoot, err := findCgroupMountpoint(cgroupType)
+	cgroupVer, cgroupRoot, err := findCgroupMountpoint(cgroupType)
 	if err != nil {
 		return pid, err
 	}
 
-	cgroupThis, err := getThisCgroup(cgroupType)
+	cgroupDocker, err := getDockerCgroup(cgroupVer, cgroupType)
 	if err != nil {
 		return pid, err
 	}
 
 	id += "*"
 
+	var pidFile string
+	if cgroupVer == 1 {
+		pidFile = "tasks"
+	} else if cgroupVer == 2 {
+		pidFile = "cgroup.procs"
+	} else {
+		return -1, fmt.Errorf("Invalid cgroup version '%d'", cgroupVer)
+	}
+
 	attempts := []string{
-		filepath.Join(cgroupRoot, cgroupThis, id, "tasks"),
+		filepath.Join(cgroupRoot, cgroupDocker, id, pidFile),
 		// With more recent lxc versions use, cgroup will be in lxc/
-		filepath.Join(cgroupRoot, cgroupThis, "lxc", id, "tasks"),
+		filepath.Join(cgroupRoot, cgroupDocker, "lxc", id, pidFile),
 		// With more recent docker, cgroup will be in docker/
-		filepath.Join(cgroupRoot, cgroupThis, "docker", id, "tasks"),
+		filepath.Join(cgroupRoot, cgroupDocker, "docker", id, pidFile),
 		// Even more recent docker versions under systemd use docker-<id>.scope/
-		filepath.Join(cgroupRoot, "system.slice", "docker-"+id+".scope", "tasks"),
+		filepath.Join(cgroupRoot, "system.slice", "docker-"+id+".scope", pidFile),
 		// Even more recent docker versions under cgroup/systemd/docker/<id>/
-		filepath.Join(cgroupRoot, "..", "systemd", "docker", id, "tasks"),
-		// Kubernetes with docker and CNI is even more different
-		filepath.Join(cgroupRoot, "..", "systemd", "kubepods", "*", "pod*", id, "tasks"),
-		// Another flavor of containers location in recent kubernetes 1.11+
-		filepath.Join(cgroupRoot, cgroupThis, "kubepods.slice", "kubepods-besteffort.slice", "*", "docker-"+id+".scope", "tasks"),
-		// When runs inside of a container with recent kubernetes 1.11+
-		filepath.Join(cgroupRoot, "kubepods.slice", "kubepods-besteffort.slice", "*", "docker-"+id+".scope", "tasks"),
+		filepath.Join(cgroupRoot, "..", "systemd", "docker", id, pidFile),
+		// Kubernetes with docker and CNI is even more different. Works for BestEffort and Burstable QoS
+		filepath.Join(cgroupRoot, "..", "systemd", "kubepods", "*", "pod*", id, pidFile),
+		// Same as above but for Guaranteed QoS
+		filepath.Join(cgroupRoot, "..", "systemd", "kubepods", "pod*", id, pidFile),
+		// Another flavor of containers location in recent kubernetes 1.11+. Works for BestEffort and Burstable QoS
+		filepath.Join(cgroupRoot, cgroupDocker, "kubepods.slice", "*.slice", "*", "docker-"+id+".scope", pidFile),
+		// Same as above but for Guaranteed QoS
+		filepath.Join(cgroupRoot, cgroupDocker, "kubepods.slice", "*", "docker-"+id+".scope", pidFile),
+		// When runs inside of a container with recent kubernetes 1.11+. Works for BestEffort and Burstable QoS
+		filepath.Join(cgroupRoot, "kubepods.slice", "*.slice", "*", "docker-"+id+".scope", pidFile),
+		// Same as above but for Guaranteed QoS
+		filepath.Join(cgroupRoot, "kubepods.slice", "*", "docker-"+id+".scope", pidFile),
 	}
 
 	var filename string
@@ -241,7 +264,7 @@ func getPidForContainer(id string) (int, error) {
 		return pid, fmt.Errorf("Unable to find container: %v", id[:len(id)-1])
 	}
 
-	output, err := ioutil.ReadFile(filename)
+	output, err := os.ReadFile(filename)
 	if err != nil {
 		return pid, err
 	}

--- a/vendor/github.com/vishvananda/netns/netns_others.go
+++ b/vendor/github.com/vishvananda/netns/netns_others.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package netns
@@ -10,12 +11,28 @@ var (
 	ErrNotImplemented = errors.New("not implemented")
 )
 
+// Setns sets namespace using golang.org/x/sys/unix.Setns on Linux. It
+// is not implemented on other platforms.
+//
+// Deprecated: Use golang.org/x/sys/unix.Setns instead.
+func Setns(ns NsHandle, nstype int) (err error) {
+	return ErrNotImplemented
+}
+
 func Set(ns NsHandle) (err error) {
 	return ErrNotImplemented
 }
 
 func New() (ns NsHandle, err error) {
 	return -1, ErrNotImplemented
+}
+
+func NewNamed(name string) (NsHandle, error) {
+	return -1, ErrNotImplemented
+}
+
+func DeleteNamed(name string) error {
+	return ErrNotImplemented
 }
 
 func Get() (NsHandle, error) {

--- a/vendor/github.com/vishvananda/netns/nshandle_linux.go
+++ b/vendor/github.com/vishvananda/netns/nshandle_linux.go
@@ -1,11 +1,3 @@
-// Package netns allows ultra-simple network namespace handling. NsHandles
-// can be retrieved and set. Note that the current namespace is thread
-// local so actions that set and reset namespaces should use LockOSThread
-// to make sure the namespace doesn't change due to a goroutine switch.
-// It is best to close NsHandles when you are done with them. This can be
-// accomplished via a `defer ns.Close()` on the handle. Changing namespaces
-// requires elevated privileges, so in most cases this code needs to be run
-// as root.
 package netns
 
 import (
@@ -38,7 +30,7 @@ func (ns NsHandle) Equal(other NsHandle) bool {
 // String shows the file descriptor number and its dev and inode.
 func (ns NsHandle) String() string {
 	if ns == -1 {
-		return "NS(None)"
+		return "NS(none)"
 	}
 	var s unix.Stat_t
 	if err := unix.Fstat(int(ns), &s); err != nil {
@@ -71,7 +63,7 @@ func (ns *NsHandle) Close() error {
 	if err := unix.Close(int(*ns)); err != nil {
 		return err
 	}
-	(*ns) = -1
+	*ns = -1
 	return nil
 }
 

--- a/vendor/github.com/vishvananda/netns/nshandle_others.go
+++ b/vendor/github.com/vishvananda/netns/nshandle_others.go
@@ -1,0 +1,45 @@
+//go:build !linux
+// +build !linux
+
+package netns
+
+// NsHandle is a handle to a network namespace. It can only be used on Linux,
+// but provides stub methods on other platforms.
+type NsHandle int
+
+// Equal determines if two network handles refer to the same network
+// namespace. It is only implemented on Linux.
+func (ns NsHandle) Equal(_ NsHandle) bool {
+	return false
+}
+
+// String shows the file descriptor number and its dev and inode.
+// It is only implemented on Linux, and returns "NS(none)" on other
+// platforms.
+func (ns NsHandle) String() string {
+	return "NS(none)"
+}
+
+// UniqueId returns a string which uniquely identifies the namespace
+// associated with the network handle. It is only implemented on Linux,
+// and returns "NS(none)" on other platforms.
+func (ns NsHandle) UniqueId() string {
+	return "NS(none)"
+}
+
+// IsOpen returns true if Close() has not been called. It is only implemented
+// on Linux and always returns false on other platforms.
+func (ns NsHandle) IsOpen() bool {
+	return false
+}
+
+// Close closes the NsHandle and resets its file descriptor to -1.
+// It is only implemented on Linux.
+func (ns *NsHandle) Close() error {
+	return nil
+}
+
+// None gets an empty (closed) NsHandle.
+func None() NsHandle {
+	return NsHandle(-1)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -40,8 +40,8 @@ github.com/cespare/xxhash/v2
 # github.com/clarketm/json v1.17.1
 ## explicit
 github.com/clarketm/json
-# github.com/containernetworking/cni v0.8.0
-## explicit
+# github.com/containernetworking/cni v1.3.0
+## explicit; go 1.21
 github.com/containernetworking/cni/pkg/types
 # github.com/coreos/fcct v0.5.0
 ## explicit; go 1.12
@@ -627,8 +627,8 @@ github.com/vincent-petithory/dataurl
 ## explicit; go 1.12
 github.com/vishvananda/netlink
 github.com/vishvananda/netlink/nl
-# github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae
-## explicit; go 1.12
+# github.com/vishvananda/netns v0.0.4
+## explicit; go 1.17
 github.com/vishvananda/netns
 # github.com/x448/float16 v0.8.4
 ## explicit; go 1.11


### PR DESCRIPTION
Bump github.com/containernetworking/cni to v1.3.0 to address CVE-2021-20206.

Fixes GHSA-xjqr-g762-pxwp (path traversal in CNI plugin FindInPath). CNO only uses cnitypes.Route and cnitypes.DNS from pkg/types and never calls the vulnerable functions, but the module is compiled into the binary and scanners correctly flag it.

v1.3.0 is the version standardized across the OpenShift networking ecosystem (multus-cni, sriov-cni, ovn-kubernetes, etc.).

Backport of https://github.com/openshift/cluster-network-operator/pull/3031


go mod tidy
go mod vendor

make build
<pre>
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
go build -mod=vendor -trimpath -ldflags "-X github.com/openshift/cluster-network-operator/pkg/version.versionFromGit="v0.0.0-unknown-b5955e9ed" -X github.com/openshift/cluster-network-operator/pkg/version.commitFromGit="b5955e9ed" -X github.com/openshift/cluster-network-operator/pkg/version.gitTreeState="dirty" -X github.com/openshift/cluster-network-operator/pkg/version.buildDate="2026-07-13T13:51:48Z" " github.com/openshift/cluster-network-operator/cmd/cluster-network-check-endpoints
go build -mod=vendor -trimpath -ldflags "-X github.com/openshift/cluster-network-operator/pkg/version.versionFromGit="v0.0.0-unknown-b5955e9ed" -X github.com/openshift/cluster-network-operator/pkg/version.commitFromGit="b5955e9ed" -X github.com/openshift/cluster-network-operator/pkg/version.gitTreeState="dirty" -X github.com/openshift/cluster-network-operator/pkg/version.buildDate="2026-07-13T13:51:48Z" " github.com/openshift/cluster-network-operator/cmd/cluster-network-check-target
go build -mod=vendor -trimpath -ldflags "-X github.com/openshift/cluster-network-operator/pkg/version.versionFromGit="v0.0.0-unknown-b5955e9ed" -X github.com/openshift/cluster-network-operator/pkg/version.commitFromGit="b5955e9ed" -X github.com/openshift/cluster-network-operator/pkg/version.gitTreeState="dirty" -X github.com/openshift/cluster-network-operator/pkg/version.buildDate="2026-07-13T13:51:48Z" " github.com/openshift/cluster-network-operator/cmd/cluster-network-operator
</pre>

 make test
</pre>
go test -mod=vendor -race ./pkg/... ./cmd/... 
?   	github.com/openshift/cluster-network-operator/pkg/apis/network/v1	[no test files]
ok  	github.com/openshift/cluster-network-operator/pkg/apply	1.878s
?   	github.com/openshift/cluster-network-operator/pkg/bootstrap	[no test files]
?   	github.com/openshift/cluster-network-operator/pkg/client	[no test files]
?   	github.com/openshift/cluster-network-operator/pkg/client/fake	[no test files]
?   	github.com/openshift/cluster-network-operator/pkg/cmd/checkendpoints	[no test files]
ok  	github.com/openshift/cluster-network-operator/pkg/cmd/checkendpoints/controller	1.297s
ok  	github.com/openshift/cluster-network-operator/pkg/cmd/checkendpoints/operatorcontrolplane/podnetworkconnectivitycheck/v1alpha1helpers	1.023s
?   	github.com/openshift/cluster-network-operator/pkg/cmd/checkendpoints/trace	[no test files]
?   	github.com/openshift/cluster-network-operator/pkg/controller	[no test files]
?   	github.com/openshift/cluster-network-operator/pkg/controller/allowlist	[no test files]
ok  	github.com/openshift/cluster-network-operator/pkg/controller/clusterconfig	1.851s
?   	github.com/openshift/cluster-network-operator/pkg/controller/configmap_ca_injector	[no test files]
?   	github.com/openshift/cluster-network-operator/pkg/controller/connectivitycheck	[no test files]
?   	github.com/openshift/cluster-network-operator/pkg/controller/dashboards	[no test files]
?   	github.com/openshift/cluster-network-operator/pkg/controller/egress_router	[no test files]
?   	github.com/openshift/cluster-network-operator/pkg/controller/eventrecorder	[no test files]
ok  	github.com/openshift/cluster-network-operator/pkg/controller/infrastructureconfig	1.120s
ok  	github.com/openshift/cluster-network-operator/pkg/controller/ingressconfig	1.787s
ok  	github.com/openshift/cluster-network-operator/pkg/controller/operconfig	2.084s
?   	github.com/openshift/cluster-network-operator/pkg/controller/pki	[no test files]
?   	github.com/openshift/cluster-network-operator/pkg/controller/proxyconfig	[no test files]
ok  	github.com/openshift/cluster-network-operator/pkg/controller/signer	2.291s
ok  	github.com/openshift/cluster-network-operator/pkg/controller/statusmanager	4.207s
ok  	github.com/openshift/cluster-network-operator/pkg/hypershift	1.019s
?   	github.com/openshift/cluster-network-operator/pkg/names	[no test files]
ok  	github.com/openshift/cluster-network-operator/pkg/network	14.142s
?   	github.com/openshift/cluster-network-operator/pkg/operator	[no test files]
?   	github.com/openshift/cluster-network-operator/pkg/platform	[no test files]
ok  	github.com/openshift/cluster-network-operator/pkg/render	1.034s
?   	github.com/openshift/cluster-network-operator/pkg/util	[no test files]
ok  	github.com/openshift/cluster-network-operator/pkg/util/ip	1.022s
?   	github.com/openshift/cluster-network-operator/pkg/util/ipsec	[no test files]
ok  	github.com/openshift/cluster-network-operator/pkg/util/k8s	1.051s
?   	github.com/openshift/cluster-network-operator/pkg/util/machineconfig	[no test files]
ok  	github.com/openshift/cluster-network-operator/pkg/util/proxyconfig	1.018s
ok  	github.com/openshift/cluster-network-operator/pkg/util/validation	1.018s
ok  	github.com/openshift/cluster-network-operator/pkg/version	1.020s
?   	github.com/openshift/cluster-network-operator/cmd/cluster-network-check-endpoints	[no test files]
?   	github.com/openshift/cluster-network-operator/cmd/cluster-network-check-target	[no test files]
?   	github.com/openshift/cluster-network-operator/cmd/cluster-network-operator	[no test files]
</pre>