### PR TITLE
[release-4.20] OCPBUGS-113989: frr-k8s: use Recreate strategy for webhook server deployment on SNO

### DIFF
--- a/bindata/network/frr-k8s/webhook.yaml
+++ b/bindata/network/frr-k8s/webhook.yaml
@@ -52,6 +52,10 @@ metadata:
   annotations:
     release.openshift.io/version: "{{.ReleaseVersion}}"
 spec:
+{{- if .IsSNO }}
+  strategy:
+    type: Recreate
+{{- end }}
   selector:
     matchLabels:
       component: frr-k8s-webhook-server

--- a/bindata/network/frr-k8s/webhook.yaml
+++ b/bindata/network/frr-k8s/webhook.yaml
@@ -51,10 +51,19 @@ metadata:
     component: frr-k8s-webhook-server
   annotations:
     release.openshift.io/version: "{{.ReleaseVersion}}"
+{{- if .IsSNO }}
+    networkoperator.openshift.io/pre-patch: '{"spec":{"strategy":{"type":"Recreate","rollingUpdate":null}}}'
+{{- end }}
 spec:
 {{- if .IsSNO }}
   strategy:
     type: Recreate
+{{- else }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
 {{- end }}
   selector:
     matchLabels:

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -110,6 +110,23 @@ func ApplyObject(ctx context.Context, client cnoclient.Client, obj Object, subco
 		fieldManager = fmt.Sprintf("%s/%s", fieldManager, subcontroller)
 	}
 
+	// If pre-patch is specified, apply it as a strategic-merge-patch to the live
+	// object before SSA. This handles cases where SSA cannot remove a field it
+	// does not own (e.g. defaulted rollingUpdate when switching to Recreate).
+	// The pre-patch is silently skipped if the object does not exist yet, making
+	// this mainly relevant on upgrades where defaulted fields must be removed.
+	if prePatch, ok := obj.GetAnnotations()[names.PrePatchAnnotation]; ok {
+		log.Printf("Object %s has pre-patch annotation, attempting strategic-merge-patch before SSA", objDesc)
+		patchOptions := metav1.PatchOptions{FieldManager: fieldManager}
+		_, err := clusterClient.Dynamic().Resource(rm.Resource).Namespace(namespace).Patch(
+			ctx, name, types.StrategicMergePatchType, []byte(prePatch), patchOptions)
+		if apierrors.IsNotFound(err) {
+			log.Printf("Object %s not found, skipping pre-patch", objDesc)
+		} else if err != nil {
+			return fmt.Errorf("failed to pre-patch %s: %w", objDesc, err)
+		}
+	}
+
 	// Use server-side apply to merge the desired object with the object on disk
 	patchOptions := metav1.PatchOptions{
 		// It is considered best-practice for controllers to force

--- a/pkg/apply/apply_test.go
+++ b/pkg/apply/apply_test.go
@@ -1,0 +1,130 @@
+package apply
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openshift/cluster-network-operator/pkg/client/fake"
+	"github.com/openshift/cluster-network-operator/pkg/names"
+
+	. "github.com/onsi/gomega"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	fakedynamic "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+const prePatchValue = `{"spec":{"strategy":{"type":"Recreate","rollingUpdate":null}}}`
+
+func newTestDeployment(annotations map[string]string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"})
+	obj.SetName("test-deployment")
+	obj.SetNamespace("test-ns")
+	obj.SetAnnotations(annotations)
+	return obj
+}
+
+func patchRecorder(patchTypes *[]types.PatchType, prePatchBody *string, prePatchErr error) func(action clienttesting.Action) (bool, runtime.Object, error) {
+	return func(action clienttesting.Action) (bool, runtime.Object, error) {
+		patchAction := action.(clienttesting.PatchAction)
+		*patchTypes = append(*patchTypes, patchAction.GetPatchType())
+		if patchAction.GetPatchType() == types.StrategicMergePatchType {
+			*prePatchBody = string(patchAction.GetPatch())
+			if prePatchErr != nil {
+				return true, nil, prePatchErr
+			}
+		}
+		return true, newTestDeployment(nil), nil
+	}
+}
+
+func TestApplyObjectPrePatchRunsBeforeSSA(t *testing.T) {
+	g := NewWithT(t)
+
+	client := fake.NewFakeClient()
+
+	var patchTypes []types.PatchType
+	var prePatchBody string
+	pr := patchRecorder(&patchTypes, &prePatchBody, nil)
+	client.Default().Dynamic().(*fakedynamic.FakeDynamicClient).PrependReactor("patch", "deployments", pr)
+
+	obj := newTestDeployment(map[string]string{
+		names.PrePatchAnnotation: prePatchValue,
+	})
+
+	err := ApplyObject(t.Context(), client, obj, "test-controller")
+	g.Expect(err).To(Succeed())
+	g.Expect(patchTypes).To(HaveLen(2))
+	g.Expect(patchTypes[0]).To(Equal(types.StrategicMergePatchType), "pre-patch should be strategic-merge-patch")
+	g.Expect(patchTypes[1]).To(Equal(types.ApplyPatchType), "second patch should be SSA apply")
+	g.Expect(prePatchBody).To(Equal(prePatchValue), "pre-patch body should match annotation value")
+}
+
+func TestApplyObjectPrePatchNotFoundAllowsSSA(t *testing.T) {
+	g := NewWithT(t)
+
+	client := fake.NewFakeClient()
+
+	var patchTypes []types.PatchType
+	var prePatchBody string
+	pr := patchRecorder(&patchTypes, &prePatchBody, apierrors.NewNotFound(
+		schema.GroupResource{Group: "apps", Resource: "deployments"}, "test-deployment"))
+	client.Default().Dynamic().(*fakedynamic.FakeDynamicClient).PrependReactor("patch", "deployments", pr)
+
+	obj := newTestDeployment(map[string]string{
+		names.PrePatchAnnotation: prePatchValue,
+	})
+
+	err := ApplyObject(t.Context(), client, obj, "test-controller")
+	g.Expect(err).To(Succeed())
+	g.Expect(patchTypes).To(HaveLen(2))
+	g.Expect(patchTypes[0]).To(Equal(types.StrategicMergePatchType), "pre-patch was attempted")
+	g.Expect(patchTypes[1]).To(Equal(types.ApplyPatchType), "SSA apply still proceeded")
+	g.Expect(prePatchBody).To(Equal(prePatchValue), "pre-patch body should match annotation value")
+}
+
+func TestApplyObjectPrePatchErrorStopsReconciliation(t *testing.T) {
+	g := NewWithT(t)
+
+	client := fake.NewFakeClient()
+
+	var patchTypes []types.PatchType
+	var prePatchBody string
+	pr := patchRecorder(&patchTypes, &prePatchBody, fmt.Errorf("API server error"))
+	client.Default().Dynamic().(*fakedynamic.FakeDynamicClient).PrependReactor("patch", "deployments", pr)
+
+	obj := newTestDeployment(map[string]string{
+		names.PrePatchAnnotation: prePatchValue,
+	})
+
+	err := ApplyObject(t.Context(), client, obj, "test-controller")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("failed to pre-patch"))
+	g.Expect(patchTypes).To(HaveLen(1), "SSA apply should not have been reached")
+	g.Expect(patchTypes[0]).To(Equal(types.StrategicMergePatchType), "pre-patch should be strategic-merge-patch")
+	g.Expect(prePatchBody).To(Equal(prePatchValue), "pre-patch body should match annotation value")
+}
+
+func TestApplyObjectNoPrePatchAnnotationSkipsPrePatch(t *testing.T) {
+	g := NewWithT(t)
+
+	client := fake.NewFakeClient()
+
+	var patchTypes []types.PatchType
+	var prePatchBody string
+	pr := patchRecorder(&patchTypes, &prePatchBody, nil)
+	client.Default().Dynamic().(*fakedynamic.FakeDynamicClient).PrependReactor("patch", "deployments", pr)
+
+	obj := newTestDeployment(nil)
+
+	err := ApplyObject(t.Context(), client, obj, "test-controller")
+	g.Expect(err).To(Succeed())
+	g.Expect(patchTypes).To(HaveLen(1))
+	g.Expect(patchTypes[0]).To(Equal(types.ApplyPatchType), "only SSA apply should have run")
+	g.Expect(prePatchBody).To(BeEmpty(), "no pre-patch should have been sent")
+}

--- a/pkg/client/fake/fake_client.go
+++ b/pkg/client/fake/fake_client.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/meta/testrestmapper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -45,6 +46,8 @@ type FakeClusterClient struct {
 	crclient crclient.Client
 
 	osOperClient osoperclient.Interface
+
+	scheme *runtime.Scheme
 }
 
 func (fc *FakeClient) ClientFor(name string) cnoclient.ClusterClient {
@@ -100,53 +103,30 @@ func NewFakeClient(objs ...crclient.Object) cnoclient.Client {
 		}
 	}
 	co := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: ""}}
