### PR TITLE
hypershift: support Minimal control plane availability-zone scheduling

### DIFF
--- a/pkg/hypershift/hypershift.go
+++ b/pkg/hypershift/hypershift.go
@@ -38,6 +38,27 @@ const (
 	HyperShiftConditionTypePrefix = "network.operator.openshift.io/"
 	// RestartDateAnnotation is used to trigger rolling restarts of control plane operands
 	RestartDateAnnotation = "hypershift.openshift.io/restart-date"
+
+	// ControlPlaneNodeRoleLabel is the well-known label the management-cluster infrastructure
+	// applies to control plane node pools to identify their scheduling role for the Minimal
+	// control plane availability-zone scheduling policy. It mirrors
+	// hypershift.openshift.io/v1beta1.ControlPlaneNodeRoleLabel and is also the key of the
+	// NoSchedule taint applied to zonal pools in hard (Required) placement mode.
+	ControlPlaneNodeRoleLabel = "hypershift.openshift.io/control-plane-node-role"
+	// ControlPlaneNodeRoleZonal labels the balanced, availability-zone-spread node pools.
+	ControlPlaneNodeRoleZonal = "zonal"
+	// ControlPlaneNodeRoleOverflow labels the non-zonal ("overflow") node pools.
+	ControlPlaneNodeRoleOverflow = "overflow"
+	// ControlPlaneSchedulingTierLabel records a control plane pod's scheduling tier so that
+	// colocation affinity is scoped per tier. It mirrors the hypershift API constant.
+	ControlPlaneSchedulingTierLabel = "hypershift.openshift.io/control-plane-scheduling-tier"
+
+	// MinimalAvailabilityZoneSchedulingPolicy is the opt-in policy value that minimizes the
+	// set of components spread across availability zones and places the rest on overflow
+	// capacity.
+	MinimalAvailabilityZoneSchedulingPolicy = "Minimal"
+	// NonZonalPlacementRequired is the hard placement-mode value; the default is Preferred.
+	NonZonalPlacementRequired = "Required"
 )
 
 type RelatedObject struct {
@@ -62,6 +83,13 @@ type HostedControlPlane struct {
 	PriorityClass                string
 	APIServerSpec                *configv1.APIServerSpec
 	RestartDate                  string
+	// AvailabilityZoneSchedulingPolicy is the control plane availability-zone scheduling
+	// policy (e.g. MinimalAvailabilityZoneSchedulingPolicy); empty when not opted in.
+	AvailabilityZoneSchedulingPolicy string
+	// NonZonalPlacement selects Preferred (soft, the default) or Required (hard) placement
+	// of non-zone-critical ("float") components onto overflow capacity under the Minimal
+	// policy.
+	NonZonalPlacement string
 }
 
 // AvailabilityPolicy specifies a high level availability policy for components.
@@ -274,18 +302,29 @@ func ParseHostedControlPlane(hcp *unstructured.Unstructured) (*HostedControlPlan
 		}
 	}
 
+	azSchedulingPolicy, _, err := unstructured.NestedString(hcp.UnstructuredContent(), "spec", "controlPlaneAvailabilityZoneScheduling", "policy")
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract controlPlaneAvailabilityZoneScheduling.policy: %v", err)
+	}
+	nonZonalPlacement, _, err := unstructured.NestedString(hcp.UnstructuredContent(), "spec", "controlPlaneAvailabilityZoneScheduling", "nonZonalPlacement")
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract controlPlaneAvailabilityZoneScheduling.nonZonalPlacement: %v", err)
+	}
+
 	return &HostedControlPlane{
-		Namespace:                    hcp.GetNamespace(),
-		ControllerAvailabilityPolicy: AvailabilityPolicy(controllerAvailabilityPolicy),
-		ClusterID:                    clusterID,
-		NodeSelector:                 nodeSelector,
-		Labels:                       labels,
-		Tolerations:                  tolerationsYaml,
-		AdvertiseAddress:             advertiseAddress,
-		AdvertisePort:                int(advertisePort),
-		PriorityClass:                controlPlanePriorityClassAnnotation,
-		APIServerSpec:                apiServerSpec,
-		RestartDate:                  restartDate,
+		Namespace:                        hcp.GetNamespace(),
+		ControllerAvailabilityPolicy:     AvailabilityPolicy(controllerAvailabilityPolicy),
+		ClusterID:                        clusterID,
+		NodeSelector:                     nodeSelector,
+		Labels:                           labels,
+		Tolerations:                      tolerationsYaml,
+		AdvertiseAddress:                 advertiseAddress,
+		AdvertisePort:                    int(advertisePort),
+		PriorityClass:                    controlPlanePriorityClassAnnotation,
+		APIServerSpec:                    apiServerSpec,
+		RestartDate:                      restartDate,
+		AvailabilityZoneSchedulingPolicy: azSchedulingPolicy,
+		NonZonalPlacement:                nonZonalPlacement,
 	}, nil
 }
 

