### PR TITLE
OCPBUGS-115428: Adds rendering of enable-multi-network-policy in ovnkube-node

### DIFF
--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -568,6 +568,11 @@ data:
 
       echo "I$(date "+%m%d %H:%M:%S.%N") - starting ovnkube-node"
 
+      multinetwork_policy_enabled_flag=
+      {{- if .OVN_MULTI_NETWORK_POLICY_ENABLE }}
+        multinetwork_policy_enabled_flag="--enable-multi-networkpolicy"
+      {{ end }}
+
       ovn_eip_reachability_timeout_opt=
       {{- if .ReachabilityTotalTimeoutSeconds }}        
         ovn_eip_reachability_timeout_opt="--egressip-reachability-total-timeout {{.ReachabilityTotalTimeoutSeconds}}"
@@ -762,5 +767,6 @@ data:
         ${ovn_v4_transit_switch_subnet_opt} \
         ${ovn_v6_transit_switch_subnet_opt} \
         ${dpu_lease_flags} \
-        ${ovn_eip_reachability_timeout_opt}
+        ${ovn_eip_reachability_timeout_opt} \
+        ${multinetwork_policy_enabled_flag}
     }

--- a/docs/ovn_node_mode.md
+++ b/docs/ovn_node_mode.md
@@ -19,6 +19,6 @@ Feature enablement is managed through two mechanisms:
 
 - **ConfigMap-based** (`004-config.yaml`): Most features (egress IP, multi-network, network segmentation, admin network policy, etc.) are configured in the cluster-wide ConfigMap which is passed to ovnkube via `--config-file`.
 
-- **CLI flags** (`ovnkube-control-plane.yaml`): Features that require ovnkube-control-plane pod restarts on configuration changes (multicast, multi-networkpolicy) are enabled via CLI flags (e.g., `--enable-multicast`, `--enable-multi-networkpolicy`) to ensure the control-plane pods restart automatically when the feature is toggled. Note that ovnkube-node pods already restart when the ConfigMap changes, so only control-plane-specific features require CLI flags.
+- **CLI flags** (`ovnkube-control-plane.yaml`): Features that require ovnkube-control-plane pod restarts on configuration changes (e.g., multicast) are enabled via CLI flags (e.g., `--enable-multicast`) to ensure the control-plane pods restart automatically when the feature is toggled. Similarly, ovnkube-node also restarts on configuration changes via specific CLI flags.
 
 These features are not gated per node mode.

--- a/pkg/network/ovn_kubernetes_test.go
+++ b/pkg/network/ovn_kubernetes_test.go
@@ -763,7 +763,7 @@ logfile-maxage=0`,
 			disableGRO:               true,
 		},
 		{
-			desc: "enable multi-network policies and admin network policies",
+			desc: "enable admin network policies",
 			expected: `
 [default]
 mtu="1500"
