### PR TITLE
OCPBUGS-64582: Drop strategy.rollingUpdate and switch strategy.type to Recreate via pre-patch in frr-k8s-statuscleaner deployments on SNO

### DIFF
--- a/bindata/network/frr-k8s/node-status-cleaner.yaml
+++ b/bindata/network/frr-k8s/node-status-cleaner.yaml
@@ -8,10 +8,19 @@ metadata:
     component: frr-k8s-statuscleaner
   annotations:
     release.openshift.io/version: "{{.ReleaseVersion}}"
+{{- if .IsSNO }}
+    networkoperator.openshift.io/pre-patch: '{"spec":{"strategy":{"type":"Recreate","rollingUpdate":null}}}'
+{{- end }}
 spec:
 {{- if .IsSNO }}
   strategy:
     type: Recreate
+{{- else }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
 {{- end }}
   selector:
     matchLabels:

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -108,6 +108,23 @@ func ApplyObject(ctx context.Context, client cnoclient.Client, obj Object, subco
 		fieldManager = fmt.Sprintf("%s/%s", fieldManager, subcontroller)
 	}
 
+	// If pre-patch is specified, apply it as a strategic-merge-patch to the live
+	// object before SSA. This handles cases where SSA cannot remove a field it
+	// does not own (e.g. defaulted rollingUpdate when switching to Recreate).
+	// The pre-patch is silently skipped if the object does not exist yet, making
+	// this mainly relevant on upgrades where defaulted fields must be removed.
+	if prePatch, ok := obj.GetAnnotations()[names.PrePatchAnnotation]; ok {
+		log.Printf("Object %s has pre-patch annotation, attempting strategic-merge-patch before SSA", objDesc)
+		patchOptions := metav1.PatchOptions{FieldManager: fieldManager}
+		_, err := clusterClient.Dynamic().Resource(rm.Resource).Namespace(namespace).Patch(
+			ctx, name, types.StrategicMergePatchType, []byte(prePatch), patchOptions)
+		if apierrors.IsNotFound(err) {
+			log.Printf("Object %s not found, skipping pre-patch", objDesc)
+		} else if err != nil {
+			return fmt.Errorf("failed to pre-patch %s: %w", objDesc, err)
+		}
+	}
+
 	// Use server-side apply to merge the desired object with the object on disk
 	patchOptions := metav1.PatchOptions{
 		// It is considered best-practice for controllers to force

--- a/pkg/apply/apply_test.go
+++ b/pkg/apply/apply_test.go
@@ -1,0 +1,131 @@
+package apply
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/openshift/cluster-network-operator/pkg/client/fake"
+	"github.com/openshift/cluster-network-operator/pkg/names"
+
+	. "github.com/onsi/gomega"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	fakedynamic "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+const prePatchValue = `{"spec":{"strategy":{"type":"Recreate","rollingUpdate":null}}}`
+
+func newTestDeployment(annotations map[string]string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"})
+	obj.SetName("test-deployment")
+	obj.SetNamespace("test-ns")
+	obj.SetAnnotations(annotations)
+	return obj
+}
+
+func patchRecorder(patchTypes *[]types.PatchType, prePatchBody *string, prePatchErr error) func(action clienttesting.Action) (bool, runtime.Object, error) {
+	return func(action clienttesting.Action) (bool, runtime.Object, error) {
+		patchAction := action.(clienttesting.PatchAction)
+		*patchTypes = append(*patchTypes, patchAction.GetPatchType())
+		if patchAction.GetPatchType() == types.StrategicMergePatchType {
+			*prePatchBody = string(patchAction.GetPatch())
+			if prePatchErr != nil {
+				return true, nil, prePatchErr
+			}
+		}
+		return true, newTestDeployment(nil), nil
+	}
+}
+
+func TestApplyObjectPrePatchRunsBeforeSSA(t *testing.T) {
+	g := NewWithT(t)
+
+	client := fake.NewFakeClient()
+
+	var patchTypes []types.PatchType
+	var prePatchBody string
+	pr := patchRecorder(&patchTypes, &prePatchBody, nil)
+	client.Default().Dynamic().(*fakedynamic.FakeDynamicClient).PrependReactor("patch", "deployments", pr)
+
+	obj := newTestDeployment(map[string]string{
+		names.PrePatchAnnotation: prePatchValue,
+	})
+
+	err := ApplyObject(context.Background(), client, obj, "test-controller")
+	g.Expect(err).To(Succeed())
+	g.Expect(patchTypes).To(HaveLen(2))
+	g.Expect(patchTypes[0]).To(Equal(types.StrategicMergePatchType), "pre-patch should be strategic-merge-patch")
+	g.Expect(patchTypes[1]).To(Equal(types.ApplyPatchType), "second patch should be SSA apply")
+	g.Expect(prePatchBody).To(Equal(prePatchValue), "pre-patch body should match annotation value")
+}
+
+func TestApplyObjectPrePatchNotFoundAllowsSSA(t *testing.T) {
+	g := NewWithT(t)
+
+	client := fake.NewFakeClient()
+
+	var patchTypes []types.PatchType
+	var prePatchBody string
+	pr := patchRecorder(&patchTypes, &prePatchBody, apierrors.NewNotFound(
+		schema.GroupResource{Group: "apps", Resource: "deployments"}, "test-deployment"))
+	client.Default().Dynamic().(*fakedynamic.FakeDynamicClient).PrependReactor("patch", "deployments", pr)
+
+	obj := newTestDeployment(map[string]string{
+		names.PrePatchAnnotation: prePatchValue,
+	})
+
+	err := ApplyObject(context.Background(), client, obj, "test-controller")
+	g.Expect(err).To(Succeed())
+	g.Expect(patchTypes).To(HaveLen(2))
+	g.Expect(patchTypes[0]).To(Equal(types.StrategicMergePatchType), "pre-patch was attempted")
+	g.Expect(patchTypes[1]).To(Equal(types.ApplyPatchType), "SSA apply still proceeded")
+	g.Expect(prePatchBody).To(Equal(prePatchValue), "pre-patch body should match annotation value")
+}
+
+func TestApplyObjectPrePatchErrorStopsReconciliation(t *testing.T) {
+	g := NewWithT(t)
+
+	client := fake.NewFakeClient()
+
+	var patchTypes []types.PatchType
+	var prePatchBody string
+	pr := patchRecorder(&patchTypes, &prePatchBody, fmt.Errorf("API server error"))
+	client.Default().Dynamic().(*fakedynamic.FakeDynamicClient).PrependReactor("patch", "deployments", pr)
+
+	obj := newTestDeployment(map[string]string{
+		names.PrePatchAnnotation: prePatchValue,
+	})
+
+	err := ApplyObject(context.Background(), client, obj, "test-controller")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("failed to pre-patch"))
+	g.Expect(patchTypes).To(HaveLen(1), "SSA apply should not have been reached")
+	g.Expect(patchTypes[0]).To(Equal(types.StrategicMergePatchType), "pre-patch should be strategic-merge-patch")
+	g.Expect(prePatchBody).To(Equal(prePatchValue), "pre-patch body should match annotation value")
+}
+
+func TestApplyObjectNoPrePatchAnnotationSkipsPrePatch(t *testing.T) {
+	g := NewWithT(t)
+
+	client := fake.NewFakeClient()
+
+	var patchTypes []types.PatchType
+	var prePatchBody string
+	pr := patchRecorder(&patchTypes, &prePatchBody, nil)
+	client.Default().Dynamic().(*fakedynamic.FakeDynamicClient).PrependReactor("patch", "deployments", pr)
+
+	obj := newTestDeployment(nil)
+
+	err := ApplyObject(context.Background(), client, obj, "test-controller")
+	g.Expect(err).To(Succeed())
+	g.Expect(patchTypes).To(HaveLen(1))
+	g.Expect(patchTypes[0]).To(Equal(types.ApplyPatchType), "only SSA apply should have run")
+	g.Expect(prePatchBody).To(BeEmpty(), "no pre-patch should have been sent")
+}

--- a/pkg/client/fake/fake_client.go
+++ b/pkg/client/fake/fake_client.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/meta/testrestmapper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	fakedynamic "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
@@ -125,42 +125,6 @@ func NewFakeClient(objs ...crclient.Object) cnoclient.Client {
 	}
 }
 
