### PR TITLE
OCPBUGS-112278: Add ConfigMap hash annotation to networking console plugin deployment

### DIFF
--- a/bindata/networking-console-plugin/003-deployment.yaml
+++ b/bindata/networking-console-plugin/003-deployment.yaml
@@ -33,6 +33,7 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         openshift.io/required-scc: restricted-v2
+        network.operator.openshift.io/config-hash: "{{.NetworkingConsolePluginConfigHash}}"
       labels:
         app.kubernetes.io/component: networking-console-plugin
         app.kubernetes.io/managed-by: cluster-network-operator

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -2,6 +2,9 @@ package network
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net"
@@ -822,6 +825,25 @@ func renderNetworkingConsolePlugin(manifestDir string, bootstrapResult *bootstra
 	data.Data["NetworkingConsolePluginImage"] = consolePluginImage
 
 	addTLSInfoToRenderData(data.Data, bootstrapResult, true)
+
+	// Calculate hash of the ConfigMap to trigger pod restarts when TLS config changes
+	h := sha256.New()
+	configMapPath := filepath.Join(manifestDir, "networking-console-plugin", "002-config-map.yaml")
+	configMapManifests, err := render.RenderTemplate(configMapPath, &data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to render ConfigMap template: %w", err)
+	}
+
+	for _, m := range configMapManifests {
+		bytes, err := json.Marshal(m)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal ConfigMap manifest: %w", err)
+		}
+		if _, err := h.Write(bytes); err != nil {
+			return nil, fmt.Errorf("failed to hash ConfigMap data: %w", err)
+		}
+	}
+	data.Data["NetworkingConsolePluginConfigHash"] = hex.EncodeToString(h.Sum(nil))
 
 	manifests, err := render.RenderDir(filepath.Join(manifestDir, "networking-console-plugin"), &data)
 	if err != nil {

--- a/pkg/network/render_test.go
+++ b/pkg/network/render_test.go
@@ -782,4 +782,41 @@ func Test_renderNetworkingConsolePlugin(t *testing.T) {
 			g.Expect(nginxConf).NotTo(ContainSubstring("ssl_prefer_server_ciphers"))
 		})
 	})
+
+	t.Run("config hash annotation should be present in deployment and change when TLS config changes", func(t *testing.T) {
+		g := NewWithT(t)
+		t.Setenv("NETWORKING_CONSOLE_PLUGIN_IMAGE", "quay.io/openshift/networking-console-plugin:latest")
+		bootstrapResult := fakeBootstrapResult()
+		bootstrapResult.Infra.ConsolePluginCRDExists = true
+		bootstrapResult.TLSProfile = bootstrap.TLSProfile{
+			Spec: configv1.TLSProfileSpec{
+				MinTLSVersion: configv1.VersionTLS12,
+				Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+			},
+			Adherence: configv1.TLSAdherencePolicyStrictAllComponents,
+		}
+
+		objs, err := renderNetworkingConsolePlugin(manifestDir, bootstrapResult)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		deploy := mustFindRenderedObj[*appsv1.Deployment](t, objs, "Deployment", "networking-console-plugin")
+		hash1, ok := deploy.Spec.Template.Annotations["network.operator.openshift.io/config-hash"]
+		g.Expect(ok).To(BeTrue(), "config-hash annotation should be present")
+		g.Expect(hash1).NotTo(BeEmpty(), "config-hash should not be empty")
+
+		// Render with different TLS config
+		bootstrapResult.TLSProfile = bootstrap.TLSProfile{
+			Spec: configv1.TLSProfileSpec{
+				MinTLSVersion: configv1.VersionTLS13,
+				Ciphers:       nil,
+			},
+			Adherence: configv1.TLSAdherencePolicyStrictAllComponents,
+		}
+		objs2, err := renderNetworkingConsolePlugin(manifestDir, bootstrapResult)
+		g.Expect(err).NotTo(HaveOccurred())
+		deploy2 := mustFindRenderedObj[*appsv1.Deployment](t, objs2, "Deployment", "networking-console-plugin")
+		hash2 := deploy2.Spec.Template.Annotations["network.operator.openshift.io/config-hash"]
+
+		g.Expect(hash1).NotTo(Equal(hash2), "config-hash should change when TLS config changes")
+	})
 }


### PR DESCRIPTION
When TLS parameters change, the nginx ConfigMap is updated but the pods don't automatically restart to pick up the new configuration. This adds a hash of the ConfigMap content as a pod template annotation, which triggers a rolling update when the ConfigMap changes.