### PR TITLE
OCPBUGS-113532: ovn-kubernetes: Move MNP from ConfigMap to CLI flags

### DIFF
--- a/bindata/network/ovn-kubernetes/managed/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/managed/004-config.yaml
@@ -43,10 +43,6 @@ data:
     enable-multi-network=true
     enable-network-segmentation=true
     enable-preconfigured-udn-addresses=true
-
-{{- if .OVN_MULTI_NETWORK_POLICY_ENABLE }}
-    enable-multi-networkpolicy=true
-{{- end }}
     enable-admin-network-policy=true
     enable-multi-external-gateway=true
 {{- if .DNS_NAME_RESOLVER_ENABLE }}
@@ -131,9 +127,6 @@ data:
     enable-multi-network=true
     enable-network-segmentation=true
     enable-preconfigured-udn-addresses=true
-{{- if .OVN_MULTI_NETWORK_POLICY_ENABLE }}
-    enable-multi-networkpolicy=true
-{{- end }}
     enable-admin-network-policy=true
     enable-multi-external-gateway=true
 {{- if .DNS_NAME_RESOLVER_ENABLE }}

--- a/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/managed/ovnkube-control-plane.yaml
@@ -195,6 +195,11 @@ spec:
             evpn_enable_flag="--enable-evpn"
           fi
 
+          multi_network_policy_enabled_flag=
+          if [[ "{{.OVN_MULTI_NETWORK_POLICY_ENABLE}}" == "true" ]]; then
+            multi_network_policy_enabled_flag="--enable-multi-networkpolicy"
+          fi
+
           # DROP: remove when older OVN-K images that require --enable-interconnect are no longer supported
           enable_interconnect_flag=
           if /usr/bin/ovnkube --help 2>&1 | grep -q -- '--enable-interconnect'; then
@@ -221,6 +226,7 @@ spec:
             ${ovn_v4_masquerade_subnet_opt} \
             ${ovn_v6_masquerade_subnet_opt} \
             ${persistent_ips_enabled_flag} \
+            ${multi_network_policy_enabled_flag} \
             ${route_advertisements_enable_flag} \
             ${evpn_enable_flag}
         volumeMounts:

--- a/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml
@@ -49,9 +49,6 @@ data:
     enable-multi-network=true
     enable-network-segmentation=true
     enable-preconfigured-udn-addresses=true
-{{- if .OVN_MULTI_NETWORK_POLICY_ENABLE }}
-    enable-multi-networkpolicy=true
-{{- end }}
     enable-admin-network-policy=true
     enable-multi-external-gateway=true
 {{- if .DNS_NAME_RESOLVER_ENABLE }}

--- a/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
+++ b/bindata/network/ovn-kubernetes/self-hosted/ovnkube-control-plane.yaml
@@ -142,6 +142,11 @@ spec:
             evpn_enable_flag="--enable-evpn"
           fi
 
+          multi_network_policy_enabled_flag=
+          if [[ "{{.OVN_MULTI_NETWORK_POLICY_ENABLE}}" == "true" ]]; then
+            multi_network_policy_enabled_flag="--enable-multi-networkpolicy"
+          fi
+
           if [ "{{.OVN_GATEWAY_MODE}}" == "shared" ]; then
             gateway_mode_flags="--gateway-mode shared"
           elif [ "{{.OVN_GATEWAY_MODE}}" == "local" ]; then
@@ -174,6 +179,7 @@ spec:
             ${ovn_v4_masquerade_subnet_opt} \
             ${ovn_v6_masquerade_subnet_opt} \
             ${persistent_ips_enabled_flag} \
+            ${multi_network_policy_enabled_flag} \
             ${gateway_mode_flags} \
             ${route_advertisements_enable_flag} \
             ${evpn_enable_flag}

