### PR TITLE
OCPBUGS-98724: egress-router: Propagate macvlan master to NAD

### DIFF
--- a/bindata/egress-router/000-nad.yaml
+++ b/bindata/egress-router/000-nad.yaml
@@ -11,6 +11,11 @@ spec:
     "cniVersion": "0.4.0",
     "type": "egress-router",
     "name": "egress-router-cni-nad",
+    "interfaceType": "macvlan",
+    "interfaceArgs": {
+      {{ $master := .MacvlanMaster}} {{ if ne $master "" }}"master": "{{$master}}",{{ end }}
+      "mode": "{{.MacvlanMode}}"
+    },
     "ip": {
       "addresses": [
         "{{.Addresses}}"

--- a/pkg/controller/egress_router/egress_router_controller.go
+++ b/pkg/controller/egress_router/egress_router_controller.go
@@ -216,7 +216,8 @@ func (r *EgressRouterReconciler) ensureEgressRouter(ctx context.Context, manifes
 	}
 	data.Data["FallbackIP"] = router.Spec.Redirect.FallbackIP
 	data.Data["mode"] = router.Spec.Mode
-	data.Data["network_interfaces"] = router.Spec.NetworkInterface
+	data.Data["MacvlanMaster"] = router.Spec.NetworkInterface.Macvlan.Master
+	data.Data["MacvlanMode"] = strings.ToLower(string(router.Spec.NetworkInterface.Macvlan.Mode))
 	data.Data["EgressRouterPodImage"] = os.Getenv("EGRESS_ROUTER_CNI_IMAGE")
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "egress-router"), &data)
 	if err != nil {

--- a/pkg/controller/egress_router/egress_router_controller.go
+++ b/pkg/controller/egress_router/egress_router_controller.go
@@ -16,6 +16,7 @@ import (
 
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"strings"
 	"time"
 
@@ -77,6 +78,7 @@ type EgressRouterReconciler struct {
 
 var ResyncPeriod = 5 * time.Minute
 
+// newEgressRouterReconciler wires up the reconciler with a shared client and status manager.
 func newEgressRouterReconciler(mgr manager.Manager, status *statusmanager.StatusManager, c cnoclient.Client) (reconcile.Reconciler, error) {
 
 	return &EgressRouterReconciler{
@@ -89,6 +91,7 @@ func newEgressRouterReconciler(mgr manager.Manager, status *statusmanager.Status
 	}, nil
 }
 
+// Reconcile fetches the EgressRouter CR, renders its manifests, and applies them to the cluster.
 func (r EgressRouterReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	defer utilruntime.HandleCrash(r.status.SetDegradedOnPanicAndCrash)
 	klog.Infof("Reconciling egressrouter.network.operator.openshift.io %s\n", request.NamespacedName)
@@ -194,13 +197,11 @@ func getAllowedDestinationsConfigJSON(RedirectRules []netopv1.L4RedirectRule) (s
 	return string(jsonByte), nil
 }
 
-func (r *EgressRouterReconciler) ensureEgressRouter(ctx context.Context, manifestDir string, namespace string, router *netopv1.EgressRouter, EgressRouterOwnerReferences []metav1.OwnerReference) error {
-	var err error
+// buildEgressRouterRenderData populates template render data from an EgressRouter CR.
+func buildEgressRouterRenderData(data *render.RenderData, namespace string, router *netopv1.EgressRouter) error {
 	if len(router.Spec.Addresses) == 0 {
 		return fmt.Errorf("router without addresses")
 	}
-	out := []*uns.Unstructured{}
-	data := render.MakeRenderData()
 	data.Data["ReleaseVersion"] = os.Getenv("RELEASE_VERSION")
 	data.Data["EgressRouterNamespace"] = namespace
 	if isItValidCidr(router.Spec.Addresses[0].IP) {
@@ -209,17 +210,37 @@ func (r *EgressRouterReconciler) ensureEgressRouter(ctx context.Context, manifes
 	if isItValidIPAddress(router.Spec.Addresses[0].Gateway) {
 		data.Data["Gateway"] = router.Spec.Addresses[0].Gateway
 	}
+	var err error
 	data.Data["AllowedDestinations"], err = getAllowedDestinationsConfigJSON(router.Spec.Redirect.RedirectRules)
 	if err != nil {
 		return fmt.Errorf("failed to render AllowedDestinations config: %w", err)
 	}
 	data.Data["FallbackIP"] = router.Spec.Redirect.FallbackIP
 	data.Data["mode"] = router.Spec.Mode
-	data.Data["network_interfaces"] = router.Spec.NetworkInterface
+	master := router.Spec.NetworkInterface.Macvlan.Master
+	if err := validateMacvlanMaster(master); err != nil {
+		return fmt.Errorf("validate macvlan master: %w", err)
+	}
+	data.Data["MacvlanMaster"] = master
+	if master != "" {
+		klog.Infof("EgressRouter %s/%s: using explicit macvlan master %q", namespace, router.Name, master)
+	}
+	data.Data["MacvlanMode"] = strings.ToLower(string(router.Spec.NetworkInterface.Macvlan.Mode))
 	data.Data["EgressRouterPodImage"] = os.Getenv("EGRESS_ROUTER_CNI_IMAGE")
+	return nil
+}
+
+// ensureEgressRouter builds render data from the CR, renders the NAD/pod/service
+// templates under bindata/egress-router/, and applies them with owner references.
+func (r *EgressRouterReconciler) ensureEgressRouter(ctx context.Context, manifestDir string, namespace string, router *netopv1.EgressRouter, EgressRouterOwnerReferences []metav1.OwnerReference) error {
+	out := []*uns.Unstructured{}
+	data := render.MakeRenderData()
+	if err := buildEgressRouterRenderData(&data, namespace, router); err != nil {
+		return err
+	}
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "egress-router"), &data)
 	if err != nil {
-		return err
+		return fmt.Errorf("render egress-router manifests: %w", err)
 	}
 	out = append(out, manifests...)
 
@@ -228,8 +249,7 @@ func (r *EgressRouterReconciler) ensureEgressRouter(ctx context.Context, manifes
 		obj.SetOwnerReferences(EgressRouterOwnerReferences)
 		klog.Infof("Applying manifest")
 		if err := apply.ApplyObject(ctx, r.client, obj, "egress_router"); err != nil {
-			klog.Infof("could not apply egress router object: %v", err)
-			return err
+			return fmt.Errorf("apply egress-router object: %w", err)
 		}
 	}
 
@@ -247,4 +267,19 @@ func isItValidCidr(cidr string) bool {
 
 func isItValidIPAddress(ip string) bool {
 	return net.ParseIP(ip) != nil
+}
+
+// macvlanMasterRE allows only characters that appear in real Linux interface
+// names and enforces IFNAMSIZ (15 usable chars). Full CRD-level validation
+// belongs in openshift/api via +kubebuilder:validation:Pattern.
+var macvlanMasterRE = regexp.MustCompile(`^[a-zA-Z0-9._@:-]{1,15}$`)
+
+func validateMacvlanMaster(master string) error {
+	if master == "" {
+		return nil
+	}
+	if !macvlanMasterRE.MatchString(master) {
+		return fmt.Errorf("invalid macvlan master interface name %q: must be 1-15 chars of [a-zA-Z0-9._@:-]", master)
+	}
+	return nil
 }

--- a/pkg/controller/egress_router/egress_router_controller_test.go
+++ b/pkg/controller/egress_router/egress_router_controller_test.go
@@ -1,0 +1,220 @@
+package egress_router
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	netopv1 "github.com/openshift/api/networkoperator/v1"
+	"github.com/openshift/cluster-network-operator/pkg/render"
+)
+
+func renderNAD(t *testing.T, router *netopv1.EgressRouter) map[string]interface{} {
+	t.Helper()
+	data := render.MakeRenderData()
+	data.Data["ReleaseVersion"] = "test"
+	data.Data["EgressRouterNamespace"] = "test-ns"
+	data.Data["Addresses"] = router.Spec.Addresses[0].IP
+	data.Data["Gateway"] = router.Spec.Addresses[0].Gateway
+	if router.Spec.Redirect != nil {
+		dest, _ := getAllowedDestinationsConfigJSON(router.Spec.Redirect.RedirectRules)
+		data.Data["AllowedDestinations"] = dest
+		data.Data["FallbackIP"] = router.Spec.Redirect.FallbackIP
+	} else {
+		data.Data["AllowedDestinations"] = "[]"
+		data.Data["FallbackIP"] = ""
+	}
+	data.Data["mode"] = router.Spec.Mode
+	data.Data["MacvlanMaster"] = router.Spec.NetworkInterface.Macvlan.Master
+	data.Data["MacvlanMode"] = strings.ToLower(string(router.Spec.NetworkInterface.Macvlan.Mode))
+	data.Data["EgressRouterPodImage"] = "test-image"
+
+	manifests, err := render.RenderDir(filepath.Join(manifestDir, "egress-router"), &data)
+	if err != nil {
+		t.Fatalf("failed to render egress-router manifests: %v", err)
+	}
+
+	for _, obj := range manifests {
+		if obj.GetKind() == "NetworkAttachmentDefinition" {
+			configStr, found, err := unstructuredNestedString(obj.Object, "spec", "config")
+			if err != nil || !found {
+				t.Fatalf("NAD missing spec.config: found=%v, err=%v", found, err)
+			}
+			var config map[string]interface{}
+			if err := json.Unmarshal([]byte(configStr), &config); err != nil {
+				t.Fatalf("NAD spec.config is not valid JSON: %v\nraw: %s", err, configStr)
+			}
+			return config
+		}
+	}
+	t.Fatal("no NetworkAttachmentDefinition found in rendered manifests")
+	return nil
+}
+
+func unstructuredNestedString(obj map[string]interface{}, fields ...string) (string, bool, error) {
+	current := obj
+	for i, field := range fields {
+		if i == len(fields)-1 {
+			val, ok := current[field]
+			if !ok {
+				return "", false, nil
+			}
+			s, ok := val.(string)
+			return s, ok, nil
+		}
+		next, ok := current[field]
+		if !ok {
+			return "", false, nil
+		}
+		current, ok = next.(map[string]interface{})
+		if !ok {
+			return "", false, nil
+		}
+	}
+	return "", false, nil
+}
+
+func makeRouter(master string, mode netopv1.MacvlanMode) *netopv1.EgressRouter {
+	return &netopv1.EgressRouter{
+		Spec: netopv1.EgressRouterSpec{
+			Mode: netopv1.EgressRouterModeRedirect,
+			Redirect: &netopv1.RedirectConfig{
+				RedirectRules: []netopv1.L4RedirectRule{
+					{
+						DestinationIP: "192.168.1.100",
+						Port:          8080,
+						Protocol:      netopv1.ProtocolTypeTCP,
+					},
+				},
+			},
+			NetworkInterface: netopv1.EgressRouterInterface{
+				Macvlan: netopv1.MacvlanConfig{
+					Mode:   mode,
+					Master: master,
+				},
+			},
+			Addresses: []netopv1.EgressRouterAddress{
+				{
+					IP:      "10.0.0.10/24",
+					Gateway: "10.0.0.1",
+				},
+			},
+		},
+	}
+}
+
+func TestMain(m *testing.M) {
+	manifestDir = findBindataDir()
+	os.Exit(m.Run())
+}
+
+func findBindataDir() string {
+	dir, _ := os.Getwd()
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "bindata")); err == nil {
+			return filepath.Join(dir, "bindata") + "/"
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "bindata/"
+		}
+		dir = parent
+	}
+}
+
+func TestNADContainsMasterWhenSpecified(t *testing.T) {
+	router := makeRouter("eth0.100", netopv1.MacvlanModeBridge)
+	config := renderNAD(t, router)
+
+	args, ok := config["interfaceArgs"].(map[string]interface{})
+	if !ok {
+		t.Fatal("NAD config missing interfaceArgs")
+	}
+	if args["master"] != "eth0.100" {
+		t.Errorf("expected master=eth0.100, got %v", args["master"])
+	}
+	if args["mode"] != "bridge" {
+		t.Errorf("expected mode=bridge, got %v", args["mode"])
+	}
+	if config["interfaceType"] != "macvlan" {
+		t.Errorf("expected interfaceType=macvlan, got %v", config["interfaceType"])
+	}
+}
+
+func TestNADOmitsMasterWhenEmpty(t *testing.T) {
+	router := makeRouter("", netopv1.MacvlanModeBridge)
+	config := renderNAD(t, router)
+
+	args, ok := config["interfaceArgs"].(map[string]interface{})
+	if !ok {
+		t.Fatal("NAD config missing interfaceArgs")
+	}
+	if _, hasMaster := args["master"]; hasMaster {
+		t.Errorf("expected no master key when empty, got %v", args["master"])
+	}
+	if args["mode"] != "bridge" {
+		t.Errorf("expected mode=bridge, got %v", args["mode"])
+	}
+}
+
+func TestNADModeLowercased(t *testing.T) {
+	tests := []struct {
+		apiMode  netopv1.MacvlanMode
+		expected string
+	}{
+		{netopv1.MacvlanModeBridge, "bridge"},
+		{netopv1.MacvlanModePrivate, "private"},
+		{netopv1.MacvlanModeVEPA, "vepa"},
+		{netopv1.MacvlanModePassthru, "passthru"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.apiMode), func(t *testing.T) {
+			router := makeRouter("", tt.apiMode)
+			config := renderNAD(t, router)
+
+			args := config["interfaceArgs"].(map[string]interface{})
+			if args["mode"] != tt.expected {
+				t.Errorf("mode %s: expected %q, got %v", tt.apiMode, tt.expected, args["mode"])
+			}
+		})
+	}
+}
+
+func TestGetAllowedDestinationsConfigJSON(t *testing.T) {
+	rules := []netopv1.L4RedirectRule{
+		{
+			DestinationIP: "192.168.1.100",
+			Port:          8080,
+			Protocol:      netopv1.ProtocolTypeTCP,
+		},
+		{
+			DestinationIP: "192.168.1.200",
+			Port:          9090,
+			Protocol:      netopv1.ProtocolTypeUDP,
+			TargetPort:    9091,
+		},
+	}
+
+	result, err := getAllowedDestinationsConfigJSON(rules)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var destinations []string
+	if err := json.Unmarshal([]byte(result), &destinations); err != nil {
+		t.Fatalf("result is not valid JSON array: %v", err)
+	}
+
+	if len(destinations) != 2 {
+		t.Fatalf("expected 2 destinations, got %d", len(destinations))
+	}
+	if destinations[0] != "8080 TCP 192.168.1.100" {
+		t.Errorf("unexpected destination[0]: %s", destinations[0])
+	}
+	if destinations[1] != "9090 UDP 192.168.1.200 9091" {
+		t.Errorf("unexpected destination[1]: %s", destinations[1])
+	}
+}

--- a/pkg/controller/egress_router/egress_router_controller_test.go
+++ b/pkg/controller/egress_router/egress_router_controller_test.go
@@ -1,0 +1,256 @@
+package egress_router
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	netopv1 "github.com/openshift/api/networkoperator/v1"
+	"github.com/openshift/cluster-network-operator/pkg/render"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// renderNAD uses the production buildEgressRouterRenderData path to render
+// the egress-router NAD template and returns the parsed CNI config.
+func renderNAD(t *testing.T, router *netopv1.EgressRouter) map[string]interface{} {
+	t.Helper()
+	data := render.MakeRenderData()
+	if err := buildEgressRouterRenderData(&data, "test-ns", router); err != nil {
+		t.Fatalf("buildEgressRouterRenderData failed: %v", err)
+	}
+	manifests, err := render.RenderDir(filepath.Join(manifestDir, "egress-router"), &data)
+	if err != nil {
+		t.Fatalf("failed to render egress-router manifests: %v", err)
+	}
+
+	for _, obj := range manifests {
+		if obj.GetKind() == "NetworkAttachmentDefinition" {
+			configStr, found, err := unstructured.NestedString(obj.Object, "spec", "config")
+			if err != nil || !found {
+				t.Fatalf("NAD missing spec.config: found=%v, err=%v", found, err)
+			}
+			var config map[string]interface{}
+			if err := json.Unmarshal([]byte(configStr), &config); err != nil {
+				t.Fatalf("NAD spec.config is not valid JSON: %v\nraw: %s", err, configStr)
+			}
+			return config
+		}
+	}
+	t.Fatal("no NetworkAttachmentDefinition found in rendered manifests")
+	return nil
+}
+
+// makeRouter builds a minimal EgressRouter CR suitable for NAD rendering tests.
+func makeRouter(master string, mode netopv1.MacvlanMode) *netopv1.EgressRouter {
+	return &netopv1.EgressRouter{
+		Spec: netopv1.EgressRouterSpec{
+			Mode: netopv1.EgressRouterModeRedirect,
+			Redirect: &netopv1.RedirectConfig{
+				RedirectRules: []netopv1.L4RedirectRule{
+					{
+						DestinationIP: "192.168.1.100",
+						Port:          8080,
+						Protocol:      netopv1.ProtocolTypeTCP,
+					},
+				},
+			},
+			NetworkInterface: netopv1.EgressRouterInterface{
+				Macvlan: netopv1.MacvlanConfig{
+					Mode:   mode,
+					Master: master,
+				},
+			},
+			Addresses: []netopv1.EgressRouterAddress{
+				{
+					IP:      "10.0.0.10/24",
+					Gateway: "10.0.0.1",
+				},
+			},
+		},
+	}
+}
+
+func TestMain(m *testing.M) {
+	var err error
+	manifestDir, err = findBindataDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to locate bindata directory: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}
+
+// findBindataDir walks up from the working directory to locate the bindata directory.
+func findBindataDir() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("get working directory: %w", err)
+	}
+	for {
+		bindataDir := filepath.Join(dir, "bindata")
+		if _, err := os.Stat(bindataDir); err == nil {
+			return bindataDir + "/", nil
+		} else if !os.IsNotExist(err) {
+			return "", fmt.Errorf("stat %q: %w", bindataDir, err)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("bindata directory not found")
+		}
+		dir = parent
+	}
+}
+
+// TestNADContainsMasterWhenSpecified ensures the user's chosen parent interface lands in the CNI config.
+func TestNADContainsMasterWhenSpecified(t *testing.T) {
+	router := makeRouter("eth0.100", netopv1.MacvlanModeBridge)
+	config := renderNAD(t, router)
+
+	args, ok := config["interfaceArgs"].(map[string]interface{})
+	if !ok {
+		t.Fatal("NAD config missing interfaceArgs")
+	}
+	if args["master"] != "eth0.100" {
+		t.Errorf("expected master=eth0.100, got %v", args["master"])
+	}
+	if args["mode"] != "bridge" {
+		t.Errorf("expected mode=bridge, got %v", args["mode"])
+	}
+	if config["interfaceType"] != "macvlan" {
+		t.Errorf("expected interfaceType=macvlan, got %v", config["interfaceType"])
+	}
+}
+
+// TestNADOmitsMasterWhenEmpty ensures backward compat — CNI plugin auto-detects when master is unset.
+func TestNADOmitsMasterWhenEmpty(t *testing.T) {
+	router := makeRouter("", netopv1.MacvlanModeBridge)
+	config := renderNAD(t, router)
+
+	args, ok := config["interfaceArgs"].(map[string]interface{})
+	if !ok {
+		t.Fatal("NAD config missing interfaceArgs")
+	}
+	if _, hasMaster := args["master"]; hasMaster {
+		t.Errorf("expected no master key when empty, got %v", args["master"])
+	}
+	if args["mode"] != "bridge" {
+		t.Errorf("expected mode=bridge, got %v", args["mode"])
+	}
+}
+
+// TestNADModeLowercased catches the API→CNI case mismatch (e.g. "Bridge" must become "bridge").
+func TestNADModeLowercased(t *testing.T) {
+	tests := []struct {
+		apiMode  netopv1.MacvlanMode
+		expected string
+	}{
+		{netopv1.MacvlanModeBridge, "bridge"},
+		{netopv1.MacvlanModePrivate, "private"},
+		{netopv1.MacvlanModeVEPA, "vepa"},
+		{netopv1.MacvlanModePassthru, "passthru"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.apiMode), func(t *testing.T) {
+			router := makeRouter("", tt.apiMode)
+			config := renderNAD(t, router)
+
+			args, ok := config["interfaceArgs"].(map[string]interface{})
+			if !ok {
+				t.Fatal("NAD config missing interfaceArgs")
+			}
+			if args["mode"] != tt.expected {
+				t.Errorf("mode %s: expected %q, got %v", tt.apiMode, tt.expected, args["mode"])
+			}
+		})
+	}
+}
+
+// TestGetAllowedDestinationsConfigJSON checks the "port proto ip [targetPort]" format egress-router-cni expects.
+func TestGetAllowedDestinationsConfigJSON(t *testing.T) {
+	rules := []netopv1.L4RedirectRule{
+		{
+			DestinationIP: "192.168.1.100",
+			Port:          8080,
+			Protocol:      netopv1.ProtocolTypeTCP,
+		},
+		{
+			DestinationIP: "192.168.1.200",
+			Port:          9090,
+			Protocol:      netopv1.ProtocolTypeUDP,
+			TargetPort:    9091,
+		},
+	}
+
+	result, err := getAllowedDestinationsConfigJSON(rules)
+	if err != nil {
+		t.Fatalf("getAllowedDestinationsConfigJSON returned an error: %v", err)
+	}
+
+	var destinations []string
+	if err := json.Unmarshal([]byte(result), &destinations); err != nil {
+		t.Fatalf("result is not valid JSON array: %v", err)
+	}
+
+	if len(destinations) != 2 {
+		t.Fatalf("expected 2 destinations, got %d", len(destinations))
+	}
+	if destinations[0] != "8080 TCP 192.168.1.100" {
+		t.Errorf("unexpected destination[0]: %s", destinations[0])
+	}
+	if destinations[1] != "9090 UDP 192.168.1.200 9091" {
+		t.Errorf("unexpected destination[1]: %s", destinations[1])
+	}
+}
+
+// TestValidateMacvlanMaster guards against JSON injection via crafted interface names in the NAD template.
+func TestValidateMacvlanMaster(t *testing.T) {
+	tests := []struct {
+		name    string
+		master  string
+		wantErr bool
+	}{
+		{"valid interface", "eth0.100", false},
+		{"valid bond", "bond0", false},
+		{"valid vlan subinterface", "bond0.4094", false},
+		{"valid with at sign", "macvlan@eth0", false},
+		{"valid with colon", "ens3f0np0:1", false},
+		{"empty allowed", "", false},
+		{"double quote rejected", `eth"0`, true},
+		{"single quote rejected", "eth'0", true},
+		{"backslash rejected", `eth\0`, true},
+		{"newline rejected", "eth0\n", true},
+		{"tab rejected", "eth0\t", true},
+		{"carriage return rejected", "eth0\r", true},
+		{"null byte rejected", "eth0\x00", true},
+		{"space rejected", "eth 0", true},
+		{"unicode rejected", "eth0é", true},
+		{"16 chars rejected (IFNAMSIZ)", "abcdefghijklmnop", true},
+		{"15 chars allowed (IFNAMSIZ)", "abcdefghijklmno", false},
+		{"injection attempt rejected", `eth0", "injected": true, "x`, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateMacvlanMaster(tt.master)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateMacvlanMaster(%q) error = %v, wantErr = %v", tt.master, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuildRenderDataRejectsBadMaster(t *testing.T) {
+	router := makeRouter(`eth0"x`, netopv1.MacvlanModeBridge)
+	data := render.MakeRenderData()
+	err := buildEgressRouterRenderData(&data, "test-ns", router)
+	if err == nil {
+		t.Fatal("expected error for invalid master, got nil")
+	}
+	if !strings.Contains(err.Error(), "validate macvlan master") {
+		t.Errorf("expected validation context in error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Why

The EgressRouter controller sets `network_interfaces` render data but the NAD template never references it. The egress-router-cni plugin sees no `interfaceArgs` in the CNI config, so it auto-detects master as the default route interface (`br-ex` on OVN-Kubernetes nodes) and defaults mode to `bridge` — ignoring user-specified `spec.networkInterface.macvlan.master` and `spec.networkInterface.macvlan.mode`.

Fixes: OCPBUGS-98724

## What

- Replace unused `network_interfaces` render data with explicit `MacvlanMaster` and `MacvlanMode` values in the controller
- Add `interfaceType` and `interfaceArgs` fields to the NAD template, with conditional `master` inclusion
- Lowercase the mode to match CNI plugin expectation (API: `Bridge` → CNI: `bridge`)
- When `master` is not specified in the CR, behavior is unchanged — the CNI plugin continues to auto-detect
- Validate `MacvlanMaster` to reject quotes and backslashes that would break the rendered NAD JSON config
- Extract `buildEgressRouterRenderData` so tests share the production controller-to-template data path
- Wrap error returns in `ensureEgressRouter` with operation context
- Replace custom `unstructuredNestedString` test helper with stdlib `unstructured.NestedString`

## Testing / How to verify it

### Automated
- Unit tests use the production `buildEgressRouterRenderData` path, covering: master propagation, master omission when empty, mode lowercasing for all 4 macvlan modes (Bridge/Private/VEPA/Passthru), AllowedDestinations JSON generation, and MacvlanMaster validation (quote/backslash/injection rejection)
- `make test-unit` passes locally
- CI lanes: `ci/prow/e2e-gcp-ovn`, `ci/prow/e2e-aws-ovn-serial-*` cover EgressRouter functionality

### E2E test note
No in-repo E2E test infrastructure exists for egress-router in the cluster-network-operator repository. End-to-end coverage is provided by Prow CI lanes (`ci/prow/e2e-gcp-ovn`, `ci/prow/e2e-aws-ovn-serial-*`) which exercise EgressRouter CR creation and traffic validation.

### Manual verification
- [x] Deploy EgressRouter CR with explicit `master` set to a VLAN subinterface — verify NAD contains correct `interfaceArgs.master`
- [x] Deploy EgressRouter CR without `master` — verify CNI plugin still auto-detects (backward compat)
- [x] Verify egress traffic flows through the specified parent interface

## Note

The `MacvlanMaster` field in the EgressRouter CRD (`openshift/api`) currently accepts any string without input validation. Constraining interface names (e.g., via `+kubebuilder:validation:Pattern`) would require a change in the `openshift/api` repo. This PR focuses on fixing the macvlan master propagation within CNO.

## User impact
EgressRouter CRs with `spec.networkInterface.macvlan.master` set will now correctly use the specified parent interface instead of silently falling back to `br-ex`.

## Upgrade / Rollback
- On upgrade: existing EgressRouter NADs will be re-rendered with the new `interfaceArgs` fields on next reconciliation. CRs without explicit `master` are unaffected.
- On rollback: NADs revert to omitting `interfaceArgs`; CNI plugin auto-detects as before.