### PR TITLE
OCPBUGS-99270: frr-k8s: Replace privileged SCC with custom frr-k8s SCC

### DIFF
--- a/bindata/network/frr-k8s/002-rbac.yaml
+++ b/bindata/network/frr-k8s/002-rbac.yaml
@@ -173,14 +173,29 @@ subjects:
   namespace: openshift-frr-k8s
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: frr-k8s-scc
+  namespace: openshift-frr-k8s
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - frr-k8s
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: system:openshift:scc:privileged
+  name: frr-k8s-scc
   namespace: openshift-frr-k8s
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:openshift:scc:privileged
+  kind: Role
+  name: frr-k8s-scc
 subjects:
 - kind: ServiceAccount
   name: frr-k8s-daemon

--- a/bindata/network/frr-k8s/003-scc.yaml
+++ b/bindata/network/frr-k8s/003-scc.yaml
@@ -1,0 +1,45 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: frr-k8s
+  annotations:
+    kubernetes.io/description: >-
+      Custom SCC for FRR-K8s.
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: false
+allowHostPorts: true
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+  - CHOWN
+  - DAC_OVERRIDE
+  - NET_ADMIN
+  - NET_BIND_SERVICE
+  - NET_RAW
+  - SETGID
+  - SETUID
+  - SYS_ADMIN
+defaultAddCapabilities:
+  - DAC_OVERRIDE
+fsGroup:
+  type: MustRunAs
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - ALL
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - projected
+  - secret
+users: []
+groups: []
+priority: null

--- a/bindata/network/frr-k8s/frr-k8s.yaml
+++ b/bindata/network/frr-k8s/frr-k8s.yaml
@@ -25,7 +25,7 @@ spec:
         component: frr-k8s
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        openshift.io/required-scc: privileged
+        openshift.io/required-scc: frr-k8s
     spec:
       serviceAccountName: frr-k8s-daemon
       priorityClassName: system-node-critical
@@ -167,10 +167,13 @@ spec:
           readOnlyRootFilesystem: true
           capabilities:
             add:
+            - CHOWN
             - NET_ADMIN
-            - NET_RAW
-            - SYS_ADMIN
             - NET_BIND_SERVICE
+            - NET_RAW
+            - SETGID
+            - SETUID
+            - SYS_ADMIN
         image: {{.FRRK8sImage}}
         env:
         - name: TINI_SUBREAPER

--- a/bindata/network/frr-k8s/node-status-cleaner.yaml
+++ b/bindata/network/frr-k8s/node-status-cleaner.yaml
@@ -18,7 +18,7 @@ spec:
         component: frr-k8s-statuscleaner
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        openshift.io/required-scc: privileged
+        openshift.io/required-scc: frr-k8s
     spec:
       containers:
       - command:

--- a/pkg/network/render_test.go
+++ b/pkg/network/render_test.go
@@ -593,7 +593,7 @@ func Test_renderAdditionalRoutingCapabilities(t *testing.T) {
 					},
 				},
 			},
-			want:        21,
+			want:        23,
 			expectedErr: nil,
 		},
 	}


### PR DESCRIPTION
The frr-k8s DaemonSet and node-status-cleaner Deployment were using the broad privileged SCC. Replace it with a purpose-built SCC that grants only the capabilities required for BGP routing (NET_RAW, NET_ADMIN, SYS_ADMIN, NET_BIND_SERVICE) plus hostNetwork/hostPorts access.