### PR TITLE
OCPBUGS-105556: [4.22] frr-k8s: use Recreate strategy for statuscleaner deployment

### DIFF
--- a/bindata/network/frr-k8s/node-status-cleaner.yaml
+++ b/bindata/network/frr-k8s/node-status-cleaner.yaml
@@ -8,10 +8,19 @@ metadata:
     component: frr-k8s-statuscleaner
   annotations:
     release.openshift.io/version: "{{.ReleaseVersion}}"
+{{- if .IsSNO }}
+    networkoperator.openshift.io/pre-patch: '{"spec":{"strategy":{"type":"Recreate","rollingUpdate":null}}}'
+{{- end }}
 spec:
 {{- if .IsSNO }}
   strategy:
     type: Recreate
+{{- else }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
 {{- end }}
   selector:
     matchLabels:

--- a/bindata/network/frr-k8s/node-status-cleaner.yaml
+++ b/bindata/network/frr-k8s/node-status-cleaner.yaml
@@ -9,6 +9,10 @@ metadata:
   annotations:
     release.openshift.io/version: "{{.ReleaseVersion}}"
 spec:
+{{- if .IsSNO }}
+  strategy:
+    type: Recreate
+{{- end }}
   selector:
     matchLabels:
       component: frr-k8s-statuscleaner

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -110,6 +110,23 @@ func ApplyObject(ctx context.Context, client cnoclient.Client, obj Object, subco
 		fieldManager = fmt.Sprintf("%s/%s", fieldManager, subcontroller)
 	}
 
+	// If pre-patch is specified, apply it as a strategic-merge-patch to the live
+	// object before SSA. This handles cases where SSA cannot remove a field it
+	// does not own (e.g. defaulted rollingUpdate when switching to Recreate).
+	// The pre-patch is silently skipped if the object does not exist yet, making
+	// this mainly relevant on upgrades where defaulted fields must be removed.
+	if prePatch, ok := obj.GetAnnotations()[names.PrePatchAnnotation]; ok {
+		log.Printf("Object %s has pre-patch annotation, attempting strategic-merge-patch before SSA", objDesc)
+		patchOptions := metav1.PatchOptions{FieldManager: fieldManager}
+		_, err := clusterClient.Dynamic().Resource(rm.Resource).Namespace(namespace).Patch(
+			ctx, name, types.StrategicMergePatchType, []byte(prePatch), patchOptions)
+		if apierrors.IsNotFound(err) {
+			log.Printf("Object %s not found, skipping pre-patch", objDesc)
+		} else if err != nil {
+			return fmt.Errorf("failed to pre-patch %s: %w", objDesc, err)
+		}
+	}
+
 	// Use server-side apply to merge the desired object with the object on disk
 	patchOptions := metav1.PatchOptions{
 		// It is considered best-practice for controllers to force

--- a/pkg/apply/apply_test.go
+++ b/pkg/apply/apply_test.go
@@ -1,0 +1,131 @@
+package apply
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/openshift/cluster-network-operator/pkg/client/fake"
+	"github.com/openshift/cluster-network-operator/pkg/names"
+
+	. "github.com/onsi/gomega"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	fakedynamic "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+const prePatchValue = `{"spec":{"strategy":{"type":"Recreate","rollingUpdate":null}}}`
+
+func newTestDeployment(annotations map[string]string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"})
+	obj.SetName("test-deployment")
+	obj.SetNamespace("test-ns")
+	obj.SetAnnotations(annotations)
+	return obj
+}
+
+func patchRecorder(patchTypes *[]types.PatchType, prePatchBody *string, prePatchErr error) func(action clienttesting.Action) (bool, runtime.Object, error) {
+	return func(action clienttesting.Action) (bool, runtime.Object, error) {
+		patchAction := action.(clienttesting.PatchAction)
+		*patchTypes = append(*patchTypes, patchAction.GetPatchType())
+		if patchAction.GetPatchType() == types.StrategicMergePatchType {
+			*prePatchBody = string(patchAction.GetPatch())
+			if prePatchErr != nil {
+				return true, nil, prePatchErr
+			}
+		}
+		return true, newTestDeployment(nil), nil
+	}
+}
+
+func TestApplyObjectPrePatchRunsBeforeSSA(t *testing.T) {
+	g := NewWithT(t)
+
+	client := fake.NewFakeClient()
+
+	var patchTypes []types.PatchType
+	var prePatchBody string
+	pr := patchRecorder(&patchTypes, &prePatchBody, nil)
+	client.Default().Dynamic().(*fakedynamic.FakeDynamicClient).PrependReactor("patch", "deployments", pr)
+
+	obj := newTestDeployment(map[string]string{
+		names.PrePatchAnnotation: prePatchValue,
+	})
+
+	err := ApplyObject(context.Background(), client, obj, "test-controller")
+	g.Expect(err).To(Succeed())
+	g.Expect(patchTypes).To(HaveLen(2))
+	g.Expect(patchTypes[0]).To(Equal(types.StrategicMergePatchType), "pre-patch should be strategic-merge-patch")
+	g.Expect(patchTypes[1]).To(Equal(types.ApplyPatchType), "second patch should be SSA apply")
+	g.Expect(prePatchBody).To(Equal(prePatchValue), "pre-patch body should match annotation value")
+}
+
+func TestApplyObjectPrePatchNotFoundAllowsSSA(t *testing.T) {
+	g := NewWithT(t)
+
+	client := fake.NewFakeClient()
+
+	var patchTypes []types.PatchType
+	var prePatchBody string
+	pr := patchRecorder(&patchTypes, &prePatchBody, apierrors.NewNotFound(
+		schema.GroupResource{Group: "apps", Resource: "deployments"}, "test-deployment"))
+	client.Default().Dynamic().(*fakedynamic.FakeDynamicClient).PrependReactor("patch", "deployments", pr)
+
+	obj := newTestDeployment(map[string]string{
+		names.PrePatchAnnotation: prePatchValue,
+	})
+
+	err := ApplyObject(context.Background(), client, obj, "test-controller")
+	g.Expect(err).To(Succeed())
+	g.Expect(patchTypes).To(HaveLen(2))
+	g.Expect(patchTypes[0]).To(Equal(types.StrategicMergePatchType), "pre-patch was attempted")
+	g.Expect(patchTypes[1]).To(Equal(types.ApplyPatchType), "SSA apply still proceeded")
+	g.Expect(prePatchBody).To(Equal(prePatchValue), "pre-patch body should match annotation value")
+}
+
+func TestApplyObjectPrePatchErrorStopsReconciliation(t *testing.T) {
+	g := NewWithT(t)
+
+	client := fake.NewFakeClient()
+
+	var patchTypes []types.PatchType
+	var prePatchBody string
+	pr := patchRecorder(&patchTypes, &prePatchBody, fmt.Errorf("API server error"))
+	client.Default().Dynamic().(*fakedynamic.FakeDynamicClient).PrependReactor("patch", "deployments", pr)
+
+	obj := newTestDeployment(map[string]string{
+		names.PrePatchAnnotation: prePatchValue,
+	})
+
+	err := ApplyObject(context.Background(), client, obj, "test-controller")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("failed to pre-patch"))
+	g.Expect(patchTypes).To(HaveLen(1), "SSA apply should not have been reached")
+	g.Expect(patchTypes[0]).To(Equal(types.StrategicMergePatchType), "pre-patch should be strategic-merge-patch")
+	g.Expect(prePatchBody).To(Equal(prePatchValue), "pre-patch body should match annotation value")
+}
+
+func TestApplyObjectNoPrePatchAnnotationSkipsPrePatch(t *testing.T) {
+	g := NewWithT(t)
+
+	client := fake.NewFakeClient()
+
+	var patchTypes []types.PatchType
+	var prePatchBody string
+	pr := patchRecorder(&patchTypes, &prePatchBody, nil)
+	client.Default().Dynamic().(*fakedynamic.FakeDynamicClient).PrependReactor("patch", "deployments", pr)
+
+	obj := newTestDeployment(nil)
+
+	err := ApplyObject(context.Background(), client, obj, "test-controller")
+	g.Expect(err).To(Succeed())
+	g.Expect(patchTypes).To(HaveLen(1))
+	g.Expect(patchTypes[0]).To(Equal(types.ApplyPatchType), "only SSA apply should have run")
+	g.Expect(prePatchBody).To(BeEmpty(), "no pre-patch should have been sent")
+}

--- a/pkg/client/fake/fake_client.go
+++ b/pkg/client/fake/fake_client.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/meta/testrestmapper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	fakedynamic "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
@@ -113,42 +113,6 @@ func NewFakeClient(objs ...crclient.Object) cnoclient.Client {
 	}
 }
 
