### PR TITLE
[RETEST] OCPBUGS-88063: ovn-kubernetes: Move MNP from ConfigMap to CLI flags

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/004-config.yaml
@@ -43,10 +43,6 @@ data:
     enable-multi-network=true
     enable-network-segmentation=true
     enable-preconfigured-udn-addresses=true
-
-{{- if .OVN_MULTI_NETWORK_POLICY_ENABLE }}
-    enable-multi-networkpolicy=true
-{{- end }}
     enable-admin-network-policy=true
     enable-multi-external-gateway=true
 {{- if .DNS_NAME_RESOLVER_ENABLE }}
@@ -131,9 +127,6 @@ data:
     enable-multi-network=true
     enable-network-segmentation=true
     enable-preconfigured-udn-addresses=true
-{{- if .OVN_MULTI_NETWORK_POLICY_ENABLE }}
-    enable-multi-networkpolicy=true
-{{- end }}
     enable-admin-network-policy=true
     enable-multi-external-gateway=true
 {{- if .DNS_NAME_RESOLVER_ENABLE }}

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
@@ -200,6 +200,11 @@ spec:
             evpn_enable_flag="--enable-evpn"
           fi
 
+          multi_network_policy_enabled_flag=
+          if [[ "{{.OVN_MULTI_NETWORK_POLICY_ENABLE}}" == "true" ]]; then
+            multi_network_policy_enabled_flag="--enable-multi-networkpolicy"
+          fi
+
           # DROP: remove when older OVN-K images that require --enable-interconnect are no longer supported
           enable_interconnect_flag=
           if /usr/bin/ovnkube --help 2>&1 | grep -q -- '--enable-interconnect'; then
@@ -226,6 +231,7 @@ spec:
             ${ovn_v4_masquerade_subnet_opt} \
             ${ovn_v6_masquerade_subnet_opt} \
             ${persistent_ips_enabled_flag} \
+            ${multi_network_policy_enabled_flag} \
             ${route_advertisements_enable_flag} \
             ${evpn_enable_flag} \
             ${ovn_eip_reachability_timeout_opt}

--- a/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
@@ -46,9 +46,6 @@ data:
     enable-multi-network=true
     enable-network-segmentation=true
     enable-preconfigured-udn-addresses=true
-{{- if .OVN_MULTI_NETWORK_POLICY_ENABLE }}
-    enable-multi-networkpolicy=true
-{{- end }}
     enable-admin-network-policy=true
     enable-multi-external-gateway=true
 {{- if .DNS_NAME_RESOLVER_ENABLE }}

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
@@ -147,6 +147,11 @@ spec:
             evpn_enable_flag="--enable-evpn"
           fi
 
+          multi_network_policy_enabled_flag=
+          if [[ "{{.OVN_MULTI_NETWORK_POLICY_ENABLE}}" == "true" ]]; then
+            multi_network_policy_enabled_flag="--enable-multi-networkpolicy"
+          fi
+
           if [ "{{.OVN_GATEWAY_MODE}}" == "shared" ]; then
             gateway_mode_flags="--gateway-mode shared"
           elif [ "{{.OVN_GATEWAY_MODE}}" == "local" ]; then
@@ -179,6 +184,7 @@ spec:
             ${ovn_v4_masquerade_subnet_opt} \
             ${ovn_v6_masquerade_subnet_opt} \
             ${persistent_ips_enabled_flag} \
+            ${multi_network_policy_enabled_flag} \
             ${gateway_mode_flags} \
             ${route_advertisements_enable_flag} \
             ${evpn_enable_flag} \

--- a/docs/ovn_node_mode.md
+++ b/docs/ovn_node_mode.md
@@ -15,4 +15,10 @@ The `OVN_NODE_MODE` environment variable is injected into the `ovnkube-node` Pod
 
 ### Feature configuration
 
