### PR TITLE
Restore ConfigMap enable-multi-networkpolicy setting for ovn-kubernetes

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/004-config.yaml
@@ -43,6 +43,9 @@ data:
     enable-multi-network=true
     enable-network-segmentation=true
     enable-preconfigured-udn-addresses=true
+{{- if .OVN_MULTI_NETWORK_POLICY_ENABLE }}
+    enable-multi-networkpolicy=true
+{{- end }}
     enable-admin-network-policy=true
     enable-multi-external-gateway=true
 {{- if .DNS_NAME_RESOLVER_ENABLE }}
@@ -127,6 +130,9 @@ data:
     enable-multi-network=true
     enable-network-segmentation=true
     enable-preconfigured-udn-addresses=true
+{{- if .OVN_MULTI_NETWORK_POLICY_ENABLE }}
+    enable-multi-networkpolicy=true
+{{- end }}
     enable-admin-network-policy=true
     enable-multi-external-gateway=true
 {{- if .DNS_NAME_RESOLVER_ENABLE }}

--- a/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
@@ -46,6 +46,9 @@ data:
     enable-multi-network=true
     enable-network-segmentation=true
     enable-preconfigured-udn-addresses=true
+{{- if .OVN_MULTI_NETWORK_POLICY_ENABLE }}
+    enable-multi-networkpolicy=true
+{{- end }}
     enable-admin-network-policy=true
     enable-multi-external-gateway=true
 {{- if .DNS_NAME_RESOLVER_ENABLE }}


### PR DESCRIPTION
## Summary

This PR restores the `enable-multi-networkpolicy=true` ConfigMap setting that was removed by PR #3072, fixing a regression where MultiNetworkPolicy is not enforced on UDN (User Defined Network) Layer2 secondary interfaces.

## Problem

PR #3072 attempted to migrate MultiNetworkPolicy enablement from ConfigMap to CLI flags by:
- Adding CLI flag: `--enable-multi-networkpolicy` 
- Removing ConfigMap setting: `enable-multi-networkpolicy=true`

However, this created a regression because **ovn-kubernetes prioritizes ConfigMap settings over CLI flags** during config loading. When the ConfigMap doesn't specify the setting, it defaults to `false`, causing the CLI flag to be ignored.

### Evidence

After PR #3072 merged, when `useMultiNetworkPolicy: true` is enabled:

```bash
$ oc -n openshift-ovn-kubernetes get configmap ovnkube-config -o yaml | grep enable-multi-networkpolicy
# No output - setting missing from ConfigMap

$ oc -n openshift-ovn-kubernetes logs deployment/ovnkube-control-plane | grep EnableMultiNetworkPolicy
EnableMultiNetworkPolicy:false  # ❌ False despite CLI flag being set
```

**Result:** MultiNetworkPolicy created but not enforced → test 77656 fails (traffic not blocked).

## Solution

Restore the ConfigMap setting alongside the CLI flag, ensuring dual coverage:

- **CLI flag**: `--enable-multi-networkpolicy` (from PR #3072)
- **ConfigMap**: `enable-multi-networkpolicy=true` (restored by this PR)

This ensures ovn-kubernetes loads `EnableMultiNetworkPolicy=true` regardless of config loading order.

## Test Plan

**Before this fix:**
```bash
# Test 77656: Verify ingress-ipblock policy for UDN pod's secondary interface (Layer2)
FAIL: Expected curl to fail (blocked by policy), but connection succeeded
```

**After this fix:**
```bash
# Manual ConfigMap patch simulating this PR
$ oc patch configmap ovnkube-config --patch 'enable-multi-networkpolicy=true'
$ oc rollout restart deployment/ovnkube-control-plane

# Verify runtime config
$ oc logs deployment/ovnkube-control-plane | grep EnableMultiNetworkPolicy
EnableMultiNetworkPolicy:true  # ✅ Now true

# Re-run test 77656
✅ PASS: Traffic correctly blocked by MultiNetworkPolicy (rc: 28 timeout)
```

## Files Changed

- `bindata/network/ovn-kubernetes/managed/004-config.yaml`: Restore ConfigMap setting (2 occurrences)
- `bindata/network/ovn-kubernetes/self-hosted/004-config.yaml`: Restore ConfigMap setting (1 occurrence)

## Related

- Fixes test: `77656 - Verify ingress-ipblock policy for UDN pod's secondary interface (Layer2)`
- Related PR: #3072 (introduced the regression)
- Related PR: #3026 (rejected alternative approach)

🤖 Generated with [Claude Code](https://claude.com/claude-code)