### PR TITLE
OCPBUGS-120940: quote YAML string fields in iptables-alerter Event

### DIFF
--- a/bindata/network/iptables-alerter/002-script.yaml
+++ b/bindata/network/iptables-alerter/002-script.yaml
@@ -101,18 +101,18 @@ data:
     apiVersion: events.k8s.io/v1
     kind: Event
     metadata:
-      namespace: ${pod_namespace}
+      namespace: "${pod_namespace}"
       generateName: iptables-alert-
       labels:
-        pod-uid: ${pod_uid}
+        pod-uid: "${pod_uid}"
     regarding:
       apiVersion: v1
       kind: Pod
-      namespace: ${pod_namespace}
-      name: ${pod_name}
-      uid: ${pod_uid}
+      namespace: "${pod_namespace}"
+      name: "${pod_name}"
+      uid: "${pod_uid}"
     reportingController: openshift.io/iptables-deprecation-alerter
-    reportingInstance: ${ALERTER_POD_NAME}
+    reportingInstance: "${ALERTER_POD_NAME}"
     action: IPTablesUsageObserved
     reason: IPTablesUsageObserved
     type: Normal

--- a/pkg/network/iptables_alerter_test.go
+++ b/pkg/network/iptables_alerter_test.go
@@ -1,0 +1,40 @@
+package network
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	operv1 "github.com/openshift/api/operator/v1"
+	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestRenderIPTablesAlerterQuotesYAMLStringFields(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	bootstrapResult := fakeBootstrapResult()
+	bootstrapResult.IPTablesAlerter.Enabled = true
+
+	objs, err := renderIPTablesAlerter(&operv1.NetworkSpec{}, bootstrapResult, manifestDir)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var scriptCM *uns.Unstructured
+	for _, obj := range objs {
+		if obj.GetKind() == "ConfigMap" && obj.GetName() == "iptables-alerter-script" {
+			scriptCM = obj
+			break
+		}
+	}
+	g.Expect(scriptCM).NotTo(BeNil())
+
+	script, found, err := uns.NestedString(scriptCM.Object, "data", "iptables-alerter.sh")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(found).To(BeTrue())
+
+	// Unquoted YAML 1.1 booleans such as yes/no/true/false/on/off unmarshal as
+	// bool and crash kubectl when metadata.namespace/name must be strings.
+	g.Expect(script).To(ContainSubstring(`namespace: "${pod_namespace}"`))
+	g.Expect(script).To(ContainSubstring(`name: "${pod_name}"`))
+	g.Expect(script).To(ContainSubstring(`uid: "${pod_uid}"`))
+	g.Expect(script).To(ContainSubstring(`pod-uid: "${pod_uid}"`))
+	g.Expect(script).To(ContainSubstring(`reportingInstance: "${ALERTER_POD_NAME}"`))
+}


### PR DESCRIPTION
## Summary
- Quote name/namespace interpolations in the iptables-alerter Event YAML so YAML 1.1 boolean keywords (`yes`, `no`, `true`, `false`, `on`, `off`) are treated as strings
- Prevents `kubectl create` from failing with `cannot unmarshal bool into Go struct field ObjectMeta.metadata.namespace of type string`, which CrashLoopBackOffs the DaemonSet and can leave cluster operator `network` Progressing
- Add a render unit test asserting those Event fields are quoted

Fixes: https://redhat.atlassian.net/browse/OCPBUGS-120940

## Test plan
- [ ] Unit test `TestRenderIPTablesAlerterQuotesYAMLStringFields` passes
- [ ] Create a namespace named `yes`, run a pod in it that installs legacy iptables rules, and confirm iptables-alerter logs the Event instead of crashing
- [ ] Confirm `kubectl get events -n yes` shows `IPTablesUsageObserved`
- [ ] Confirm the `network` ClusterOperator does not stay Progressing due to iptables-alerter CrashLoopBackOff

## Special notes for your reviewer
This change was prepared with AI assistance (Cursor). I reviewed the iptables-alerter script and the YAML 1.1 unmarshalling failure before opening this PR.


Made with [Cursor](https://cursor.com)