-type fakeRESTMapper struct {
-	kindForInput schema.GroupVersionResource
-}
-
-func (f *fakeRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
-	f.kindForInput = resource
-	return schema.GroupVersionKind{
-		Group:   "test",
-		Version: "test",
-		Kind:    "test"}, nil
-}
-
-func (f *fakeRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
-	return nil, nil
-}
-
-func (f *fakeRESTMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
-	return schema.GroupVersionResource{}, nil
-}
-
-func (f *fakeRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
-	return nil, nil
-}
-
-func (f *fakeRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
-	return nil, nil
-}
-
-func (f *fakeRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
-	return nil, nil
-}
-
-func (f *fakeRESTMapper) ResourceSingularizer(resource string) (singular string, err error) {
-	return "", nil
-}
-
 func (fc *FakeClusterClient) Kubernetes() kubernetes.Interface {
 	return fc.kClient
 }
@@ -182,11 +146,11 @@ func (fc *FakeClusterClient) CRClient() crclient.Client {
 }
 
 func (fc *FakeClusterClient) RESTMapper() meta.RESTMapper {
-	return &fakeRESTMapper{}
+	return testrestmapper.TestOnlyStaticRESTMapper(scheme.Scheme)
 }
 
 func (fc *FakeClusterClient) Scheme() *runtime.Scheme {
-	panic("not implemented!")
+	return scheme.Scheme
 }
 func (fc *FakeClusterClient) OperatorHelperClient() operatorv1helpers.OperatorClient {
 	panic("not implemented!")

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -48,6 +48,12 @@ const CreateOnlyAnnotation = "networkoperator.openshift.io/create-only"
 // tells the CNO reconciliation engine to ignore creating this object until conditions are met.
 const CreateWaitAnnotation = "networkoperator.openshift.io/create-wait"
 
+// PrePatchAnnotation is an annotation whose value is a JSON object applied as a
+// strategic-merge-patch to the live object before the SSA apply. This is needed
+// when SSA cannot remove a field it does not own (e.g. removing defaulted
+// rollingUpdate when switching a Deployment strategy to Recreate).
+const PrePatchAnnotation = "networkoperator.openshift.io/pre-patch"
+
 // NonCriticalAnnotation is an annotation on Deployments/DaemonSets to indicate
 // that they are not critical to the functioning of the pod network
 const NonCriticalAnnotation = "networkoperator.openshift.io/non-critical"

--- a/pkg/network/render_test.go
+++ b/pkg/network/render_test.go
@@ -21,6 +21,7 @@ import (
 	apifeatures "github.com/openshift/api/features"
 	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
+	"github.com/openshift/cluster-network-operator/pkg/names"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -702,12 +703,19 @@ func Test_renderFRRStatusCleanerStrategy(t *testing.T) {
 		g := NewWithT(t)
 		d := render(1)
 		g.Expect(d.Spec.Strategy.Type).To(Equal(appsv1.RecreateDeploymentStrategyType))
+		g.Expect(d.Annotations).To(
+			HaveKeyWithValue(
+				names.PrePatchAnnotation,
+				`{"spec":{"strategy":{"type":"Recreate","rollingUpdate":null}}}`,
+			),
+		)
 	})
 
-	t.Run("HA: no strategy override", func(t *testing.T) {
+	t.Run("HA: strategy is RollingUpdate", func(t *testing.T) {
 		g := NewWithT(t)
 		d := render(3)
-		g.Expect(d.Spec.Strategy.Type).To(BeEmpty())
+		g.Expect(d.Spec.Strategy.Type).To(Equal(appsv1.RollingUpdateDeploymentStrategyType))
+		g.Expect(d.Annotations).NotTo(HaveKey(names.PrePatchAnnotation))
 	})
 }
 


### PR DESCRIPTION
## Summary

On upgrade, the frr-k8s-statuscleaner Deployment has `rollingUpdate` fields defaulted by the API server. SSA cannot remove fields it does not own, so switching `strategy.type` to `Recreate` fails on upgrade with:

```
spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
```

This fix adds a new annotation to run a PatchType "application/strategic-merge-patch+json". With this trick we can remove strategy.rollingUpdate and switch strategy.type to Recreate simultaneously before the actual Apply logic for frr-k8s-statuscleaner deployments on SNO.

### Root cause

CNO uses Server-Side Apply (SSA) to apply rendered manifests. SSA tracks field ownership per field manager — it can only remove fields that the field manager previously set and now omits. The original template never included `rollingUpdate`, so those fields were set by the API server's defaulting mechanism, not by CNO's field manager. When the template switches to `type: Recreate` and omits `rollingUpdate`, SSA cannot remove it because it never owned it.

Setting `rollingUpdate: null` in the manifest does not work either.

### Fix

- **Pre-patch annotation**: Add a generic `networkoperator.openshift.io/pre-patch` annotation whose value is applied as a strategic-merge-patch to the live object before SSA. On the SNO template path, this atomically sets `type: Recreate` and removes `rollingUpdate` in a single strategic-merge-patch, before SSA takes over. The pre-patch is silently skipped if the object does not exist yet (initial install), making it relevant only on upgrades.
- **Explicit strategy in template**: The non-SNO path now explicitly sets `strategy.type: RollingUpdate` with `rollingUpdate` fields, so CNO's field manager owns them going forward. This prevents the issue from recurring on future strategy changes.

### Evaluation of potential fixes

Verified two approaches for removing defaulted fields not owned by the field manager:

**a) SSA with explicit fields to claim ownership**

If the desired fields (e.g. `rollingUpdate`) are explicitly included in an SSA apply, the field manager takes ownership of them (with `Force: true`). On a subsequent SSA apply that omits those fields, SSA removes them because the field manager now owns them. This works but requires two applies and knowing the current field values — impractical in a generic apply path where objects are unstructured.

```
kubectl apply --server-side --force-conflicts -f deployment-with-rolling-fields.yaml  # claims ownership
kubectl apply --server-side --force-conflicts -f deployment-with-recreate.yaml         # SSA removes rollingUpdate
```

**b) Strategic merge patch that explicitly removes the field**

