### PR TITLE
CORENET-7479: Add status.vrfName and shortNames to UDN/CUDN CRDs

### DIFF
--- a/bindata/network/ovn-kubernetes/common/001-crd.yaml
+++ b/bindata/network/ovn-kubernetes/common/001-crd.yaml
@@ -3245,6 +3245,8 @@ spec:
     kind: UserDefinedNetwork
     listKind: UserDefinedNetworkList
     plural: userdefinednetworks
+    shortNames:
+    - udn
     singular: userdefinednetwork
   scope: Namespaced
   versions:
@@ -3688,6 +3690,15 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              vrfName:
+                description: |-
+                  VRFName is the name of the Linux VRF device that OVN-Kubernetes creates
+                  for this network on every node where the network is present. It is
+                  populated for primary networks. Consumers that must name the VRF, such
+                  as FRRConfiguration authors filling in the routers 'vrf' field, should
+                  read this value instead of deriving it.
+                maxLength: 15
+                type: string
             type: object
         required:
         - spec
@@ -3709,6 +3720,8 @@ spec:
     kind: ClusterUserDefinedNetwork
     listKind: ClusterUserDefinedNetworkList
     plural: clusteruserdefinednetworks
+    shortNames:
+    - cudn
     singular: clusteruserdefinednetwork
   scope: Cluster
   versions:
@@ -4610,6 +4623,15 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              vrfName:
+                description: |-
+                  VRFName is the name of the Linux VRF device that OVN-Kubernetes creates
+                  for this network on every node where the network is present. It is
+                  populated for primary networks. Consumers that must name the VRF, such
+                  as FRRConfiguration authors filling in the routers 'vrf' field, should
+                  read this value instead of deriving it.
+                maxLength: 15
+                type: string
             type: object
         required:
         - spec


### PR DESCRIPTION
## What this does

Adds `status.vrfName` and short names to the **UserDefinedNetwork (UDN)** and
**ClusterUserDefinedNetwork (CUDN)** CRDs that CNO ships in
`bindata/network/ovn-kubernetes/common/001-crd.yaml`.

Two edits, applied identically to **both** CRDs:

1. **`status.vrfName`** — a `string` (maxLength 15) added under `status.properties`
   (after `conditions`, preserving controller-gen's alphabetical ordering).
2. **`shortNames`** — `udn` on the UDN CRD and `cudn` on the CUDN CRD, added under
   `spec.names`.

## Why

Upstream ovn-kubernetes PR openshift/ovn-kubernetes#6845 ("udn, cudn: publish the
derived VRF name in status.vrfName") landed in the 08-31 downstream merge
openshift/ovn-kubernetes#3426. The cluster-manager UDN controller
(`cluster-user-defined-network-controller`) now actively writes `status.vrfName`
on both UDN and CUDN objects.

Downstream, these CRDs are shipped by **CNO**, not by ovn-kubernetes. CNO's copy of
the schema did not have `status.vrfName`, so the API server rejected every status
apply-patch with:

```
failed to create typed patch object (... Kind=ClusterUserDefinedNetwork):
.status.vrfName: field not declared in schema
```

This caused the controller to error on every UDN/CUDN reconcile, failing ~19 e2e
jobs on the merge PR. **This PR unblocks openshift/ovn-kubernetes#3426.**

Mirrors upstream commits:
- `e0ae49b4a` — cudn API: add `status.vrfName`
- `418d3eed7` — udn API: add `status.vrfName`
- `272e9873b` — fix: add short names for (c)udn

## Scope / notes

- **5.1 (4.21 / master) only** — must **not** be backported to 5.0.
- **No feature gate**, intentionally (decided that a feature gate is overkill here).
- These CRDs are hand-maintained in CNO (copied from upstream ovn-kubernetes); they
  are not produced by `hack/update-codegen.sh`, so hand-editing is correct.
  `hack/update-codegen.sh` runs clean and leaves this file untouched.

## TODO for reviewer / human

⚠️ **A suitable OCPBUGS Jira still needs to be prepended to the PR title and
commit** so the jira-lifecycle bot is satisfied. None of the bugs listed on the
merge PR (OCPBUGS-114403 EVPN panic, OCPBUGS-112563 OpenTelemetry CVE,
OCPBUGS-99451 DNS pod role, OCPBUGS-99273 EgressIP host-cidrs) is the UDN
`vrfName` issue, and no dedicated OCPBUGS for this schema breakage was found — so
one should be identified or created rather than guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
