### PR TITLE
CORENET-7275: Add AGENTS.md, point CodeRabbit knowledge base at it

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,186 +1,78 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 # Inherit settings from the organization-level .coderabbit.yaml configuration.
 inheritance: true
+
+# https://docs.coderabbit.ai/reference/configuration#knowledge-base
+# Feed AGENTS.md (architecture, conventions, gotchas) to CodeRabbit as review
+# context so it doesn't need to be duplicated into path_instructions below.
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "**/AGENTS.md"
+      - "docs/**/*.md"
+
 # https://docs.coderabbit.ai/reference/configuration#reviews
 reviews:
   high_level_summary: true
   high_level_summary_in_walkthrough: true
   poem: false
   # https://docs.coderabbit.ai/configuration/path-instructions
+  # Keep these short — they're path-scoping + reviewer-tone hints. Architecture
+  # facts and gotchas live in AGENTS.md (loaded via knowledge_base above); link
+  # to a section there instead of repeating it here.
   path_instructions:
     - path: '**'
       instructions: |
-        This is the OpenShift Cluster Network Operator (CNO). It manages the lifecycle
-        of cluster networking components in OpenShift including OVN-Kubernetes, Multus,
-        kube-proxy, network-diagnostics, egress-router, cloud-network-config-controller,
-        network-metrics, node-identity, FRR-K8s, iptables-alerter, MTU-prober,
-        container-networking-plugins, bond CNI, whereabouts CNI, route-override CNI,
-        multi-network-policy, EVPN, and the networking console plugin.
+        This is the OpenShift Cluster Network Operator (CNO) — see AGENTS.md for
+        project overview, architecture, and conventions.
         - Focus on major issues impacting performance, readability, maintainability and security.
         - Consider backward compatibility, upgrade safety, and multi-platform support.
         - Avoid nitpicks and avoid verbosity.
-        - In HyperShift, CNO is deployed by openshift/hypershift (not CVO). If changes
-          touch `manifests/` or the CNO deployment, check whether corresponding changes
-          are needed in the openshift/hypershift repo.
         - Dual-stack (IPv4+IPv6) must always be considered. Flag changes that only
-          handle single-stack addresses (e.g. missing net.JoinHostPort for IPv6).
-        - Two CRDs drive CNO configuration:
-          `network.config.openshift.io/cluster` is the source of truth set by the
-          installer. `network.operator.openshift.io/cluster` is the operational
-          config CNO actually renders from. On each reconcile, CNO copies
-          `clusterNetwork`, `serviceNetwork`, and `networkType` from config → operator,
-          unconditionally overwriting whatever is in the operator CR for those fields.
-          Fields that exist only on the operator CR (e.g. `defaultNetwork.ovnKubernetesConfig`,
-          `ManagementState`, `disableNetworkDiagnostics`) are NOT touched by this merge
-          and are the user/admin's to control. Setting a config-owned field directly on
-          the operator CR has no effect — it gets overwritten on next reconcile.
-          `ManagementState` and `disableNetworkDiagnostics` need special SSA merge
-          protection (`pkg/apply/merge.go`) because they are non-pointer fields whose
-          zero values would otherwise clobber user-set values.
+          handle single-stack addresses (e.g. joining an IP address and port
+          manually rather than using net.JoinHostPort).
+        - See AGENTS.md § "Config flow" for the config→operator CR merge semantics
+          before flagging a field as unused or a merge as incomplete.
 
-    # -------------------------------------------------------------------------
-    # CVO-managed manifests (applied before CNO starts)
-    # -------------------------------------------------------------------------
     - path: 'manifests/**'
       instructions: |
-        Files in `manifests/` are applied by the Cluster Version Operator (CVO) before
-        CNO starts. They define the operator's own namespace, deployment, RBAC, CRDs,
-        and monitoring resources.
-        - Every resource MUST have the correct `include.release.openshift.io/*`
-          annotations (`self-managed-high-availability`, `single-node-developer`,
-          and `ibm-cloud-managed` where applicable). Missing annotations cause the
-          resource to be skipped on certain profiles.
-        - CVO applies `manifests/` before CNO starts, so resources there must
-          not depend on CNO running.
-        - The CNO deployment manifest (`03_deployment.yaml`) has a companion
-          `03_deployment-ibm-cloud-managed.yaml` variant. Changes to one may
-          require changes to the other.
+        CVO-applied manifests — see AGENTS.md § "manifests/ vs bindata/" for the
+        required `include.release.openshift.io/*` annotations and the
+        03_deployment.yaml / 03_deployment-ibm-cloud-managed.yaml pairing.
 