A strategic-merge-patch with `{"spec":{"strategy":{"type":"Recreate","rollingUpdate":null}}}` atomically sets the new strategy type and removes `rollingUpdate` in one request. The API server processes both changes together, so the resulting object (`type: Recreate`, no `rollingUpdate`) passes validation. This approach is also idempotent. This is the approach used in the fix.

```
# cat patch-short.yaml
---
spec:
  strategy:
    type: Recreate
    rollingUpdate: null
# kubectl patch --patch-file patch-short.yaml deployment client
# kubectl patch --patch-file patch-short.yaml deployment client
deployment.apps/client patched (no change)
```

Note: removing `rollingUpdate` alone (without also setting `type: Recreate`) would not work on upgrade — the API server would re-default `rollingUpdate` because `type` is still `RollingUpdate`.

The issue is also documented in various sources and it's easy to find a description of it just searching for it on the web.

## CLI reproducer

Deployment:

```
# cat deployment.yaml
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test
  labels:
    app: test
spec:
  replicas: 1
  selector:
    matchLabels:
      app: test
  template:
    metadata:
      labels:
        app: test
    spec:
      containers:
      - name: client
        image: busybox:latest
        imagePullPolicy: IfNotPresent
        command:
        - sleep
        - "3600"
```

```
# kubectl apply -f deployment.yaml
deployment.apps/test created
```