--- a/pkg/hypershift/hypershift_test.go
+++ b/pkg/hypershift/hypershift_test.go
@@ -89,6 +89,33 @@ spec:
       port: 2040
 `,
 		},
+		{
+			name: "Picks up the control plane availability-zone scheduling policy",
+			expectedOutput: &HostedControlPlane{
+				ClusterID:                        "31df7fa9-b1a7-4a66-98ef-c6920bf213d8",
+				ControllerAvailabilityPolicy:     HighlyAvailable,
+				NodeSelector:                     nil,
+				AdvertiseAddress:                 HostedClusterDefaultAdvertiseAddressIPV4,
+				AdvertisePort:                    int(HostedClusterDefaultAdvertisePort),
+				AvailabilityZoneSchedulingPolicy: MinimalAvailabilityZoneSchedulingPolicy,
+				NonZonalPlacement:                NonZonalPlacementRequired,
+			},
+			inputUnstructuredContent: `
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedControlPlane
+spec:
+  autoscaling: {}
+  clusterID: 31df7fa9-b1a7-4a66-98ef-c6920bf213d8
+  controllerAvailabilityPolicy: HighlyAvailable
+  controlPlaneAvailabilityZoneScheduling:
+    policy: Minimal
+    nonZonalPlacement: Required
+  dns:
+    baseDomain: tf71faa489656c98b18e2-a383e1dc466c308d41a756a1a66c2b6a-c000.us-south.satellite.test.appdomain.cloud
+  infrastructureAvailabilityPolicy: HighlyAvailable
+  issuerURL: https://kubernetes.default.svc
+`,
+		},
 	}
 	g := NewGomegaWithT(t)
 	for _, tc := range testCases {

--- a/pkg/network/render.go
+++ b/pkg/network/render.go
@@ -151,6 +151,13 @@ func Render(operConf *operv1.NetworkSpec, clusterConf *configv1.NetworkSpec, man
 		return nil, progressing, err
 	}
 
+	// In HyperShift mode, apply the Minimal control plane availability-zone scheduling
+	// policy to the network control-plane operands when the hosted control plane has opted
+	// in. This is a no-op otherwise.
+	if err := applyMinimalZonalScheduling(objs, bootstrapResult.Infra.HostedControlPlane); err != nil {
+		return nil, progressing, err
+	}
+
 	log.Printf("Render phase done, rendered %d objects", len(objs))
 	return objs, progressing, nil
 }

--- a/pkg/network/zonal_scheduling.go
+++ b/pkg/network/zonal_scheduling.go
@@ -1,0 +1,205 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/openshift/cluster-network-operator/pkg/hypershift"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+)
+
+// networkOperandZoneCritical maps each HyperShift-mode network control-plane operand
+// Deployment to whether it must be spread across availability zones ("zone-critical")
+// under the Minimal control plane availability-zone scheduling policy. The blocking-webhook
+// backends (network-node-identity, multus-admission-controller) stay zone-critical because
+// their failurePolicy: Fail webhooks gate the guest apiserver; ovnkube-control-plane is a
+// leader-elected controller and floats to overflow capacity.
+var networkOperandZoneCritical = map[string]bool{
+	"network-node-identity":       true,
+	"multus-admission-controller": true,
+	"ovnkube-control-plane":       false,
+}
+
+// applyMinimalZonalScheduling transforms the network control-plane operand Deployments
+// for the Minimal control plane availability-zone scheduling policy: it replaces the zone
+// podAntiAffinity with topologySpreadConstraints, steers each operand onto the correct
+// management-cluster node pool (zonal for the blocking-webhook backends, overflow for
+// ovnkube-control-plane), scopes colocation per tier, and runs network-node-identity as a
+// two-replica pair instead of three. It is a no-op unless the hosted control plane has
+// opted into the Minimal policy.
+func applyMinimalZonalScheduling(objs []*uns.Unstructured, hcp *hypershift.HostedControlPlane) error {
+	if hcp == nil || hcp.AvailabilityZoneSchedulingPolicy != hypershift.MinimalAvailabilityZoneSchedulingPolicy {
+		return nil
+	}
+	hard := hcp.NonZonalPlacement == hypershift.NonZonalPlacementRequired
+
+	for _, obj := range objs {
+		if obj.GetKind() != "Deployment" || obj.GroupVersionKind().Group != "apps" {
+			continue
+		}
+		zoneCritical, known := networkOperandZoneCritical[obj.GetName()]
+		if !known {
+			continue
+		}
+
+		deploy := &appsv1.Deployment{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, deploy); err != nil {
+			return fmt.Errorf("converting %s to Deployment for zonal scheduling: %w", obj.GetName(), err)
+		}
+		mutateDeploymentForMinimalZonalScheduling(deploy, zoneCritical, hard)
+		out, err := runtime.DefaultUnstructuredConverter.ToUnstructured(deploy)
+		if err != nil {
+			return fmt.Errorf("converting %s back to unstructured for zonal scheduling: %w", obj.GetName(), err)
+		}
+		obj.Object = out
+	}
+	return nil
+}
+
+func mutateDeploymentForMinimalZonalScheduling(deploy *appsv1.Deployment, zoneCritical, hard bool) {
+	tier := hypershift.ControlPlaneNodeRoleOverflow
+	if zoneCritical {
+		tier = hypershift.ControlPlaneNodeRoleZonal
+	}
+
+	// The blocking-webhook backends run as two-replica pairs under the Minimal policy
+	// (network-node-identity is otherwise three replicas in HA).
+	if zoneCritical && deploy.Spec.Replicas != nil && *deploy.Spec.Replicas > 2 {
+		deploy.Spec.Replicas = ptr.To[int32](2)
+	}
+	multiReplica := deploy.Spec.Replicas == nil || *deploy.Spec.Replicas > 1
+
+	pt := &deploy.Spec.Template
+	if pt.Labels == nil {
+		pt.Labels = map[string]string{}
+	}
+	pt.Labels[hypershift.ControlPlaneSchedulingTierLabel] = tier
+
+	if pt.Spec.Affinity == nil {
+		pt.Spec.Affinity = &corev1.Affinity{}
+	}
+
+	// Replace the zone podAntiAffinity with topologySpreadConstraints below.
+	if pt.Spec.Affinity.PodAntiAffinity != nil {
+		removeZonePodAntiAffinity(pt.Spec.Affinity.PodAntiAffinity)
+		if len(pt.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution) == 0 &&
+			len(pt.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution) == 0 {
+			pt.Spec.Affinity.PodAntiAffinity = nil
+		}
+	}
+
+	// Steer onto the correct node pool. Zone-critical components are required onto the
+	// zonal pools; float components are required (hard) or preferred (soft) onto overflow.
+	if pt.Spec.Affinity.NodeAffinity == nil {
+		pt.Spec.Affinity.NodeAffinity = &corev1.NodeAffinity{}
+	}
+	roleRequirement := corev1.NodeSelectorRequirement{
+		Key:      hypershift.ControlPlaneNodeRoleLabel,
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   []string{tier},
+	}
+	if zoneCritical || hard {
+		pt.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = requireNodeSelector(
+			pt.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution, roleRequirement)
+	} else {
+		pt.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
+			pt.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
+			corev1.PreferredSchedulingTerm{
+				Weight:     100,
+				Preference: corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{roleRequirement}},
+			})
+	}
+
+	// Zone-critical components tolerate the zonal NoSchedule taint (present in hard mode).
+	if zoneCritical {
+		pt.Spec.Tolerations = append(pt.Spec.Tolerations, corev1.Toleration{
+			Key:      hypershift.ControlPlaneNodeRoleLabel,
+			Operator: corev1.TolerationOpEqual,
+			Value:    hypershift.ControlPlaneNodeRoleZonal,
+			Effect:   corev1.TaintEffectNoSchedule,
+		})
+	}
+
+	// Scope colocation per tier so float pods are not pulled onto the zonal pools.
+	if pt.Spec.Affinity.PodAffinity != nil {
+		for i := range pt.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
+			term := &pt.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution[i]
+			if term.PodAffinityTerm.LabelSelector == nil {
+				continue
+			}
+			if term.PodAffinityTerm.LabelSelector.MatchLabels == nil {
+				term.PodAffinityTerm.LabelSelector.MatchLabels = map[string]string{}
+			}
+			term.PodAffinityTerm.LabelSelector.MatchLabels[hypershift.ControlPlaneSchedulingTierLabel] = tier
+		}
+	}
+
+	// Spreading via topologySpreadConstraints (only meaningful for multi-replica
+	// workloads): hard per-host spread for all, hard zone spread for zone-critical, and
+	// best-effort zone spread for float.
+	if multiReplica {
+		selector := &metav1.LabelSelector{MatchLabels: deploy.Spec.Selector.MatchLabels}
+		matchLabelKeys := []string{"pod-template-hash"}
+		zoneWhenUnsatisfiable := corev1.ScheduleAnyway
+		if zoneCritical {
+			zoneWhenUnsatisfiable = corev1.DoNotSchedule
+		}
+		pt.Spec.TopologySpreadConstraints = append(pt.Spec.TopologySpreadConstraints,
+			corev1.TopologySpreadConstraint{
+				MaxSkew:           1,
+				TopologyKey:       corev1.LabelHostname,
+				WhenUnsatisfiable: corev1.DoNotSchedule,
+				LabelSelector:     selector,
+				MatchLabelKeys:    matchLabelKeys,
+			},
+			corev1.TopologySpreadConstraint{
+				MaxSkew:           1,
+				TopologyKey:       corev1.LabelTopologyZone,
+				WhenUnsatisfiable: zoneWhenUnsatisfiable,
+				LabelSelector:     selector,
+				MatchLabelKeys:    matchLabelKeys,
+			})
+	}
+}
+
+// removeZonePodAntiAffinity drops any pod anti-affinity term keyed on
+// topology.kubernetes.io/zone (replaced by topologySpreadConstraints).
+func removeZonePodAntiAffinity(paa *corev1.PodAntiAffinity) {
+	required := paa.RequiredDuringSchedulingIgnoredDuringExecution[:0]
+	for _, term := range paa.RequiredDuringSchedulingIgnoredDuringExecution {
+		if term.TopologyKey != corev1.LabelTopologyZone {
+			required = append(required, term)
+		}
+	}
+	paa.RequiredDuringSchedulingIgnoredDuringExecution = required
+
+	preferred := paa.PreferredDuringSchedulingIgnoredDuringExecution[:0]
+	for _, term := range paa.PreferredDuringSchedulingIgnoredDuringExecution {
+		if term.PodAffinityTerm.TopologyKey != corev1.LabelTopologyZone {
+			preferred = append(preferred, term)
+		}
+	}
+	paa.PreferredDuringSchedulingIgnoredDuringExecution = preferred
+}
+
+// requireNodeSelector ANDs requirement into every existing required NodeSelectorTerm (or
+// creates one if none exist). Required NodeSelectorTerms are ORed, so appending the
+// requirement to each term ANDs it with all pre-existing constraints.
+func requireNodeSelector(existing *corev1.NodeSelector, requirement corev1.NodeSelectorRequirement) *corev1.NodeSelector {
+	if existing == nil || len(existing.NodeSelectorTerms) == 0 {
+		return &corev1.NodeSelector{
+			NodeSelectorTerms: []corev1.NodeSelectorTerm{
+				{MatchExpressions: []corev1.NodeSelectorRequirement{requirement}},
+			},
+		}
+	}
+	for i := range existing.NodeSelectorTerms {
+		existing.NodeSelectorTerms[i].MatchExpressions = append(existing.NodeSelectorTerms[i].MatchExpressions, requirement)
+	}
+	return existing
+}

--- a/pkg/network/zonal_scheduling_test.go
+++ b/pkg/network/zonal_scheduling_test.go
@@ -1,0 +1,175 @@
+package network
+
+import (
+	"testing"
+
+	"github.com/openshift/cluster-network-operator/pkg/hypershift"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+
+	. "github.com/onsi/gomega"
+)
+
+// legacyOperandDeployment builds an operand Deployment shaped like the rendered
+// HyperShift-mode manifests: replicas, a zone podAntiAffinity, and a colocation podAffinity.
+func legacyOperandDeployment(name string, replicas int32) *uns.Unstructured {
+	deploy := &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ocm-test"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(replicas),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": name}},
+				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						PodAntiAffinity: &corev1.PodAntiAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+								TopologyKey:   corev1.LabelTopologyZone,
+								LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
+							}},
+						},
+						PodAffinity: &corev1.PodAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{
+								Weight: 100,
+								PodAffinityTerm: corev1.PodAffinityTerm{
+									TopologyKey:   corev1.LabelHostname,
+									LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"hypershift.openshift.io/hosted-control-plane": "ocm-test"}},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+	out, err := runtime.DefaultUnstructuredConverter.ToUnstructured(deploy)
+	if err != nil {
+		panic(err)
+	}
+	return &uns.Unstructured{Object: out}
+}
+
+func toDeployment(g *WithT, obj *uns.Unstructured) *appsv1.Deployment {
+	d := &appsv1.Deployment{}
+	g.Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, d)).To(Succeed())
+	return d
+}
+
+func findTSC(cs []corev1.TopologySpreadConstraint, key string) *corev1.TopologySpreadConstraint {
+	for i := range cs {
+		if cs[i].TopologyKey == key {
+			return &cs[i]
+		}
+	}
+	return nil
+}
+
+func requiredHasRole(na *corev1.NodeAffinity, value string) bool {
+	if na == nil || na.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		return false
+	}
+	for _, t := range na.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
+		for _, r := range t.MatchExpressions {
+			if r.Key == hypershift.ControlPlaneNodeRoleLabel && len(r.Values) == 1 && r.Values[0] == value {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func preferredHasRole(na *corev1.NodeAffinity, value string) bool {
+	if na == nil {
+		return false
+	}
+	for _, t := range na.PreferredDuringSchedulingIgnoredDuringExecution {
+		for _, r := range t.Preference.MatchExpressions {
+			if r.Key == hypershift.ControlPlaneNodeRoleLabel && len(r.Values) == 1 && r.Values[0] == value {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func TestApplyMinimalZonalScheduling(t *testing.T) {
+	minimalHCP := func(placement string) *hypershift.HostedControlPlane {
+		return &hypershift.HostedControlPlane{
+			Namespace:                        "ocm-test",
+			ControllerAvailabilityPolicy:     hypershift.HighlyAvailable,
+			AvailabilityZoneSchedulingPolicy: hypershift.MinimalAvailabilityZoneSchedulingPolicy,
+			NonZonalPlacement:                placement,
+		}
+	}
+
+	t.Run("is a no-op when the policy is not set", func(t *testing.T) {
+		g := NewWithT(t)
+		objs := []*uns.Unstructured{legacyOperandDeployment("ovnkube-control-plane", 2)}
+		g.Expect(applyMinimalZonalScheduling(objs, &hypershift.HostedControlPlane{Namespace: "ocm-test"})).To(Succeed())
+		d := toDeployment(g, objs[0])
+		g.Expect(d.Spec.Template.Spec.TopologySpreadConstraints).To(BeEmpty())
+		g.Expect(d.Spec.Template.Spec.Affinity.PodAntiAffinity).ToNot(BeNil(), "legacy zone podAntiAffinity should be preserved")
+	})
+
+	t.Run("network-node-identity becomes a strict zonal two-replica pair", func(t *testing.T) {
+		g := NewWithT(t)
+		objs := []*uns.Unstructured{legacyOperandDeployment("network-node-identity", 3)}
+		g.Expect(applyMinimalZonalScheduling(objs, minimalHCP("Preferred"))).To(Succeed())
+		d := toDeployment(g, objs[0])
+
+		g.Expect(d.Spec.Replicas).ToNot(BeNil())
+		g.Expect(*d.Spec.Replicas).To(Equal(int32(2)), "should drop from three to two replicas")
+		g.Expect(d.Spec.Template.Labels).To(HaveKeyWithValue(hypershift.ControlPlaneSchedulingTierLabel, hypershift.ControlPlaneNodeRoleZonal))
+		g.Expect(d.Spec.Template.Spec.Affinity.PodAntiAffinity).To(BeNil(), "zone podAntiAffinity should be removed")
+		g.Expect(requiredHasRole(d.Spec.Template.Spec.Affinity.NodeAffinity, hypershift.ControlPlaneNodeRoleZonal)).To(BeTrue())
+
+		zone := findTSC(d.Spec.Template.Spec.TopologySpreadConstraints, corev1.LabelTopologyZone)
+		g.Expect(zone).ToNot(BeNil())
+		g.Expect(zone.WhenUnsatisfiable).To(Equal(corev1.DoNotSchedule))
+		g.Expect(zone.MatchLabelKeys).To(ContainElement("pod-template-hash"))
+		g.Expect(findTSC(d.Spec.Template.Spec.TopologySpreadConstraints, corev1.LabelHostname)).ToNot(BeNil())
+
+		// tolerates the zonal taint
+		hasTol := false
+		for _, tol := range d.Spec.Template.Spec.Tolerations {
+			if tol.Key == hypershift.ControlPlaneNodeRoleLabel && tol.Value == hypershift.ControlPlaneNodeRoleZonal {
+				hasTol = true
+			}
+		}
+		g.Expect(hasTol).To(BeTrue())
+
+		// colocation scoped to the zonal tier
+		term := d.Spec.Template.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0]
+		g.Expect(term.PodAffinityTerm.LabelSelector.MatchLabels).To(HaveKeyWithValue(hypershift.ControlPlaneSchedulingTierLabel, hypershift.ControlPlaneNodeRoleZonal))
+	})
+
+	t.Run("ovnkube-control-plane floats to overflow with best-effort zone spread", func(t *testing.T) {
+		g := NewWithT(t)
+		objs := []*uns.Unstructured{legacyOperandDeployment("ovnkube-control-plane", 2)}
+		g.Expect(applyMinimalZonalScheduling(objs, minimalHCP("Preferred"))).To(Succeed())
+		d := toDeployment(g, objs[0])
+
+		g.Expect(*d.Spec.Replicas).To(Equal(int32(2)), "float replicas are unchanged")
+		g.Expect(d.Spec.Template.Labels).To(HaveKeyWithValue(hypershift.ControlPlaneSchedulingTierLabel, hypershift.ControlPlaneNodeRoleOverflow))
+		g.Expect(preferredHasRole(d.Spec.Template.Spec.Affinity.NodeAffinity, hypershift.ControlPlaneNodeRoleOverflow)).To(BeTrue())
+		g.Expect(d.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(BeNil())
+
+		zone := findTSC(d.Spec.Template.Spec.TopologySpreadConstraints, corev1.LabelTopologyZone)
+		g.Expect(zone).ToNot(BeNil())
+		g.Expect(zone.WhenUnsatisfiable).To(Equal(corev1.ScheduleAnyway))
+	})
+
+	t.Run("hard placement makes float overflow affinity required", func(t *testing.T) {
+		g := NewWithT(t)
+		objs := []*uns.Unstructured{legacyOperandDeployment("ovnkube-control-plane", 2)}
+		g.Expect(applyMinimalZonalScheduling(objs, minimalHCP(hypershift.NonZonalPlacementRequired))).To(Succeed())
+		d := toDeployment(g, objs[0])
+		g.Expect(requiredHasRole(d.Spec.Template.Spec.Affinity.NodeAffinity, hypershift.ControlPlaneNodeRoleOverflow)).To(BeTrue())
+	})
+}


### PR DESCRIPTION
When the HostedControlPlane opts into the Minimal control plane availability-zone scheduling policy (spec.controlPlaneAvailabilityZoneScheduling.policy=Minimal), transform the network control-plane operands accordingly:

- network-node-identity and multus-admission-controller (blocking-webhook backends) stay spread across availability zones as two-replica pairs on the zonal node pools (network-node-identity drops from three replicas to two).
- ovnkube-control-plane (a leader-elected controller) floats onto the non-zonal overflow node pools.

For each, the zone podAntiAffinity is replaced with topologySpreadConstraints (hard zone spread for zone-critical, best-effort for float; hard host spread for all), the pod is steered onto the correct node pool via the well-known hypershift.openshift.io/control-plane-node-role label (required for zone-critical and hard float placement, preferred for soft float placement), zone-critical pods tolerate the zonal taint, and colocation is scoped per scheduling tier. Parsed from the HostedControlPlane CR; a no-op when the policy is not set.