### PR TITLE
OCPBUGS-99460: Fix connectivity check for nodes named with IP address

### DIFF
--- a/pkg/controller/connectivitycheck/connectivity_check_controller.go
+++ b/pkg/controller/connectivitycheck/connectivity_check_controller.go
@@ -3,12 +3,14 @@ package connectivitycheck
 import (
 	"context"
 	"fmt"
-	"k8s.io/utils/clock"
 	"net"
+	"net/netip"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
+
+	"k8s.io/utils/clock"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	applyconfigv1 "github.com/openshift/client-go/config/applyconfigurations/config/v1"
@@ -174,7 +176,7 @@ func (c *connectivityCheckTemplateProvider) generate(ctx context.Context, syncCo
 		}
 		for _, template := range templates {
 			check := copySpecFields(template)
-			WithSource("network-check-source-" + strings.Split(pod.Spec.NodeName, ".")[0])(check)
+			WithSource("network-check-source-" + nodeNameForLabel(pod.Spec.NodeName))(check)
 			check.Spec.SourcePod = &pod.Name
 			nodeUID := node.GetUID()
 			nodeName := node.GetName()
@@ -375,7 +377,7 @@ func (c *connectivityCheckTemplateProvider) getTemplatesForGenericPodServiceEndp
 	}
 
 	for _, address := range addresses {
-		templates = append(templates, NewPodNetworkConnectivityCheckTemplate(net.JoinHostPort(address.hostName, address.port), "openshift-network-diagnostics", withTarget("network-check-target", strings.Split(address.nodeName, ".")[0])))
+		templates = append(templates, NewPodNetworkConnectivityCheckTemplate(net.JoinHostPort(address.hostName, address.port), "openshift-network-diagnostics", withTarget("network-check-target", nodeNameForLabel(address.nodeName))))
 	}
 	return templates
 }
@@ -434,6 +436,18 @@ type endpointInfo struct {
 
 func withTarget(label, target string) func(check *applyconfigv1alpha1.PodNetworkConnectivityCheckApplyConfiguration) {
 	return WithTarget(label + "-" + target)
+}
+
+// nodeNameForLabel returns a string derived from a node name that is safe to embed
+// in a Kubernetes resource name. For bare IP addresses (IPv4 or IPv6), dots and
+// colons are replaced with dashes so the full address is preserved and collisions
+// between different IPs are avoided. For all other names (e.g. FQDNs), only the
+// segment before the first dot is returned, preserving the existing behaviour.
+func nodeNameForLabel(nodeName string) string {
+	if _, err := netip.ParseAddr(nodeName); err == nil {
+		return strings.NewReplacer(".", "-", ":", "-").Replace(nodeName)
+	}
+	return strings.Split(nodeName, ".")[0]
 }
 
 func Start(ctx context.Context, kubeConfig *rest.Config) error {

--- a/pkg/controller/connectivitycheck/connectivity_check_controller_test.go
+++ b/pkg/controller/connectivitycheck/connectivity_check_controller_test.go
@@ -1,0 +1,48 @@
+package connectivitycheck
+
+import (
+	"testing"
+)
+
+func TestNodeNameForLabel(t *testing.T) {
+	testCases := []struct {
+		name     string
+		nodeName string
+		expected string
+	}{
+		{
+			name:     "FQDN returns only the segment before the first dot",
+			nodeName: "node1.example.com",
+			expected: "node1",
+		},
+		{
+			name:     "simple name with no dots is returned unchanged",
+			nodeName: "node999",
+			expected: "node999",
+		},
+		{
+			name:     "valid IPv6 address has colons replaced with dashes",
+			nodeName: "fd00::1",
+			expected: "fd00--1",
+		},
+		{
+			name:     "valid IPv4 address has dots replaced with dashes",
+			nodeName: "192.168.0.1",
+			expected: "192-168-0-1",
+		},
+		{
+			name:     "invalid IPv4 address (octet out of range) is treated as an FQDN",
+			nodeName: "192.168.0.300",
+			expected: "192",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := nodeNameForLabel(tc.nodeName)
+			if actual != tc.expected {
+				t.Errorf("nodeNameForLabel(%q): expected %q, got %q", tc.nodeName, tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The code that creates the PodNetworkConnectivityCheck resources to allow connection checks from network-check-source to network-check-target uses only the first part of the node name up to the first '.'  This means this function is completely broken for clusters that use the IPv4 IP address as the start of the node name (like Managed OpenShift on IBM Cloud) since only one resource is created (since all the node names start with 10. or 192.)

This fix identifies these types of node names and uses the full IP address (replacing the '.' with '-') so that each resource name is unique.  Its focus is narrow on purpose, so the behavior is only changed (fixed) for node names that are IP addresses and that are broken currently.