-Feature enablement (egress IP, multicast, multi-network, network segmentation, admin network policy, etc.) is managed through the cluster-wide ConfigMap (`004-config.yaml`) which is passed to ovnkube via `--config-file`. These features are not gated per node mode.
+Feature enablement is managed through two mechanisms:
+
+- **ConfigMap-based** (`004-config.yaml`): Most features (egress IP, multi-network, network segmentation, admin network policy, etc.) are configured in the cluster-wide ConfigMap which is passed to ovnkube via `--config-file`.
+
+- **CLI flags** (`ovnkube-control-plane.yaml`): Features that require ovnkube-control-plane pod restarts on configuration changes (multicast, multi-networkpolicy) are enabled via CLI flags (e.g., `--enable-multicast`, `--enable-multi-networkpolicy`) to ensure the control-plane pods restart automatically when the feature is toggled. Note that ovnkube-node pods already restart when the ConfigMap changes, so only control-plane-specific features require CLI flags.
+
+These features are not gated per node mode.

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -747,7 +747,6 @@ egressip-node-healthcheck-port=9107
 enable-multi-network=true
 enable-network-segmentation=true
 enable-preconfigured-udn-addresses=true
-enable-multi-networkpolicy=true
 enable-admin-network-policy=true
 enable-multi-external-gateway=true
 
@@ -842,7 +841,6 @@ egressip-node-healthcheck-port=9107
 enable-multi-network=true
 enable-network-segmentation=true
 enable-preconfigured-udn-addresses=true
-enable-multi-networkpolicy=true
 enable-admin-network-policy=true
 enable-multi-external-gateway=true
 


### PR DESCRIPTION
## ⚠️ Retest of Merged PR #3072 - For CI Validation Only

This PR contains the **exact same changes** as the already-merged PR #3072 for CI testing purposes.

## Original PR
- **Original PR**: https://github.com/openshift/cluster-network-operator/pull/3072  
- **Status**: ✅ Already merged into master
- **Original commit**: 17f08a709659914743be851d72bf70a39a9abbf5

## Summary

MultiNetworkPolicy is not enforced on UDN secondary interfaces in OCP 5.0 because ovnkube-control-plane pods do not restart when the ConfigMap is updated with `enable-multi-networkpolicy=true`.

## Root Cause

PR #2944 moved MNP enablement to ConfigMap, but:
1. The ConfigMap hash only includes 008-script-lib.yaml, not 004-config.yaml
2. ovnkube-control-plane has no hash annotation to trigger restarts

## Solution

Follow the same pattern as commit f4734c557 (OCPBUGS-78731): move MNP back to CLI flags where pod restart happens automatically on spec changes.

This creates consistency with multicast (also a CLI flag) and avoids the ConfigMap hash timing issues.

## Changes

- **managed/004-config.yaml**: Remove MNP from both ConfigMaps (HyperShift nodes + control plane)
- **managed/ovnkube-control-plane.yaml**: Add `--enable-multi-networkpolicy` CLI flag
- **self-hosted/004-config.yaml**: Remove MNP from ConfigMap
- **self-hosted/ovnkube-control-plane.yaml**: Add `--enable-multi-networkpolicy` CLI flag
- **ovn_kubernetes_test.go**: Update test expectations
- **docs/ovn_node_mode.md**: Document ConfigMap vs CLI flag feature enablement mechanisms

## Testing Focus

- ✅ CI job execution and validation
- ✅ MNP enforcement on UDN Layer2 and Layer3 networks  
- ✅ Upgrade paths (4.x → 5.0)
- ✅ HyperShift managed control plane
- ✅ DPU-host mode compatibility
- ✅ Test cases: OCP-77656, OCP-78125, OCP-78259, OCP-77657

## Related

- **Jira**: https://redhat.atlassian.net/browse/OCPBUGS-88063
- **Follows pattern from**: OCPBUGS-78731 (commit f4734c557)
- **Addresses regression from**: PR #2944

---

**DO NOT MERGE** - This is identical to already-merged PR #3072

/hold