### PR TITLE
OCPBUGS-98918: Use service-ca certificates for network-check-source metrics

### DIFF
--- a/bindata/network-diagnostics/network-check-source.yaml
+++ b/bindata/network-diagnostics/network-check-source.yaml
@@ -71,6 +71,10 @@ spec:
           requests:
             memory: 40Mi
             cpu: 10m
+        volumeMounts:
+        - name: metrics-certs
+          mountPath: /etc/pki/tls/metrics-certs
+          readOnly: true
       {{ if .NetworkCheckSourceNodeSelector }}
       nodeSelector:
         {{ range $key, $value := .NetworkCheckSourceNodeSelector }}
@@ -98,6 +102,10 @@ spec:
           {{ end }}
       {{ end }}
       {{ end }}
+      volumes:
+      - name: metrics-certs
+        secret:
+          secretName: network-check-source-metrics-certs
 
 ---
 apiVersion: v1
@@ -107,6 +115,7 @@ metadata:
   namespace: openshift-network-diagnostics
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    service.beta.openshift.io/serving-cert-secret-name: network-check-source-metrics-certs
   labels:
     app: network-check-source
 spec:
@@ -134,7 +143,8 @@ spec:
     port: check-endpoints
     scheme: https
     tlsConfig:
-      insecureSkipVerify: true
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: network-check-source.openshift-network-diagnostics.svc
   jobLabel: component
   namespaceSelector:
     matchNames:

--- a/pkg/cmd/checkendpoints/cmd.go
+++ b/pkg/cmd/checkendpoints/cmd.go
@@ -75,6 +75,9 @@ func run(ctx context.Context, listenAddr, tlsMinVersion string, tlsCipherSuites 
 		Metrics: metricsserver.Options{
 			BindAddress:    listenAddr,
 			SecureServing:  true,
+			CertDir:        "/etc/pki/tls/metrics-certs",
+			CertName:       "tls.crt",
+			KeyName:        "tls.key",
 			TLSOpts:        tlsOpts,
 			FilterProvider: filters.WithAuthenticationAndAuthorization,
 		},


### PR DESCRIPTION
Replace `insecureSkipVerify` with proper certificate validation using OpenShift's service-ca operator. This fixes a security vulnerability where Prometheus scrapes metrics without validating the server's TLS certificate, making it vulnerable to man-in-the-middle attacks.

Previously, the metrics endpoint used self-signed certificates which Prometheus could not validate, requiring insecureSkipVerify: true. Now we use service-ca to generate properly signed certificates that Prometheus can validate using the cluster's CA bundle.

Changes:
- Configure controller-runtime metrics server to use service-ca certs instead of self-signed certificates (`CertDir`, `CertName`, `KeyName`)
- Add `service.beta.openshift.io/serving-cert-secret-name` annotation to trigger automatic certificate generation and rotation
- Mount certificate secret in deployment at _/etc/pki/tls/metrics-certs_
- Update `ServiceMonitor` to validate certificates using `caFile` and `serverName` instead of `insecureSkipVerify`: true

Certificate rotation is handled automatically by controller-runtime's built-in `certwatcher`, which hot-reloads certificates when service-ca rotates them without requiring pod restart.