### PR TITLE
OCPBUGS-99652: prevent duplicate NOTRACK iptables rules on container restart

### DIFF
--- a/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
+++ b/bindata/network/ovn-kubernetes/common/008-script-lib.yaml
@@ -487,6 +487,26 @@ data:
       cp -f "/usr/libexec/cni/ovn-k8s-cni-overlay" /cni-bin-dir/
     }
 
+    # ensure-notrack-rule ensures exactly one NOTRACK rule exists for the given
+    # iptables command, chain, and port. Adds the rule if missing, removes only
+    # duplicates if present, and does nothing if a single rule already exists.
+    ensure-notrack-rule()
+    {
+      local cmd=$1
+      local chain=$2
+      local port=$3
+      local count
+      count=$($cmd -t raw -S $chain 2>/dev/null | grep -c "\-\-dport $port -j NOTRACK" || true)
+      if [ "$count" -eq 0 ]; then
+        $cmd -t raw -A $chain -p udp --dport $port -j NOTRACK
+      elif [ "$count" -gt 1 ]; then
+        local to_delete=$((count - 1))
+        for ((i=0; i<to_delete; i++)); do
+          $cmd -t raw -D $chain -p udp --dport $port -j NOTRACK
+        done
+      fi
+    }
+
     # start-ovnkube-node starts the ovnkube-node process. This function does not
     # return.
     start-ovnkube-node()
@@ -520,15 +540,15 @@ data:
       cni-bin-copy
 
       echo "I$(date "+%m%d %H:%M:%S.%N") - disable conntrack on geneve port"
-      iptables -t raw -A PREROUTING -p udp --dport {{.GenevePort}} -j NOTRACK
-      iptables -t raw -A OUTPUT -p udp --dport {{.GenevePort}} -j NOTRACK
-      ip6tables -t raw -A PREROUTING -p udp --dport {{.GenevePort}} -j NOTRACK
-      ip6tables -t raw -A OUTPUT -p udp --dport {{.GenevePort}} -j NOTRACK
+      ensure-notrack-rule iptables PREROUTING {{.GenevePort}}
+      ensure-notrack-rule iptables OUTPUT {{.GenevePort}}
+      ensure-notrack-rule ip6tables PREROUTING {{.GenevePort}}
+      ensure-notrack-rule ip6tables OUTPUT {{.GenevePort}}
 
       {{- if .OVNHybridOverlayVXLANPort}}
       echo "I$(date "+%m%d %H:%M:%S.%N") - disable conntrack on hybrid overlay VXLAN port"
-      iptables -t raw -A PREROUTING -p udp --dport {{.OVNHybridOverlayVXLANPort}} -j NOTRACK
-      iptables -t raw -A OUTPUT -p udp --dport {{.OVNHybridOverlayVXLANPort}} -j NOTRACK
+      ensure-notrack-rule iptables PREROUTING {{.OVNHybridOverlayVXLANPort}}
+      ensure-notrack-rule iptables OUTPUT {{.OVNHybridOverlayVXLANPort}}
       {{- end}}
 
       echo "I$(date "+%m%d %H:%M:%S.%N") - starting ovnkube-node"


### PR DESCRIPTION
## What does this PR do?
Prevents duplicate NOTRACK iptables rules from being added to the `raw` table on every ovnkube-controller container restart by checking if each rule already exists before appending it.

## Why is this important?
Without this fix, every ovnkube-controller restart blindly appends duplicate rules for the Geneve and hybrid overlay VXLAN ports. Because NOTRACK is a non-terminating target, all duplicates are evaluated sequentially, inflating packet counters and wasting CPU cycles.

## Implementation
The fix adds an `ensure-notrack-rule` helper function that:
- Checks if the rule already exists
- Adds it if missing
- Removes duplicates if present
- Does nothing if exactly one rule exists

> **Note:** On `master` / OCP 5.x, this bug was already resolved as a side effect of the nftables migration (PR #3038), which uses `nft flush table` before re-adding rules. This fix targets the `release-4.x` branches that still use iptables.

## Jira
https://redhat.atlassian.net/browse/OCPBUGS-99652

## Related PRs
- #3093 (same fix for release-4.23)

## Test plan
- [x] `make build` passes
- [x] `make test-unit` passes
- [ ] Manual: restart ovnkube-node pod multiple times, verify `iptables -t raw -L PREROUTING -n -v --line-numbers` shows no duplicate NOTRACK rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)