### PR TITLE
[release-4.18] OCPBUGS-111878: backport of #2662

### DIFF
--- a/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
@@ -499,7 +499,8 @@ spec:
             # Wait upto 15 seconds for ovs-monitor-ipsec process to terminate before
             # cleaning up ipsec entries.
             counter=0
-            while kill -0 "$(cat /var/run/openvswitch/ovs-monitor-ipsec.pid 2>/dev/null)"; do
+            pid=$(cat /var/run/openvswitch/ovs-monitor-ipsec.pid 2>/dev/null)
+            while [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; do
               counter=$((counter+1))
               sleep 1
               if [ $counter -gt 15 ];
@@ -532,7 +533,8 @@ spec:
           # in the ovn-ipsec container's pre stop hook.
           if ! grep -q "openshift.conf" /etc/sysconfig/openvswitch; then
             # Monitor the ovs-monitor-ipsec process.
-            while kill -0 "$(cat /var/run/openvswitch/ovs-monitor-ipsec.pid 2>/dev/null)"; do
+            pid=$(cat /var/run/openvswitch/ovs-monitor-ipsec.pid 2>/dev/null)
+            while [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; do
               sleep 1
             done
 

--- a/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
@@ -319,12 +319,12 @@ spec:
 
           # Workaround for https://github.com/libreswan/libreswan/issues/373
           ulimit -n 1024
-
-          /usr/libexec/ipsec/addconn --config /etc/ipsec.conf --checkconfig
-          # Check kernel modules
-          /usr/libexec/ipsec/_stackmanager start
-          # Check nss database status
-          /usr/sbin/ipsec --checknss
+          
+          # Check kernel modules only for libreswan version <= 5.2. The _stackmanager binary is
+          # removed from 5.3 onwards, so this check is not needed on later versions.
+          if [ -e /usr/libexec/ipsec/_stackmanager ]; then
+            /usr/libexec/ipsec/_stackmanager start
+          fi
 
           # Start ovs-monitor-ipsec which will monitor for changes in the ovs
           # tunnelling configuration (for example addition of a node) and configures
@@ -378,8 +378,6 @@ spec:
           name: host-var-lib
         - mountPath: /etc
           name: host-etc
-        - mountPath: /usr/sbin
-          name: usr-sbin
         - mountPath: /usr/libexec
           name: usr-libexec
         resources:
@@ -414,8 +412,10 @@ spec:
                   fi
                 fi
               else
-                if [[ $(ipsec whack --trafficstatus | wc -l) -eq 0 ]]; then
-                  echo "no ipsec traffic configured"
+                # Check if ovs-monitor-ipsec is running and has configured IPsec tunnels
+                status=$(ovs-appctl -t ovs-monitor-ipsec ipsec/status 2>/dev/null)
+                if [ -z "$status" ] || [ "$status" = "{}" ]; then
+                  echo "no ipsec tunnels configured"
                   exit 10
                 fi
               fi
@@ -601,10 +601,6 @@ spec:
           path: /etc
           type: Directory
         name: host-etc
-      - hostPath:
-          path: /usr/sbin
-          type: Directory
-        name: usr-sbin
       - hostPath:
           path: /usr/libexec
           type: Directory

--- a/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
@@ -319,12 +319,6 @@ spec:
 
           # Workaround for https://github.com/libreswan/libreswan/issues/373
           ulimit -n 1024
-          
-          # Check kernel modules only for libreswan version <= 5.2. The _stackmanager binary is
-          # removed from 5.3 onwards, so this check is not needed on later versions.
-          if [ -e /usr/libexec/ipsec/_stackmanager ]; then
-            /usr/libexec/ipsec/_stackmanager start
-          fi
 
           # Start ovs-monitor-ipsec which will monitor for changes in the ovs
           # tunnelling configuration (for example addition of a node) and configures
@@ -378,8 +372,6 @@ spec:
           name: host-var-lib
         - mountPath: /etc
           name: host-etc
-        - mountPath: /usr/libexec
-          name: usr-libexec
         resources:
           requests:
             cpu: 10m
@@ -601,10 +593,6 @@ spec:
           path: /etc
           type: Directory
         name: host-etc
-      - hostPath:
-          path: /usr/libexec
-          type: Directory
-        name: usr-libexec
       tolerations:
       - operator: "Exists"
 {{end}}

--- a/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
+++ b/bindata/network/ovn-kubernetes/common/ipsec-host.yaml
@@ -109,8 +109,9 @@ spec:
           # authentic.
           echo "Configuring IPsec keys"
 
-          cert_pem=/etc/openvswitch/keys/ipsec-cert.pem
+          cert_pem=/var/lib/openvswitch/etc/keys/ipsec-cert.pem
 
+          ovs_ipsec_restart_needed="false"
           # If the certificate does not exist or it will expire in the next 6 months
           # (15770000 seconds), we will generate a new one.
           if ! openssl x509 -noout -dates -checkend 15770000 -in $cert_pem; then
@@ -118,25 +119,25 @@ spec:
             # is a requirement by OVN.
             cn=$(ovs-vsctl --retry -t 60 get Open_vSwitch . external-ids:system-id | tr -d "\"")
 
-            mkdir -p /etc/openvswitch/keys
+            mkdir -p /var/lib/openvswitch/etc/keys
 
             # Generate an SSL private key and use the key to create a certitificate signing request
-            umask 077 && openssl genrsa -out /etc/openvswitch/keys/ipsec-privkey.pem 2048
+            umask 077 && openssl genrsa -out /var/lib/openvswitch/etc/keys/ipsec-privkey.pem 2048
             if ! openssl req -new -text \
                         -extensions v3_req \
                         -addext "subjectAltName = DNS:${cn}" \
                         -subj "/C=US/O=ovnkubernetes/OU=kind/CN=${cn}" \
-                        -key /etc/openvswitch/keys/ipsec-privkey.pem \
-                        -out /etc/openvswitch/keys/ipsec-req.pem; then
+                        -key /var/lib/openvswitch/etc/keys/ipsec-privkey.pem \
+                        -out /var/lib/openvswitch/etc/keys/ipsec-req.pem; then
               echo "openssl req failed with -extensions v3_req, retrying without it"
               openssl req -new -text \
                           -addext "subjectAltName = DNS:${cn}" \
                           -subj "/C=US/O=ovnkubernetes/OU=kind/CN=${cn}" \
-                          -key /etc/openvswitch/keys/ipsec-privkey.pem \
-                          -out /etc/openvswitch/keys/ipsec-req.pem
+                          -key /var/lib/openvswitch/etc/keys/ipsec-privkey.pem \
+                          -out /var/lib/openvswitch/etc/keys/ipsec-req.pem
             fi
 
-            csr_64=$(base64 -w0 /etc/openvswitch/keys/ipsec-req.pem) # -w0 to avoid line-wrap
+            csr_64=$(base64 -w0 /var/lib/openvswitch/etc/keys/ipsec-req.pem) # -w0 to avoid line-wrap
 
             # Request that our generated certificate signing request is
             # signed by the "network.openshift.io/signer" signer that is
@@ -176,7 +177,10 @@ spec:
             # kubectl delete csr/$(hostname)
 
             # Get the CA certificate so we can authenticate peer nodes.
-            openssl x509 -in /signer-ca/ca-bundle.crt -outform pem -text -out /etc/openvswitch/keys/ipsec-cacert.pem
+            openssl x509 -in /signer-ca/ca-bundle.crt -outform pem -text -out /var/lib/openvswitch/etc/keys/ipsec-cacert.pem
+
+            # New certs are generated, so openvswitch-ipsec service may need restart to load new certificates.
+            ovs_ipsec_restart_needed="true"
           fi
 
           # Configure OVS with the relevant keys for this node. This is required by ovs-monitor-ipsec.
@@ -185,8 +189,13 @@ spec:
           # the will get read and loaded into NSS by the ovs-monitor-ipsec process
           # which has not started yet.
           ovs-vsctl --retry -t 60 set Open_vSwitch . other_config:certificate=$cert_pem \
-                                                     other_config:private_key=/etc/openvswitch/keys/ipsec-privkey.pem \
-                                                     other_config:ca_cert=/etc/openvswitch/keys/ipsec-cacert.pem
+                                                     other_config:private_key=/var/lib/openvswitch/etc/keys/ipsec-privkey.pem \
+                                                     other_config:ca_cert=/var/lib/openvswitch/etc/keys/ipsec-cacert.pem
+
+          # Restart openvswitch-ipsec systemd service when OVS is configured with new certificate when old one expired.
+          if grep -q "openshift.conf" /etc/sysconfig/openvswitch && [ "$ovs_ipsec_restart_needed" = "true" ]; then
+            chroot /proc/1/root systemctl restart openvswitch-ipsec
+          fi
         env:
         - name: K8S_NODE
           valueFrom:
@@ -203,8 +212,8 @@ spec:
           name: host-var-run
         - mountPath: /signer-ca
           name: signer-ca
-        - mountPath: /etc/openvswitch
-          name: etc-openvswitch
+        - mountPath: /var/lib
+          name: host-var-lib
         - mountPath: /etc
           name: host-etc
         resources:
@@ -247,6 +256,38 @@ spec:
           if ! pgrep pluto; then
             echo "pluto is not running, enable the service and/or check system logs"
             exit 2
+          fi
+
+          # Configure IPsec using the host's openvswitch-ipsec systemd service if present.
+          # This avoids running host binaries from the container and solves compatibility issues.
+          # Fall back to container-based ovs-monitor-ipsec when the openvswitch-ipsec systemd service
+          # is not yet available on the node.
+          ovsipsecservice="openvswitch-ipsec"
+          if chroot /proc/1/root systemctl list-unit-files --type=service | grep "$ovsipsecservice" &> /dev/null; then
+            if ! grep -q "openshift.conf" /etc/sysconfig/openvswitch; then
+              sed -i 's|OPTIONS=\"\"|OPTIONS=\"--no-restart-ike-daemon --ovs-monitor-ipsec-options='\''--ipsec-conf=\/etc\/ipsec.d\/openshift.conf --root-ipsec-conf=\/etc\/ipsec.conf --ipsec-d=\/var\/lib\/ipsec\/nss --use-default-crypto'\''\"|' /etc/sysconfig/openvswitch
+              if ! grep -q "openshift.conf" /etc/sysconfig/openvswitch; then
+                echo "failed to configure /etc/sysconfig/openvswitch"
+                exit 1
+              fi
+              chroot /proc/1/root systemctl enable --now $ovsipsecservice
+            fi
+
+            # Capture PID and InvocationID atomically, verify no restart occurred
+            invocation_id=$(chroot /proc/1/root systemctl show -p InvocationID --value openvswitch-ipsec)
+            main_pid=$(chroot /proc/1/root systemctl show -p MainPID --value openvswitch-ipsec)
+            file_pid=$(cat /var/run/openvswitch/ovs-monitor-ipsec.pid 2>/dev/null)
+            if [ "$main_pid" != "$file_pid" ]; then
+              echo "openvswitch-ipsec PID mismatch: systemd reports $main_pid, PID file has $file_pid"
+              exit 1
+            fi
+            echo "$main_pid" > /tmp/ovs-monitor-ipsec-main.pid
+
+            while true; do
+              chroot /proc/1/root journalctl -f "_SYSTEMD_INVOCATION_ID=$invocation_id" -n all
+              echo "journalctl exited unexpectedly, retrying..."
+              sleep 2
+            done
           fi
 
           # The ovs-monitor-ipsec doesn't set authby, so when it calls ipsec auto --start
@@ -302,6 +343,10 @@ spec:
                  - |
                    #!/bin/bash
                    set -exuo pipefail
+                   if grep -q "openshift.conf" /etc/sysconfig/openvswitch; then
+                     echo "openvswitch-ipsec service is configured on the host, no action needed in pre stop"
+                     exit 0
+                   fi
                    # In order to maintain traffic flows during container restart, we
                    # need to ensure that xfrm state and policies are not flushed.
 
@@ -329,8 +374,6 @@ spec:
           name: host-var-run
         - mountPath: /var/log/openvswitch/
           name: host-var-log-ovs
-        - mountPath: /etc/openvswitch
-          name: etc-openvswitch
         - mountPath: /var/lib
           name: host-var-lib
         - mountPath: /etc
@@ -357,9 +400,24 @@ spec:
                 exit 0
               fi
 {{ end }}
-              if [[ $(ipsec whack --trafficstatus | wc -l) -eq 0 ]]; then
-                echo "no ipsec traffic configured"
-                exit 10
+              if grep -q "openshift.conf" /etc/sysconfig/openvswitch; then
+                if ! chroot /proc/1/root systemctl is-active --quiet openvswitch-ipsec; then
+                  echo "openvswitch-ipsec service is not active"
+                  exit 1
+                fi
+                if [ -f /tmp/ovs-monitor-ipsec-main.pid ]; then
+                  file_pid=$(cat /var/run/openvswitch/ovs-monitor-ipsec.pid 2>/dev/null)
+                  main_pid=$(cat /tmp/ovs-monitor-ipsec-main.pid)
+                  if [ "$main_pid" != "$file_pid" ]; then
+                    echo "openvswitch-ipsec service restarted (PID changed from $main_pid to $file_pid)"
+                    exit 1
+                  fi
+                fi
+              else
+                if [[ $(ipsec whack --trafficstatus | wc -l) -eq 0 ]]; then
+                  echo "no ipsec traffic configured"
+                  exit 10
+                fi
               fi
           initialDelaySeconds: 15
           periodSeconds: 60
@@ -437,7 +495,15 @@ spec:
 
           # Function to handle SIGTERM
           cleanup() {
-            echo "received SIGTERM, flushing ipsec config"
+            echo "received SIGTERM, flushing ipsec config if required"
+            # The openvswitch-ipsec service is started by this pod. When active, it updates
+            # /etc/ipsec.d/openshift.conf for IPsec connection changes, and the pluto daemon
+            # manages xfrm state and policy entries accordingly. Skip flushing IPsec state
+            # on exit.
+            if grep -q "openshift.conf" /etc/sysconfig/openvswitch; then
+              echo "openvswitch-ipsec service is configured on the host, no ipsec flush needed"
+              exit 0
+            fi
             # Wait upto 15 seconds for ovs-monitor-ipsec process to terminate before
             # cleaning up ipsec entries.
             counter=0
@@ -469,14 +535,19 @@ spec:
           done
           echo "ovs-monitor-ipsec is started"
 
-          # Monitor the ovs-monitor-ipsec process.
-          while kill -0 "$(cat /var/run/openvswitch/ovs-monitor-ipsec.pid 2>/dev/null)"; do
-            sleep 1
-          done
+          # When ovs-monitor-ipsec process is not running via openvswitch-ipsec systemd
+          # service, then keep monitoring ovn-ipsec container process until it terminates
+          # in the ovn-ipsec container's pre stop hook.
+          if ! grep -q "openshift.conf" /etc/sysconfig/openvswitch; then
+            # Monitor the ovs-monitor-ipsec process.
+            while kill -0 "$(cat /var/run/openvswitch/ovs-monitor-ipsec.pid 2>/dev/null)"; do
+              sleep 1
+            done
 
-          # Once the ovs-monitor-ipsec process terminates, execute the cleanup command.
-          echo "ovs-monitor-ipsec is terminated, flushing ipsec config"
-          ipsecflush
+            # Once the ovs-monitor-ipsec process terminates, execute the cleanup command.
+            echo "ovs-monitor-ipsec is terminated, flushing ipsec config"
+            ipsecflush
+          fi
 
           # Continue running until SIGTERM is received (or exit naturally)
           while true; do
@@ -515,10 +586,6 @@ spec:
           defaultMode: 420
           name: signer-ca
         name: signer-ca
-      - hostPath:
-          path: /var/lib/openvswitch/etc
-          type: DirectoryOrCreate
-        name: etc-openvswitch
       - hostPath:
           path: "{{.CNIConfDir}}"
         name: host-cni-netd


### PR DESCRIPTION
Backport of #2662 to release-4.18.

Fixes ovn-ipsec-host on RHEL worker nodes as there is a shared library mismatch with RHEL 8. Since https://github.com/openshift/cluster-network-operator/pull/2576, the host binaries are used instead of the container binaries, #2662 fixed it.

This will also be backported to 4.17, 4.16, 4.15. 
4.19+ is not impacted as RHEL worker node is no longer supported.
RHEL worker nodes with RHEL 9+ is not impacted as shared library are existing.

`/usr/libexec/ipsec/addconn: error while loading shared libraries: libunbound.so.2: cannot open shared object file: No such file or directory`