@@ -806,9 +806,7 @@ logfile-maxsize=100
 logfile-maxbackups=5
 logfile-maxage=0`,
 			controlPlaneReplicaCount: 2,
-
-			enableMultiNetPolicies: true,
-			enabledFeatureGates:    []configv1.FeatureGateName{},
+			enabledFeatureGates:      []configv1.FeatureGateName{},
 		},
 		{
 			desc: "enable network segmentation and multi-network",
@@ -857,7 +855,7 @@ logfile-maxage=0`,
 			enabledFeatureGates:      []configv1.FeatureGateName{},
 		},
 		{
-			desc: "enable multi-network policies with DisableMultiNetwork",
+			desc: "Set DisableMultiNetwork",
 			expected: `
 [default]
 mtu="1500"
@@ -901,7 +899,6 @@ logfile-maxbackups=5
 logfile-maxage=0`,
 			controlPlaneReplicaCount: 2,
 			disableMultiNet:          true,
-			enableMultiNetPolicies:   true,
 			enabledFeatureGates:      []configv1.FeatureGateName{},
 		},
 		{
@@ -4073,51 +4070,53 @@ func TestRenderOVNKubernetesEnablePersistentIPs(t *testing.T) {
 	g.Expect(objs).To(ContainElement(HaveKubernetesID("CustomResourceDefinition", "", "ipamclaims.k8s.cni.cncf.io")))
 }
 
-// TestRenderOVNKubernetesReachability tests egress IP reachability timeout rendering
-func TestRenderOVNKubernetesReachability(t *testing.T) {
+// TestRenderOVNKubernetesFlags tests the rendering of different ovnkube flags
+// ReachabilityTotalTimeoutSeconds: --egressip-reachability-total-timeout
+// OVN_MULTI_NETWORK_POLICY_ENABLE: --enable-multi-networkpolicy
+func TestRenderOVNKubernetesFlags(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	testCases := []struct {
 		name                                string
 		reachabilityTimeout                 *uint32
+		enableMultiNetworkPolicy            bool
 		expectKubernetesFeatureReachability bool
-		expectErr                           bool
 	}{
 		{
 			name:                                "No reachability timeout (nil)",
 			reachabilityTimeout:                 nil,
 			expectKubernetesFeatureReachability: false,
-			expectErr:                           false,
 		},
 		{
 			name:                                "Reachability timeout set to 0",
 			reachabilityTimeout:                 ptrToUint32(0),
 			expectKubernetesFeatureReachability: true,
-			expectErr:                           false,
 		},
 		{
 			name:                                "Reachability timeout changed to 10",
 			reachabilityTimeout:                 ptrToUint32(10),
 			expectKubernetesFeatureReachability: true,
-			expectErr:                           false,
 		},
 		{
 			name:                                "Reachability timeout unchanged to 10",
 			reachabilityTimeout:                 ptrToUint32(10),
 			expectKubernetesFeatureReachability: true,
-			expectErr:                           false,
 		},
 		{
 			name:                                "Reachability timeout changed to 5",
 			reachabilityTimeout:                 ptrToUint32(5),
 			expectKubernetesFeatureReachability: true,
-			expectErr:                           false,
 		},
 		{
 			name:                                "Reachability timeout disabled",
 			reachabilityTimeout:                 nil,
 			expectKubernetesFeatureReachability: false,
-			expectErr:                           false,
+		},
+		{
+			name:                                "Enable Multi Network Policy",
+			reachabilityTimeout:                 nil,
+			expectKubernetesFeatureReachability: false,
+			enableMultiNetworkPolicy:            true,
 		},
 	}
 
@@ -4126,6 +4125,7 @@ func TestRenderOVNKubernetesReachability(t *testing.T) {
 			crd := OVNKubernetesConfig.DeepCopy()
 			config := &crd.Spec
 			config.DefaultNetwork.OVNKubernetesConfig.EgressIPConfig.ReachabilityTotalTimeoutSeconds = tc.reachabilityTimeout
+			config.UseMultiNetworkPolicy = &tc.enableMultiNetworkPolicy
 
 			errs := validateOVNKubernetes(config)
 			g.Expect(errs).To(HaveLen(0))
@@ -4154,10 +4154,6 @@ func TestRenderOVNKubernetesReachability(t *testing.T) {
 			bootstrapResult.Infra = bootstrap.InfraStatus{}
 			bootstrapResult.Infra.HostedControlPlane = &hypershift.HostedControlPlane{}
 			objs, _, err := renderOVNKubernetes(config, bootstrapResult, manifestDirOvn, fakeClient, featureGatesCNO)
-			if tc.expectErr {
-				g.Expect(err).To(HaveOccurred())
-				return
-			}
 			g.Expect(err).NotTo(HaveOccurred())
 
 			var configMap *uns.Unstructured
@@ -4212,6 +4208,18 @@ func TestRenderOVNKubernetesReachability(t *testing.T) {
 				g.Expect(scriptNode).NotTo(
 					ContainSubstring("--egressip-reachability-total-timeout"),
 					"ovnkube-node pod template should not contain the configured reachability timeout value",
+				)
+			}
+
+			if tc.enableMultiNetworkPolicy {
+				g.Expect(scriptNode).To(
+					ContainSubstring("--enable-multi-networkpolicy"),
+					"ovnkube-node pod template should contain the flag --enable-multi-networkpolicy",
+				)
+			} else {
+				g.Expect(scriptNode).NotTo(
+					ContainSubstring("--enable-multi-networkpolicy"),
+					"ovnkube-node pod template should not contain the flag --enable-multi-networkpolicy",
 				)
 			}
 		})


### PR DESCRIPTION
Sets the flag `--enable-multi-networkpolicy` to be properly rendered in ovnkube-node config flags when updated by CNO.

Modifies unit test to evaluate the rendering of multiple Flags to ovnkube cluster-manager and node.


(cherry picked from commit d36382db73b023848218ee9bfd9c79871d7ebb57)

No conflicts found on cherry-pick.