-type fakeRESTMapper struct {
-	kindForInput schema.GroupVersionResource
-}
-
-func (f *fakeRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
-	f.kindForInput = resource
-	return schema.GroupVersionKind{
-		Group:   "test",
-		Version: "test",
-		Kind:    "test"}, nil
-}
-
-func (f *fakeRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
-	return nil, nil
-}
-
-func (f *fakeRESTMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
-	return schema.GroupVersionResource{}, nil
-}
-
-func (f *fakeRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
-	return nil, nil
-}
-
-func (f *fakeRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
-	return nil, nil
-}
-
-func (f *fakeRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
-	return nil, nil
-}
-
-func (f *fakeRESTMapper) ResourceSingularizer(resource string) (singular string, err error) {
-	return "", nil
-}
-
 func (fc *FakeClusterClient) Kubernetes() kubernetes.Interface {
 	return fc.kClient
 }
@@ -170,11 +134,11 @@ func (fc *FakeClusterClient) CRClient() crclient.Client {
 }
 
 func (fc *FakeClusterClient) RESTMapper() meta.RESTMapper {
-	return &fakeRESTMapper{}
+	return testrestmapper.TestOnlyStaticRESTMapper(scheme.Scheme)
 }
 
 func (fc *FakeClusterClient) Scheme() *runtime.Scheme {
-	panic("not implemented!")
+	return scheme.Scheme
 }
 func (fc *FakeClusterClient) OperatorHelperClient() operatorv1helpers.OperatorClient {
 	panic("not implemented!")

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -48,6 +48,12 @@ const CreateOnlyAnnotation = "networkoperator.openshift.io/create-only"
 // tells the CNO reconciliation engine to ignore creating this object until conditions are met.
 const CreateWaitAnnotation = "networkoperator.openshift.io/create-wait"
 
+// PrePatchAnnotation is an annotation whose value is a JSON object applied as a
+// strategic-merge-patch to the live object before the SSA apply. This is needed
+// when SSA cannot remove a field it does not own (e.g. removing defaulted
+// rollingUpdate when switching a Deployment strategy to Recreate).
+const PrePatchAnnotation = "networkoperator.openshift.io/pre-patch"
+
 // NonCriticalAnnotation is an annotation on Deployments/DaemonSets to indicate
 // that they are not critical to the functioning of the pod network
 const NonCriticalAnnotation = "networkoperator.openshift.io/non-critical"

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -129,7 +129,7 @@ func Render(operConf *operv1.NetworkSpec, clusterConf *configv1.NetworkSpec, man
 	}
 	objs = append(objs, o...)
 
-	o, err = renderAdditionalRoutingCapabilities(operConf, manifestDir)
+	o, err = renderAdditionalRoutingCapabilities(operConf, bootstrapResult, manifestDir)
 	if err != nil {
 		return nil, progressing, err
 	}
@@ -849,7 +849,7 @@ func registerNetworkingConsolePlugin(bootstrapResult *bootstrap.BootstrapResult,
 	})
 }
 
