### PR TITLE
CORENET-5658: Bump ovn-controller CPU request to 50m to prevent CPU starvation

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -150,7 +150,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         resources:
           requests:
-            cpu: 10m
+            cpu: 50m
             memory: 300Mi
       - name: ovn-acl-logging
         image: "{{.OvnImage}}"

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -186,7 +186,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         resources:
           requests:
-            cpu: 10m
+            cpu: 50m
             memory: 300Mi
       - name: ovn-acl-logging
         image: "{{.OvnImage}}"


### PR DESCRIPTION
**Why this change is needed:**
The default 10m CPU request for ovn-controller causes CPU starvation during bulk User Defined Network (UDN) creation, resulting in "Unreasonably long poll interval" warnings (1000ms-4000ms+) and delayed network provisioning.

**What this change does:**
Increases the ovn-controller CPU request from 10m to 50m in the ovnkube-node DaemonSet to ensure sufficient CPU resources during heavy control-plane reconciliation operations.

**Testing:**
- Manual testing: Created 50 UDNs across multiple namespaces on a 3-node cluster
- Before: Multiple "Unreasonably long poll interval" warnings (1154ms-4401ms) with 0ms user time indicating CPU starvation
- After: Zero warnings during the same bulk UDN creation test