### PR TITLE
Bug 105513: Increase ovnkube-node CPU requests to prevent CNI timeout

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-node.yaml
@@ -150,7 +150,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         resources:
           requests:
-            cpu: 50m
+            cpu: 150m
             memory: 300Mi
       - name: ovn-acl-logging
         image: "{{.OvnImage}}"
@@ -258,7 +258,7 @@ spec:
           name: env-overrides
         resources:
           requests:
-            cpu: 10m
+            cpu: 100m
             memory: 300Mi
         terminationMessagePolicy: FallbackToLogsOnError
 
@@ -322,7 +322,7 @@ spec:
           name: env-overrides
         resources:
           requests:
-            cpu: 10m
+            cpu: 100m
             memory: 300Mi
         terminationMessagePolicy: FallbackToLogsOnError
 
@@ -382,7 +382,7 @@ spec:
           name: env-overrides
         resources:
           requests:
-            cpu: 10m
+            cpu: 100m
             memory: 300Mi
         terminationMessagePolicy: FallbackToLogsOnError
 {{ end }}
@@ -527,7 +527,7 @@ spec:
           name: env-overrides
         resources:
           requests:
-            cpu: 10m
+            cpu: 100m
             memory: 600Mi
             {{ if and (.MgmtPortResourceName) (or (eq .OVN_NODE_MODE "smart-nic") (eq .OVN_NODE_MODE "dpu-host")) }}
             {{ .MgmtPortResourceName }}: '{{ .MgmtPortResourceCount }}'

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-node.yaml
@@ -186,7 +186,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         resources:
           requests:
-            cpu: 50m
+            cpu: 150m
             memory: 300Mi
       - name: ovn-acl-logging
         image: "{{.OvnImage}}"
@@ -294,7 +294,7 @@ spec:
           name: env-overrides
         resources:
           requests:
-            cpu: 10m
+            cpu: 100m
             memory: 70Mi
         terminationMessagePolicy: FallbackToLogsOnError
 
@@ -358,7 +358,7 @@ spec:
           name: env-overrides
         resources:
           requests:
-            cpu: 10m
+            cpu: 100m
             memory: 300Mi
         terminationMessagePolicy: FallbackToLogsOnError
 
@@ -418,7 +418,7 @@ spec:
           name: env-overrides
         resources:
           requests:
-            cpu: 10m
+            cpu: 100m
             memory: 300Mi
         terminationMessagePolicy: FallbackToLogsOnError
 {{ end }}
@@ -551,7 +551,7 @@ spec:
           name: env-overrides
         resources:
           requests:
-            cpu: 10m
+            cpu: 100m
             memory: 600Mi
             {{ if and (.MgmtPortResourceName) (or (eq .OVN_NODE_MODE "smart-nic") (eq .OVN_NODE_MODE "dpu-host")) }}
             {{ .MgmtPortResourceName }}: '{{ .MgmtPortResourceCount }}'


### PR DESCRIPTION
## Summary

Increases CPU requests for critical OVN containers in the ovnkube-node DaemonSet to prevent CNI ADD timeouts under high CPU utilization.

**Bug:** [OCPBUGS-105513](https://issues.redhat.com/browse/OCPBUGS-105513)
**Related:** OCPBUGS-99643, OCPBUGS-76596

### Root Cause

Under high CPU contention (~95-100%), the CFS scheduler starves ovn-controller, ovnkube-controller, northd, nbdb, and sbdb containers due to their low CPU requests. This causes CNI ADD operations to exceed timeout, leaving pods stuck in `ContainerCreating` with `DeadlineExceeded`.

### Changes

| Container          | CPU Request (before) | CPU Request (after) |
|--------------------|----------------------|---------------------|
| ovn-controller     | 50m                  | 150m                |
| northd             | 10m                  | 100m                |
| nbdb               | 10m                  | 100m                |
| sbdb               | 10m                  | 100m                |
| ovnkube-controller | 10m                  | 100m                |

---

## Verification

Tested on OCP 4.19.39 (AWS), 3.5 vCPU worker node.

### BEFORE fix (default CPU requests)

Stress: CPU stress pod (6x busy loops) + aggressive pod churn (30 pods/cycle, 2s gap).
Node CPU: **114% (4000m/3500m)**

`FailedCreatePodSandBox` events appeared within minutes:

```
Warning   FailedCreatePodSandBox
  Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create pod network sandbox ...
  error adding pod to CNI network "multus-cni-network":
  CmdAdd (shim): CNI request failed with status 400:
  ... error configuring pod networking:
  error waiting for pod: ... context deadline exceeded
```

### AFTER fix (increased CPU requests)

Identical stress conditions — same node, same CPU utilization (**114%**), same pod churn rate.

Patched the ovnkube-node DaemonSet with the new CPU request values (CVO paused, CNO scaled down).

**Result: 20 minutes of stress testing — zero FailedCreatePodSandBox errors, zero DeadlineExceeded errors.**

All churn pods created and completed successfully.

---

## Test Plan

- [x] Reproduced the bug with default CPU requests under CPU contention
- [x] Verified the fix eliminates CNI timeouts under identical stress conditions
- [ ] CI passes