### PR TITLE
multus: Fix typo from 'k8d' to 'k8s' in multus.yaml

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -451,7 +451,7 @@ spec:
             function generateKubeConfig {
             # Check if we're running as a k8s pod.
             if [ -f "$SERVICE_ACCOUNT_PATH/token" ]; then
-              # We're running as a k8d pod - expect some variables.
+              # We're running as a k8s pod - expect some variables.
               if [ -z ${KUBERNETES_SERVICE_HOST} ]; then
                 error "KUBERNETES_SERVICE_HOST not set"; exit 1;
               fi
@@ -827,7 +827,7 @@ spec:
           function generateKubeConfig {
           # Check if we're running as a k8s pod.
           if [ -f "$SERVICE_ACCOUNT_PATH/token" ]; then
-            # We're running as a k8d pod - expect some variables.
+            # We're running as a k8s pod - expect some variables.
             if [ -z ${KUBERNETES_SERVICE_HOST} ]; then
               error "KUBERNETES_SERVICE_HOST not set"; exit 1;
             fi


### PR DESCRIPTION
There is mention of k8d instead of k8s in the code which needs to be corrected as its not a good practice to have typos in the code.