```
# kubectl get deployment --show-managed-fields=true test -o yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  annotations:
    deployment.kubernetes.io/revision: "1"
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"labels":{"app":"test"},"name":"test","namespace":"default"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"test"}},"template":{"metadata":{"labels":{"app":"test"}},"spec":{"containers":[{"command":["sleep","3600"],"image":"busybox:latest","imagePullPolicy":"IfNotPresent","name":"client"}]}}}}
  creationTimestamp: "2026-08-15T02:26:32Z"
  generation: 1
  labels:
    app: test
  managedFields:
  - apiVersion: apps/v1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .: {}
          f:kubectl.kubernetes.io/last-applied-configuration: {}
        f:labels:
          .: {}
          f:app: {}
      f:spec:
        f:progressDeadlineSeconds: {}
        f:replicas: {}
        f:revisionHistoryLimit: {}
        f:selector: {}
        f:strategy:
          f:rollingUpdate:
            .: {}
            f:maxSurge: {}
            f:maxUnavailable: {}
          f:type: {}
        f:template:
          f:metadata:
            f:labels:
              .: {}
              f:app: {}
          f:spec:
            f:containers:
              k:{"name":"client"}:
                .: {}
                f:command: {}
                f:image: {}
                f:imagePullPolicy: {}
                f:name: {}
                f:resources: {}
                f:terminationMessagePath: {}
                f:terminationMessagePolicy: {}
            f:dnsPolicy: {}
            f:restartPolicy: {}
            f:schedulerName: {}
            f:securityContext: {}
            f:terminationGracePeriodSeconds: {}
    manager: kubectl-client-side-apply
    operation: Update
    time: "2026-08-15T02:26:32Z"
  - apiVersion: apps/v1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          f:deployment.kubernetes.io/revision: {}
      f:status:
        f:availableReplicas: {}
        f:conditions:
          .: {}
          k:{"type":"Available"}:
            .: {}
            f:lastTransitionTime: {}
            f:lastUpdateTime: {}
            f:message: {}
            f:reason: {}
            f:status: {}
            f:type: {}
          k:{"type":"Progressing"}:
            .: {}
            f:lastTransitionTime: {}
            f:lastUpdateTime: {}
            f:message: {}
            f:reason: {}
            f:status: {}
            f:type: {}
        f:observedGeneration: {}
        f:readyReplicas: {}
        f:replicas: {}
        f:updatedReplicas: {}
    manager: kube-controller-manager
    operation: Update
    subresource: status
    time: "2026-08-15T02:26:38Z"
  name: test
  namespace: default
  resourceVersion: "578"
  uid: cb48101e-6d7f-41ac-a775-99c238b08673
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: test
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: test
    spec:
      containers:
      - command:
        - sleep
        - "3600"
        image: busybox:latest
        imagePullPolicy: IfNotPresent
        name: client
        resources: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 30
status:
  availableReplicas: 1
  conditions:
  - lastTransitionTime: "2026-08-15T02:26:38Z"
    lastUpdateTime: "2026-08-15T02:26:38Z"
    message: Deployment has minimum availability.
    reason: MinimumReplicasAvailable
    status: "True"
    type: Available
  - lastTransitionTime: "2026-08-15T02:26:32Z"
    lastUpdateTime: "2026-08-15T02:26:38Z"
    message: ReplicaSet "test-7ffc8f498b" has successfully progressed.
    reason: NewReplicaSetAvailable
    status: "True"
    type: Progressing
  observedGeneration: 1
  readyReplicas: 1
  replicas: 1
  updatedReplicas: 1
```

