### PR TITLE
multus: Add tolerations to whereabouts-controller Deployment

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -752,6 +752,8 @@ spec:
       securityContext: {}
       serviceAccountName: multus-ancillary-tools
       terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
       volumes:
         - hostPath:
             path: {{ .CNIBinDir }}


### PR DESCRIPTION
Bug: https://redhat.atlassian.net/browse/OCPBUGS-77772

## What

Adds `operator: Exists` toleration to the `whereabouts-controller` Deployment in `bindata/network/multus/multus.yaml`.

## Why

The whereabouts-controller Deployment had no tolerations at all. When all worker nodes are tainted, the pod cannot be scheduled anywhere. This was discovered during testing of the whereabouts-reconciler toleration fix (#3105).

All other Multus DaemonSets already have `operator: Exists` tolerations.

## How to verify

1. Taint all worker nodes:
   ```
   oc adm taint nodes -l node-role.kubernetes.io/worker test-taint=true:NoExecute
   ```
2. Verify the whereabouts-controller pod is running:
   ```
   oc get pods -n openshift-multus -o wide | grep whereabouts-controller
   ```

## Related

- #3105 — Fixes the whereabouts-reconciler DaemonSet toleration (separate change)