### PR TITLE
OCPBUGS-105556: [4.22] frr-k8s: use Recreate strategy for statuscleaner deployment

### DIFF
--- a/bindata/network/frr-k8s/node-status-cleaner.yaml
+++ b/bindata/network/frr-k8s/node-status-cleaner.yaml
@@ -9,6 +9,10 @@ metadata:
   annotations:
     release.openshift.io/version: "{{.ReleaseVersion}}"
 spec:
+{{- if .IsSNO }}
+  strategy:
+    type: Recreate
+{{- end }}
   selector:
     matchLabels:
       component: frr-k8s-statuscleaner

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -129,7 +129,7 @@ func Render(operConf *operv1.NetworkSpec, clusterConf *configv1.NetworkSpec, man
 	}
 	objs = append(objs, o...)
 
-	o, err = renderAdditionalRoutingCapabilities(operConf, manifestDir)
+	o, err = renderAdditionalRoutingCapabilities(operConf, bootstrapResult, manifestDir)
 	if err != nil {
 		return nil, progressing, err
 	}
@@ -849,7 +849,7 @@ func registerNetworkingConsolePlugin(bootstrapResult *bootstrap.BootstrapResult,
 	})
 }
 
-func renderAdditionalRoutingCapabilities(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Unstructured, error) {
+func renderAdditionalRoutingCapabilities(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapResult, manifestDir string) ([]*uns.Unstructured, error) {
 	if conf == nil || conf.AdditionalRoutingCapabilities == nil {
 		return nil, nil
 	}
@@ -861,6 +861,7 @@ func renderAdditionalRoutingCapabilities(conf *operv1.NetworkSpec, manifestDir s
 			data.Data["FRRK8sImage"] = os.Getenv("FRR_K8S_IMAGE")
 			data.Data["KubeRBACProxyImage"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
 			data.Data["ReleaseVersion"] = os.Getenv("RELEASE_VERSION")
+			data.Data["IsSNO"] = bootstrapResult.OVN.ControlPlaneReplicaCount == 1
 			objs, err := render.RenderDir(filepath.Join(manifestDir, "network/frr-k8s"), &data)
 			if err != nil {
 				return nil, fmt.Errorf("failed to render frr-k8s manifests: %w", err)

--- a/pkg/network/render_test.go
+++ b/pkg/network/render_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/hypershift"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 
 	"testing"
@@ -576,11 +577,42 @@ func Test_renderAdditionalRoutingCapabilities(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := renderAdditionalRoutingCapabilities(tt.args.operConf, manifestDir)
+			got, err := renderAdditionalRoutingCapabilities(tt.args.operConf, fakeBootstrapResult(), manifestDir)
 			if !reflect.DeepEqual(tt.expectedErr, err) {
 				t.Errorf("renderAdditionalRoutingCapabilities() err = %v, want %v", err, tt.expectedErr)
 			}
 			assert.Equalf(t, tt.want, len(got), "renderAdditionalRoutingCapabilities(%v, %v)", tt.args.operConf, manifestDir)
 		})
 	}
+}
+
+func Test_renderFRRStatusCleanerStrategy(t *testing.T) {
+	frrConf := &operv1.NetworkSpec{
+		AdditionalRoutingCapabilities: &operv1.AdditionalRoutingCapabilities{
+			Providers: []operv1.RoutingCapabilitiesProvider{
+				operv1.RoutingCapabilitiesProviderFRR,
+			},
+		},
+	}
+
+	render := func(replicaCount int) *appsv1.Deployment {
+		g := NewWithT(t)
+		br := fakeBootstrapResult()
+		br.OVN.ControlPlaneReplicaCount = replicaCount
+		objs, err := renderAdditionalRoutingCapabilities(frrConf, br, manifestDir)
+		g.Expect(err).NotTo(HaveOccurred())
+		return mustFindRenderedObj[*appsv1.Deployment](t, objs, "Deployment", "frr-k8s-statuscleaner")
+	}
+
+	t.Run("SNO: strategy is Recreate", func(t *testing.T) {
+		g := NewWithT(t)
+		d := render(1)
+		g.Expect(d.Spec.Strategy.Type).To(Equal(appsv1.RecreateDeploymentStrategyType))
+	})
+
+	t.Run("HA: no strategy override", func(t *testing.T) {
+		g := NewWithT(t)
+		d := render(3)
+		g.Expect(d.Spec.Strategy.Type).To(BeEmpty())
+	})
 }

--- a/pkg/network/testutil_test.go
+++ b/pkg/network/testutil_test.go
@@ -3,7 +3,10 @@ package network
 import (
 	"context"
 	"fmt"
+	"slices"
+	"testing"
 
+	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
@@ -11,6 +14,7 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/hypershift"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // Fun matcher for testing the presence of Kubernetes objects
@@ -107,4 +111,22 @@ func createProxy(client client.Client) error {
 		},
 	}
 	return client.Default().CRClient().Create(context.TODO(), proxy)
+}
+
+// mustFindRenderedObj finds and converts an unstructured object from a list of rendered objects.
+// It uses Go generics to return the properly typed object.
+func mustFindRenderedObj[T any](t *testing.T, objs []*uns.Unstructured, kind, name string) T {
+	t.Helper()
+	g := NewWithT(t)
+
+	index := slices.IndexFunc(objs, func(obj *uns.Unstructured) bool {
+		return obj.GetKind() == kind && obj.GetName() == name
+	})
+	g.Expect(index).NotTo(Equal(-1), "Could not find object with kind %q and name %q", kind, name)
+
+	var result T
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(objs[index].Object, &result)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	return result
 }


### PR DESCRIPTION
A NOT clean cherry-pick of https://github.com/openshift/cluster-network-operator/pull/3104
differences:
* 1st commit needed for unit tests, semi-clean: dropped definiton of `mustFindContainer` and `findExecCommand` (otherwise `lint` fails)
* 2nd commit is semi clean , added bootstrap result wiring to additionalRoutingCapibilities (that was already there for 5.0), aligned existing unit test with fakeBootstrapResult() as in 5.0