Try server side apply with the fields unmanaged (default by the API server):

```
# cat deployment.with-recreate.yaml
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test
  labels:
    app: test
spec:
  strategy:
    type: Recreate
  replicas: 1
  selector:
    matchLabels:
      app: test
  template:
    metadata:
      labels:
        app: test
    spec:
      containers:
      - name: client
        image: busybox:latest
        imagePullPolicy: IfNotPresent
        command:
        - sleep
        - "3600"
```

```
# kubectl apply --server-side --force-conflicts -f deployment.with-recreate.yaml
The Deployment "test" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
```

Now explicitly set strategy to rolligUpdate to own the fields, followed by a patch to set type: Recreate and drop strategy.rollingUpdate via server side apply:

```
# cat deployment.with-rolling.yaml
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test
  labels:
    app: test
spec:
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  replicas: 1
  selector:
    matchLabels:
      app: test
  template:
    metadata:
      labels:
        app: test
    spec:
      containers:
      - name: client
        image: busybox:latest
        imagePullPolicy: IfNotPresent
        command:
        - sleep
        - "3600"
[# kubectl apply --server-side --force-conflicts -f deployment.with-rolling.yaml
deployment.apps/test serverside-applied
# kubectl apply --server-side --force-conflicts -f deployment.with-recreate.yaml
deployment.apps/test serverside-applied
```

