### PR TITLE
[release-4.22] OCPBUGS-119956: Allow per-node OVN encap IP override via env-overrides

### DIFF
--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -475,6 +475,21 @@ data:
         echo "$(date --iso-8601=seconds) [{$1}] ${2}"
     }
 
+    # set-encap-ip-flag() sets --encap-ip from the OVN_ENCAP_IP environment
+    # variable when present.
+    set-encap-ip-flag()
+    {
+      local ovn_encap_ip_normalized
+      ovn_encap_ip_flag=
+
+      ovn_encap_ip_normalized="${OVN_ENCAP_IP//[[:space:]]/}"
+
+      if [[ -n "${ovn_encap_ip_normalized}" ]]; then
+        log "encapip" "Using OVN_ENCAP_IP=${OVN_ENCAP_IP}"
+        ovn_encap_ip_flag="--encap-ip=${ovn_encap_ip_normalized}"
+      fi
+    }
+
     # cni-bin-copy() detects the host OS and copies the correct shim binary to
     # the CNI binary directory.
     #
@@ -675,6 +690,8 @@ data:
         enable_interconnect_flag="--enable-interconnect"
       fi
 
+      set-encap-ip-flag
+
       exec /usr/bin/ovnkube \
         ${init_ovnkube_controller} \
         --init-node "${K8S_NODE}" \
@@ -685,6 +702,7 @@ data:
         ${gateway_mode_flags} \
         ${node_mgmt_port_netdev_flags} \
         ${ovnkube_node_mode} \
+        ${ovn_encap_ip_flag} \
         --metrics-bind-address "127.0.0.1:${metrics_port}" \
         --ovn-metrics-bind-address "127.0.0.1:${ovn_metrics_port}" \
         --metrics-enable-pprof \

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -4366,6 +4366,72 @@ func TestRenderOVNKubernetes_OpenFlowProbeOverride(t *testing.T) {
 	})
 }
 
+// TestRenderOVNKubernetes_NodeDaemonSetEnvOverridesVolume verifies the
+// ovnkube-node DaemonSet keeps the optional env-overrides ConfigMap mounted so
+// node-specific OVN encapsulation overrides can be sourced at startup.
+func TestRenderOVNKubernetes_NodeDaemonSetEnvOverridesVolume(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	crd := OVNKubernetesConfig.DeepCopy()
+	config := &crd.Spec
+	fillDefaults(config, nil)
+
+	bootstrapResult := fakeBootstrapResult()
+	bootstrapResult.OVN = bootstrap.OVNBootstrapResult{
+		ControlPlaneReplicaCount: 3,
+		OVNKubernetesConfig: &bootstrap.OVNConfigBoostrapResult{
+			DpuHostModeLabel:     OVN_NODE_SELECTOR_DEFAULT_DPU_HOST,
+			DpuModeLabel:         OVN_NODE_SELECTOR_DEFAULT_DPU,
+			SmartNicModeLabel:    OVN_NODE_SELECTOR_DEFAULT_SMART_NIC,
+			MgmtPortResourceName: "",
+			HyperShiftConfig: &bootstrap.OVNHyperShiftBootstrapResult{
+				Enabled: false,
+			},
+		},
+	}
+	featureGatesCNO := getDefaultFeatureGates()
+	fakeClient := cnofake.NewFakeClient()
+
+	objs, _, err := renderOVNKubernetes(config, bootstrapResult, manifestDirOvn, fakeClient, featureGatesCNO)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	nodeDS := findInObjs("apps", "DaemonSet", "ovnkube-node", "openshift-ovn-kubernetes", objs)
+	g.Expect(nodeDS).NotTo(BeNil())
+
+	ds := appsv1.DaemonSet{}
+	g.Expect(convert(nodeDS, &ds)).To(Succeed())
+
+	var envOverridesVolume *v1.Volume
+	for i := range ds.Spec.Template.Spec.Volumes {
+		volume := &ds.Spec.Template.Spec.Volumes[i]
+		if volume.Name == "env-overrides" {
+			envOverridesVolume = volume
+			break
+		}
+	}
+
+	g.Expect(envOverridesVolume).NotTo(BeNil())
+	g.Expect(envOverridesVolume.ConfigMap).NotTo(BeNil())
+	g.Expect(envOverridesVolume.ConfigMap.Name).To(Equal("env-overrides"))
+	g.Expect(envOverridesVolume.ConfigMap.Optional).NotTo(BeNil())
+	g.Expect(*envOverridesVolume.ConfigMap.Optional).To(BeTrue())
+
+	nodeContainer, ok := findContainer(ds.Spec.Template.Spec.Containers, "ovnkube-node")
+	if !ok {
+		nodeContainer, ok = findContainer(ds.Spec.Template.Spec.Containers, "ovnkube-controller")
+	}
+	g.Expect(ok).To(BeTrue(), "expecting container named ovnkube-node or ovnkube-controller in the DaemonSet")
+
+	hasEnvOverridesMount := false
+	for _, mount := range nodeContainer.VolumeMounts {
+		if mount.Name == "env-overrides" && mount.MountPath == "/env" {
+			hasEnvOverridesMount = true
+			break
+		}
+	}
+	g.Expect(hasEnvOverridesMount).To(BeTrue())
+}
+
 func TestRenderOVNKubernetes_AllowICMPNetworkPolicyOverride(t *testing.T) {
 	g := NewGomegaWithT(t)
 


### PR DESCRIPTION
Teach the ovnkube node startup wrapper to source OVN_ENCAP_IP from the
per-node env-overrides ConfigMap and pass it to ovnkube as --encap-ip.
Normalize whitespace in the override so single-IP and comma-separated
encap IP values are passed safely as one shell argument, and keep
coverage for the optional env-overrides mount used for day2 updates.


Manual cherry-pick because https://github.com/openshift/cluster-network-operator/pull/3147 failed.
Had to drop DpuNodeLeaseRenewInterval and DpuNodeLeaseDuration from the
env-overrides DaemonSet test, bootstrap fields do not exist on
the release-4.22 OVNConfigBoostrapResult API.