### PR TITLE
NO-ISSUE: Restore deepcopy generation

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -6,10 +6,9 @@ set -o pipefail
 
 SCRIPT_ROOT="$(dirname "${BASH_SOURCE[0]}")/.."
 
-bash "${SCRIPT_ROOT}/vendor/k8s.io/code-generator/kube_codegen.sh" deepcopy \
-  github.com/openshift/openshift-network-operator/pkg/generated github.com/openshift/cluster-network-operator/pkg/apis \
-  "network:v1" \
-  --go-header-file "${SCRIPT_ROOT}/hack/custom-boilerplate.go.txt"
+. "${SCRIPT_ROOT}/vendor/k8s.io/code-generator/kube_codegen.sh"
+
+GOFLAGS=-mod=readonly kube::codegen::gen_helpers --boilerplate "${SCRIPT_ROOT}/hack/custom-boilerplate.go.txt" ./pkg/apis
 
 
 echo "Generating CRDs"


### PR DESCRIPTION
kube_codegen.sh no longer does anything when invoked; it's intended to be sourced, and defines functions to call for various code generation features.

This adjusts hack/update-codegen.sh to match: kube_codegen.sh is sourced, and kube::codegen::gen_helpers is used to generate deepcopy functions. This requires GOFLAGS=-mod=readonly because kube_codegen.sh expects "go install" to work, and the default -mod=vendor (because the vendor directory is present) doesn't work for that.

To verify this, delete `pkg/apis/network/v1/zz_generated.deepcopy.go`; the current `hack/update-codegen.sh` won’t regenerate it, whereas the updated version will.