### PR TITLE
OCPBUGS-105887:Filter unsupported cipher suites to prevent ovnkube-identity crash

### DIFF
--- a/pkg/network/tls.go
+++ b/pkg/network/tls.go
@@ -49,9 +49,9 @@ func addTLSInfoToRenderData(data map[string]interface{}, bootstrapResult *bootst
 		converted := crypto.OpenSSLToIANACipherSuites([]string{cipher})
 		if len(converted) > 0 {
 			ianaCiphers = append(ianaCiphers, converted...)
-		} else {
-			ianaCiphers = append(ianaCiphers, cipher)
 		}
+		// If conversion fails, silently drop the cipher (it's unsupported by Go's crypto/tls).
+		// The library-go OpenSSLToIANACipherSuites function already logs dropped ciphers at V(4).
 	}
 
 	// Add Go-style TLS parameters (IANA cipher names, comma-separated)

--- a/pkg/network/tls_test.go
+++ b/pkg/network/tls_test.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"strings"
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -173,6 +174,48 @@ func TestAddTLSInfoToRenderData(t *testing.T) {
 		expectedNginxCiphers := ""
 		if v, ok := data[NginxTLSCiphersKey]; !ok || v != expectedNginxCiphers {
 			t.Errorf("Expected %s to be %q, got %v", NginxTLSCiphersKey, expectedNginxCiphers, v)
+		}
+	})
+
+	t.Run("should filter out ciphers unsupported by Go crypto/tls", func(t *testing.T) {
+		data := make(map[string]interface{})
+		bootstrapResult := &bootstrap.BootstrapResult{
+			TLSProfile: bootstrap.TLSProfile{
+				Spec: configv1.TLSProfileSpec{
+					MinTLSVersion: configv1.VersionTLS12,
+					Ciphers: []string{
+						// Supported ciphers
+						"ECDHE-ECDSA-AES128-GCM-SHA256",
+						"ECDHE-RSA-AES128-GCM-SHA256",
+						// Unsupported ciphers (Go doesn't implement CBC mode for these)
+						"ECDHE-ECDSA-AES256-SHA384",
+						"ECDHE-RSA-AES256-SHA384",
+						"AES256-SHA256",
+						// More supported ciphers
+						"ECDHE-ECDSA-AES256-GCM-SHA384",
+					},
+				},
+				Adherence: configv1.TLSAdherencePolicyStrictAllComponents,
+			},
+		}
+
+		addTLSInfoToRenderData(data, bootstrapResult, true)
+
+		// Should use TLS profile
+		if v, ok := data[UseTLSProfileKey]; !ok || v != true {
+			t.Errorf("Expected %s to be true, got %v", UseTLSProfileKey, v)
+		}
+
+		// Only supported ciphers should be in the IANA list (unsupported ones filtered out)
+		expectedCiphers := "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
+		if v, ok := data[TLSCipherSuitesKey]; !ok || v != expectedCiphers {
+			t.Errorf("Expected %s to be %q, got %q", TLSCipherSuitesKey, expectedCiphers, v)
+		}
+
+		// NGINX should keep all ciphers (original OpenSSL names)
+		expectedNginxCiphers := strings.Join(bootstrapResult.TLSProfile.Spec.Ciphers, ":")
+		if v, ok := data[NginxTLSCiphersKey]; !ok || v != expectedNginxCiphers {
+			t.Errorf("Expected %s to be %q, got %q", NginxTLSCiphersKey, expectedNginxCiphers, v)
 		}
 	})
 }


### PR DESCRIPTION
When the Old TLS profile is configured with StrictAllComponents adherence, three cipher suites (ECDHE-ECDSA-AES256-SHA384, ECDHE-RSA-AES256-SHA384, AES256-SHA256) are included in the profile but are not supported by Go's crypto/tls package.

Previously, these OpenSSL cipher names were passed unconverted to ovnkube-identity's --tls-cipher-suites argument, causing the webhook container to crash with "Cipher suite ECDHE-ECDSA-AES256-SHA384 not supported or doesn't exist".

The fix silently filters out ciphers that cannot be converted from OpenSSL to IANA format, which indicates they are unsupported by Go's crypto/tls. This aligns with library-go's intentional design where OpenSSLToIANACipherSuites() already logs dropped ciphers at V(4).

NGINX components continue to receive the full OpenSSL cipher list since they support these ciphers natively.