-func renderAdditionalRoutingCapabilities(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Unstructured, error) {
+func renderAdditionalRoutingCapabilities(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapResult, manifestDir string) ([]*uns.Unstructured, error) {
 	if conf == nil || conf.AdditionalRoutingCapabilities == nil {
 		return nil, nil
 	}
@@ -861,6 +861,7 @@ func renderAdditionalRoutingCapabilities(conf *operv1.NetworkSpec, manifestDir s
 			data.Data["FRRK8sImage"] = os.Getenv("FRR_K8S_IMAGE")
 			data.Data["KubeRBACProxyImage"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
 			data.Data["ReleaseVersion"] = os.Getenv("RELEASE_VERSION")
+			data.Data["IsSNO"] = bootstrapResult.OVN.ControlPlaneReplicaCount == 1
 			objs, err := render.RenderDir(filepath.Join(manifestDir, "network/frr-k8s"), &data)
 			if err != nil {
 				return nil, fmt.Errorf("failed to render frr-k8s manifests: %w", err)

--- a/pkg/network/render_test.go
+++ b/pkg/network/render_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/hypershift"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 
 	"testing"
@@ -576,11 +577,42 @@ func Test_renderAdditionalRoutingCapabilities(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := renderAdditionalRoutingCapabilities(tt.args.operConf, manifestDir)
+			got, err := renderAdditionalRoutingCapabilities(tt.args.operConf, fakeBootstrapResult(), manifestDir)
 			if !reflect.DeepEqual(tt.expectedErr, err) {
 				t.Errorf("renderAdditionalRoutingCapabilities() err = %v, want %v", err, tt.expectedErr)
 			}
 			assert.Equalf(t, tt.want, len(got), "renderAdditionalRoutingCapabilities(%v, %v)", tt.args.operConf, manifestDir)
 		})
 	}
+}
+
+func Test_renderFRRStatusCleanerStrategy(t *testing.T) {
+	frrConf := &operv1.NetworkSpec{
+		AdditionalRoutingCapabilities: &operv1.AdditionalRoutingCapabilities{
+			Providers: []operv1.RoutingCapabilitiesProvider{
+				operv1.RoutingCapabilitiesProviderFRR,
+			},
+		},
+	}
+
+	render := func(replicaCount int) *appsv1.Deployment {
+		g := NewWithT(t)
+		br := fakeBootstrapResult()
+		br.OVN.ControlPlaneReplicaCount = replicaCount
+		objs, err := renderAdditionalRoutingCapabilities(frrConf, br, manifestDir)
+		g.Expect(err).NotTo(HaveOccurred())
+		return mustFindRenderedObj[*appsv1.Deployment](t, objs, "Deployment", "frr-k8s-statuscleaner")
+	}
+
+	t.Run("SNO: strategy is Recreate", func(t *testing.T) {
+		g := NewWithT(t)
+		d := render(1)
+		g.Expect(d.Spec.Strategy.Type).To(Equal(appsv1.RecreateDeploymentStrategyType))
+	})
+
+	t.Run("HA: no strategy override", func(t *testing.T) {
+		g := NewWithT(t)
+		d := render(3)
+		g.Expect(d.Spec.Strategy.Type).To(BeEmpty())
+	})
 }

--- a/pkg/network/render_test.go
+++ b/pkg/network/render_test.go
@@ -18,6 +18,7 @@ import (
 	apifeatures "github.com/openshift/api/features"
 	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
+	"github.com/openshift/cluster-network-operator/pkg/names"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -608,11 +609,18 @@ func Test_renderFRRStatusCleanerStrategy(t *testing.T) {
 		g := NewWithT(t)
 		d := render(1)
 		g.Expect(d.Spec.Strategy.Type).To(Equal(appsv1.RecreateDeploymentStrategyType))
+		g.Expect(d.Annotations).To(
+			HaveKeyWithValue(
+				names.PrePatchAnnotation,
+				`{"spec":{"strategy":{"type":"Recreate","rollingUpdate":null}}}`,
+			),
+		)
 	})
 
-	t.Run("HA: no strategy override", func(t *testing.T) {
+	t.Run("HA: strategy is RollingUpdate", func(t *testing.T) {
 		g := NewWithT(t)
 		d := render(3)
-		g.Expect(d.Spec.Strategy.Type).To(BeEmpty())
+		g.Expect(d.Spec.Strategy.Type).To(Equal(appsv1.RollingUpdateDeploymentStrategyType))
+		g.Expect(d.Annotations).NotTo(HaveKey(names.PrePatchAnnotation))
 	})
 }

--- a/pkg/network/testutil_test.go
+++ b/pkg/network/testutil_test.go
@@ -3,7 +3,10 @@ package network
 import (
 	"context"
 	"fmt"
+	"slices"
+	"testing"
 
+	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
@@ -11,6 +14,7 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/hypershift"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // Fun matcher for testing the presence of Kubernetes objects
@@ -107,4 +111,22 @@ func createProxy(client client.Client) error {
 		},
 	}
 	return client.Default().CRClient().Create(context.TODO(), proxy)
+}
+
+// mustFindRenderedObj finds and converts an unstructured object from a list of rendered objects.
+// It uses Go generics to return the properly typed object.
+func mustFindRenderedObj[T any](t *testing.T, objs []*uns.Unstructured, kind, name string) T {
+	t.Helper()
+	g := NewWithT(t)
+
+	index := slices.IndexFunc(objs, func(obj *uns.Unstructured) bool {
+		return obj.GetKind() == kind && obj.GetName() == name
+	})
+	g.Expect(index).NotTo(Equal(-1), "Could not find object with kind %q and name %q", kind, name)
+
+	var result T
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(objs[index].Object, &result)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	return result
 }


### PR DESCRIPTION
This PR brings in commits from 3 PRs (that belong together) at the same time:
- a) commit https://github.com/openshift/cluster-network-operator/commit/c617131b92f33d65a9c0938cc111a6a7821ccea4 from https://github.com/openshift/cluster-network-operator/pull/3043 as a pre-requisite for b)   
- b) #3104 was the original fix from fede  
- c) but b) needs #3129 to work correctly

Further details:
- a) added additional 1st commit which is a semi-clean cherry-pick of https://github.com/openshift/cluster-network-operator/commit/c617131b92f33d65a9c0938cc111a6a7821ccea4 , needed for unit tests, dropped definiton of mustFindContainer and findExecCommand (otherwise lint fails)
- b) 2nd commit is a cherry-pick of https://github.com/openshift/cluster-network-operator/commit/3d86b7522a7c313ba49d49be23b9f11b51a96d96  from 3104 semi clean , added bootstrap result wiring to additionalRoutingCapibilities (that was already there for 5.0), aligned existing unit test with fakeBootstrapResult() as in 5.0
For c) Clean cherry-pick of the 2 commits from https://github.com/openshift/cluster-network-operator/pull/3129