--- a/docs/ovn_node_mode.md
+++ b/docs/ovn_node_mode.md
@@ -15,4 +15,10 @@ The `OVN_NODE_MODE` environment variable is injected into the `ovnkube-node` Pod
 
 ### Feature configuration
 
-Feature enablement (egress IP, multicast, multi-network, network segmentation, admin network policy, etc.) is managed through the cluster-wide ConfigMap (`004-config.yaml`) which is passed to ovnkube via `--config-file`. These features are not gated per node mode.
+Feature enablement is managed through two mechanisms:
+
+- **ConfigMap-based** (`004-config.yaml`): Most features (egress IP, multi-network, network segmentation, admin network policy, etc.) are configured in the cluster-wide ConfigMap which is passed to ovnkube via `--config-file`.
+
+- **CLI flags** (`ovnkube-control-plane.yaml`): Features that require ovnkube-control-plane pod restarts on configuration changes (multicast, multi-networkpolicy) are enabled via CLI flags (e.g., `--enable-multicast`, `--enable-multi-networkpolicy`) to ensure the control-plane pods restart automatically when the feature is toggled. Note that ovnkube-node pods already restart when the ConfigMap changes, so only control-plane-specific features require CLI flags.
+
+These features are not gated per node mode.

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -743,7 +743,6 @@ egressip-node-healthcheck-port=9107
 enable-multi-network=true
 enable-network-segmentation=true
 enable-preconfigured-udn-addresses=true
-enable-multi-networkpolicy=true
 enable-admin-network-policy=true
 enable-multi-external-gateway=true
 
@@ -838,7 +837,6 @@ egressip-node-healthcheck-port=9107
 enable-multi-network=true
 enable-network-segmentation=true
 enable-preconfigured-udn-addresses=true
-enable-multi-networkpolicy=true
 enable-admin-network-policy=true
 enable-multi-external-gateway=true
 


### PR DESCRIPTION
MultiNetworkPolicy is not enforced on UDN secondary interfaces in OCP 5.0 because ovnkube-control-plane pods do not restart when the ConfigMap is updated with enable-multi-networkpolicy=true.

Root cause: PR #2944 moved MNP enablement to ConfigMap, but:
1. The ConfigMap hash only includes 008-script-lib.yaml, not 004-config.yaml
2. ovnkube-control-plane has no hash annotation to trigger restarts

Solution: Follow the same pattern as commit f4734c557 (OCPBUGS-78731): move MNP back to CLI flags where pod restart happens automatically on spec changes.

This creates consistency with multicast (also a CLI flag) and avoids the ConfigMap hash timing issues that caused the original [NVIDIA-554](https://redhat.atlassian.net/browse/NVIDIA-554) fix to be reverted.

How to verify:
1. Deploy cluster with UseMultiNetworkPolicy=false
   - Verify ovnkube-control-plane pods lack --enable-multi-networkpolicy flag
2. Set UseMultiNetworkPolicy=true via network.operator/cluster
   - Verify ovnkube-control-plane pods restart with --enable-multi-networkpolicy
3. Test MNP enforcement on UDN Layer2/Layer3 networks
4. Verify DPU-host mode still works correctly
5. CI lanes: e2e-aws-ovn, e2e-gcp-ovn, e2e-metal-ipi-ovn-dualstack

Tested:
- MNP works on UDN Layer2 and Layer3 networks
- Pods restart when UseMultiNetworkPolicy changes
- DPU-host mode still works correctly
- Other ConfigMap features (egress-ip, etc.) unaffected

Jira: OCPBUGS-88063

docs: Clarify CLI flags are for control-plane pod restarts

Update ovn_node_mode.md to specify that CLI flags are used for features requiring ovnkube-control-plane pod restarts, not just any pod restarts. This clarifies that ovnkube-node pods already restart when the ConfigMap changes, so CLI flags are only needed for control-plane-specific features.

Addresses review feedback from danwinship.


(cherry picked from commit 17f08a709659914743be851d72bf70a39a9abbf5)