### PR TITLE
NO-JIRA: [release-4.17]Fix invalid JSON in daemon-config-lm-ovn.json perNodeCertificate block

### DIFF
--- a/bindata/network/multus/multus.yaml
+++ b/bindata/network/multus/multus.yaml
@@ -174,6 +174,7 @@ data:
           "bootstrapKubeconfig": "{{ .KubeletKubeconfigPath }}",
           "certDir": "/etc/cni/multus/certs",
           "certDuration": "24h"
+        },
 {{ end }}
         "cniConfigDir": "/host/etc/cni/net.d",
         "multusConfigFile": "auto",


### PR DESCRIPTION
Add missing `},` closing the perNodeCertificate object in daemon-config-lm-ovn.json. Without this, the rendered JSON is invalid when NETWORK_NODE_IDENTITY_ENABLE is true.

Caught during review of #3040.