```
# kubectl get deployment --show-managed-fields=true test -o yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  annotations:
    deployment.kubernetes.io/revision: "1"
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"labels":{"app":"test"},"name":"test","namespace":"default"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"test"}},"strategy":{"type":"Recreate"},"template":{"metadata":{"labels":{"app":"test"}},"spec":{"containers":[{"command":["sleep","3600"],"image":"busybox:latest","imagePullPolicy":"IfNotPresent","name":"client"}]}}}}
  creationTimestamp: "2026-08-15T02:26:32Z"
  generation: 3
  labels:
    app: test
  managedFields:
  - apiVersion: apps/v1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          f:kubectl.kubernetes.io/last-applied-configuration: {}
    manager: kubectl-last-applied
    operation: Apply
  - apiVersion: apps/v1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:labels:
          f:app: {}
      f:spec:
        f:replicas: {}
        f:selector: {}
        f:strategy:
          f:type: {}
        f:template:
          f:metadata:
            f:labels:
              f:app: {}
          f:spec:
            f:containers:
              k:{"name":"client"}:
                .: {}
                f:command: {}
                f:image: {}
                f:imagePullPolicy: {}
                f:name: {}
    manager: kubectl
    operation: Apply
    time: "2026-08-15T02:32:54Z"
  - apiVersion: apps/v1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          f:deployment.kubernetes.io/revision: {}
      f:status:
        f:availableReplicas: {}
        f:conditions:
          .: {}
          k:{"type":"Available"}:
            .: {}
            f:lastTransitionTime: {}
            f:lastUpdateTime: {}
            f:message: {}
            f:reason: {}
            f:status: {}
            f:type: {}
          k:{"type":"Progressing"}:
            .: {}
            f:lastTransitionTime: {}
            f:lastUpdateTime: {}
            f:message: {}
            f:reason: {}
            f:status: {}
            f:type: {}
        f:observedGeneration: {}
        f:readyReplicas: {}
        f:replicas: {}
        f:updatedReplicas: {}
    manager: kube-controller-manager
    operation: Update
    subresource: status
    time: "2026-08-15T02:32:54Z"
  name: test
  namespace: default
  resourceVersion: "1074"
  uid: cb48101e-6d7f-41ac-a775-99c238b08673
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: test
  strategy:
    type: Recreate
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: test
    spec:
      containers:
      - command:
        - sleep
        - "3600"
        image: busybox:latest
        imagePullPolicy: IfNotPresent
        name: client
        resources: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 30
status:
  availableReplicas: 1
  conditions:
  - lastTransitionTime: "2026-08-15T02:26:38Z"
    lastUpdateTime: "2026-08-15T02:26:38Z"
    message: Deployment has minimum availability.
    reason: MinimumReplicasAvailable
    status: "True"
    type: Available
  - lastTransitionTime: "2026-08-15T02:26:32Z"
    lastUpdateTime: "2026-08-15T02:26:38Z"
    message: ReplicaSet "test-7ffc8f498b" has successfully progressed.
    reason: NewReplicaSetAvailable
    status: "True"
    type: Progressing
  observedGeneration: 3
  readyReplicas: 1
  replicas: 1
  updatedReplicas: 1
```