-    # -------------------------------------------------------------------------
-    # CNO-managed bindata (rendered and applied by the operator at runtime)
-    # -------------------------------------------------------------------------
     - path: 'bindata/**'
       instructions: |
-        Files in `bindata/` are Go-template YAML manifests rendered and applied by CNO
-        at runtime. They define the actual networking components (DaemonSets, Deployments,
-        ConfigMaps, RBAC, etc.).
+        CNO-rendered runtime manifests — see AGENTS.md § "manifests/ vs bindata/"
+        for the annotations CNO acts on (release version, HyperShift cluster-name,
+        create-only, copy-from, non-critical) and the DaemonSet node-selector rule.
+        Verify new container fields are applied to *all* containers, including init
+        containers — partial coverage is a recurring bug here.
+        In HyperShift, CNO itself is deployed by openshift/hypershift (not CVO); if
+        changes touch this dir or the CNO deployment, check whether the hypershift
+        repo needs a matching change.
 
-        **Critical annotations CNO acts upon — verify correctness when adding/modifying resources:**
-        - `release.openshift.io/version: "{{.ReleaseVersion}}"` — annotation that MUST
-          be present on every Deployment, DaemonSet, and StatefulSet. CNO uses this to
-          track upgrade progress. Missing annotation = operator never reports upgrade
-          complete.
-        - `network.operator.openshift.io/cluster-name` — annotation specifying which
-          cluster a resource belongs to in HyperShift (management vs guest). CNO uses
-          this to select the correct API client for applying. Wrong value = resource
-          applied to wrong cluster.
-        - `networkoperator.openshift.io/create-only` — annotation marking a resource as
-          created but never updated. Removing this changes apply semantics.
-        - `network.operator.openshift.io/copy-from` — annotation indicating resource
-          content is copied from another object (format: `ClusterName/Namespace/Name`).
-          Verify source exists.
-        - `networkoperator.openshift.io/non-critical` — annotation marking resources
-          that should not block the operator from becoming `Available` during cluster
-          install, because they depend on other operators.
-
-        **Namespace manifests:**
-        - Namespaces running DaemonSets MUST have `openshift.io/node-selector: ""`
-          annotation to override any default node selector. Missing this causes pods
-          to be unschedulable when cluster-wide defaultNodeSelector is set.
-
-        **General:**
-        - When a field is added to containers in a DaemonSet/Deployment (e.g.
-          `terminationMessagePolicy`, resource limits), verify ALL containers
-          including init containers are covered — partial coverage is a recurring bug.
-
-    # -------------------------------------------------------------------------
-    # OVN-Kubernetes: managed (HyperShift) vs self-hosted alignment
-    # -------------------------------------------------------------------------
     - path: 'bindata/network/ovn-kubernetes/**'
       instructions: |
-        OVN-Kubernetes manifests are split into three directories:
-        - `common/` — shared across both HyperShift (managed) and standalone (self-hosted)
-        - `managed/` — HyperShift control plane (runs in the management cluster)
-        - `self-hosted/` — standalone OCP control plane (runs on cluster nodes)
+        See AGENTS.md § "OVN-Kubernetes: managed vs self-hosted" — the
+        `managed/`/`self-hosted/`/`common/` split, restart-hash triggers, and
+        rollout ordering are the #1 source of HyperShift drift bugs here.
+        Also audit container command/args for duplicated or obsolete CLI flags.
 
