### PR TITLE
[TEST] Retest PR #3072: ovn-kubernetes: Move MNP from ConfigMap to CLI flags

### DIFF
--- a/.retest-pr-3072
+++ b/.retest-pr-3072
@@ -1,0 +1,1 @@
+[TEST] Retest PR #3072 - MNP CLI flags


### PR DESCRIPTION
## ⚠️ Test PR Only - Do Not Merge

This PR is for CI validation only. **All changes from PR #3072 are already merged in master.**

## Purpose
Trigger CI jobs to validate the MNP CLI flags changes from PR #3072.

## Original PR
- **Original PR**: https://github.com/openshift/cluster-network-operator/pull/3072
- **Status**: ✅ Merged
- **Merge commit**: 00e6cc59b92af5c8f73f9c3908ed3b0ef591bf63
- **Original commit**: 17f08a709659914743be851d72bf70a39a9abbf5

## Summary
MultiNetworkPolicy was not being enforced on UDN secondary interfaces in OCP 5.0 because ovnkube-control-plane pods did not restart when the ConfigMap was updated with `enable-multi-networkpolicy=true`.

**Solution**: Move MNP enablement from ConfigMap to CLI flags (following the same pattern as multicast in OCPBUGS-78731).

## Changes in Original PR
- **bindata/network/ovn-kubernetes/managed/004-config.yaml**: Remove MNP from ConfigMaps
- **bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml**: Add `--enable-multi-networkpolicy` CLI flag
- **bindata/network/ovn-kubernetes/self-hosted/004-config.yaml**: Remove MNP from ConfigMap  
- **bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml**: Add `--enable-multi-networkpolicy` CLI flag
- **pkg/network/ovn_kubernetes_test.go**: Update test expectations
- **docs/ovn_node_mode.md**: Document ConfigMap vs CLI flag patterns

## Testing Focus
- ✅ CI job execution and pass rates
- ✅ MNP enforcement on UDN Layer2 and Layer3 networks
- ✅ Upgrade paths (4.x → 5.0)
- ✅ HyperShift managed control plane
- ✅ DPU-host mode compatibility

## Test Marker
This PR adds a trivial `.retest-pr-3072` file to create a commit difference from master, allowing PR creation for CI testing.

## Related
- **Jira**: https://redhat.atlassian.net/browse/OCPBUGS-88063
- **Follow-up pattern from**: OCPBUGS-78731 (commit f4734c557)

/hold
/test all