### PR TITLE
OCPBUGS-113648: Remove NoSchedule effect from tolerations

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -652,7 +652,6 @@ spec:
       priorityClassName: "system-node-critical"
       tolerations:
       - operator: Exists
-        effect: NoSchedule
       containers:
       - name: whereabouts
         command: [ "/bin/sh" ]


### PR DESCRIPTION
Bug: https://redhat.atlassian.net/browse/OCPBUGS-77772

## What

Removes the `effect: NoSchedule` restriction from the whereabouts-reconciler DaemonSet toleration in `bindata/network/multus/multus.yaml`, leaving just `operator: Exists`.

## Why

The whereabouts-reconciler DaemonSet is the only Multus DaemonSet in multus.yaml that specifies `effect: NoSchedule` on its toleration. All other Multus DaemonSets (kube-multus, multus-additional-cni-plugins, multus-networkpolicy) use a catch-all `operator: Exists` toleration with no effect restriction.

The `NoSchedule` restriction prevents the whereabouts-reconciler pods from being scheduled on nodes with `NoExecute` or `PreferNoSchedule` taints, causing IP address reconciliation gaps on those nodes.

## How to verify

1. Apply a `NoExecute` taint to a worker node:
   ```
   oc adm taint nodes <node-name> test-taint=true:NoExecute
   ```
2. Verify the whereabouts-reconciler pod is running on the tainted node:
   ```
   oc get pods -n openshift-multus -o wide | grep whereabouts-reconciler
   ```
3. Confirm all other Multus DaemonSet pods continue to run normally:
   ```
   oc get ds -n openshift-multus
   ```

## Behavioral impact

- **Before**: whereabouts-reconciler pods only tolerate `NoSchedule` taints; pods are not scheduled on nodes with `NoExecute` or `PreferNoSchedule` taints.
- **After**: whereabouts-reconciler pods tolerate all taints, matching the behavior of every other Multus DaemonSet.

## Upgrade/Rollback

- **Upgrade**: The CNO will reconcile the DaemonSet and roll out the updated toleration. Pods on previously untolerated nodes will be scheduled automatically.
- **Rollback**: Reverting restores the `NoSchedule` restriction. Pods on nodes with other taint effects will be evicted by the scheduler.

## Container privileges note

The `hostNetwork: true`, `hostPID: true`, and `privileged: true` settings flagged by static analysis are pre-existing and required by the Multus network stack — they are not introduced by this change.