-        **Managed ↔ Self-hosted alignment (HIGH PRIORITY):**
-        - `managed/` and `self-hosted/` contain parallel files for the same components
-          (ovnkube-control-plane, ovnkube-node, config, monitoring).
-        - When changing a file in one, ALWAYS check if the same change is needed in
-          the other. This is the #1 source of HyperShift drift bugs. Examples:
-          masquerade subnet config, interconnect flags, IPv6 URL formatting.
-          Some settings are HyperShift-only (SOCKS proxy, different cert paths,
-          `{{.OVNControlPlaneImage}}`), but most feature flags must appear in both.
-
-        **OVN-K rollout behavior:**
-        - CNO rolls out OVN-K changes in a specific order: control-plane first, then
-          nodes (only after control-plane rollout completes). The pre-puller DaemonSet
-          runs before node rollout to pull images.
-        - `release.openshift.io/version` on DaemonSets/Deployments drives rollout
-          progress tracking. `networkoperator.openshift.io/rollout-hung` is set when
-          a rollout appears stuck.
-        - Rollout/progress checks must handle zero-node and zero-replica edge cases
-          (HyperShift clusters can have zero workers during provisioning).
-
-        **What triggers OVN-K pod restarts (and what does not):**
-        - The `ovnkube-script-lib` ConfigMap (`008-script-lib.yaml`) is hashed into a
-          pod template annotation (`OVNKubeConfigHash`). Changes to this ConfigMap
-          trigger ovnkube-node restarts.
-        - Separate hashes exist for node-only config (`OVNKubeNodeConfigHash` — tracks
-          `outboundSNAT`) and control-plane-only config (`OVNKubeControlPlaneConfigHash`
-          — tracks BGP `asNumber`/`topology`), so changes to one don't restart the other.
-        - Annotations set via `setOVNObjectAnnotation` (`ip-family-mode`,
-          `cluster-network-cidr`, `hybrid-overlay-status`) are placed on both the
-          object AND the pod template, so changes trigger a rollout.
-        - Other ConfigMaps (e.g. `004-config.yaml`) are NOT hashed — changes to them
-          are only picked up on next pod restart. If a new config option is added to a
-          non-hashed ConfigMap and must take effect immediately, either add it to the
-          hash computation or use a different restart mechanism.
-
-        **CLI flags:**
-        - OVN-K containers are especially prone to duplicated or obsolete CLI flags
-          in command/args. Audit for duplicates when modifying container specs.
-
-    # -------------------------------------------------------------------------
-    # Other components with managed/self-hosted variants
-    # -------------------------------------------------------------------------
     - path: 'bindata/network/node-identity/**'
       instructions: |
-        Node identity controller — has `managed/` and `self-hosted/` variants
-        like OVN-K. Ensure both variants stay aligned when making changes.
-
-    # -------------------------------------------------------------------------
-    # Go source: rendering, apply, and operator logic
-    # -------------------------------------------------------------------------
-    - path: 'pkg/network/*.go'
-      instructions: |
-        Network component rendering functions. Each file (multus.go, kube_proxy.go,
-        ovn_kubernetes.go, etc.) renders bindata templates for its component.
-        - Every render function must set `data.Data["ReleaseVersion"]` from
-          `os.Getenv("RELEASE_VERSION")`. Missing this = the component's workloads
-          won't have the version annotation and upgrades stall.
-        - `daemonSetProgressing()` / `deploymentProgressing()` in ovn_kubernetes.go
-          drive upgrade status. Must handle zero DesiredNumberScheduled, rollout-hung
-          annotation, generation mismatch. Bugs here block cluster upgrades.
+        Has the same `managed/`/`self-hosted/` split as OVN-Kubernetes
+        (see AGENTS.md). Ensure both variants stay aligned.
 
     - path: 'pkg/apply/**'
       instructions: |
-        CNO uses Server-Side Apply exclusively (`Force: true`). Changes here
-        affect ALL components.
-        - Fields NOT included in the applied object are released (not deleted).
-          To actually remove a field from the live object, explicit deletion
-          logic is needed.
-        - `merge.go` has special-case merge functions for non-pointer fields
-          whose zero values conflict with SSA (`disableNetworkDiagnostics`,
-          `managementState`). Changes here need careful review.
+        See AGENTS.md § "Apply: Server-Side Apply only" — SSA release-not-delete
+        semantics and the merge.go zero-value special cases affect ALL components.
 
     - path: 'pkg/hypershift/**'
       instructions: |
