### PR TITLE
Add short names for NetworkAttachmentDefinition

### DIFF
--- a/bindata/network/additional-networks/crd/001-crd.yaml
+++ b/bindata/network/additional-networks/crd/001-crd.yaml
@@ -12,7 +12,9 @@ spec:
     kind: NetworkAttachmentDefinition
     listKind: NetworkAttachmentDefinitionList
     shortNames:
+    - nad
     - net-attach-def
+    - networkattachmentdefinition
   versions:
   - name: v1
     served: true

--- a/pkg/network/additional_networks_test.go
+++ b/pkg/network/additional_networks_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	operv1 "github.com/openshift/api/operator/v1"
+	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 var NetworkAttachmentConfigRaw = operv1.Network{
@@ -77,6 +78,25 @@ func TestRenderAdditionalNetworksCRD(t *testing.T) {
 	objs, err := renderAdditionalNetworksCRD(manifestDir)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(objs).To(HaveLen(4))
+
+	var nadCRD *uns.Unstructured
+	for _, obj := range objs {
+		if obj.GetKind() == "CustomResourceDefinition" &&
+			obj.GetName() == "network-attachment-definitions.k8s.cni.cncf.io" {
+			nadCRD = obj
+			break
+		}
+	}
+	g.Expect(nadCRD).NotTo(BeNil())
+
+	shortNames, found, err := uns.NestedStringSlice(nadCRD.Object, "spec", "names", "shortNames")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(found).To(BeTrue())
+	g.Expect(shortNames).To(Equal([]string{
+		"nad",
+		"net-attach-def",
+		"networkattachmentdefinition",
+	}))
 }
 
 func TestRenderRawCNIConfig(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `nad` and `networkattachmentdefinition` short names to the NetworkAttachmentDefinition CRD
- Keep existing `net-attach-def` alias for compatibility
- Add unit-test coverage asserting rendered CRD shortNames

## Test plan
- [x] Deployed custom CNO image with the CRD change
- [x] Confirmed `oc api-resources | grep network-attachment` shows `nad,net-attach-def,networkattachmentdefinition`
- [x] Confirmed `oc get networkattachmentdefinition -A` works
- [x] Unit test covers rendered shortNames (`TestRenderAdditionalNetworksCRD`)

## Special notes for your reviewer
This change was prepared with AI assistance (Cursor). I reviewed and tested the resulting CRD/shortNames behavior on a cluster before opening/updating this PR.

