### PR TITLE
frr-k8s: fix asn format in FRRConfiguration CRD

### DIFF
--- a/bindata/network/frr-k8s/001-crd.yaml
+++ b/bindata/network/frr-k8s/001-crd.yaml
@@ -125,7 +125,7 @@ spec:
                         asn:
                           description: ASN is the AS number to use for the local end
                             of the session.
-                          format: int32
+                          format: int64
                           maximum: 4294967295
                           minimum: 0
                           type: integer
@@ -159,7 +159,7 @@ spec:
                                 description: |-
                                   ASN is the AS number to use for the local end of the session.
                                   ASN and DynamicASN are mutually exclusive and one of them must be specified.
-                                format: int32
+                                format: int64
                                 maximum: 4294967295
                                 minimum: 0
                                 type: integer


### PR DESCRIPTION
## What

Change `format: int32` to `format: int64` for the two `asn` fields in `bindata/network/frr-k8s/001-crd.yaml` (`spec.bgp.routers[].asn` and `spec.bgp.routers[].neighbors[].asn`).

## Why

These fields declare `format: int32` together with `maximum: 4294967295`, which exceeds the int32 range. Starting with the Kubernetes 1.36 rebase, the apiserver rejects **any** `FRRConfiguration` that sets `asn`:

```
FRRConfiguration.frrk8s.metallb.io "bgp-vip" is invalid: [<nil>: Invalid value: "":
Maximum boundary value must be of type integer with format int32 in spec.bgp.routers[0].asn,
<nil>: Invalid value: "": Maximum boundary value must be of type integer with format int32
in spec.bgp.routers[0].neighbors[0].asn]
```

This leaves CNO Degraded (`Error while updating operator configuration: could not apply ... FRRConfiguration`) and breaks BGP functionality on current nightlies.

ASN is a `uint32` in the frr-k8s API, so the OpenAPI representation needs `format: int64` to hold the full range. The same controller-gen quirk (uint32 rendered as int32) may need addressing in the upstream frr-k8s CRD sync as well.

## Testing

Reproduced on a baremetal IPI cluster installed from a 2026-07-19 nightly: applying an FRRConfiguration with `asn` fails as above; with this fix applied the CR is accepted and BGP sessions establish.

---
This PR was prepared with AI assistance. Please verify before acting on it.