-        HyperShift integration layer.
-        - Uses a locally-defined subset of the HostedControlPlane API to avoid
-          importing the full openshift/hypershift dependency.
-        - Environment variables (`HYPERSHIFT`, `HOSTED_CLUSTER_NAME`, etc.) control
-          HyperShift mode detection.
+        See AGENTS.md § "HyperShift" — local HostedControlPlane API subset,
+        HYPERSHIFT/HOSTED_CLUSTER_NAME mode detection.
 
   # https://docs.coderabbit.ai/configuration/path-instructions#path-filters
   path_filters:
@@ -205,6 +97,8 @@ reviews:
   # checks, which blocks the PR from merging until resolved or overridden.
   request_changes_workflow: true
   # https://docs.coderabbit.ai/pr-reviews/pre-merge-checks
+  # These are gating/process checks (pass-fail mechanics, thresholds) — kept
+  # here rather than in AGENTS.md, which is proactive guidance, not a gate.
   pre_merge_checks:
     # Built-in checks
     title:
@@ -285,9 +179,8 @@ reviews:
           5. Flag vague, uninformative, or generic messages like
           "fix", "update", "wip", "changes", "misc", or "address
           review comments" that provide no meaningful context. Review
-          feedback should be squashed into the relevant logical
-          commit, not added as a separate "address review comments"
-          commit.
+          feedback must be squashed into the relevant logical commit;
+          do not add a separate "address review comments" commit.
 
           6. Flag overly verbose commit messages that read like
           AI-generated changelogs — listing every function name,
@@ -356,15 +249,12 @@ reviews:
         mode: "warning"
         instructions: >-
           In YAML files under bindata/ and manifests/, if ClusterRole or
-          Role rules are added or modified:
-
-          1. Flag any rule that uses a wildcard verb ("*") or wildcard
-          resource ("*") unless explicitly justified.
-
-          2. Flag rules granting mutation verbs (create, update, patch,
-          delete, deletecollection) and ask the author to justify why
-          mutation access is needed. Read-only verbs (get, list, watch)
-          are fine without justification.
+          Role rules are added or modified, flag any rule that uses a
+          wildcard verb/resource without justification, and any rule
+          granting mutation verbs (create, update, patch, delete,
+          deletecollection) without the author explaining why mutation
+          access is needed. Read-only verbs (get, list, watch) need no
+          justification.
 
           Fail if any new RBAC rule uses wildcards without
           justification or grants mutation access without explanation.
@@ -421,12 +311,13 @@ reviews:
 
           Examples of staleness:
           1. A file or directory is renamed, moved, or deleted but is
-          still referenced by path in .coderabbit.yaml.
+          still referenced by path in .coderabbit.yaml or AGENTS.md.
           2. A code entity (CRD, flag, binary, config key) is renamed
-          or removed but still referenced in docs.
+          or removed but still referenced in docs or AGENTS.md.
           3. Architecture or component boundaries change but
-          docs/architecture.md is not updated.
-          4. A new operand is added but docs/operands.md is not updated.
+          docs/architecture.md or AGENTS.md is not updated.
+          4. A new operand is added but docs/operands.md or the AGENTS.md
+          component list is not updated.
           5. DPU/DPF mode behavior changes but docs/ovn_node_mode.md
           is not updated.
 
@@ -442,86 +333,31 @@ reviews:
       - name: "Go and Test Code Quality"
         mode: "warning"
         instructions: >-
-          Check new or modified Go code (excluding vendor/) for these
-          objective issues:
+          Check new or modified Go code (excluding vendor/) against the
+          "Go Code Quality" conventions in AGENTS.md (klog-only logging,
+          wrapped errors with %w/%v, explicit time.Duration units, no
+          err-shadowing in nested blocks, dual-stack IPv4/IPv6 handling,
+          guarded concurrent map/slice access) and the test conventions
+          there (t.Fatalf with context, no time.Sleep in favor of
+          gomega Eventually/Consistently, t.Setenv over os.Setenv).
 
