### PR TITLE
NETOBSERV-2877: do not merge: Adding openshift- prefix to network observability namespaces 

### DIFF
--- a/bindata/observability/07-observability-operator.yaml
+++ b/bindata/observability/07-observability-operator.yaml
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: netobserv-operator
+  name: openshift-netobserv-operator
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: netobserv-operator
-  namespace: netobserv-operator
+  namespace: openshift-netobserv-operator
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: netobserv-operator
-  namespace: netobserv-operator
+  name: openshift-netobserv-operator
+  namespace: openshift-netobserv-operator
 spec:
   channel: stable
   installPlanApproval: Automatic

--- a/bindata/observability/08-flowcollector.yaml
+++ b/bindata/observability/08-flowcollector.yaml
@@ -22,4 +22,4 @@ spec:
   deploymentModel: Service
   loki:
     enable: false
-  namespace: netobserv
+  namespace: openshift-netobserv

--- a/pkg/controller/observability/observability_controller.go
+++ b/pkg/controller/observability/observability_controller.go
@@ -32,7 +32,7 @@ import (
 const (
 	OperatorYAML         = "bindata/observability/07-observability-operator.yaml"
 	FlowCollectorYAML    = "bindata/observability/08-flowcollector.yaml"
-	OperatorNamespace    = "netobserv-operator"
+	OperatorNamespace    = "openshift-netobserv-operator"
 	FlowCollectorVersion = "v1beta2"
 	FlowCollectorName    = "cluster"
 	NetworkCRName        = "cluster"


### PR DESCRIPTION
This PR add `openshift-` prefix to namespaces used to deploy network observability.

For now, this PR goal is to track the missing requirements needed to deploy network observability in an openshift namespaces.