### PR TITLE
OCPBUGS-86429: Skip _stackmanager for libreswan 5.x compat

### DIFF
--- a/bindata/network/ovn-kubernetes/common/ipsec-containerized.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-containerized.yaml
@@ -270,7 +270,9 @@ spec:
 
           /usr/libexec/ipsec/addconn --config /etc/ipsec.conf --checkconfig
           # Check kernel modules
-          /usr/libexec/ipsec/_stackmanager start
+          if [ -e /usr/libexec/ipsec/_stackmanager ]; then
+            /usr/libexec/ipsec/_stackmanager start
+          fi
           # Check nss database status
           /usr/sbin/ipsec --checknss
           # Start the pluto IKE daemon

--- a/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
@@ -281,7 +281,9 @@ spec:
 
           /usr/libexec/ipsec/addconn --config /etc/ipsec.conf --checkconfig
           # Check kernel modules
-          /usr/libexec/ipsec/_stackmanager start
+          if [ -e /usr/libexec/ipsec/_stackmanager ]; then
+            /usr/libexec/ipsec/_stackmanager start
+          fi
           # Check nss database status
           /usr/sbin/ipsec --checknss
 


### PR DESCRIPTION
## Summary
Backport of #2885 from release-4.19. Makes the `_stackmanager` binary call conditional — only runs when the binary exists.

The `_stackmanager` binary was removed in libreswan 5.3, causing IPsec pod startup failures when upgrading to libreswan 5.x.

## Background
At 75+ node IPsec mesh scale, libreswan 4.6 pluto crashes with a segfault in `set_larval_v2_transition()` during concurrent Child SA negotiation, causing permanent tunnel failures. Libreswan 5.x fixes this. This PR is part of a set that unpins libreswan in 4.18.z:
- openshift/os: unpin libreswan in RHCOS extensions
- openshift/machine-config-operator: libreswan 5.x compat changes
- **openshift/cluster-network-operator: this PR**
- openshift/ovn-kubernetes: unpin libreswan in Dockerfile