### PR TITLE
OCPBUGS-98149: use python3 instead of platform-python

### DIFF
--- a/bindata/network/ovn-kubernetes/common/ipsec-containerized.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-containerized.yaml
@@ -283,7 +283,7 @@ spec:
           # tunnelling configuration (for example addition of a node) and configures
           # libreswan appropriately.
           # We are running this in the foreground so that the container will be restarted when ovs-monitor-ipsec fails.
-          /usr/libexec/platform-python /usr/share/openvswitch/scripts/ovs-monitor-ipsec \
+          /usr/bin/python3 /usr/share/openvswitch/scripts/ovs-monitor-ipsec \
             --pidfile=/var/run/openvswitch/ovs-monitor-ipsec.pid --ike-daemon=libreswan --no-restart-ike-daemon \
             --ipsec-d /var/lib/ipsec/nss \
             --log-file --monitor unix:/var/run/openvswitch/db.sock

--- a/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
@@ -324,7 +324,7 @@ spec:
           # tunnelling configuration (for example addition of a node) and configures
           # libreswan appropriately.
           # We are running this in the foreground so that the container will be restarted when ovs-monitor-ipsec fails.
-          /usr/libexec/platform-python /usr/share/openvswitch/scripts/ovs-monitor-ipsec \
+          /usr/bin/python3 /usr/share/openvswitch/scripts/ovs-monitor-ipsec \
             --pidfile=/var/run/openvswitch/ovs-monitor-ipsec.pid --ike-daemon=libreswan --no-restart-ike-daemon \
             --ipsec-conf /etc/ipsec.d/openshift.conf --ipsec-d /var/lib/ipsec/nss \
             --log-file --monitor unix:/var/run/openvswitch/db.sock


### PR DESCRIPTION
RHEL10 on s390x does not have platform-python. Switch to /usr/bin/python3 for ovs-monitor-ipsec invocation.