+
+	s := runtime.NewScheme()
+	if err := scheme.AddToScheme(s); err != nil {
+		panic(err)
+	}
+
+	metav1.AddToGroupVersion(s, schema.GroupVersion{Version: "v1"})
+	s.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: "test", Version: "test", Kind: "test"},
+		&metav1.PartialObjectMetadata{},
+	)
+
 	fc := FakeClusterClient{
 		kClient:      faketyped.NewSimpleClientset(ooTyped...),
 		dynclient:    fakedynamic.NewSimpleDynamicClient(scheme.Scheme, oo...),
 		crclient:     crfake.NewClientBuilder().WithStatusSubresource(co).WithObjects(objs...).Build(),
 		osOperClient: osoperfakeclient.NewSimpleClientset(),
+		scheme:       s,
 	}
 	return &FakeClient{
 		clusterClients: map[string]*FakeClusterClient{
 			names.DefaultClusterName: &fc,
 		},
 	}
-}
-
-type fakeRESTMapper struct {
-	kindForInput schema.GroupVersionResource
-}
-
-func (f *fakeRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
-	f.kindForInput = resource
-	return schema.GroupVersionKind{
-		Group:   "test",
-		Version: "test",
-		Kind:    "test"}, nil
-}
-
-func (f *fakeRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
-	return nil, nil
-}
-
-func (f *fakeRESTMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
-	return schema.GroupVersionResource{}, nil
-}
-
-func (f *fakeRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
-	return nil, nil
-}
-
-func (f *fakeRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
-	return nil, nil
-}
-
-func (f *fakeRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
-	return nil, nil
-}
-
-func (f *fakeRESTMapper) ResourceSingularizer(resource string) (singular string, err error) {
-	return "", nil
 }
 
 func (fc *FakeClusterClient) Kubernetes() kubernetes.Interface {
@@ -170,12 +150,13 @@ func (fc *FakeClusterClient) CRClient() crclient.Client {
 }
 
 func (fc *FakeClusterClient) RESTMapper() meta.RESTMapper {
-	return &fakeRESTMapper{}
+	return testrestmapper.TestOnlyStaticRESTMapper(fc.scheme)
 }
 
 func (fc *FakeClusterClient) Scheme() *runtime.Scheme {
-	panic("not implemented!")
+	return fc.scheme
 }
+
 func (fc *FakeClusterClient) OperatorHelperClient() operatorv1helpers.OperatorClient {
 	panic("not implemented!")
 }

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -48,6 +48,12 @@ const CreateOnlyAnnotation = "networkoperator.openshift.io/create-only"
 // tells the CNO reconciliation engine to ignore creating this object until conditions are met.
 const CreateWaitAnnotation = "networkoperator.openshift.io/create-wait"
 
+// PrePatchAnnotation is an annotation whose value is a JSON object applied as a
+// strategic-merge-patch to the live object before the SSA apply. This is needed
+// when SSA cannot remove a field it does not own (e.g. removing defaulted
+// rollingUpdate when switching a Deployment strategy to Recreate).
+const PrePatchAnnotation = "networkoperator.openshift.io/pre-patch"
+
 // NonCriticalAnnotation is an annotation on Deployments/DaemonSets to indicate
 // that they are not critical to the functioning of the pod network
 const NonCriticalAnnotation = "networkoperator.openshift.io/non-critical"

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -147,7 +147,7 @@ func Render(operConf *operv1.NetworkSpec, clusterConf *configv1.NetworkSpec, man
 	}
 	objs = append(objs, o...)
 
-	o, err = renderAdditionalRoutingCapabilities(operConf, manifestDir)
+	o, err = renderAdditionalRoutingCapabilities(operConf, bootstrapResult, manifestDir)
 	if err != nil {
 		return nil, progressing, err
 	}
@@ -978,7 +978,7 @@ func isSupportedDualStackPlatform(platformType configv1.PlatformType) bool {
 	return dualStackPlatforms.Has(string(platformType))
 }
 
-func renderAdditionalRoutingCapabilities(conf *operv1.NetworkSpec, manifestDir string) ([]*uns.Unstructured, error) {
+func renderAdditionalRoutingCapabilities(conf *operv1.NetworkSpec, bootstrapResult *bootstrap.BootstrapResult, manifestDir string) ([]*uns.Unstructured, error) {
 	if conf == nil || conf.AdditionalRoutingCapabilities == nil {
 		return nil, nil
 	}
@@ -990,6 +990,7 @@ func renderAdditionalRoutingCapabilities(conf *operv1.NetworkSpec, manifestDir s
 			data.Data["FRRK8sImage"] = os.Getenv("FRR_K8S_IMAGE")
 			data.Data["KubeRBACProxyImage"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
 			data.Data["ReleaseVersion"] = os.Getenv("RELEASE_VERSION")
+			data.Data["IsSNO"] = bootstrapResult.OVN.ControlPlaneReplicaCount == 1
 			objs, err := render.RenderDir(filepath.Join(manifestDir, "network/frr-k8s"), &data)
 			if err != nil {
 				return nil, fmt.Errorf("failed to render frr-k8s manifests: %w", err)

--- a/pkg/network/render_test.go
+++ b/pkg/network/render_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/client/fake"
 	"github.com/openshift/cluster-network-operator/pkg/hypershift"
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 
 	"testing"
@@ -547,7 +548,6 @@ func setupTestInfraAndBasicRenderConfigs(t *testing.T, prevType, nextType operv1
 	*bootstrap.InfraStatus,
 	*operv1.NetworkSpec,
 	*operv1.NetworkSpec) {
-
 	g := NewGomegaWithT(t)
 	infra := &fakeBootstrapResult().Infra
 
@@ -644,11 +644,42 @@ func Test_renderAdditionalRoutingCapabilities(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := renderAdditionalRoutingCapabilities(tt.args.operConf, manifestDir)
+			got, err := renderAdditionalRoutingCapabilities(tt.args.operConf, fakeBootstrapResult(), manifestDir)
 			if !reflect.DeepEqual(tt.expectedErr, err) {
 				t.Errorf("renderAdditionalRoutingCapabilities() err = %v, want %v", err, tt.expectedErr)
 			}
 			assert.Equalf(t, tt.want, len(got), "renderAdditionalRoutingCapabilities(%v, %v)", tt.args.operConf, manifestDir)
 		})
 	}
+}
+
+func Test_renderFRRWebhookServerStrategy(t *testing.T) {
+	frrConf := &operv1.NetworkSpec{
+		AdditionalRoutingCapabilities: &operv1.AdditionalRoutingCapabilities{
+			Providers: []operv1.RoutingCapabilitiesProvider{
+				operv1.RoutingCapabilitiesProviderFRR,
+			},
+		},
+	}
+
+	render := func(replicaCount int) *appsv1.Deployment {
+		g := NewWithT(t)
+		br := fakeBootstrapResult()
+		br.OVN.ControlPlaneReplicaCount = replicaCount
+		objs, err := renderAdditionalRoutingCapabilities(frrConf, br, manifestDir)
+		g.Expect(err).NotTo(HaveOccurred())
+		return mustFindRenderedObj[*appsv1.Deployment](t, objs, "Deployment", "frr-k8s-webhook-server")
+	}
+
+	t.Run("SNO: strategy is Recreate", func(t *testing.T) {
+		g := NewWithT(t)
+		d := render(1)
+		g.Expect(d.Spec.Strategy.Type).To(Equal(appsv1.RecreateDeploymentStrategyType))
+	})
+
+	t.Run("HA: no strategy override", func(t *testing.T) {
+		g := NewWithT(t)
+		d := render(3)
+		g.Expect(d.Spec.Strategy.Type).To(BeEmpty())
+	})
 }

--- a/pkg/network/render_test.go
+++ b/pkg/network/render_test.go
@@ -17,6 +17,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
+	"github.com/openshift/cluster-network-operator/pkg/names"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -675,11 +676,18 @@ func Test_renderFRRWebhookServerStrategy(t *testing.T) {
 		g := NewWithT(t)
 		d := render(1)
 		g.Expect(d.Spec.Strategy.Type).To(Equal(appsv1.RecreateDeploymentStrategyType))
+		g.Expect(d.Annotations).To(
+			HaveKeyWithValue(
+				names.PrePatchAnnotation,
+				`{"spec":{"strategy":{"type":"Recreate","rollingUpdate":null}}}`,
+			),
+		)
 	})
 
-	t.Run("HA: no strategy override", func(t *testing.T) {
+	t.Run("HA: strategy is RollingUpdate", func(t *testing.T) {
 		g := NewWithT(t)
 		d := render(3)
-		g.Expect(d.Spec.Strategy.Type).To(BeEmpty())
+		g.Expect(d.Spec.Strategy.Type).To(Equal(appsv1.RollingUpdateDeploymentStrategyType))
+		g.Expect(d.Annotations).NotTo(HaveKey(names.PrePatchAnnotation))
 	})
 }

--- a/pkg/network/testutil_test.go
+++ b/pkg/network/testutil_test.go
@@ -3,7 +3,10 @@ package network
 import (
 	"context"
 	"fmt"
+	"slices"
+	"testing"
 
+	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-network-operator/pkg/bootstrap"
@@ -11,6 +14,7 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/hypershift"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // Fun matcher for testing the presence of Kubernetes objects
@@ -107,4 +111,22 @@ func createProxy(client client.Client) error {
 		},
 	}
 	return client.Default().CRClient().Create(context.TODO(), proxy)
+}
+
+// mustFindRenderedObj finds and converts an unstructured object from a list of rendered objects.
+// It uses Go generics to return the properly typed object.
+func mustFindRenderedObj[T any](t *testing.T, objs []*uns.Unstructured, kind, name string) T {
+	t.Helper()
+	g := NewWithT(t)
+
+	index := slices.IndexFunc(objs, func(obj *uns.Unstructured) bool {
+		return obj.GetKind() == kind && obj.GetName() == name
+	})
+	g.Expect(index).NotTo(Equal(-1), "Could not find object with kind %q and name %q", kind, name)
+
+	var result T
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(objs[index].Object, &result)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	return result
 }


### PR DESCRIPTION
Manual backport of github.com/openshift/cluster-network-operator/pull/3135 to release 4.20.

-------------

A few issues during the backport process.

a) The template changes in newer versions are applied to node-status-cleaner.yaml, here they must be made to webhook.yaml

b) In 4.21 and beyond, the GVK is registered automatically, and thus test TestStatusManager_set passes even though it does not explicitly register the test/test/test GVK. In 4.20, this automatic registration does not happen, so we must explicitly register that GVK in the FakeClusterClient's scheme to make that test pass.

From Claude:

```
  The GVK test/test/test is registered dynamically by controller-runtime's fake client itself.
 
  When the test calls set(t, client, obj) at line 259 (which does Create on the CRClient), the
  controller-runtime fake client's Create method calls addToSchemeIfUnknownAndUnstructuredOrPartial (line
  1869). Since obj is an *unstructured.Unstructured, it hits line 1886-1887:

  if !c.scheme.Recognizes(gvk) {
      c.scheme.AddKnownTypeWithName(gvk, obj)
  }   

  This mutates the scheme to add test/test/test at the time of the first Create call. After that, the GVK
  is known to the scheme.

  However, the RESTMapper() on the FakeClusterClient (line 136-138 of fake_client.go) calls
  testrestmapper.TestOnlyStaticRESTMapper(scheme.Scheme) — which creates a new mapper from the scheme on
  every call. Since the scheme was already mutated by the Create above, the mapper built at line 219 of
  status_manager.go will include the test group and its test kind, so KindFor succeeds.
  
  In short: the controller-runtime fake client auto-registers unknown unstructured GVKs into the scheme as
  a side effect of Create, and because RESTMapper() rebuilds from that same (now-mutated) scheme each
  time, KindFor works despite no explicit registration.
```

And here are the changes to the vendor directory where addToSchemeIfUnknownAndUnstructuredOrPartial is added (4.21 and beyond):

```
[akaris@workstation 4.21 (release-4.21)]$ git blame /media/psf/Home/development/cluster-network-operator/release/4.21/vendor/sigs.k8s.io/controller-ru
ntime/pkg/client/fake/client.go | grep 'addToSchemeIfUnknownAndUnstructuredOrPartial(' -B2
8c2b9f99df (Anil Vishnoi          2020-05-05 12:28:01 -0700  612) 
34e6b52190 (Jamo Luhrsen          2022-09-26 11:05:59 -0700  613) func (c *fakeClient) Get(ctx context.Context, key client.ObjectKey, obj client.Objec
t, opts ...client.GetOption) error {
b8cdede8e3 (Jamo Luhrsen          2025-11-07 12:16:55 -0800  614)       if err := c.addToSchemeIfUnknownAndUnstructuredOrPartial(obj); err != nil {
--
ca9c0d2515 (Casey Callendrello    2018-11-02 14:12:27 +0100  659) 
6194226f73 (qJkee                 2021-12-20 18:50:53 -0500  660) func (c *fakeClient) Watch(ctx context.Context, list client.ObjectList, opts ...clie
nt.ListOption) (watch.Interface, error) {
b8cdede8e3 (Jamo Luhrsen          2025-11-07 12:16:55 -0800  661)       if err := c.addToSchemeIfUnknownAndUnstructuredOrPartial(list); err != nil {
--
6194226f73 (qJkee                 2021-12-20 18:50:53 -0500  681) 
1f33245b8a (Jacob Tanenbaum       2021-04-28 13:28:32 -0400  682) func (c *fakeClient) List(ctx context.Context, obj client.ObjectList, opts ...client
.ListOption) error {
b8cdede8e3 (Jamo Luhrsen          2025-11-07 12:16:55 -0800  683)       if err := c.addToSchemeIfUnknownAndUnstructuredOrPartial(obj); err != nil {
--
db57a477b1 (Tim Rozet             2023-06-01 18:44:35 -0400  850) 
1f33245b8a (Jacob Tanenbaum       2021-04-28 13:28:32 -0400  851) func (c *fakeClient) Create(ctx context.Context, obj client.Object, opts ...client.C
reateOption) error {
b8cdede8e3 (Jamo Luhrsen          2025-11-07 12:16:55 -0800  852)       if err := c.addToSchemeIfUnknownAndUnstructuredOrPartial(obj); err != nil {
--
ca9c0d2515 (Casey Callendrello    2018-11-02 14:12:27 +0100  909) 
1f33245b8a (Jacob Tanenbaum       2021-04-28 13:28:32 -0400  910) func (c *fakeClient) Delete(ctx context.Context, obj client.Object, opts ...client.D
eleteOption) error {
b8cdede8e3 (Jamo Luhrsen          2025-11-07 12:16:55 -0800  911)       if err := c.addToSchemeIfUnknownAndUnstructuredOrPartial(obj); err != nil {
--
ca9c0d2515 (Casey Callendrello    2018-11-02 14:12:27 +0100  961) 
1f33245b8a (Jacob Tanenbaum       2021-04-28 13:28:32 -0400  962) func (c *fakeClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...cli
ent.DeleteAllOfOption) error {
b8cdede8e3 (Jamo Luhrsen          2025-11-07 12:16:55 -0800  963)       if err := c.addToSchemeIfUnknownAndUnstructuredOrPartial(obj); err != nil {
--
db57a477b1 (Tim Rozet             2023-06-01 18:44:35 -0400 1017) 
db57a477b1 (Tim Rozet             2023-06-01 18:44:35 -0400 1018) func (c *fakeClient) update(obj client.Object, isStatus bool, opts ...client.UpdateO
ption) error {
b8cdede8e3 (Jamo Luhrsen          2025-11-07 12:16:55 -0800 1019)       if err := c.addToSchemeIfUnknownAndUnstructuredOrPartial(obj); err != nil {
--
b8cdede8e3 (Jamo Luhrsen          2025-11-07 12:16:55 -0800 1128) 
db57a477b1 (Tim Rozet             2023-06-01 18:44:35 -0400 1129) func (c *fakeClient) patch(obj client.Object, patch client.Patch, opts ...client.Pat
chOption) error {
b8cdede8e3 (Jamo Luhrsen          2025-11-07 12:16:55 -0800 1130)       if err := c.addToSchemeIfUnknownAndUnstructuredOrPartial(obj); err != nil {
--
c2467eea0c (Arti Sood             2025-03-25 13:01:44 -0400 1867) }
b8cdede8e3 (Jamo Luhrsen          2025-11-07 12:16:55 -0800 1868) 
b8cdede8e3 (Jamo Luhrsen          2025-11-07 12:16:55 -0800 1869) func (c *fakeClient) addToSchemeIfUnknownAndUnstructuredOrPartial(obj runtime.Object
) error {
```

In 4.20, that's missing:

```
[akaris@workstation OCPBUGS-113989 (jechen0648/OCPBUGS-113989)]$ grep addToSchemeIfUnknownAndUnstructuredOrPartial /media/psf/Home/develo
pment/cluster-network-operator/release/4.20/vendor/sigs.k8s.io/controller-runtime/ -R
[akaris@workstation OCPBUGS-113989 (jechen0648/OCPBUGS-113989)]$ 
```

Meaning that's due to the change in controller-runtime:

```
[akaris@workstation OCPBUGS-113989 (jechen0648/OCPBUGS-113989)]$ grep controller-runtime go.mod 
        sigs.k8s.io/controller-runtime v0.21.0
```

```
[akaris@workstation 4.21 (release-4.21)]$ grep controller-runtime go.mod 
        sigs.k8s.io/controller-runtime v0.22.4
```
