### PR TITLE
OCPBUGS-99208: iptables-alerter: ignore Azure Monitor Agent rules

### DIFF
--- a/bindata/network/iptables-alerter/002-script.yaml
+++ b/bindata/network/iptables-alerter/002-script.yaml
@@ -33,11 +33,12 @@ data:
         for netns_pid in $(lsns -t net -o pid -nr | sort -u | grep -v '^1$'); do
             # Set iptables_output to the first iptables rule in the network namespace, if any.
             # (We use `awk` here rather than `grep` intentionally to avoid awkwardness with
-            # grep's exit status on no match.)
+            # grep's exit status on no match. The "127.0.0.1:8421" exclusion skips Azure Monitor
+            # Agent rules.)
             iptables_output=$(
                 (nsenter -n -t "${netns_pid}" iptables-save || true;
                  nsenter -n -t "${netns_pid}" ip6tables-save || true) 2>/dev/null | \
-                awk '/^-A/ {print; exit}'
+                awk '/127\.0\.0\.1:8421/ {next} /^-A/ {print; exit}'
             )
             if [[ -n "${iptables_output}" ]]; then
                 break

--- a/bindata/network/iptables-alerter/002-script.yaml
+++ b/bindata/network/iptables-alerter/002-script.yaml
@@ -33,11 +33,12 @@ data:
         for netns_pid in $(lsns -t net -o pid -nr | sort -u | grep -v '^1$'); do
             # Set iptables_output to the first iptables rule in the network namespace, if any.
             # (We use `awk` here rather than `grep` intentionally to avoid awkwardness with
-            # grep's exit status on no match.)
+            # grep's exit status on no match. The "127.0.0.1:8421" exclusion skips Azure Monitor
+            # Agent rules.)
             iptables_output=$(
                 (nsenter -n -t "${netns_pid}" iptables-save || true;
                  nsenter -n -t "${netns_pid}" ip6tables-save || true) 2>/dev/null | \
-                awk '/^-A/ {print; exit}'
+                awk '/127\.0\.0\.1:8421/ {next} /^-A/ {print; exit}'
             )
             if [[ -n "${iptables_output}" ]]; then
                 break
@@ -79,7 +80,7 @@ data:
             iptables_output=$(
                 (ip netns exec "${netns}" iptables-save || true;
                  ip netns exec "${netns}" ip6tables-save || true) 2>/dev/null | \
-                awk '/^-A/ {print; exit}'
+                awk '/127\.0\.0\.1:8421/ {next} /^-A/ {print; exit}'
             )
             if [[ -z "${iptables_output}" ]]; then
                 continue


### PR DESCRIPTION
In (some?) ARO clusters, there is an upstream Azure Monitor Agent that creates iptables rules in its pods. There's a bug telling the ARO team they need to get rid of them (https://redhat.atlassian.net/browse/OCPBUGS-99624). Make CNO ignore them now rather than logging errors about them (since it's not something end users can fix).