-          Production code (excluding *_test.go):
-
-          1. Flag use of fmt.Print, fmt.Println, log.Print,
-          log.Fatal, or log.* for logging. The project uses klog
-          exclusively.
-
-          2. Flag bare error returns (return err) without adding
-          context in functions that perform meaningful work. Errors
-          should be wrapped with fmt.Errorf to add context. Use %w
-          when the caller should be able to inspect the underlying
-          error with errors.Is/errors.As. Use %v when the underlying
-          error is an implementation detail that should not be exposed
-          as part of the API. Do not flag bare returns in thin
-          wrappers or delegation functions where the caller already
-          provides sufficient context.
-
-          3. Flag bare integers passed as time.Duration without
-          explicit units. Must use e.g. 10*time.Second, not 10.
-
-          4. Flag err := inside nested blocks that shadow an outer
-          err variable, silently losing errors.
-
-          5. Flag changes that only handle IPv4 without considering
-          IPv6. Dual-stack (IPv4+IPv6) must always be considered.
-
-          6. Flag unprotected concurrent map or slice access. Shared
-          state between goroutines must be guarded by locks.
-
-          Test code (pkg/**/*_test.go, cmd/**/*_test.go, test/e2e/**):
-
-          7. Flag bare t.Fatal(err) or t.Fatalf calls that only pass
-          the error without describing what operation failed. Must
-          include context, e.g. t.Fatalf("failed to render ovn: %v",
-          err).
-
-          8. Flag time.Sleep in tests: prefer retry/poll loops or
-          gomega Eventually/Consistently for async assertions.
-
-          9. Flag os.Setenv in tests: use t.Setenv which
-          auto-restores on cleanup. This is already the established
-          pattern in the CNO codebase.
-
-          Fail if any of the above 9 issues are found in new or
-          modified code.
+          Fail if any of those conventions are violated in new or
+          modified code without justification.
 
           Pass only if none of the above issues are present.
       - name: "AI-Generated Code Smell"
         mode: "error"
         instructions: >-
-          Flag signs of AI-generated code that was not properly
-          reviewed by the author before submission:
+          Flag signs of AI-generated code that was not properly reviewed
+          by the author before submission, per the "AI-slop" conventions
+          in AGENTS.md: comments that merely restate the code, large
+          blocks of unit tests unrelated to the PR's functional change,
+          unnecessarily verbose code (redundant intermediate variables,
+          defensive checks for conditions that can't occur in context,
+          copy-pasted blocks that should be a shared helper/table-driven
+          test), and comments/names referencing AI tools or prompts.
 
-          1. Obvious comment slop: comments that merely restate the
-          code they annotate (e.g. "// set a to b" above "a = b",
-          "// return the error" above "return err", "// create the
-          pod" above "CreatePod()"). These add no value and clutter
-          the codebase.
-
-          2. Large blocks of unit tests that are auto-generated by AI
-          and are unrelated to the functional changes in the PR.
-          Flag if the PR adds hundreds of lines of tests for code
-          that was not modified in this PR.
-
-          3. Unnecessarily verbose code: unnecessary intermediate
-          variables (e.g. x := foo(); return x), redundant nil/error
-          checks already handled by the next line, defensive checks
-          for conditions that cannot occur in context, logic that a
-          single stdlib call replaces, or consecutive copy-paste
-          blocks differing only in names/literals that should be a
-          shared helper or table-driven approach.
-
-          4. Comments or variable names that reference AI tools or
-          prompts (e.g. "as suggested by", "generated by", "TODO:
-          verify this AI suggestion").
-
-          Fail if any of the above 4 patterns are found in new or
-          modified code.
+          Fail if any of those patterns are found in new or modified code.
 
           Pass only if the code is clean, comments add genuine value,
           and test changes are proportional to the functional changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,190 @@
+# AGENTS.md — Cluster Network Operator
+
+Project context for AI coding agents.
+
+## Project Overview
+
+The Cluster Network Operator (CNO) installs, configures, and upgrades the lifecycle of
+networking components on an OpenShift cluster. It follows the
+[Controller pattern](https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg#hdr-Controller):
+it watches `Network.config.openshift.io/v1` and `Network.operator.openshift.io/v1`,
+reconciling rendered manifests to the latter.
+
+Each managed component has its own `bindata/<component>/` templates and a
+`render<Component>` function in `pkg/network/` — `ls bindata/` for the current set rather
+than trusting an enumerated list here, since it drifts.
+
+## Repository Layout
+
+```text
+cmd/                    # Binaries: cluster-network-operator, cluster-network-check-endpoints, cluster-network-check-target
+pkg/controller/         # controller-runtime reconcilers (operconfig, proxyconfig, infrastructureconfig,
+                         #   pki, signer, statusmanager, egress_router, ...)
+pkg/network/            # Core render logic: one render<Component> function per managed component
+pkg/render/             # Generic manifest templating engine (Go text/template + sprig)
+pkg/bootstrap/          # BootstrapResult — cluster facts (infra, proxy, ...) gathered before rendering
+pkg/apply/              # Applies rendered objects via Server-Side Apply; merge.go has SSA special cases
+pkg/operator/           # controllercmd wiring, manager startup
+pkg/hypershift/         # HyperShift-specific behavior (local subset of HostedControlPlane API)
+pkg/platform/           # Platform (cloud provider) specific logic
+pkg/client/             # cnoclient — wraps default + HyperShift-aware clients
+pkg/apis/               # Generated API types/clientsets — do not hand-edit, see Codegen below
+bindata/                # Go-template manifests, one dir per component; rendered+applied at runtime
+manifests/              # CVO-applied manifests for the operator itself (namespace, CRDs, RBAC, deployment)
+profile-patches/        # Patches layered on manifests/ per install profile (see Makefile)
+docs/                   # architecture.md, operands.md, IPsec/DPU docs — kept in sync with behavior changes
+test/e2e/               # Ginkgo e2e suites
+hack/                   # Dev scripts: update-codegen.sh, test-go.sh, verify-style.sh, kind.yaml, ...
+```
+
+## Build and Test
+
+```bash
+make build      # Build cluster-network-operator, cluster-network-check-endpoints, and cluster-network-check-target
+make check      # verify (incl. codegen diff) + test-unit + golangci-lint — run this before a PR
+
+# `check`'s pieces, for faster iteration on just one:
+make test-unit             # Unit tests only (./pkg/... ./cmd/...)
+make golangci-lint          # Lint only
+make verify-update-codegen  # Regenerate deepcopy/clientset code and diff-check
+```
+
+## Key Conventions
+
+- **Commit/PR titles**: imperative mood, under 72 chars, prefixed by affected component when
+  scoped (e.g. `ovn-kubernetes: Fix EgressIP race condition`). Include the Jira ref
+  (`OCPBUGS-12345`) in the title or description for bug fixes.
+- **Commits are logical units**: one self-contained change per commit; body explains *why*,
+  not a narration of the diff. No "address review comments" commits — squash into the
+  relevant commit. No merge commits — rebase onto target instead.
+- **PR description** must cover Why / What / How-to-verify (which CI lanes/platforms tested
+  it — AWS, GCP, Azure, bare-metal, vSphere, SNO, HyperShift). Manual testing alone doesn't
+  count. Bug fixes need root cause + fix explanation. Keep PRs under ~7000 lines diff
+  (excl. vendor); split large features.
+- **Tests are expected alongside changes**: modified `pkg/`/`cmd/` Go code or `bindata/`
+  templates need corresponding `*_test.go` changes. User-facing behavior changes/bug fixes
+  need `test/e2e/` coverage. If genuinely infeasible, justify in the PR description.
+- **Docs**: new features / behavior changes / architecture changes need `docs/` updates
+  (new feature → new doc file). DPU/DPF changes need docs on data-path impact, config
+  keys, failure modes. IPsec changes update `docs/enabling_ns_ipsec.md`. Operand/component
+  boundary changes update `docs/operands.md` / `docs/architecture.md`.
+- **RBAC least privilege**: no wildcard verb/resource in ClusterRole/Role without
+  justification; mutation verbs (create/update/patch/delete) need explicit justification.
+- **Generated files are not hand-edited**: `pkg/apis/**` comes from `hack/update-codegen.sh`.
+- **Keep this file and `.coderabbit.yaml` in sync** with reality — both go stale the same way
+  (renamed files/flags/CRDs, changed architecture). CodeRabbit's "Stale Project Docs and
+  Config" pre-merge check flags AGENTS.md drift and blocks merge on it, but that's a
+  best-effort AI check, not a real CI job — don't rely on it catching everything.
+
+## Go Code Quality (applies to code you write here)
+
+- Logging: klog only, never `fmt.Print*`/`log.*`.
+- Wrap errors with context (`fmt.Errorf`): `%w` when callers need `errors.Is/As`, `%v` when
+  the underlying error is an implementation detail. Don't return bare `err` from functions
+  doing meaningful work (thin wrappers/delegation are fine bare).
+  Watch for `err :=` in nested blocks shadowing an outer `err`.
+  Always use explicit `time.Duration` units (`10*time.Second`, never bare `10`).
+- **Dual-stack always**: never handle IPv4 only where IPv6 also applies (e.g. joining
+  an IP address and port manually rather than using `net.JoinHostPort`).
+- Guard shared map/slice state accessed from multiple goroutines.
+- Tests: `t.Fatalf` needs context, not just the bare error. Prefer gomega
+  `Eventually`/`Consistently` or poll loops over `time.Sleep`. Use `t.Setenv`, not
+  `os.Setenv` (auto-restores).
+- Avoid AI-slop patterns: comments that restate the code (`// set a to b` above `a = b`),
+  unnecessary intermediate variables, defensive checks for conditions that can't occur in
+  context, copy-pasted blocks that should be a helper/table-driven test, and large
+  unrelated test additions unconnected to the functional change.
+
+## Architecture Notes
+
+### Config flow: config.openshift.io → operator.openshift.io
+
+Two CRDs drive configuration. `network.config.openshift.io/cluster` is the installer-set
+source of truth. `network.operator.openshift.io/cluster` is what CNO actually renders from.
+On each reconcile CNO copies `clusterNetwork`, `serviceNetwork`, and `networkType` from
+config → operator, **unconditionally overwriting** the operator CR for those fields. Fields
+that exist only on the operator CR (`defaultNetwork.ovnKubernetesConfig`, `ManagementState`,
+`disableNetworkDiagnostics`) are untouched by this merge — they're the admin's to control,
+and setting them on the operator CR directly has no effect for config-owned fields (gets
+overwritten next reconcile). `ManagementState`/`disableNetworkDiagnostics` need special SSA
+merge protection (`pkg/apply/merge.go`) since they're non-pointer fields whose zero values
+would otherwise clobber user-set values under SSA.
+
+`pkg/bootstrap.BootstrapResult` carries ambient cluster facts (infra platform, proxy, etc.)
+that rendering needs but that don't come from either CR.
+
+### Render pipeline
+
+`pkg/network.Render()` calls one `render<Component>` function per component — order matters
+(e.g. CNCC renders before the CNI plugin because the plugin depends on the CRD CNCC defines).
+Each function feeds `bindata/<component>/` Go-template YAML through
+`pkg/render.RenderDir(s)` (sprig funcs) into `[]*unstructured.Unstructured`.
+
+### Apply: Server-Side Apply only
+
+`pkg/apply.ApplyObject` uses SSA exclusively (`Force: true`, field manager
+`cluster-network-operator[/<subcontroller>]`) for all components. Omitting a field the
+manager owns **releases** it — the API server deletes the field or resets it to its
+default if no other manager owns it, but leaves it alone if another manager still does.
+Don't assume removing a field from a template is a no-op on the live object.
+
+### manifests/ vs bindata/
+
+For standalone/self-hosted OpenShift, `manifests/` is applied by the CVO **before CNO
+starts** — namespace, CNO's own deployment, RBAC, CRDs, monitoring. In HyperShift, CNO
+itself is deployed by `openshift/hypershift` instead of CVO (see HyperShift section below);
+changes here may need a matching change in that repo. Every resource needs correct
+`include.release.openshift.io/*`
+annotations (`self-managed-high-availability`, `single-node-developer`,
+`ibm-cloud-managed` where applicable) or it's skipped on that profile.
+`0000_70_cluster-network-operator_03_deployment.yaml` has a companion
+`0000_70_cluster-network-operator_03_deployment-ibm-cloud-managed.yaml` — keep them aligned.
+
+`bindata/` is rendered and applied by CNO **at runtime** — the actual networking component
+workloads. Critical annotations CNO acts on:
+- `release.openshift.io/version: "{{.ReleaseVersion}}"` — required on every
+  Deployment/DaemonSet/StatefulSet; drives upgrade-progress tracking.
+- `network.operator.openshift.io/cluster-name` — HyperShift: which cluster (management vs
+  guest) a resource belongs to; wrong value applies it to the wrong cluster.
+- `networkoperator.openshift.io/create-only` — created once, never updated.
+- `network.operator.openshift.io/copy-from` — content copied from `ClusterName/Namespace/Name`.
+- `networkoperator.openshift.io/non-critical` — doesn't block operator `Available` during install.
+- Namespaces running DaemonSets need `openshift.io/node-selector: ""` or pods can become
+  unschedulable under a cluster-wide default node selector.
+- When adding a field to containers in a DaemonSet/Deployment, check *all* containers
+  including init containers — partial coverage is a recurring bug class here.
+
+### OVN-Kubernetes: managed vs self-hosted
+
+`bindata/network/ovn-kubernetes/` splits into `common/` (shared), `managed/` (HyperShift
+control plane, runs in management cluster), `self-hosted/` (standalone OCP control plane).
+**#1 source of HyperShift drift bugs**: `managed/` and `self-hosted/` have parallel files for
+the same components (ovnkube-control-plane, ovnkube-node, config, monitoring) — a change to
+one almost always needs the mirrored change in the other (masquerade subnet, interconnect
+flags, IPv6 URL formatting are recurring examples). Some settings are legitimately
+HyperShift-only (SOCKS proxy, cert paths, `{{.OvnControlPlaneImage}}`).
+
+Rollout order: control-plane first, then nodes only after control-plane rollout completes;
+a pre-puller DaemonSet pulls images ahead of node rollout. Bugs in the rollout-progress
+checks in `pkg/network/ovn_kubernetes.go` block cluster upgrades.
+
+Pod restart triggers: `ovnkube-script-lib` ConfigMap (`008-script-lib.yaml`) is hashed into
+`OVNKubeConfigHash` on the pod template → triggers ovnkube-node restart on change. Separate
+`OVNKubeNodeConfigHash` (tracks `outboundSNAT`) and `OVNKubeControlPlaneConfigHash` (tracks
+BGP `asNumber`/`topology`) keep node-only vs control-plane-only changes from cross-restarting.
+Annotations set via `setOVNObjectAnnotation` (`ip-family-mode`, `cluster-network-cidr`,
+`hybrid-overlay-status`) go on both the object and pod template, so they do trigger rollout.
+Other ConfigMaps (e.g. `004-config.yaml`) are **not hashed** — changes only take effect on
+next natural pod restart; a new option needing immediate effect must join the hash
+computation or use another restart mechanism. Audit container command/args for duplicated
+or obsolete CLI flags when touching OVN-K containers — a recurring bug source.
+
+`bindata/network/node-identity/` has the same `managed/`/`self-hosted/` split; keep aligned.
+
+### HyperShift
+
+CNO itself is deployed by `openshift/hypershift` (not CVO) in HyperShift mode — changes to
+`manifests/` or the CNO deployment may need a corresponding change there too.
+`pkg/hypershift` defines a local subset of the HostedControlPlane API to avoid importing the
+full `openshift/hypershift` dependency; `HYPERSHIFT`/`HOSTED_CLUSTER_NAME` env vars control
+mode detection.

--- a/pkg/network/ovn_kubernetes.go
+++ b/pkg/network/ovn_kubernetes.go
@@ -1912,6 +1912,8 @@ func shouldUpdateOVNKonUpgrade(ovn bootstrap.OVNBootstrapResult, releaseVersion 
 }
 
 // daemonSetProgressing returns true if a daemonset is rolling out a change.
+// A DaemonSet with no desired pods is complete, because there are no pods to
+// roll out. This can occur in zero-node clusters.
 // If allowHung is true, then treat a daemonset hung at 90% as "done" for our purposes.
 func daemonSetProgressing(ds *appsv1.DaemonSet, allowHung bool) bool {
 	status := ds.Status
@@ -1950,6 +1952,8 @@ func daemonSetProgressing(ds *appsv1.DaemonSet, allowHung bool) bool {
 }
 
 // deploymentProgressing returns true if a deployment is rolling out a change.
+// A Deployment with zero desired replicas is complete, because there are no
+// replicas to roll out. This can occur in zero-node clusters.
 func deploymentProgressing(d *appsv1.Deployment) bool {
 	status := d.Status
 


### PR DESCRIPTION
Centralize CNO architecture/conventions/gotchas in AGENTS.md so both AI coding agents and CodeRabbit share one source of truth instead of duplicating knowledge into .coderabbit.yaml path_instructions.